### PR TITLE
Don't tell Realm to delete the database on migration

### DIFF
--- a/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Shared/Common/Extensions/Realm+Initialization.swift
@@ -60,7 +60,7 @@ extension Realm {
         #endif
 
         let config = Realm.Configuration(fileURL: storeURL, schemaVersion: 4,
-                                         migrationBlock: nil, deleteRealmIfMigrationNeeded: true)
+                                         migrationBlock: nil, deleteRealmIfMigrationNeeded: false)
         var configuredRealm: Realm!
         do {
             configuredRealm = try Realm(configuration: config)


### PR DESCRIPTION
Although it's easier for development (I've done it before) it's better to leave this `false` so you don't accidentally lose user data, e.g. Realm describes this property as:

> delete the Realm if migration is needed; this is useful under development since the data model might change often

The reason upgrading to Realm 5.x from the current version was losing the database is that Realm is doing an internal migration to a newer version of its database, and it is using this setting to decide whether to migrate or wipe.

Tested this out by upgrading a few times, with and without the flag. The migration doesn't have issues preserving the data.