### PR TITLE
Fix building MaterialDesignIcons

### DIFF
--- a/Tools/BuildMaterialDesignIconsFont.sh
+++ b/Tools/BuildMaterialDesignIconsFont.sh
@@ -3,11 +3,11 @@
 # Just run this script and it should handle everything.
 # You do need enough of a Python environment setup to be able to pip install things.
 
-cd Tools
+pushd `dirname $0`
 
 # Ensure fonttools is installed
 echo "Ensuring fonttools is installed via pip"
-pip install fonttools
+pip3 install --user fonttools
 
 if [ ! -f fontname.py ]; then
   # Download the fontname script
@@ -18,9 +18,10 @@ else
   echo "fontname.py is already downloaded"
 fi
 
-# Get the latest MDI TTF
+# Get the MDI TTF
+# versions >=5.0 do not work with the version of SwiftGen in Iconic, this is locking at version v4.9.95
 echo "Downloading the latest MaterialDesignIcons TTF"
-curl -O --silent https://raw.githubusercontent.com/Templarian/MaterialDesign-Webfont/master/fonts/materialdesignicons-webfont.ttf
+curl -O --silent https://raw.githubusercontent.com/Templarian/MaterialDesign-Webfont/c8ed1f706deb089e05cb46655a786210991f1e92/fonts/materialdesignicons-webfont.ttf
 echo "Downloaded the latest MaterialDesignIcons TTF"
 
 # Rename file
@@ -29,6 +30,8 @@ mv materialdesignicons-webfont.ttf MaterialDesignIcons.ttf
 
 # Change font name to be MaterialDesignIcons so it works with Iconic.
 echo "Changing font name to MaterialDesignIcons"
-python fontname.py MaterialDesignIcons MaterialDesignIcons.ttf
+python3 fontname.py MaterialDesignIcons MaterialDesignIcons.ttf
 
 echo "Successfully built MaterialDesignIcons.ttf"
+
+popd


### PR DESCRIPTION
This fixes executing `Tools/BuildMaterialDesignIconsFont.sh` at least on 10.15.5 (Catalina). There are a few underlying issues here:

1. The `fontname.py` dependency was updated to require python3+, so we need to both install python3 variants and execute using the python3 binary.
2. The `MaterialDesign-Webfont` dependency, for versions ≥5.0, no longer parses successfully with the version of SwiftGen in Iconic.

```bash
$ Vendor/SwiftGen/build/swiftgen/bin/swiftgen icons /…/materialdesignicons-webfont-v5.0.45.ttf
// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen

import UIKit

// No icon found
```

I started down the rabbit hole for 2 but couldn't find an obvious path forward -- it seems like SwiftGen has dropped icon-font building support, so updating to the latest version there doesn't seem fruitful.

While I was in here, I made the script a little less sensitive to executing location by wrapping it in a `pushd`/`popd` block.