### PR TITLE
Don't re-register when update has a network error

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -136,7 +136,12 @@ public class HomeAssistantAPI {
     public func Connect() -> Promise<ConfigResponse> {
         return firstly {
             self.UpdateRegistration()
-        }.recover { _ -> Promise<MobileAppRegistrationResponse> in
+        }.recover { error -> Promise<MobileAppRegistrationResponse> in
+            guard (error as NSError).domain != NSURLErrorDomain else {
+                Current.Log.info("not re-registering because of network error")
+                throw error
+            }
+
             let message = "Failed to update integration; trying to register instead."
             Current.clientEventStore.addEvent(ClientEvent(text: message, type: .networkRequest))
             return self.Register()


### PR DESCRIPTION
Refs #612. This was trying to register on every possible error. A better solution would be to look for specific error responses, but these all come through as 200's from the API calls even if the request fails.