### PR TITLE
Fix editing a just-created notification category or action

### DIFF
--- a/HomeAssistant/Views/NotificationCategoryConfigurator.swift
+++ b/HomeAssistant/Views/NotificationCategoryConfigurator.swift
@@ -236,7 +236,9 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
         }
     }
 
-    func getActionRow(_ action: NotificationAction?) -> ButtonRowWithPresent<NotificationActionConfigurator> {
+    func getActionRow(_ existingAction: NotificationAction?) -> ButtonRowWithPresent<NotificationActionConfigurator> {
+        var action = existingAction
+        
         var identifier = "new_action_"+UUID().uuidString
         var title = L10n.NotificationsConfigurator.NewAction.title
 
@@ -245,16 +247,19 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
             title = action.Title
         }
 
-        return ButtonRowWithPresent<NotificationActionConfigurator> {
-            $0.tag = identifier
-            $0.title = title
+        return ButtonRowWithPresent<NotificationActionConfigurator> { row in
+            row.tag = identifier
+            row.title = title
 
-            $0.presentationMode = PresentationMode.show(controllerProvider: ControllerProvider.callback {
+            row.presentationMode = PresentationMode.show(controllerProvider: ControllerProvider.callback {
                 return NotificationActionConfigurator(action: action)
             }, onDismiss: { vc in
                 vc.navigationController?.popViewController(animated: true)
 
                 if let vc = vc as? NotificationActionConfigurator {
+                    // if the user goes to re-edit the action before saving the category, we want to show the same one
+                    action = vc.action
+                    row.tag = vc.action.Identifier
                     vc.row.title = vc.action.Title
                     vc.row.updateCell()
                     Current.Log.verbose("action \(vc.action)")

--- a/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
@@ -318,8 +318,10 @@ class NotificationSettingsViewController: FormViewController {
         self.dismiss(animated: true, completion: nil)
     }
 
-    func getNotificationCategoryRow(_ category: NotificationCategory?) ->
+    func getNotificationCategoryRow(_ existingCategory: NotificationCategory?) ->
         ButtonRowWithPresent<NotificationCategoryConfigurator> {
+            var category = existingCategory
+            
             var identifier = "new_category_"+UUID().uuidString
             var title = L10n.SettingsDetails.Notifications.NewCategory.title
 
@@ -328,10 +330,10 @@ class NotificationSettingsViewController: FormViewController {
                 title = category.Name
             }
 
-            return ButtonRowWithPresent<NotificationCategoryConfigurator> {
-                $0.tag = identifier
-                $0.title = title
-                $0.presentationMode = .show(controllerProvider: ControllerProvider.callback {
+            return ButtonRowWithPresent<NotificationCategoryConfigurator> { row in
+                row.tag = identifier
+                row.title = title
+                row.presentationMode = .show(controllerProvider: ControllerProvider.callback {
                     return NotificationCategoryConfigurator(category: category)
                 }, onDismiss: { vc in
                     _ = vc.navigationController?.popViewController(animated: true)
@@ -341,7 +343,10 @@ class NotificationSettingsViewController: FormViewController {
                             Current.Log.verbose("Not saving category to DB and returning early!")
                             return
                         }
-
+                        
+                        // if the user goes to re-edit the category after saving it, we want to show the same one
+                        category = vc.category
+                        row.tag = vc.category.Identifier
                         vc.row.title = vc.category.Name
                         vc.row.updateCell()
 


### PR DESCRIPTION
When saving a notification action or category right now, tapping the row representing the just-created one will not open the edit screen for that existing one but instead opens as if it is creating a new one again.

This fixes the issue by making sure the ButtonRowWithPresent keeps a reference to the action it wants to open, and allows that action to be changed to point to a different one once it's created.