### PR TITLE
Settings Permissions: Add Background Refresh

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0C6645270B5B70DF1C404144 /* Pods-SiriIntents-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = E3052AE62E057BB6257EDC1C /* Pods-SiriIntents-metadata.plist */; };
+		1100D51D2496AECE00B1073C /* PermissionStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100D51C2496AECE00B1073C /* PermissionStatusRow.swift */; };
 		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */; };
@@ -712,6 +713,7 @@
 /* Begin PBXFileReference section */
 		09D3A786745B7C6D0D364BF0 /* Pods-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-watchOS/Pods-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		0CE51F0910A76C0B0D8B795E /* Pods-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-Shared-watchOS-metadata.plist"; path = "Pods/Pods-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
+		1100D51C2496AECE00B1073C /* PermissionStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatusRow.swift; sourceTree = "<group>"; };
 		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
 		113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocationTests.swift"; sourceTree = "<group>"; };
 		113D29E224946F930014067C /* OneShotLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneShotLocationManager.swift; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 				B616B291227EB00D00828165 /* DNSResolver.swift */,
 				B6CDC095228CF5C2009355DD /* RemoteMediaPlayer.swift */,
 				119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */,
+				1100D51C2496AECE00B1073C /* PermissionStatusRow.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -4018,6 +4021,7 @@
 				B6CDC096228CF5C2009355DD /* RemoteMediaPlayer.swift in Sources */,
 				B661FC88226D478300E541DD /* DiscoverInstancesViewController.swift in Sources */,
 				B67CE8CD22201EFA0034C1D0 /* RegionManager.swift in Sources */,
+				1100D51D2496AECE00B1073C /* PermissionStatusRow.swift in Sources */,
 				D0B25BD221323CA600678C2C /* ClientEventPayloadViewController.swift in Sources */,
 				B641BC1F1E2097EF002CCBC1 /* AboutViewController.swift in Sources */,
 				B68EDD07215F215E00DD6B28 /* Notifications.swift in Sources */,

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -729,6 +729,9 @@ Thank you.\
 "settings_details.location.motion_permission.enabled" = "Enabled";
 "settings_details.location.motion_permission.denied" = "Denied";
 "settings_details.location.motion_permission.needs_request" = "Disabled";
+"settings_details.location.background_refresh.title" = "Background Refresh";
+"settings_details.location.background_refresh.enabled" = "Enabled";
+"settings_details.location.background_refresh.disabled" = "Disabled";
 "actions_configurator.trigger_example.title" = "Example Trigger";
 "actions_configurator.trigger_example.share" = "Share Contents";
 "settings_details.general.app_icon.enum.caribbean_green" = "Caribbean Green";

--- a/HomeAssistant/Utilities/PermissionStatusRow.swift
+++ b/HomeAssistant/Utilities/PermissionStatusRow.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Eureka
+import UIKit
+import CoreLocation
+import CoreMotion
+
+public final class LocationPermissionRow: Row<LabelCellOf<CLAuthorizationStatus>>, RowType {
+    required public init(tag: String?) {
+        super.init(tag: tag)
+
+        displayValueFor = { value in
+            guard let value = value else { return nil }
+
+            switch value {
+            case .authorizedAlways:
+                return L10n.SettingsDetails.Location.LocationPermission.always
+            case .authorizedWhenInUse:
+                return L10n.SettingsDetails.Location.LocationPermission.whileInUse
+            case .denied, .restricted:
+                return L10n.SettingsDetails.Location.LocationPermission.never
+            case .notDetermined:
+                return L10n.SettingsDetails.Location.LocationPermission.needsRequest
+            @unknown default:
+                return L10n.SettingsDetails.Location.LocationPermission.never
+            }
+        }
+    }
+}
+
+@available(iOS 11, *)
+public final class MotionPermissionRow: Row<LabelCellOf<CMAuthorizationStatus>>, RowType {
+    required public init(tag: String?) {
+        super.init(tag: tag)
+
+        displayValueFor = { value in
+            guard let value = value else { return nil }
+
+            switch value {
+            case .authorized:
+                return L10n.SettingsDetails.Location.MotionPermission.enabled
+            case .denied, .restricted:
+                return L10n.SettingsDetails.Location.MotionPermission.denied
+            case .notDetermined:
+                return L10n.SettingsDetails.Location.MotionPermission.needsRequest
+            @unknown default:
+                return L10n.SettingsDetails.Location.MotionPermission.denied
+            }
+        }
+    }
+}
+
+public final class BackgroundRefreshStatusRow: Row<LabelCellOf<UIBackgroundRefreshStatus>>, RowType {
+    required public init(tag: String?) {
+        super.init(tag: tag)
+
+        displayValueFor = { value in
+            guard let value = value else { return nil }
+
+            switch value {
+            case .restricted, .denied:
+                return L10n.SettingsDetails.Location.BackgroundRefresh.disabled
+            case .available:
+                return L10n.SettingsDetails.Location.BackgroundRefresh.enabled
+            @unknown default:
+                return L10n.SettingsDetails.Location.BackgroundRefresh.disabled
+            }
+        }
+    }
+}
+
+extension Condition {
+    static var locationPermissionNotAlways: Condition {
+        .function(["locationPermission"], { form in
+            guard let row = form.rowBy(tag: "locationPermission") as? LocationPermissionRow else {
+                return true
+            }
+
+            switch row.value {
+            case .some(.authorizedAlways):
+                return false
+            default:
+                return true
+            }
+        })
+    }
+
+    static var locationNotAlwaysOrBackgroundRefreshNotAvailable: Condition {
+        return .function(["locationPermission", "backgroundRefresh"], { form in
+            guard
+                let locationPermissionRow = form.rowBy(tag: "locationPermission") as? LocationPermissionRow,
+                let backgroundRefreshRow = form.rowBy(tag: "backgroundRefresh") as? BackgroundRefreshStatusRow
+            else {
+                return true
+            }
+
+            switch (locationPermissionRow.value, backgroundRefreshRow.value) {
+            case (.some(.authorizedAlways), .some(.available)):
+                return false
+            default:
+                return true
+            }
+        })
+    }
+}

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1321,6 +1321,14 @@ internal enum L10n {
     internal enum Location {
       /// Location
       internal static let title = L10n.tr("Localizable", "settings_details.location.title")
+      internal enum BackgroundRefresh {
+        /// Disabled
+        internal static let disabled = L10n.tr("Localizable", "settings_details.location.background_refresh.disabled")
+        /// Enabled
+        internal static let enabled = L10n.tr("Localizable", "settings_details.location.background_refresh.enabled")
+        /// Background Refresh
+        internal static let title = L10n.tr("Localizable", "settings_details.location.background_refresh.title")
+      }
       internal enum LocationPermission {
         /// Always
         internal static let always = L10n.tr("Localizable", "settings_details.location.location_permission.always")


### PR DESCRIPTION
This adds a Background Refresh status row and adds disabling like:
- Zone enter/exit: when location isn't always
- Background fetch: when location isn't always or background refresh is off
- Sig loc change: when location isn't always
- Push notification: when location isn't always

![Image 3](https://user-images.githubusercontent.com/74188/84603092-93db8a80-ae40-11ea-9bda-b165301d94fe.PNG)
