### PR TITLE
Handle and persist theme color

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0C6645270B5B70DF1C404144 /* Pods-SiriIntents-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = E3052AE62E057BB6257EDC1C /* Pods-SiriIntents-metadata.plist */; };
+		1100D51F2496F63400B1073C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100D51E2496F63400B1073C /* ThemeColors.swift */; };
 		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */; };
@@ -712,6 +713,7 @@
 /* Begin PBXFileReference section */
 		09D3A786745B7C6D0D364BF0 /* Pods-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-watchOS/Pods-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		0CE51F0910A76C0B0D8B795E /* Pods-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-Shared-watchOS-metadata.plist"; path = "Pods/Pods-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
+		1100D51E2496F63400B1073C /* ThemeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColors.swift; sourceTree = "<group>"; };
 		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
 		113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocationTests.swift"; sourceTree = "<group>"; };
 		113D29E224946F930014067C /* OneShotLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneShotLocationManager.swift; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 				B616B291227EB00D00828165 /* DNSResolver.swift */,
 				B6CDC095228CF5C2009355DD /* RemoteMediaPlayer.swift */,
 				119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */,
+				1100D51E2496F63400B1073C /* ThemeColors.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -3972,6 +3975,7 @@
 			files = (
 				B661FC8D226D5A0700E541DD /* ConnectInstanceViewController.swift in Sources */,
 				B648AE262275918F006972AF /* Scenes.swift in Sources */,
+				1100D51F2496F63400B1073C /* ThemeColors.swift in Sources */,
 				B6DA3C7322691A5000DE811C /* AKConverter.swift in Sources */,
 				B66528201F9D870C00EBE6D4 /* ManifestJSON.swift in Sources */,
 				B63CAE692150CE5100A68AFB /* SiriShortcut.swift in Sources */,

