### PR TITLE
New One Shot Location Logic

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		0C6645270B5B70DF1C404144 /* Pods-SiriIntents-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = E3052AE62E057BB6257EDC1C /* Pods-SiriIntents-metadata.plist */; };
+		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
+		113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
+		113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */; };
+		113D29E324946F930014067C /* OneShotLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E224946F930014067C /* OneShotLocationManager.swift */; };
+		113D29E424946F930014067C /* OneShotLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E224946F930014067C /* OneShotLocationManager.swift */; };
 		119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */; };
 		11B7FD742493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
@@ -398,7 +403,6 @@
 		B67CE8BC22200F220034C1D0 /* ClientEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF79CB20D778B50034574D /* ClientEvent.swift */; };
 		B67CE8BD22200F220034C1D0 /* ClientEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF79CD20D85C3A0034574D /* ClientEventStore.swift */; };
 		B67CE8C4222011A60034C1D0 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF31F214DE3B300D1D360 /* Strings.swift */; };
-		B67CE8C5222013B60034C1D0 /* OneShotLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B25BC82130CA0D00678C2C /* OneShotLocationManager.swift */; };
 		B67CE8C7222015E30034C1D0 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE8C6222015E30034C1D0 /* CoreLocation.framework */; };
 		B67CE8C9222015E80034C1D0 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE8C8222015E80034C1D0 /* UserNotifications.framework */; };
 		B67CE8CD22201EFA0034C1D0 /* RegionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B25BCA2130CA2D00678C2C /* RegionManager.swift */; };
@@ -548,7 +552,6 @@
 		D0EEF32D214DF94900D1D360 /* PushRegistrationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60EAE9A1DBC347C0062C97C /* PushRegistrationResponse.swift */; };
 		D0EEF32E214DF99500D1D360 /* PushRegistrationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B629E8D51DAD8CFA00040A90 /* PushRegistrationRequest.swift */; };
 		D0EEF331214E41F700D1D360 /* HomeAssistantAPI+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF330214E41F700D1D360 /* HomeAssistantAPI+Notifications.swift */; };
-		D0EEF332214EB2BC00D1D360 /* OneShotLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B25BC82130CA0D00678C2C /* OneShotLocationManager.swift */; };
 		D0EEF335214EB77100D1D360 /* CLLocation+ToDoubleArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C17E20D1F64D00BD810B /* CLLocation+ToDoubleArray.swift */; };
 		D0EEF336214EB7B800D1D360 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF31F214DE3B300D1D360 /* Strings.swift */; };
 		D0FF79D220D87D200034574D /* ClientEventTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF79D120D87D200034574D /* ClientEventTableViewController.swift */; };
@@ -709,6 +712,9 @@
 /* Begin PBXFileReference section */
 		09D3A786745B7C6D0D364BF0 /* Pods-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-watchOS/Pods-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		0CE51F0910A76C0B0D8B795E /* Pods-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-Shared-watchOS-metadata.plist"; path = "Pods/Pods-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
+		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
+		113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocationTests.swift"; sourceTree = "<group>"; };
+		113D29E224946F930014067C /* OneShotLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneShotLocationManager.swift; sourceTree = "<group>"; };
 		1166363289B5E05B7BAB7204 /* Pods_Shared_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shared_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+BackgroundTask.swift"; sourceTree = "<group>"; };
 		11B7FD732493225200E60ED9 /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
@@ -1277,7 +1283,6 @@
 		D06C750F20D87FAF00E9DB7F /* ClientEventCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientEventCell.swift; sourceTree = "<group>"; };
 		D0A6367120DB7D1100E5C49B /* ClientEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientEventTests.swift; sourceTree = "<group>"; };
 		D0A6367420DBE93400E5C49B /* Realm+Initialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+Initialization.swift"; sourceTree = "<group>"; };
-		D0B25BC82130CA0D00678C2C /* OneShotLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneShotLocationManager.swift; sourceTree = "<group>"; };
 		D0B25BCA2130CA2D00678C2C /* RegionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionManager.swift; sourceTree = "<group>"; };
 		D0B25BCC2130CAB400678C2C /* Bonjour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bonjour.swift; sourceTree = "<group>"; };
 		D0B25BD121323CA600678C2C /* ClientEventPayloadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientEventPayloadViewController.swift; sourceTree = "<group>"; };
@@ -2147,7 +2152,6 @@
 			isa = PBXGroup;
 			children = (
 				B63CAE682150CE5100A68AFB /* SiriShortcut.swift */,
