### PR TITLE
Handle logouts and invalidated tokens

### DIFF
--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -617,12 +617,13 @@ extension WebViewController: WKScriptMessageHandler {
                 Current.tokenManager = nil
                 Current.settingsStore.connectionInfo = nil
                 Current.settingsStore.tokenInfo = nil
-                self.showSettingsViewController()
                 let script = "\(callbackName)(true)"
 
                 Current.Log.verbose("Running revoke external auth callback \(script)")
 
                 self.webView.evaluateJavaScript(script, completionHandler: { (_, error) in
+                    Current.signInRequiredCallback?(.logout)
+
                     if let error = error {
                         Current.Log.error("Failed calling sign out callback: \(error)")
                     }

--- a/Shared/API/Requests/MobileAppRegistrationRequest.swift
+++ b/Shared/API/Requests/MobileAppRegistrationRequest.swift
@@ -15,6 +15,7 @@ class MobileAppRegistrationRequest: Mappable {
     var AppName: String?
     var AppVersion: String?
     var DeviceName: String?
+    var DeviceID: String?
     var Manufacturer: String?
     var Model: String?
     var OSName: String?
@@ -32,6 +33,7 @@ class MobileAppRegistrationRequest: Mappable {
         AppName             <- map["app_name"]
         AppVersion          <- map["app_version"]
         DeviceName          <- map["device_name"]
+        DeviceID            <- map["device_id"]
         Manufacturer        <- map["manufacturer"]
         Model               <- map["model"]
         OSName              <- map["os_name"]

--- a/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
+++ b/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
@@ -13,6 +13,7 @@ class MobileAppUpdateRegistrationRequest: Mappable {
     var AppData: [String: Any]?
     var AppVersion: String?
     var DeviceName: String?
+    var DeviceID: String?
     var Manufacturer: String?
     var Model: String?
     var OSVersion: String?
@@ -25,6 +26,7 @@ class MobileAppUpdateRegistrationRequest: Mappable {
         AppData             <- map["app_data"]
         AppVersion          <- map["app_version"]
         DeviceName          <- map["device_name"]
+        DeviceID            <- map["device_id"]
         Manufacturer        <- map["manufacturer"]
         Model               <- map["model"]
         OSVersion           <- map["os_version"]

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -56,7 +56,19 @@ public class Environment {
     public var authenticationControllerPresenter: ((UIViewController) -> Void)?
     #endif
 
-    public var signInRequiredCallback: (() -> Void)?
+    public enum SignInRequiredType {
+        case logout
+        case error
+
+        public var shouldShowError: Bool {
+            switch self {
+            case .logout: return false
+            case .error:  return true
+            }
+        }
+    }
+
+    public var signInRequiredCallback: ((SignInRequiredType) -> Void)?
 
     public var onboardingComplete: (() -> Void)?
 

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -11,6 +11,11 @@ import KeychainAccess
 import DeviceKit
 import CoreLocation
 import CoreMotion
+#if os(iOS)
+import UIKit
+#elseif os(watchOS)
+import WatchKit
+#endif
 
 public class SettingsStore {
     let keychain = Constants.Keychain
@@ -103,6 +108,18 @@ public class SettingsStore {
         set {
            prefs.setValue(newValue, forKeyPath: "pushID")
         }
+    }
+
+    public var integrationDeviceID: String {
+        #if os(iOS)
+            return UIDevice.current.identifierForVendor?.uuidString ?? deviceID
+        #elseif os(watchOS)
+            if #available(watchOS 6.2, *) {
+                return WKInterfaceDevice.current().identifierForVendor?.uuidString ?? deviceID
+            } else {
+                return deviceID
+            }
+        #endif
     }
 
     public var deviceID: String {


### PR DESCRIPTION
Add handling for when the access token is removed.

- Shows the onboarding flow for manual sign outs and invalid-token sign outs. Made the onboarding flow more resilient to being called more than once (see below).
- Shows the onboarding flow on startup if the user hasn't completed onboarding _or_ if we know they should see it.
- Adds some logging so we can easily see why a particular user was logged out.

Adds handling for when the integration is removed from the server.

- In this case, we re-register from scratch. This now includes the stable value `identifierForVendor` as an integration-specific unique ID, not based on any user input, which helps avoid any duplicate integrations from showing up.
- Tested a few scenarios: with an existing integration, made sure that adding device_id didn't create a duplicate or error out; without an existing integration, registering twice doesn't create a duplicate.

---

Some of this (moving around where things are created in the AppDelegate) is in prep of adding state restoration to the WebViewController, which requires a few entry points to how the navigation controllers are created.