### PR TITLE
Fix always registering every sensor upon not_registered

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -603,17 +603,23 @@ public class HomeAssistantAPI {
             allSensors.append(triggerSensor)
             allSensors.append(self.sensorsConfig.GeocodedLocationSensorConfig)
 
-            // swiftlint:disable:next line_length
-            let promises: [Promise<WebhookSensorResponse>] = allSensors.compactMap { sensor -> Promise<WebhookSensorResponse>? in
-                let promise: Promise<WebhookSensorResponse> = self.webhook("register_sensor", payload: sensor.toJSON(),
-                                                                           callingFunctionName: "\(#function)")
-                if let limit = limitSensors {
-                    if let uniqID = sensor.UniqueID, limit.contains(uniqID) {
-                        return promise
+            let sensorsToRegister: [WebhookSensor]
+            
+            if let limitSensors = limitSensors {
+                sensorsToRegister = allSensors.filter {
+                    if let uniqueID = $0.UniqueID {
+                        return limitSensors.contains(uniqueID)
+                    } else {
+                        return false
                     }
-                    return nil
                 }
-                return promise
+            } else {
+                sensorsToRegister = allSensors
+            }
+            
+            let promises: [Promise<WebhookSensorResponse>] = sensorsToRegister.map { sensor in
+                return self.webhook("register_sensor", payload: sensor.toJSON(),
+                                    callingFunctionName: "\(#function)")
             }
 
             Current.Log.verbose("Registering sensors \(promises)")


### PR DESCRIPTION
When trying to register only a given list of sensors, all of the Promise are created immediately, and the webhook response promises invoke immediately. In the end, all the filtering was doing was preventing waiting for all of them, thus making the DoS in an infinite loop even stronger!

This modifies the filter check to do the filter before creating the promises, and thus only will register a sensor that is failing.

Refs #599.
Refs home-assistant/core#36455.