### PR TITLE
Page Zoom setting

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -482,6 +482,8 @@
 "settings_details.general.app_icon.enum.release" = "Release";
 "settings_details.general.app_icon.enum.white" = "White";
 "settings_details.general.app_icon.title" = "App Icon";
+"settings_details.general.page_zoom.title" = "Page Zoom";
+"settings_details.general.page_zoom.default" = "%@ (Default)";
 "settings_details.location.notifications.visit.title" = "Visit Location Notifications";
 "settings_details.location.notifications.x_callback_url.title" = "X-Callback-URL Location Notifications";
 "settings_details.notifications.import_legacy_settings.alert.message" = "The push notification categories and actions have been imported from the server.";

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -56,14 +56,6 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
         case "general":
             self.title = L10n.SettingsDetails.General.title
             self.form
-                +++ SwitchRow("openInChrome") {
-                    $0.title = L10n.SettingsDetails.General.Chrome.title
-                    $0.value = prefs.bool(forKey: "openInChrome")
-                    }.onChange { row in
-                        prefs.setValue(row.value, forKey: "openInChrome")
-                        prefs.synchronize()
-                }
-
                 +++ PushRow<AppIcon>("appIcon") {
                         $0.title = L10n.SettingsDetails.General.AppIcon.title
                         $0.selectorTitle = $0.title
@@ -90,6 +82,28 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
 
                         UIApplication.shared.setAlternateIconName(newAppIconName.rawValue)
                     }
+
+                +++ SwitchRow("openInChrome") {
+                    $0.title = L10n.SettingsDetails.General.Chrome.title
+                    $0.value = prefs.bool(forKey: "openInChrome")
+                }.onChange { row in
+                    prefs.setValue(row.value, forKey: "openInChrome")
+                    prefs.synchronize()
+                }
+
+                <<< PushRow<SettingsStore.PageZoom> { row in
+                    row.title = L10n.SettingsDetails.General.PageZoom.title
+                    row.options = SettingsStore.PageZoom.allCases
+
+                    if #available(iOS 12, *) {
+                        row.value = Current.settingsStore.pageZoom
+                        row.onChange { row in
+                            Current.settingsStore.pageZoom = row.value ?? .default
+                        }
+                    } else {
+                        row.hidden = true
+                    }
+                }
 
         case "location":
             self.title = L10n.SettingsDetails.Location.title

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -178,6 +178,14 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate {
 
         self.view.bottomAnchor.constraint(equalTo: self.settingsButton.bottomAnchor, constant: 16.0).isActive = true
         self.view.rightAnchor.constraint(equalTo: self.settingsButton.rightAnchor, constant: 16.0).isActive = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateWebViewSettings),
+            name: SettingsStore.webViewRelatedSettingDidChange,
+            object: nil
+        )
+        updateWebViewSettings()
     }
 
     public func showSettingsViewController() {
@@ -439,6 +447,17 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate {
         }
 
         return nil
+    }
+
+    @objc private func updateWebViewSettings() {
+        if #available(iOS 12, *) {
+            // This is quasi-private API that has existed since pre-iOS 10, but the implementation
+            // changed in iOS 12 to be like the +/- zoom buttons in Safari, which scale content without
+            // resizing the scrolling viewport.
+            let viewScale  = Current.settingsStore.pageZoom.viewScale
+            Current.Log.info("setting view scale to \(viewScale)")
+            webView.setValue(viewScale, forKey: "viewScale")
+        }
     }
 
     // swiftlint:disable:next function_body_length

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1011,7 +1011,7 @@ internal enum L10n {
         internal static let title = L10n.tr("Localizable", "settings.connection_section.home_assistant_cloud.title")
       }
       internal enum InternalBaseUrl {
-        /// http://homeassistant.local:8123/
+        /// http://hassio.local:8123/
         internal static let placeholder = L10n.tr("Localizable", "settings.connection_section.internal_base_url.placeholder")
         /// Internal URL
         internal static let title = L10n.tr("Localizable", "settings.connection_section.internal_base_url.title")
@@ -1302,6 +1302,14 @@ internal enum L10n {
       internal enum Chrome {
         /// Open links in Chrome
         internal static let title = L10n.tr("Localizable", "settings_details.general.chrome.title")
+      }
+      internal enum PageZoom {
+        /// %@ (Default)
+        internal static func `default`(_ p1: String) -> String {
+          return L10n.tr("Localizable", "settings_details.general.page_zoom.default", p1)
+        }
+        /// Page Zoom
+        internal static let title = L10n.tr("Localizable", "settings_details.general.page_zoom.title")
       }
     }
     internal enum Location {


### PR DESCRIPTION
Scales the contents of the web view to a multiple of normal. This behaves similar to the +/- button in Safari.

This is different than both:
- `document.body.style.zoom` (which causes the header to be positioned wrong)
- `-webkit-text-size-adjust` (which causes items to be badly centered)

The setting looks like:

![IMG_6596](https://user-images.githubusercontent.com/74188/84523557-571b6200-ac8d-11ea-8e94-acbf2921d51f.png)

The difference between e.g. 150%, 100% and 85% looks like:

![IMG_6599](https://user-images.githubusercontent.com/74188/84523688-98137680-ac8d-11ea-81b6-60f63888d855.png)
