### PR TITLE
Make Reset also trigger onboarding

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -43,6 +43,7 @@
 "settings.reset_section.reset_row.title" = "Reset";
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_alert.message" = "Your settings will be reset and this device will be unregistered from push notifications as well as removed from your Home Assistant configuration.";
+"settings.reset_section.reset_alert.progress_message" = "Resetting…";
 "settings_details.general.title" = "General";
 "settings_details.general.chrome.title" = "Open links in Chrome";
 "settings_details.location.title" = "Location";

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1189,6 +1189,8 @@ internal enum L10n {
       internal enum ResetAlert {
         /// Your settings will be reset and this device will be unregistered from push notifications as well as removed from your Home Assistant configuration.
         internal static let message = L10n.tr("Localizable", "settings.reset_section.reset_alert.message")
+        /// Resetting…
+        internal static let progressMessage = L10n.tr("Localizable", "settings.reset_section.reset_alert.progress_message")
         /// Reset
         internal static let title = L10n.tr("Localizable", "settings.reset_section.reset_alert.title")
       }


### PR DESCRIPTION
This now attempts to revoke the token, with a bail-out mechanism if it's taking too long, and triggers onboarding once everything is reset.