### PR TITLE
Validate manually-entered URL strings

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -640,6 +640,10 @@
 "onboarding.connection_test_result.server_error.description" = "Server error: %@";
 "onboarding.connection_test_result.too_old.description" = "You must upgrade your Home Assistant version.";
 "onboarding.connection_test_result.unknown_error.description" = "Unknown error: %@";
+"onboarding.manual_setup.no_scheme.title" = "URL entered without scheme";
+"onboarding.manual_setup.no_scheme.message" = "Should we try connecting using http:// or https://?";
+"onboarding.manual_setup.couldnt_make_url.title" = "Could not create a URL";
+"onboarding.manual_setup.couldnt_make_url.message" = "The value '%@' was not a valid URL.";
 "onboarding.discovery.results_label.plural" = "We found %d Home Assistants on your network.";
 "onboarding.discovery.results_label.singular" = "We found %d Home Assistant on your network.";
 "onboarding.connect.title" = "Connecting to %@";

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -611,6 +611,22 @@ internal enum L10n {
         }
       }
     }
+    internal enum ManualSetup {
+      internal enum CouldntMakeUrl {
+        /// The value '%@' was not a valid URL.
+        internal static func message(_ p1: String) -> String {
+          return L10n.tr("Localizable", "onboarding.manual_setup.couldnt_make_url.message", p1)
+        }
+        /// Could not create a URL
+        internal static let title = L10n.tr("Localizable", "onboarding.manual_setup.couldnt_make_url.title")
+      }
+      internal enum NoScheme {
+        /// Should we try connecting using http:// or https://?
+        internal static let message = L10n.tr("Localizable", "onboarding.manual_setup.no_scheme.message")
+        /// URL entered without scheme
+        internal static let title = L10n.tr("Localizable", "onboarding.manual_setup.no_scheme.title")
+      }
+    }
   }
 
   internal enum Permissions {


### PR DESCRIPTION
If you, for example, enter `127.0.0.1:8123` without the scheme, this ends up being a quasi-valid URL that will fail later down the pipeline.

If you enter something that's even closer to valid like `http:127.0.0.1:8123` it will crash trying to make a WebSocket connection, since that API strictly looks for http/https schemes.

This prompts the user if they forget a scheme, trims any whitespace, and makes sure that the thing passes an is-URL heuristic (by initting a URL with the string) before allowing the user to continue.