### PR TITLE
Update sensors and other information on warm-launch

### DIFF
--- a/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
+++ b/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
@@ -160,7 +160,7 @@ class ConnectInstanceViewController: UIViewController {
                 throw oldHA
             }
 
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "connected"),
+            NotificationCenter.default.post(name: HomeAssistantAPI.didConnectNotification,
                                             object: nil, userInfo: nil)
 
             api.storeZones(zones: zones)

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -91,7 +91,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         // self.remotePlayer.delegate = self
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(WebViewController.loadActiveURLIfNeeded),
-                                               name: UIApplication.didBecomeActiveNotification,
+                                               name: HomeAssistantAPI.didConnectNotification,
                                                object: nil)
 
         let statusBarView: UIView = UIView(frame: UIApplication.shared.statusBarFrame)
@@ -185,27 +185,6 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         refreshControl.addTarget(self, action: #selector(self.pullToRefresh(_:)), for: .valueChanged)
         webView.scrollView.addSubview(refreshControl)
         webView.scrollView.bounces = true
-
-        if let api = HomeAssistantAPI.authenticatedAPI() {
-            if let connectionInfo = Current.settingsStore.connectionInfo,
-                let webviewURL = connectionInfo.webviewURL() {
-                api.Connect().done {_ in
-                    Current.Log.verbose("Connected!")
-
-                    if self.webView.url == nil || self.webView.url?.baseIsEqual(to: webviewURL) == false {
-                        // only load again if it would produce a different result
-                        self.webView.load(URLRequest(url: webviewURL))
-                    }
-                    return
-                }.catch {err -> Void in
-                    Current.Log.error("Error on connect!!! \(err)")
-                    self.openSettingsWithError(error: err)
-                }
-            }
-        } else {
-            Current.Log.error("Couldn't get authenticated API, showing settings")
-            self.openSettingsWithError(error: HomeAssistantAPI.APIError.managerNotAvailable)
-        }
 
         self.settingsButton.addTarget(self, action: #selector(self.openSettingsView(_:)), for: .touchDown)
 

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -41,6 +41,7 @@ public class HomeAssistantAPI {
     }
 
     static let minimumRequiredVersion = Version(major: 0, minor: 92, patch: 2)
+    public static let didConnectNotification = Notification.Name(rawValue: "HomeAssistantAPIConnected")
 
     let prefs = UserDefaults(suiteName: Constants.AppGroupID)!
 
@@ -148,7 +149,7 @@ public class HomeAssistantAPI {
                 throw oldHA
             }
 
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "connected"),
+            NotificationCenter.default.post(name: Self.didConnectNotification,
                                             object: nil, userInfo: nil)
 
             self.storeZones(zones: zones)


### PR DESCRIPTION
Moves the connect logic from the WebViewController to the AppDelegate, allowing us to trigger the Connect flow in more cases. This still doesn't invoke a location update on cold or warm launches.

Refs #552 which asks for better Zone updates. There's definitely cases where we don't update (we're in the background, and continue to be in the background, while getting location updates), but this should help, too.