### PR TITLE
Remove `WKWebView` safeAreaInsets resetting

### DIFF
--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -813,11 +813,5 @@ extension ConnectionInfo {
 
         return try? components.asURL()
     }
-}
-
-extension WKWebView {
-    override open var safeAreaInsets: UIEdgeInsets {
-        return .zero
-    }
 // swiftlint:disable:next file_length
 }


### PR DESCRIPTION
I offer this change to start a conversation about how the safe area insets are handled in the webview that powers the frontend on iOS. I think that allowing the webview to handle the safe area on its own will work out better in the long run, and solves a lot of real frustrations that I have been running into.

Judging by the [original commit](https://github.com/home-assistant/iOS/commit/414c5be29a4b3673ebc507e62012de72f547fdb3) being long enough in the past, and early enough in the iPhone X world, I'm hoping that the safe area problem can be handled a little cleaner.

There are a few cases that I believe are significantly improved with this change:

1. Landscape handling (practically anywhere)

On devices with safe area insets for the device bezel, e.g. the iPhone 11 I'm taking these screenshots in, the contents of the dashboards are actually obscured by the notch and large rounded corners of the device. I don't own one of the iPads with the safe area insets, but I'm guessing it's also frustrating there, too.

![Photo Jun 07, 20 08 02](https://user-images.githubusercontent.com/74188/83989343-f68dcd00-a8fa-11ea-88b5-aa9071a19422.png)

2. Configuration and the pseudo-tab-bars at the bottom

These pseudo-tab-bars are underneath the home screen indicator, which is an area that's fairly difficult (both mentally and physically) to tap. 

There are a few minor issues that I'm seeing in the settings screens with safe areas re-enabled:
- The add FAB is being positioned what appears absolutely rather than relative to the container.
- There's an additional iframe or other container that's positioned based on the height of the screen, which gives an extra vertical scroll frustration.
These feel very solvable to me, though I am absolutely awful at web development enough to know where to jump in there.

![Photo Jun 07, 20 09 44](https://user-images.githubusercontent.com/74188/83989410-2d63e300-a8fb-11ea-89c9-f03bb7144e95.png)

3. Content not given a margin when at the bottom

For example, when I'm scrolling to the bottom of a dashboard, it's a lot easier to read the bottom-most cards when the home screen indicator doesn't overlap them.

![Photo Jun 07, 20 08 34](https://user-images.githubusercontent.com/74188/83989420-348af100-a8fb-11ea-901f-30d1fcfe5d6f.png)