### PR TITLE
Fix opening notification settings deeplink

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -870,8 +870,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let navController = UINavigationController(rootViewController: view)
             rootViewController?.present(navController, animated: true, completion: nil)
         })
-        let navController = UINavigationController(rootViewController: view)
-        rootViewController?.present(navController, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
The controller was added to two UINavigationControllers and the second one lost the presentation race, so the former ended up being empty.

Fixes #526.