### PR TITLE
Fix deleting notification categories when reordering them

### DIFF
--- a/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
@@ -97,7 +97,7 @@ class NotificationSettingsViewController: FormViewController {
 
         let categories = Current.realm().objects(NotificationCategory.self).sorted(byKeyPath: "Identifier")
 
-        let mvOpts: MultivaluedOptions = [.Insert, .Delete, .Reorder]
+        let mvOpts: MultivaluedOptions = [.Insert, .Delete]
         let header = L10n.SettingsDetails.Notifications.Categories.header
 
         self.form


### PR DESCRIPTION
The categories are loaded with a distinct sort:

```swift
let categories = Current.realm().objects(NotificationCategory.self).sorted(byKeyPath: "Identifier")
```

Since reordering makes no sense in this list, this removes the ability to reorder from the section.

The act of reordering actually deletes the category being dragged because Eureka does a `remove`+`insert` rather than `move`, and `NotificationSettingsViewController` will [silently delete the category](https://github.com/home-assistant/iOS/blob/d43b5ddd211c3cf98ed1b518cee92ada21b095b7/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift#L372-L389) it sees the remove for.

This does occasionally crash, I think depending upon the lifecycle of the invalidated Realm object and whether something access it from the deleted-but-we-don't-know-it-yet pointer.