### PR TITLE
Always register for remote notifications

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -747,10 +747,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Messaging.messaging().delegate = self
 
-        if Current.settingsStore.notificationsEnabled {
-            Current.Log.verbose("Calling UIApplication.shared.registerForRemoteNotifications()")
-            UIApplication.shared.registerForRemoteNotifications()
-        }
+        Current.Log.verbose("Calling UIApplication.shared.registerForRemoteNotifications()")
+        UIApplication.shared.registerForRemoteNotifications()
 
         Current.loadCrashlytics()
 

--- a/HomeAssistant/Views/Onboarding/PermissionsViewController.swift
+++ b/HomeAssistant/Views/Onboarding/PermissionsViewController.swift
@@ -27,8 +27,13 @@ class PermissionsViewController: UIViewController, PermissionViewChangeDelegate 
         }
 
         self.locationPermissionView.delegate = self
+        self.locationPermissionView.permission.updateInitial()
+
         self.motionPermissionView.delegate = self
+        self.motionPermissionView.permission.updateInitial()
+
         self.notificationsPermissionView.delegate = self
+        self.notificationsPermissionView.permission.updateInitial()
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -45,8 +50,6 @@ class PermissionsViewController: UIViewController, PermissionViewChangeDelegate 
         // Don't need to set .locationEnabled because it comes direct from CLLocationManager.
         if forPermission == .motion {
             Current.settingsStore.motionEnabled = toStatus == .authorized
-        } else if forPermission == .notification {
-            Current.settingsStore.notificationsEnabled = toStatus == .authorized
         }
     }
 }

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -156,9 +156,6 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate {
             if let connectionInfo = Current.settingsStore.connectionInfo,
                 let webviewURL = connectionInfo.webviewURL() {
                 api.Connect().done {_ in
-                    if Current.settingsStore.notificationsEnabled {
-                        UIApplication.shared.registerForRemoteNotifications()
-                    }
                     Current.Log.verbose("Connected!")
                     self.webView.load(URLRequest(url: webviewURL))
                     return

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -77,11 +77,6 @@ public class HomeAssistantAPI {
         self.webhookManager.adapter = handler
         self.webhookManager.retrier = handler
         self.webhookHandler = handler
-
-        UNUserNotificationCenter.current().getNotificationSettings(completionHandler: { (settings) in
-            let notificationsAllowed = settings.authorizationStatus == UNAuthorizationStatus.authorized
-            Current.settingsStore.notificationsEnabled = notificationsAllowed
-        })
     }
 
     private static func configureSessionManager(urlConfig: URLSessionConfiguration = .default) -> SessionManager {

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -170,18 +170,6 @@ public class SettingsStore {
         }
     }
 
-    public var notificationsEnabled: Bool {
-        get {
-            if prefs.object(forKey: "messagingEnabled") != nil && prefs.bool(forKey: "messagingEnabled") == false {
-                return false
-            }
-            return prefs.bool(forKey: "notificationsEnabled")
-        }
-        set {
-            prefs.set(newValue, forKey: "notificationsEnabled")
-        }
-    }
-
     public var showAdvancedConnectionSettings: Bool {
         get {
             return prefs.bool(forKey: "showAdvancedConnectionSettings")

--- a/WatchAppExtension/ExtensionDelegate.swift
+++ b/WatchAppExtension/ExtensionDelegate.swift
@@ -42,13 +42,13 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         if #available(watchOS 13.0, *) {
             opts.insert(.announcement)
         }
+
+        if #available(watchOSApplicationExtension 6.0, *) {
+            WKExtension.shared().registerForRemoteNotifications()
+        }
+
         UNUserNotificationCenter.current().requestAuthorization(options: opts) { (granted, error) in
             Current.Log.verbose("Requested notifications access \(granted), \(String(describing: error))")
-            if granted {
-                if #available(watchOSApplicationExtension 6.0, *) {
-                    WKExtension.shared().registerForRemoteNotifications()
-                }
-            }
         }
 
         setupWatchCommunicator()


### PR DESCRIPTION
You are allowed to request remote notification permission distinct from visual notification permission. This resolves logout->login requiring another app launch to register the push ID with the sever as well.