### PR TITLE
Update onboarding error more info link

### DIFF
--- a/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
+++ b/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
@@ -249,7 +249,7 @@ public struct ConnectionTestResult: LocalizedError {
     }
 
     public var DocumentationURL: URL {
-        return URL(string: "https://companion.home-assistant.io/en/misc/errors#\(self.kind.rawValue)")!
+        return URL(string: "https://companion.home-assistant.io/docs/troubleshooting/errors#\(self.kind.rawValue)")!
     }
 }
 


### PR DESCRIPTION
Existing link was pointing to an invalid address.

home-assistant/companion.home-assistant#241 catches the current address and redirects it the right place but we should fix the source too.
