### PR TITLE
Manual location update for While In Use permission

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -226,7 +226,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         var updatePromise: Promise<Void> = api.UpdateSensors(.BackgroundFetch).asVoid()
 
-        if Current.settingsStore.locationEnabled && prefs.bool(forKey: "locationUpdateOnBackgroundFetch") {
+        if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState),
+            prefs.bool(forKey: "locationUpdateOnBackgroundFetch") {
             updatePromise = api.GetAndSendLocation(trigger: .BackgroundFetch).asVoid()
         }
 

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -114,9 +114,27 @@ public class SettingsStore {
         }
     }
 
-    public var locationEnabled: Bool {
-        return CLLocationManager.authorizationStatus() == .authorizedAlways
+    #if os(iOS)
+    public func isLocationEnabled(for state: UIApplication.State) -> Bool {
+        switch CLLocationManager.authorizationStatus() {
+        case .authorizedAlways:
+            return true
+        case .authorizedWhenInUse:
+            switch state {
+            case .active, .inactive:
+                return true
+            case .background:
+                return false
+            @unknown default:
+                return false
+            }
+        case .denied, .notDetermined, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
     }
+    #endif
 
     public var motionEnabled: Bool {
         get {


### PR DESCRIPTION
Adds some state-aware handling to treat the While In Use permission level as valid for doing manual location updates. This also makes it so that failing to get a location doesn't result in not updating other sensors during a manual update request.