### PR TITLE
Action Configurator: Example Trigger Preview

### DIFF
--- a/HomeAssistant/Classes/Action.swift
+++ b/HomeAssistant/Classes/Action.swift
@@ -73,6 +73,23 @@ public class Action: Object, Mappable, NSCoding {
                                          userInfo: ["name": self.Name as NSSecureCoding])
     }
     #endif
+    
+    public var exampleTrigger: String {
+        let data = HomeAssistantAPI.actionEvent(actionID: ID, actionName: Name, source: .Preview)
+        let eventDataStrings = data.eventData.map { $0 + ": " + $1 }.sorted()
+        let sourceStrings = HomeAssistantAPI.ActionSource.allCases.map { $0.description }.sorted()
+        
+        let indentation = "\n    "
+        
+        return """
+        - platform: event
+          event_type: \(data.eventType)
+          event_data:
+            # source may be one of:
+            # - \(sourceStrings.joined(separator: indentation + "# - "))
+            \(eventDataStrings.joined(separator: indentation))
+        """
+    }
 }
 
 extension UIColor {

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -445,6 +445,8 @@
 "actions_configurator.rows.text.title" = "Text";
 "actions_configurator.rows.text_color.title" = "Text Color";
 "actions_configurator.title" = "New Action";
+"actions_configurator.trigger_example.title" = "Example Trigger";
+"actions_configurator.trigger_example.share" = "Share Contents";
 "alerts.alert.ok" = "OK";
 "alerts.confirm.cancel" = "Cancel";
 "alerts.confirm.ok" = "OK";

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -201,7 +201,7 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
                 
                 row.onCellSelection { _, _ in
                     // although this could be done via presentationMode, we want to preserve the 'button' look
-                    let value = self.action.exampleTrigger
+                    let value = (self.form.rowBy(tag: "trigger-yaml") as? TextAreaRow)?.value ?? self.action.exampleTrigger
                     let controller = UIActivityViewController(activityItems: [ value ], applicationActivities: [])
                     self.present(controller, animated: true, completion: nil)
                 }

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -53,12 +53,6 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self,
                                                                  action: saveSelector)
 
-        self.title = L10n.ActionsConfigurator.title
-
-        if newAction == false {
-            self.title = action.Name
-        }
-
         TextRow.defaultCellUpdate = { cell, row in
             if !row.isValid {
                 cell.textLabel?.textColor = .red
@@ -248,7 +242,12 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
     }
 
     private func updatePreviews() {
-        title = action.Name
+        if action.Name.isEmpty && newAction {
+            title = L10n.ActionsConfigurator.title
+        } else {
+            title = action.Name
+        }
+        
         preview.setup(action)
         
         if let row = form.rowBy(tag: "trigger-yaml") as? TextAreaRow {

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -134,6 +134,12 @@ internal enum L10n {
         internal static let title = L10n.tr("Localizable", "actions_configurator.rows.text_color.title")
       }
     }
+    internal enum TriggerExample {
+      /// Share Contents
+      internal static let share = L10n.tr("Localizable", "actions_configurator.trigger_example.share")
+      /// Example Trigger
+      internal static let title = L10n.tr("Localizable", "actions_configurator.trigger_example.title")
+    }
   }
 
   internal enum Alerts {


### PR DESCRIPTION
When editing an Action, the configurator currently shows a preview of what the button will look like, but it doesn't give any direct indication what the _event_ it fires will look like. One must look to the documentation to get an idea how to structure the automation.

This adds a preview of the yaml one would need to write as an automation, using the same flow as sending it to the server to avoid it getting stale over time, and allows the user to share it out via copying, email, etc.

This pulls together the different 'previews' in the configurator to be executed together:
- the title of the view controller (which wasn't updated live before)
- the actual preview button the user can tap
- this new yaml trigger preview

This also removes the toolbar with the help button from the action edit screen. It didn't work, it takes up a lot of vertical space where it's at a premium with the keyboard open, and the previous screen already has the same link/button.

![Simulator Screen Shot - iPhone 11 Pro - 2020-06-07 at 16 47 10](https://user-images.githubusercontent.com/74188/83982910-262edc00-a8df-11ea-98fc-3415abded090.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-07 at 16 47 12](https://user-images.githubusercontent.com/74188/83982912-28913600-a8df-11ea-8d1a-36cfa410aa19.png)
