### PR TITLE
Add Notification permission to settings

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -581,12 +581,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         UNUserNotificationCenter.current().getNotificationSettings { (settings) in
             guard settings.authorizationStatus == .authorized else {return}
-            var opts: UNAuthorizationOptions = [.alert, .badge, .sound, .criticalAlert,
-                                                .providesAppNotificationSettings]
-            if #available(iOS 13.0, *) {
-                opts.insert(.announcement)
-            }
-            UNUserNotificationCenter.current().requestAuthorization(options: opts) { (granted, error) in
+
+            UNUserNotificationCenter.current().requestAuthorization(options: .defaultOptions) { (granted, error) in
                 Current.Log.verbose("Requested critical alert access \(granted), \(String(describing: error))")
             }
         }

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -62,6 +62,10 @@
 "settings_details.location.zones.beacon_minor.title" = "iBeacon Minor";
 "settings_details.location.zones.footer" = "To disable location tracking add track_ios: false to each zones settings or under customize.";
 "settings_details.notifications.title" = "Notifications";
+"settings_details.notifications.permission.title" = "Permission";
+"settings_details.notifications.permission.enabled" = "Enabled";
+"settings_details.notifications.permission.disabled" = "Denied";
+"settings_details.notifications.permission.needs_request" = "Disabled";
 "settings_details.notifications.push_id_section.header" = "Push ID";
 "settings_details.notifications.push_id_section.footer" = "This is the target to use in your Home Assistant configuration. Tap to copy or share.";
 "settings_details.notifications.push_id_section.placeholder" = "Push ID";

--- a/HomeAssistant/Utilities/Permissions.swift
+++ b/HomeAssistant/Utilities/Permissions.swift
@@ -201,14 +201,7 @@ public enum PermissionType: Int {
                 return
             })
         case .notification:
-            var opts: UNAuthorizationOptions = [.alert, .badge, .sound]
-            if #available(iOS 12.0, *) {
-                opts.formUnion([.criticalAlert, .providesAppNotificationSettings])
-            }
-            if #available(iOS 13.0, *) {
-                opts.insert(.announcement)
-            }
-            UNUserNotificationCenter.current().requestAuthorization(options: opts) { (granted, error) in
+            UNUserNotificationCenter.current().requestAuthorization(options: .defaultOptions) { (granted, error) in
                 if let error = error {
                     Current.Log.error("Error when requesting notifications permissions: \(error)")
                 }
@@ -219,6 +212,19 @@ public enum PermissionType: Int {
                 }
             }
         }
+    }
+}
+
+public extension UNAuthorizationOptions {
+    static var defaultOptions: UNAuthorizationOptions {
+        var opts: UNAuthorizationOptions = [.alert, .badge, .sound]
+        if #available(iOS 12.0, *) {
+            opts.formUnion([.criticalAlert, .providesAppNotificationSettings])
+        }
+        if #available(iOS 13.0, *) {
+            opts.insert(.announcement)
+        }
+        return opts
     }
 }
 

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1447,6 +1447,16 @@ internal enum L10n {
         /// New Category
         internal static let title = L10n.tr("Localizable", "settings_details.notifications.new_category.title")
       }
+      internal enum Permission {
+        /// Denied
+        internal static let disabled = L10n.tr("Localizable", "settings_details.notifications.permission.disabled")
+        /// Enabled
+        internal static let enabled = L10n.tr("Localizable", "settings_details.notifications.permission.enabled")
+        /// Disabled
+        internal static let needsRequest = L10n.tr("Localizable", "settings_details.notifications.permission.needs_request")
+        /// Permission
+        internal static let title = L10n.tr("Localizable", "settings_details.notifications.permission.title")
+      }
       internal enum PromptToOpenUrls {
         /// Confirm before opening URL
         internal static let title = L10n.tr("Localizable", "settings_details.notifications.prompt_to_open_urls.title")


### PR DESCRIPTION
Like #618, without an entry point in the app to request notification permission, the user would have to delete the app or go through onboarding again to get the permission working.

![Simulator Screen Shot - iPhone 11 Pro - 2020-06-10 at 09 23 48](https://user-images.githubusercontent.com/74188/84293083-28ba4d00-aafc-11ea-85fb-36bf9f4ed31f.png)