-				D0B25BC82130CA0D00678C2C /* OneShotLocationManager.swift */,
 				D0B25BCA2130CA2D00678C2C /* RegionManager.swift */,
 				B6B6B14E215B6866003DE2DD /* WatchComplication.swift */,
 				B6DAC734215F069300727D2A /* NotificationCategory.swift */,
@@ -2237,6 +2241,7 @@
 				D03D894620E0BC1800D4F28D /* Info.plist */,
 				D0BE441121043B8100C74314 /* AuthorizationTests.swift */,
 				11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */,
+				113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -2273,6 +2278,8 @@
 				B6EE36A120CF593E001494E3 /* RealmZone.swift */,
 				D0EEF321214DE56B00D1D360 /* LocationTrigger.swift */,
 				B6A3EE612164B0550051A8A1 /* RealmDeviceTracker.swift */,
+				113D29E224946F930014067C /* OneShotLocationManager.swift */,
+				113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */,
 			);
 			path = Location;
 			sourceTree = "<group>";
@@ -4078,7 +4085,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B6A258492232539900ADD202 /* WebhookUpdateLocation.swift in Sources */,
-				B67CE8C5222013B60034C1D0 /* OneShotLocationManager.swift in Sources */,
 				B67CE88F22200F220034C1D0 /* Sun.swift in Sources */,
 				B67CE88722200F220034C1D0 /* Light.swift in Sources */,
 				B67CE88A22200F220034C1D0 /* Script.swift in Sources */,
@@ -4116,6 +4122,7 @@
 				B67CE89F22200F220034C1D0 /* Events.swift in Sources */,
 				B6B74CBC228398DD00D58A68 /* WKInterfaceDevice+Size.swift in Sources */,
 				B67CE88922200F220034C1D0 /* Switch.swift in Sources */,
+				113D29E424946F930014067C /* OneShotLocationManager.swift in Sources */,
 				B658AA7F2250B2A100C9BFE3 /* MobileAppUpdateRegistrationRequest.swift in Sources */,
 				B67CE8BA22200F220034C1D0 /* Constants.swift in Sources */,
 				B67CE8B222200F220034C1D0 /* CMMotion+StringExtensions.swift in Sources */,
@@ -4132,6 +4139,7 @@
 				B6D3B4EE225B26910082BB4F /* WebhookSensors.swift in Sources */,
 				B67CE8B322200F220034C1D0 /* Realm+Initialization.swift in Sources */,
 				B67CE87B22200F220034C1D0 /* RealmDeviceTracker.swift in Sources */,
+				113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */,
 				B67CE8AD22200F220034C1D0 /* AuthenticationAPI.swift in Sources */,
 				B67CE88122200F220034C1D0 /* BinarySensor.swift in Sources */,
 				B67CE8B722200F220034C1D0 /* UIImage+Icons.swift in Sources */,
@@ -4204,7 +4212,6 @@
 				D0C88464211F33CE00CCB501 /* TokenManager.swift in Sources */,
 				D0EEF315214DD7A400D1D360 /* Beacons.swift in Sources */,
 				B6B74CB6228397D100D58A68 /* WatchHelpers.swift in Sources */,
-				D0EEF332214EB2BC00D1D360 /* OneShotLocationManager.swift in Sources */,
 				D0EEF32E214DF99500D1D360 /* PushRegistrationRequest.swift in Sources */,
 				B6723344225DBACF0031D629 /* AuthRequestMessage.swift in Sources */,
 				B6C0914D2151F93D00A326DC /* GarageDoor.swift in Sources */,
@@ -4215,6 +4222,7 @@
 				B62817F2221D6CF4000BA86A /* Reachability+NetworkType.swift in Sources */,
 				D0EEF335214EB77100D1D360 /* CLLocation+ToDoubleArray.swift in Sources */,
 				B675ECC5221BD76300C65D31 /* Identify.swift in Sources */,
+				113D29E324946F930014067C /* OneShotLocationManager.swift in Sources */,
 				B6723341225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				D0EEF318214DD7A400D1D360 /* Events.swift in Sources */,
 				B672333E225DB68B0031D629 /* WebSocketMessage.swift in Sources */,
@@ -4250,6 +4258,7 @@
 				B6C0914A2151F93D00A326DC /* DeviceTracker.swift in Sources */,
 				D0EEF2C9214D89A700D1D360 /* HAAPI+RequestHelpers.swift in Sources */,
 				B672334D225DE1490031D629 /* SubscribeEvents.swift in Sources */,