--- a/HomeAssistant/Resources/WebSocketBridge.js
+++ b/HomeAssistant/Resources/WebSocketBridge.js
@@ -1,21 +1,39 @@
-const handleThemeUpdate = (event) => {
-  var payload = event.data || event;
-  let themeName = payload.default_theme;
-  if(themeName === 'default') {
-    window.webkit.messageHandlers.themesUpdated.postMessage({ 'name': themeName });
-  } else {
-    window.webkit.messageHandlers.themesUpdated.postMessage({ 'name': themeName, 'styles': payload.themes[themeName] });
-  }
+const notifyThemeColors = () => {
+    function doWait() {
+        let style = getComputedStyle(document.documentElement);
+        window.webkit.messageHandlers.updateThemeColors.postMessage({
+            '--app-header-background-color': style.getPropertyValue('--app-header-background-color'),
+            '--primary-background-color': style.getPropertyValue('--primary-background-color'),
+            '--text-primary-color': style.getPropertyValue('--text-primary-color'),
+            '--primary-color': style.getPropertyValue('--primary-color'),
+        });
+    }
+    // wait a short amount for the computed styles to change
+    setTimeout(doWait, 100);
 }
 
-window.hassConnection.then(({ conn }) => {
-  // window.activeHassConnection = conn
-  conn.sendMessagePromise({type: 'auth/current_user'}).then((user) => {
-    window.webkit.messageHandlers.currentUser.postMessage(user);
-  });
-  // conn.subscribeMessage((msg) => {
-  //  window.webkit.messageHandlers.mediaPlayerCommand.postMessage(msg);
-  // }, {type: 'mobile_app/subscribe_media_player', webhook_id: window.webhookID});
-  conn.sendMessagePromise({type: 'frontend/get_themes'}).then(handleThemeUpdate);
-  conn.subscribeEvents(handleThemeUpdate, 'themes_updated');
+const waitForHassConnection = () => {
+    var loopCount = 0;
+    return new Promise((resolve, reject) => {
+        (function doWait() {
+            if (window.hassConnection) {
+                resolve(window.hassConnection);
+            } else {
+                // really we just need to wait a run loop, but better safe than sorry for backoff
+                setTimeout(doWait, loopCount * 10);
+                loopCount++;
+            }
+        })();
+    });
+}
+
+waitForHassConnection().then(({ conn }) => {
+    conn.sendMessagePromise({type: 'auth/current_user'}).then((user) => {
+        window.webkit.messageHandlers.currentUser.postMessage(user);
+    });
+    conn.subscribeEvents(notifyThemeColors, 'themes_updated');
+    conn.sendMessagePromise({type: 'frontend/get_themes'}).then(notifyThemeColors);
+
+    // this should be moved to an event bus
+    window.addEventListener('settheme', notifyThemeColors);
 });

--- a/HomeAssistant/Utilities/ThemeColors.swift
+++ b/HomeAssistant/Utilities/ThemeColors.swift
@@ -1,0 +1,57 @@
+import Foundation
+import UIKit
+import Shared
+
+public struct ThemeColors: Codable {
+    public enum Color: String, CaseIterable {
+        // these are in WebSocketBridge.js in this repo (we inject it)
+        case appHeaderBackgroundColor = "--app-header-background-color"
+        case primaryBackgroundColor = "--primary-background-color"
+        case textPrimaryColor = "--text-primary-color"
+        case primaryColor = "--primary-color"
+    }
+
+    // we defer the hex parsing in case we have a clientside bug that can improve it later, so we don't need
+    // to write a migration when the parsing logic improves
+    private let values: [Color.RawValue: String]
+
+    subscript(_ color: Color) -> UIColor {
+        if let value = values[color.rawValue] {
+            return UIColor(hex: value)
+        } else {
+            return color.default
+        }
+    }
+
+    static var cachedThemeColors: ThemeColors {
+        let cached = prefs.object(forKey: "cachedThemeColors") as? [Color.RawValue: String] ?? [:]
+        Current.Log.verbose("loaded cached colors \(cached)")
+        return ThemeColors(values: cached)
+    }
+
+    static func updateCache(with messageBody: [String: Any]) {
+        func hex(for key: Color) -> String? {
+            return messageBody[key.rawValue]
+                .flatMap { $0 as? String }?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var dictionary: [Color.RawValue: String] = [:]
+        for color in Color.allCases {
+            dictionary[color.rawValue] = hex(for: color)
+        }
+        Current.Log.verbose("caching color values \(dictionary)")
+        prefs.set(dictionary, forKey: "cachedThemeColors")
+    }
+}
+
+private extension ThemeColors.Color {
+    var `default`: UIColor {
+        switch self {
+        case .appHeaderBackgroundColor: return UIColor(red: 0.01, green: 0.66, blue: 0.96, alpha: 1.0)
+        case .primaryBackgroundColor: return UIColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
+        case .primaryColor: return UIColor.white
+        case .textPrimaryColor: return UIColor.white
+        }
+    }
+}

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -115,7 +115,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         userContentController.add(self, name: "getExternalAuth")
         userContentController.add(self, name: "revokeExternalAuth")
         userContentController.add(self, name: "externalBus")
-        userContentController.add(self, name: "themesUpdated")
+        userContentController.add(self, name: "updateThemeColors")
         userContentController.add(self, name: "currentUser")
         userContentController.add(self, name: "mediaPlayerCommand")
 
@@ -272,18 +272,26 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         self.urlObserver = nil
     }
 
-    func styleUI(_ backgroundColor: UIColor? = UIColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0),
-                 _ headerColor: UIColor? = UIColor(red: 0.01, green: 0.66, blue: 0.96, alpha: 1.0),
-                 _ refreshTintColor: UIColor? = UIColor.white) {
+    func styleUI() {
+        let cachedColors = ThemeColors.cachedThemeColors
 
-        self.webView?.backgroundColor = backgroundColor
-        self.webView?.scrollView.backgroundColor = backgroundColor
+        self.webView?.backgroundColor = cachedColors[.primaryBackgroundColor]
+        self.webView?.scrollView.backgroundColor = cachedColors[.primaryBackgroundColor]
 
         if let statusBarView = self.view.viewWithTag(111) {
-            statusBarView.backgroundColor = headerColor
+            statusBarView.backgroundColor = cachedColors[.appHeaderBackgroundColor]
         }
 
-        self.refreshControl.tintColor = refreshTintColor
+        self.refreshControl.tintColor = cachedColors[.primaryColor]
+
+        let headerBackgroundIsLight = cachedColors[.appHeaderBackgroundColor].isLight
+        if #available(iOS 13, *) {
+            self.underlyingPreferredStatusBarStyle = headerBackgroundIsLight ? .darkContent : .lightContent
+        } else {
+            self.underlyingPreferredStatusBarStyle = headerBackgroundIsLight ? .default : .lightContent
+        }
+
+        setNeedsStatusBarAppearanceUpdate()
     }
 
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
@@ -504,8 +512,9 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         self.showSettingsViewController()
     }
 
+    private var underlyingPreferredStatusBarStyle: UIStatusBarStyle = .lightContent
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        return underlyingPreferredStatusBarStyle
     }
 
     func userReconnected() {
@@ -698,7 +707,7 @@ extension WebViewController: WKScriptMessageHandler {
             self.handleExternalMessage(messageBody)
         } else if message.name == "currentUser", let user = AuthenticatedUser(messageBody) {
             Current.settingsStore.authenticatedUser = user
-        } else if message.name == "themesUpdated" {
+        } else if message.name == "updateThemeColors" {
             self.handleThemeUpdate(messageBody)
         } else if message.name == "getExternalAuth", let callbackName = messageBody["callback"] {
             if let tokenManager = Current.tokenManager {
@@ -754,20 +763,8 @@ extension WebViewController: WKScriptMessageHandler {
     }
 
     func handleThemeUpdate(_ messageBody: [String: Any]) {
-        if let styles = messageBody["styles"] as? [String: String] {
-            // Current.Log.verbose("Styles \(styles)")
-            var headerKey = "primary-color"
-            if styles["app-header-background-color"] != nil {
-                headerKey = "app-header-background-color"
-            }
-            let backgroundColor = self.parseThemeStyle("primary-background-color", styles)
-            let headerColor = self.parseThemeStyle(headerKey, styles)
-            let refreshTintColor = self.parseThemeStyle("text-primary-color", styles)
-            self.styleUI(backgroundColor, headerColor, refreshTintColor)
-        } else {
-            // Assume default theme
-            self.styleUI()
-        }
+        ThemeColors.updateCache(with: messageBody)
+        styleUI()
     }
 
     func handleHaptic(_ hapticType: String) {

--- a/Shared/Common/Extensions/UIColor+HA.swift
+++ b/Shared/Common/Extensions/UIColor+HA.swift
@@ -12,4 +12,19 @@ extension UIColor {
     public static let onColor = UIColor(hue: 0.15, saturation: 0.75, brightness: 0.49, alpha: 1.0)
     public static let defaultEntityColor = UIColor(hue: 0.58, saturation: 0.4, brightness: 0.44, alpha: 1.0)
 
+    public var isLight: Bool {
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0
+        /*
+         https://www.w3.org/WAI/ER/WD-AERT/#color-contrast
+         ((Red value X 299) + (Green value X 587) + (Blue value X 114)) / 1000
+         Note: This algorithm is taken from a formula for converting RGB values to YIQ values.
+         This brightness value gives a perceived brightness for a color.
+         */
+        if !getRed(&red, green: &green, blue: &blue, alpha: nil) {
+            return false
+        }
+
+        let brightness = (red*299.0 + green*587.0 + blue*114.0)/1000.0
+        return brightness > 0.875
+    }
 }


### PR DESCRIPTION
## Fix knowing about when Themes themselves change

`window.hassConnection` is `undefined` when the `.js` is initially injected, so none of the registrations were working. This adds what is effectively a runloop wait (it is available 0ms later, it's really just an ordering thing) to make sure the connection exists.

Fixes #557, fixes #645 

## Fix not having the information anymore about the Themes

This now uses JavaScript to pull the underlying css variable for the particular theme colors, which should be a less fragile method to try and get it -- rather than parsing the actual CSS itself. We only care about the currently-active values, so we don't need to parse any other ones.

## Hackily observe when the current Theme changes

This is likely to break in the future and waits on home-assistant/frontend#4220 to correctly notify us when the change occurs.

## Inspect the Theme color and set an appropriate status bar color

Tries to set the right status bar text color based on the brightness of the given background color. I like the idea of trying to solve this for all cases, rather than relying on a Theme to customize it. Open to other ideas, though.

Fixes #645.

[Video](https://i.imgur.com/9lJvO0j.mp4) of clicking a button and things happening, hooray!