### PR TITLE
Add Location & Motion permission to settings

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -113,6 +113,15 @@
 "no_label" = "No";
 "alerts.open_url_from_notification.title" = "Open URL?";
 "alerts.open_url_from_notification.message" = "Open URL (%@) found in notification?";
+"settings_details.location.location_permission.title" = "Location Permission";
+"settings_details.location.location_permission.always" = "Always";
+"settings_details.location.location_permission.while_in_use" = "While In Use";
+"settings_details.location.location_permission.never" = "Never";
+"settings_details.location.location_permission.needs_request" = "Disabled";
+"settings_details.location.motion_permission.title" = "Motion Permission";
+"settings_details.location.motion_permission.enabled" = "Enabled";
+"settings_details.location.motion_permission.denied" = "Denied";
+"settings_details.location.motion_permission.needs_request" = "Disabled";
 "settings_details.location.updates.header" = "Update sources";
 "settings_details.location.updates.footer" = "Manual location updates can always be triggered";
 "settings_details.location.updates.zone.title" = "Zone enter/exit";

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1307,6 +1307,28 @@ internal enum L10n {
     internal enum Location {
       /// Location
       internal static let title = L10n.tr("Localizable", "settings_details.location.title")
+      internal enum LocationPermission {
+        /// Always
+        internal static let always = L10n.tr("Localizable", "settings_details.location.location_permission.always")
+        /// Disabled
+        internal static let needsRequest = L10n.tr("Localizable", "settings_details.location.location_permission.needs_request")
+        /// Never
+        internal static let never = L10n.tr("Localizable", "settings_details.location.location_permission.never")
+        /// Location Permission
+        internal static let title = L10n.tr("Localizable", "settings_details.location.location_permission.title")
+        /// While In Use
+        internal static let whileInUse = L10n.tr("Localizable", "settings_details.location.location_permission.while_in_use")
+      }
+      internal enum MotionPermission {
+        /// Denied
+        internal static let denied = L10n.tr("Localizable", "settings_details.location.motion_permission.denied")
+        /// Enabled
+        internal static let enabled = L10n.tr("Localizable", "settings_details.location.motion_permission.enabled")
+        /// Disabled
+        internal static let needsRequest = L10n.tr("Localizable", "settings_details.location.motion_permission.needs_request")
+        /// Motion Permission
+        internal static let title = L10n.tr("Localizable", "settings_details.location.motion_permission.title")
+      }
       internal enum Notifications {
         /// Location Notifications
         internal static let header = L10n.tr("Localizable", "settings_details.location.notifications.header")


### PR DESCRIPTION
Without an entry point in the app to force the location/motion manager to request permission, a user who didn't enable it during onboarding won't have a way to turn it on without logging out or deleting the app.

This should also reduce the confusion about the current status by allowing the user to jump into Settings to e.g. change from Never to Always.

This also needs to be done for Notifications, but that'll be a different PR.

![Simulator Screen Shot - iPhone 11 Pro - 2020-06-10 at 08 55 59](https://user-images.githubusercontent.com/74188/84290254-4dacc100-aaf8-11ea-99f0-dfe692b57739.png)