+				113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */,
 				D0EEF32C214DF83800D1D360 /* IdentifyRequest.swift in Sources */,
 				D03D893920E0AF8E00D4F28D /* ClientEvent.swift in Sources */,
 				B6C091482151F93D00A326DC /* Group.swift in Sources */,
@@ -4298,6 +4307,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D03D894D20E0BC2700D4F28D /* ClientEventTests.swift in Sources */,
+				113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */,
 				11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
 			);

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -78,7 +79,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES"
       migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -746,3 +746,5 @@ Thank you.\
 "settings_details.general.page_zoom.title" = "Page Zoom";
 "settings_details.general.page_zoom.default" = "%@ (Default)";
 "settings_details.general.restoration.title" = "Remember Last Page";
+"settings_details.location.new_one_shot.title" = "In-Development Updating";
+"settings_details.location.new_one_shot.description" = "This may or may not deliver good results for the sources above. Your feedback is appreciated.";

--- a/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
+++ b/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
@@ -4,12 +4,25 @@ import PromiseKit
 import Shared
 
 extension UIApplication {
-    func backgroundTask<T>(withName name: String, wrapping: () -> Promise<T>) -> Promise<T> {
+    func backgroundTask<PromiseValue>(
+        withName name: String,
+        wrapping: (TimeInterval?) -> Promise<PromiseValue>
+    ) -> Promise<PromiseValue> {
         HomeAssistantBackgroundTask.execute(
             withName: name,
             beginBackgroundTask: { name, expirationHandler in
                 let identifier = self.beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
-                return identifier == .invalid ? nil : identifier
+                let remaining = self.backgroundTimeRemaining < 100 ? self.backgroundTimeRemaining : nil
+
+                Current.Log.info {
+                    if let remaining = remaining {
+                        return "background time remaining \(remaining)"
+                    } else {
+                        return "background time remaining could not be determined"
+                    }
+                }
+
+                return (identifier == .invalid ? nil : identifier, remaining)
             }, endBackgroundTask: { identifier in
                 self.endBackgroundTask(identifier)
             }, wrapping: wrapping

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -154,6 +154,14 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                         }
                     })
 
+                +++ Section(header: nil, footer: L10n.SettingsDetails.Location.NewOneShot.description)
+                <<< SwitchRow {
+                    $0.title = L10n.SettingsDetails.Location.NewOneShot.title
+                    $0.value = Current.settingsStore.useNewOneShotLocation
+                }.onChange { row in
+                    Current.settingsStore.useNewOneShotLocation = row.value ?? false
+                }
+
             let zoneEntities = self.realm.objects(RLMZone.self).map { $0 }
             for zone in zoneEntities {
                 self.form

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -85,8 +85,8 @@ public class Environment {
         self.settingsStore.connectionInfo = authenticatedAPI.connectionInfo
     }
 
-    // This is private because the use of 'appConfiguration' is preferred.
-    private let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    // Use of 'appConfiguration' is preferred, but sometimes Beta builds are done as releases.
+    public let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
 
     private let isFastlaneSnapshot = UserDefaults(suiteName: Constants.AppGroupID)!.bool(forKey: "FASTLANE_SNAPSHOT")
 

--- a/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -1,0 +1,184 @@
+import CoreLocation
+import Foundation
+import PromiseKit
+
+public extension CLLocationManager {
+    static func oneShotLocation(timeout: TimeInterval) -> Promise<CLLocation> {
+        return OneShotLocationProxy(
+            locationManager: CLLocationManager(),
+            timeout: after(seconds: timeout)
+        ).promise
+    }
+}
+
+enum OneShotError: Error, Equatable {
+    case clError(CLError)
+    case outOfTime
+
+    static func == (lhs: OneShotError, rhs: OneShotError) -> Bool {
+        switch (lhs, rhs) {
+        case (.clError(let lhsClError), .clError(let rhsClError)):
+            return lhsClError.code == rhsClError.code
+        case (.outOfTime, .outOfTime):
+            return true
+        default:
+             return false
+        }
+    }
+}
+
+internal struct PotentialLocation: Comparable, CustomStringConvertible {
+    let location: CLLocation
+
+    static var desiredAccuracy: CLLocationAccuracy { 200.0 }
+    static var desiredAge: TimeInterval { 30.0 }
+
+    var description: String {
+        return "accuracy \(accuracy) from \(timestamp)"
+    }
+
+    var accuracy: CLLocationAccuracy {
+        return location.horizontalAccuracy
+    }
+
+    var timestamp: Date {
+        return location.timestamp
+    }
+
+    var isPerfect: Bool {
+        // now = 0 seconds ago
+        // timestamp = 100 seconds ago
+        // so age is the positive number of seconds since this update
+        let age = Current.date().timeIntervalSince(timestamp)
+        return accuracy < Self.desiredAccuracy && age <= Self.desiredAge
+    }
+
+    static func == (lhs: PotentialLocation, rhs: PotentialLocation) -> Bool {
+        return lhs.location == rhs.location
+    }
+
+    static func < (lhs: PotentialLocation, rhs: PotentialLocation) -> Bool {
+        switch (lhs.isPerfect, rhs.isPerfect) {
+        case (true, true):
+            // both are 'perfect' so prefer the newer one
+            return lhs.timestamp < rhs.timestamp
+        case (true, false):
+            // lhs is better, so it's 'greater'
+            return false
+        case (false, true):
+            // rhs is better, so it's 'greater'
+            return true
+        case (false, false):
+            // neither are perfect, which is more recent?
+            // if the time difference is a lot, prefer the more recent, even if less accurate
+            if lhs.timestamp.timeIntervalSince(rhs.timestamp) > 60 {
+                // lhs is more than a minute newer, prefer it
+                return false
+            } else if rhs.timestamp.timeIntervalSince(lhs.timestamp) > 60 {
+                // rhs is more than a minute newer, prefer it
+                return true
+            } else {
+                // prefer whichever is more accurate, since they're close in time to each other
+                return lhs.accuracy > rhs.accuracy
+            }
+        }
+    }
+}
+
+internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
+    let promise: Promise<CLLocation>
+    private let seal: Resolver<CLLocation>
+    private let locationManager: CLLocationManager
+    private var selfRetain: OneShotLocationProxy?
+    private var potentialLocations: [PotentialLocation] = []
+
+    init(
+        locationManager: CLLocationManager,
+        timeout: Guarantee<Void>,
+        workQueue: DispatchQueue? = nil
+    ) {
+        (self.promise, self.seal) = Promise<CLLocation>.pending()
+        self.locationManager = locationManager
+
+        super.init()
+
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.distanceFilter = kCLLocationAccuracyHundredMeters
+        locationManager.delegate = self
+
+        selfRetain = self
+        locationManager.startUpdatingLocation()
+        _ = promise.ensure(on: workQueue) {
+            locationManager.stopUpdatingLocation()
+            locationManager.delegate = nil
+            self.selfRetain = nil
+        }
+
+        timeout.done(on: workQueue) { [weak self] in
+            // we can be weak here because the alternative is that we're already resolved
+            self?.checkPotentialLocations(outOfTime: true)
+        }
+
+        if let cachedLocation = locationManager.location {
+            let potentialLocation = PotentialLocation(location: cachedLocation)
+            potentialLocations.append(potentialLocation)
+
+            let message = "Cached potential one-shot location of \(potentialLocation)"
+            Current.clientEventStore.addEvent(ClientEvent(text: message, type: .locationUpdate))
+        }
+    }
+
+    private func checkPotentialLocations(outOfTime: Bool) {
+        guard !promise.isResolved else {
+            return
+        }
+
+        let bestLocation = potentialLocations.sorted().last
+
+        if let bestLocation = bestLocation {
+            if bestLocation.isPerfect {
+                Current.Log.info("Got a perfect location!")
+                seal.fulfill(bestLocation.location)
+            } else if outOfTime {
+                Current.Log.info("Out of time, using \(bestLocation)")
+                seal.fulfill(bestLocation.location)
+            }
+        } else if outOfTime {
+            Current.Log.info("Out of time without any location!")
+            seal.reject(OneShotError.outOfTime)
+            return
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        let updatedPotentialLocations = locations.map(PotentialLocation.init(location:))
+        Current.Log.verbose("LocationManager: Got potential locations: \(potentialLocations)")
+        potentialLocations.append(contentsOf: updatedPotentialLocations)
+        checkPotentialLocations(outOfTime: false)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        let failError: Error
+
+        if let clErr = error as? CLError {
+            let realm = Current.realm()
+            // swiftlint:disable:next force_try
+            try! realm.write {
+                let locErr = LocationError(err: clErr)
+                realm.add(locErr)
+            }
+
+            Current.Log.error("Received CLError: \(clErr)")
+            failError = OneShotError.clError(clErr)
+        } else {
+            Current.Log.error("Received non-CLError when we only expected CLError: \(error)")
+            failError = error
+        }
+
+        if potentialLocations.isEmpty {
+            seal.reject(failError)
+        } else {
+            checkPotentialLocations(outOfTime: true)
+        }
+    }
+}

--- a/Shared/Location/LocationTrigger.swift
+++ b/Shared/Location/LocationTrigger.swift
@@ -35,6 +35,27 @@ public enum LocationUpdateTrigger: String {
     case AppShortcut = "App Shortcut"
     case Unknown = "Unknown"
 
+    func oneShotTimeout(maximum: TimeInterval?) -> TimeInterval {
+        if let maximum = maximum {
+            // the system appears to have given us a reasonable baseline, leave some time for network call
+            return max(maximum - 5.0, 1.0)
+        }
+
+        switch self {
+        case .RegionEnter, .RegionExit, .GPSRegionEnter, .GPSRegionExit, .BeaconRegionEnter, .BeaconRegionExit, .Visit:
+            // location events, we've probably got a bit more freedom
+            return 20.0
+        case .SignificantLocationUpdate, .BackgroundFetch, .PushNotification:
+            // background events we know are usually time sensitive
+            return 10.0
+        case .Manual, .URLScheme, .XCallbackURL, .AppShortcut, .Siri:
+            // user is actively doing this, so wait a little longer
+            return 30.0
+        case .Unknown:
+            return 10.0
+        }
+    }
+
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     public func notificationOptionsFor(zoneName: String) -> NotificationOptions {
         let shouldNotify: Bool

--- a/Shared/Location/OneShotLocationManager.swift
+++ b/Shared/Location/OneShotLocationManager.swift
@@ -16,7 +16,21 @@ public class OneShotLocationManager: NSObject, CLLocationManagerDelegate {
     let locationManager = CLLocationManager()
     var onLocationUpdated: OnLocationUpdated
 
-    public init(onLocation: @escaping OnLocationUpdated) {
+    // this is a shim to allow testing both this and the new version
+    class func promise() -> Promise<CLLocation> {
+        return Promise { seal in
+            var managerStrongReference: OneShotLocationManager?
+            managerStrongReference = OneShotLocationManager(onLocation: { location, error in
+                // this just lies to the compiler to make it think we actually care about the strong ref
+                withExtendedLifetime(managerStrongReference) {
+                    seal.resolve(location, error)
+                }
+                managerStrongReference = nil
+            })
+        }
+    }
+
+    private init(onLocation: @escaping OnLocationUpdated) {
         onLocationUpdated = onLocation
         super.init()
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1343,6 +1343,12 @@ internal enum L10n {
         /// Motion Permission
         internal static let title = L10n.tr("Localizable", "settings_details.location.motion_permission.title")
       }
+      internal enum NewOneShot {
+        /// This may or may not deliver good results for the sources above. Your feedback is appreciated.
+        internal static let description = L10n.tr("Localizable", "settings_details.location.new_one_shot.description")
+        /// In-Development Updating
+        internal static let title = L10n.tr("Localizable", "settings_details.location.new_one_shot.title")
+      }
       internal enum Notifications {
         /// Location Notifications
         internal static let header = L10n.tr("Localizable", "settings_details.location.notifications.header")

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -190,6 +190,18 @@ public class SettingsStore {
         }
     }
 
+    public var useNewOneShotLocation: Bool {
+        get {
+            if Current.isTestFlight, prefs.object(forKey: "use_new_one_shot") == nil {
+                return true
+            }
+            return prefs.bool(forKey: "use_new_one_shot")
+        }
+        set {
+            prefs.set(newValue, forKey: "use_new_one_shot")
+        }
+    }
+
     public struct PageZoom: CaseIterable, Equatable, CustomStringConvertible {
         public let zoom: Int
 

--- a/SharedTests/AuthorizationTests.swift
+++ b/SharedTests/AuthorizationTests.swift
@@ -7,7 +7,6 @@
 //
 
 import XCTest
-import Alamofire
 import PromiseKit
 @testable import Shared
 

--- a/SharedTests/BackgroundTask.test.swift
+++ b/SharedTests/BackgroundTask.test.swift
@@ -10,6 +10,7 @@ class HomeAssistantBackgroundTaskTests: XCTestCase {
 
     func testExpiredDeliversError() {
         let expectedIdentifier: Int = 123456
+        let expectedRemaining: TimeInterval = 456
 
         let wrappingExpectation = expectation(description: "wrapping")
         let endExpectation = expectation(description: "endBackgroundTask")
@@ -17,17 +18,18 @@ class HomeAssistantBackgroundTaskTests: XCTestCase {
 
         let promise: Promise<String> = HomeAssistantBackgroundTask.execute(
             withName: "name",
-            beginBackgroundTask: { (inName, inExpire) -> Int in
+            beginBackgroundTask: { (inName, inExpire) -> (Int, TimeInterval) in
                 XCTAssertEqual(inName, "name")
                 expire = inExpire
-                return expectedIdentifier
+                return (expectedIdentifier, expectedRemaining)
             }, endBackgroundTask: { (inIdentifier: Int) in
                 if inIdentifier == expectedIdentifier {
                     endExpectation.fulfill()
                 } else {
                     XCTFail("should not have called with identifier \(inIdentifier)")
                 }
-            }, wrapping: {
+            }, wrapping: { givenRemaining in
+                XCTAssertEqual(givenRemaining, expectedRemaining)
                 wrappingExpectation.fulfill()
                 return .value("hello!")
             }
@@ -47,6 +49,7 @@ class HomeAssistantBackgroundTaskTests: XCTestCase {
         let (underlyingPromise, underlyingSeal) = Promise<String>.pending()
 
         let endExpectedIdentifier: Int = 123456
+        let expectedRemaining: TimeInterval = 456
 
         let wrappingExpectation = expectation(description: "wrapping")
 
@@ -54,16 +57,17 @@ class HomeAssistantBackgroundTaskTests: XCTestCase {
 
         let promise: Promise<String> = HomeAssistantBackgroundTask.execute(
             withName: "name",
-            beginBackgroundTask: { (inName, _) -> Int in
+            beginBackgroundTask: { (inName, _) -> (Int, TimeInterval) in
                 XCTAssertEqual(inName, "name")
-                return endExpectedIdentifier
+                return (endExpectedIdentifier, expectedRemaining)
             }, endBackgroundTask: { (inIdentifier: Int) in
                 if inIdentifier == endExpectedIdentifier {
                     endExpectation.fulfill()
                 } else {
                     XCTFail("should not have called with identifier \(inIdentifier)")
                 }
-            }, wrapping: {
+            }, wrapping: { givenRemaining in
+                XCTAssertEqual(givenRemaining, expectedRemaining)
                 wrappingExpectation.fulfill()
                 return underlyingPromise
             }
@@ -83,22 +87,24 @@ class HomeAssistantBackgroundTaskTests: XCTestCase {
         let (underlyingPromise, underlyingSeal) = Promise<String>.pending()
 
         let expectedIdentifier: Int = 123456
+        let expectedRemaining: TimeInterval = 456
 
         let wrappingExpectation = expectation(description: "wrapping")
         let endExpectation = expectation(description: "endBackgroundTask")
 
         let promise: Promise<String> = HomeAssistantBackgroundTask.execute(
             withName: "name",
-            beginBackgroundTask: { (inName, _) -> Int in
+            beginBackgroundTask: { (inName, _) -> (Int, TimeInterval) in
                 XCTAssertEqual(inName, "name")
-                return expectedIdentifier
+                return (expectedIdentifier, expectedRemaining)
             }, endBackgroundTask: { (inIdentifier: Int) in
                 if inIdentifier == expectedIdentifier {
                     endExpectation.fulfill()
                 } else {
                     XCTFail("should not have called with identifier \(inIdentifier)")
                 }
-            }, wrapping: {
+            }, wrapping: { givenRemaining in
+                XCTAssertEqual(givenRemaining, expectedRemaining)
                 wrappingExpectation.fulfill()
                 return underlyingPromise
             }

--- a/SharedTests/CLLocationManager+OneShotLocationTests.swift
+++ b/SharedTests/CLLocationManager+OneShotLocationTests.swift
@@ -1,0 +1,498 @@
+// swiftlint:disable file_length
+import CoreLocation
+import Foundation
+import PromiseKit
+import XCTest
+import XCGLogger
+@testable import Shared
+
+// swiftlint:disable:next type_body_length
+class OneShotLocationTests: XCTestCase {
+    private var locationManager: FakeLocationManager!
+    private var now: Date!
+    private var workQueue: DispatchQueue!
+
+    override func setUp() {
+        let now = Date()
+        self.now = now
+        Current.date = { now }
+        locationManager = FakeLocationManager()
+        workQueue = DispatchQueue(label: "OneShotLocationTests")
+    }
+
+    override func tearDown() {
+        workQueue.sync { /* exercise queue */ }
+        XCTAssertNil(locationManager.delegate)
+        XCTAssertFalse(locationManager.isUpdatingLocation)
+    }
+
+    func testNoLocationsNoErrorJustTimeout() {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        timeoutSeal(())
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? OneShotError, OneShotError.outOfTime)
+        }
+    }
+
+    func testNoLocationsOnlyCLError() {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        let clError = CLError(.deferredAccuracyTooLow)
+        locationManager.delegate?.locationManager?(locationManager, didFailWithError: clError)
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? OneShotError, OneShotError.clError(clError))
+        }
+    }
+
+    func testNoLocationsOnlyRandomError() {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        // swiftlint:disable:next nesting
+        enum SomeError: Error {
+            case yep
+        }
+
+        locationManager.delegate?.locationManager?(locationManager, didFailWithError: SomeError.yep)
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? SomeError, SomeError.yep)
+        }
+    }
+
+    func testOnlyCachedLocationNoErrorsOnlyTimeout() throws {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let cachedLocation = CLLocation(latitude: 123, longitude: -123)
+        locationManager.cachedLocation = cachedLocation
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        timeoutSeal(())
+        XCTAssertEqual(try hang(promise), cachedLocation)
+    }
+
+    func testOnlyCachedLocationError() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let cachedLocation = CLLocation(latitude: 123, longitude: -123)
+        locationManager.cachedLocation = cachedLocation
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didFailWithError: CLError(.deferredAccuracyTooLow))
+        XCTAssertEqual(try hang(promise), cachedLocation)
+    }
+
+    func testOldCachedAndOneLocationNoError() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let cachedLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-500)
+        )
+        let newLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        locationManager.cachedLocation = cachedLocation
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
+        XCTAssertEqual(try hang(promise), newLocation)
+    }
+
+    func testNoCachedValueAndOneLocationNoError() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let newLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
+        XCTAssertEqual(try hang(promise), newLocation)
+    }
+
+    func testNoCachedValueOneLocationAndError() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let newLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
+        locationManager.delegate?.locationManager?(locationManager, didFailWithError: CLError(.deferredAccuracyTooLow))
+        XCTAssertEqual(try hang(promise), newLocation)
+    }
+
+    func testOneNewOneOldLocationWithPerfectAgeAndAccuracyOldestFirst() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-100)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1, location2])
+        XCTAssertEqual(try hang(promise), location2)
+    }
+
+    func testOneNewOneOldLocationWithPerfectAgeAndAccuracyNewestFirst() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-100)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location2, location1])
+        XCTAssertEqual(try hang(promise), location2)
+    }
+
+    func testMultiplePerfectNoError() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-5)
+        )
+        let location3 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -12, longitude: 12),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-1)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
+            location3, location1, location2
+        ])
+        XCTAssertEqual(try hang(promise), location3)
+    }
+
+    func testNoPerfectOnlyPoorChoicesOnAccuracyUntilTimeout() throws {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 2500,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-100)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 500,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let location3 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -12, longitude: 12),
+            altitude: 0,
+            horizontalAccuracy: 600,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-30)
+        )
+        let location4 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -23, longitude: 23),
+            altitude: 0,
+            horizontalAccuracy: 600,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-40)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
+            location1, location2, location3, location4
+        ])
+        XCTAssertFalse(promise.isResolved, "it shouldn't end early just because it got some")
+
+        timeoutSeal(())
+        XCTAssertEqual(try hang(promise), location2)
+    }
+
+    func testNoPerfectOnlyPoorChoicesOnAgeUntilTimeoiscut() throws {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 100,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-160)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-150)
+        )
+        let location3 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -12, longitude: 12),
+            altitude: 0,
+            horizontalAccuracy: 400,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-120)
+        )
+        let location4 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -23, longitude: 23),
+            altitude: 0,
+            horizontalAccuracy: 250,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-100)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
+            location1, location2, location3, location4
+        ])
+        XCTAssertFalse(promise.isResolved, "it shouldn't end early just because it got some")
+
+        timeoutSeal(())
+        XCTAssertEqual(try hang(promise), location1)
+    }
+
+    func testMultipleAccuracyThenPerfect() throws {
+        let (timeoutPromise, _) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 2500,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-500)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 1500,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-450)
+        )
+        let location3 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 23, longitude: -23),
+            altitude: 0,
+            horizontalAccuracy: 1000,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-400)
+        )
+        let location4 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -12, longitude: 12),
+            altitude: 0,
+            horizontalAccuracy: 100,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-10)
+        )
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            workQueue: workQueue
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1, location2])
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location4, location3])
+        XCTAssertEqual(try hang(promise), location4)
+    }
+
+    struct LocationTestCase {
+        let location1: CLLocation
+        let location2: CLLocation
+        var winnerLocation: CLLocation { location2 }
+        let reason: String
+        let hasPerfect: Bool
+
+        let file: StaticString
+        let line: UInt
+
+        init(
+            age1: TimeInterval, acc1: CLLocationAccuracy,
+            age2: TimeInterval, acc2: CLLocationAccuracy,
+            _ reason: String,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) {
+            let location1 = CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+                altitude: 0,
+                horizontalAccuracy: acc1,
+                verticalAccuracy: 0,
+                timestamp: Current.date().addingTimeInterval(-age1)
+            )
+            let location2 = CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+                altitude: 0,
+                horizontalAccuracy: acc2,
+                verticalAccuracy: 0,
+                timestamp: Current.date().addingTimeInterval(-age2)
+            )
+            self.location1 = location1
+            self.location2 = location2
+            // cheating a little so it's not constants hard-coded in two places
+            self.hasPerfect =
+                PotentialLocation(location: location1).isPerfect ||
+                PotentialLocation(location: location2).isPerfect
+            self.reason = reason
+            self.file = file
+            self.line = line
+        }
+    }
+
+    // swiftlint:disable trailing_comma
+    var testCases: [LocationTestCase] = [
+        // second one always is the winner, order is done both ways to make sure logic is fine
+        .init(age1:   5, acc1:   90, age2:  0, acc2:  100, "both perfect, more recent wins"),
+        .init(age1:   0, acc1: 2500, age2: 10, acc2:  100, "one perfect, always wins"),
+        .init(age1:  35, acc1:  500, age2: 40, acc2:  250, "close timing, more accurate wins"),
+        .init(age1: 120, acc1:  100, age2: 35, acc2: 1000, "much more recent wins, even over accuracy"),
+    ]
+    // swiftlint:enable trailing_comma
+
+    func testSimpleTestCases() throws {
+        for testCase in testCases {
+            for locations in [[testCase.location1, testCase.location2], [testCase.location2, testCase.location1]] {
+                let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+                let promise = OneShotLocationProxy(
+                    locationManager: locationManager,
+                    timeout: timeoutPromise,
+                    workQueue: workQueue
+                ).promise
+
+                locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: locations)
+
+                if testCase.hasPerfect {
+                    XCTAssertTrue(promise.isFulfilled, file: testCase.file, line: testCase.line)
+                } else {
+                    XCTAssertFalse(promise.isFulfilled, file: testCase.file, line: testCase.line)
+                    timeoutSeal(())
+                }
+
+                XCTAssertEqual(
+                    try hang(promise),
+                    testCase.winnerLocation,
+                    testCase.reason,
+                    file: testCase.file,
+                    line: testCase.line
+                )
+            }
+        }
+    }
+}
+
+private class FakeLocationManager: CLLocationManager {
+    var cachedLocation: CLLocation?
+    override var location: CLLocation? {
+        cachedLocation
+    }
+
+    // swiftlint:disable weak_delegate
+    var overrideDelegate: CLLocationManagerDelegate?
+    override var delegate: CLLocationManagerDelegate? {
+        get {
+            overrideDelegate
+        }
+        set {
+            overrideDelegate = newValue
+        }
+    }
+
+    var isUpdatingLocation = false
+    override func startUpdatingLocation() {
+        isUpdatingLocation = true
+    }
+
+    override func stopUpdatingLocation() {
+        isUpdatingLocation = false
+    }
+}


### PR DESCRIPTION
- Adds a thin wrapper around the old logic, which allows users to swap between the two, reducing the scariness of this PR.
- Wraps manual location updating in the same background task logic as background ones.
- Adds background time remaining (when available) as a part of the background task logic, so we can pipe that into the location updating logic, too.

This new logic is focused around: how many updates can we get and how much accuracy can we hit if we give Location Services a few more seconds to feed us location data? I've plugged in some random guesses at how long we're willing to tolerate these things.

Indications are that iOS is willing to toss us things like 2500m accuracy in some situations, which is a heck of a lot of drift for a background fetch update. We're being given an opportunity to do some background work, so it feels like a good time to try and use it, too.

It might be worth considering adding some analytics here to try and get a better handle on how often we have either no location, a mediocre location, or a perfect location.