### PR TITLE
Ensure that OneTimeLocationManager doesn't use SignificantLocationChange

### DIFF
--- a/HomeAssistant/Classes/OneShotLocationManager.swift
+++ b/HomeAssistant/Classes/OneShotLocationManager.swift
@@ -19,6 +19,7 @@ public class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
     public init(onLocation: @escaping OnLocationUpdated) {
         onLocationUpdated = onLocation
         super.init()
+        locationManager.stopMonitoringSignificantLocationChanges()
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         locationManager.distanceFilter = kCLLocationAccuracyHundredMeters
         locationManager.delegate = self
@@ -35,6 +36,7 @@ public class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
 
             Current.Log.verbose("LocationManager: Got location stored on manager \(location)")
             onLocationUpdated(location, nil)
+            locationManager.startMonitoringSignificantLocationChanges()
             locationManager.delegate = nil
         }
     }
@@ -42,6 +44,7 @@ public class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         Current.Log.verbose("LocationManager: Got \(locations.count) locations, stopping updates!")
         onLocationUpdated(locations.first, nil)
+        locationManager.startMonitoringSignificantLocationChanges()
         manager.delegate = nil
     }
 
@@ -60,5 +63,6 @@ public class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
             Current.Log.error("Received non-CLError when we only expected CLError: \(error)")
             onLocationUpdated(nil, error)
         }
+        locationManager.startMonitoringSignificantLocationChanges()
     }
 }

--- a/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
+++ b/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
@@ -249,7 +249,7 @@ public struct ConnectionTestResult: LocalizedError {
     }
 
     public var DocumentationURL: URL {
-        return URL(string: "https://companion.home-assistant.io/en/misc/errors#\(self.kind.rawValue)")!
+        return URL(string: "https://companion.home-assistant.io/docs/troubleshooting/errors#\(self.kind.rawValue)")!
     }
 }
 


### PR DESCRIPTION
We have seen multiple people report poor accuracy with the app including multiple reports of background fetch location accuracy being much worse than 100 m (2500 m has been reported). Background fetch, along with everything except zones, iBeacons, and significant location update, uses `OneShotLocationManager` which should never return a location with accuracy of worse than 200 m and aspires to achieve better than 100 m. 

I believe this is because `CoreLocation` works app wide and setting one manager to `startMonitoringSignificantLocationChanges()` causes all managers to disregard `desiredAccuracy` and `distanceFilter` as explained [here](https://developer.apple.com/documentation/corelocation/getting_the_user_s_location/using_the_significant-change_location_service).

Attempt to address this by calling `stopMonitoringSignificantLocationChanges` with the `OneShotLocationManager` before doing the one-shot update and then turning monitoring back on at all exit conditions. 

Potentially fixes #589 