### PR TITLE
Today Widget: Empty Handling

### DIFF
--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -15,6 +15,7 @@ import PromiseKit
 import RealmSwift
 import Firebase
 import CoreMotion
+import NotificationCenter
 
 // swiftlint:disable:next type_body_length
 class SettingsDetailViewController: FormViewController, TypedRowControllerType {
@@ -28,7 +29,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
     var doneButton: Bool = false
 
     private let realm = Current.realm()
-
+    private var notificationTokens: [NotificationToken] = []
     private var reorderingRows: [String: BaseRow] = [:]
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -396,6 +397,17 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
         case "actions":
             self.title = L10n.SettingsDetails.Actions.title
             let actions = realm.objects(Action.self).sorted(byKeyPath: "Position")
+
+            notificationTokens.append(actions.observe { change in
+                switch change {
+                case .error: break
+                case .initial(let results), .update(let results, deletions: _, insertions: _, modifications: _):
+                    NCWidgetController().setHasContent(
+                        !results.isEmpty,
+                        forWidgetWithBundleIdentifier: Constants.BundleID.appending(".TodayWidget")
+                    )
+                }
+            })
 
             let infoBarButtonItem = Constants.helpBarButtonItem
 


### PR DESCRIPTION
Tells the system to hide the today widget when it's empty, or to show it when there's content.

Fixes #304 (a different way).