### PR TITLE
Don't send device_id when updating registration

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -394,7 +394,6 @@ public class HomeAssistantAPI {
             ]
         }
         ident.AppVersion = prefs.string(forKey: "lastInstalledVersion")
-        ident.DeviceID = Current.settingsStore.integrationDeviceID
         ident.DeviceName = deviceKitDevice.name
         ident.Manufacturer = "Apple"
         ident.Model = deviceKitDevice.description

--- a/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
+++ b/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
@@ -13,7 +13,6 @@ class MobileAppUpdateRegistrationRequest: Mappable {
     var AppData: [String: Any]?
     var AppVersion: String?
     var DeviceName: String?
-    var DeviceID: String?
     var Manufacturer: String?
     var Model: String?
     var OSVersion: String?
@@ -26,7 +25,6 @@ class MobileAppUpdateRegistrationRequest: Mappable {
         AppData             <- map["app_data"]
         AppVersion          <- map["app_version"]
         DeviceName          <- map["device_name"]
-        DeviceID            <- map["device_id"]
         Manufacturer        <- map["manufacturer"]
         Model               <- map["model"]
         OSVersion           <- map["os_version"]


### PR DESCRIPTION
After retesting my expectations from #612 I discovered that the update registration call doesn't like having the  device_id included, so this removes it. Re-tested to make sure the same example registration cases still function as expected.

Shows up like:
> [homeassistant.components.mobile_app.webhook] Received invalid webhook payload: extra keys not allowed @ data['device_id']. Got '4B94573F-FFA2-4D83-BEA4-CE5BE184DBF3'