### PR TITLE
Fix infinite loop when updating sensors

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -683,7 +683,12 @@ public class HomeAssistantAPI {
 
             Current.Log.warning("Errors detected during sensor update, re-registering sensors \(failures) now")
 
-            return self.RegisterSensors(failures).then { _ -> Promise<[String: WebhookSensorResponse]> in
+            return self.RegisterSensors(failures).then { output -> Promise<[String: WebhookSensorResponse]> in
+                guard output.allSatisfy({ $0.Success }) else {
+                    Current.Log.error("couldn't register sensor(s), not going to do an update")
+                    throw APIError.invalidResponse
+                }
+
                 return self.UpdateSensors(trigger)
             }
         }


### PR DESCRIPTION
When updating sensors, any failed updates due to `not_registered` are registered and then the update is retried. However, if any of the sensors which failed to update _also_ fail to register, the fact that this is an error condition is silently ignored, and without backoff another update is immediately attempted.

You can reproduce this by e.g. hard-coding a sensor that will never successfully register into the sensors list, like so:

```swift
let sensor = WebhookSensor(name: "moo", uniqueID: "arfarf34")
sensor.State = nil
allSensors.append(sensor)
```

Fixes #599.
Refs home-assistant/core#36455.