### PR TITLE
Notifications: Camera Aspect Ratio

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -712,6 +712,7 @@
 /* Begin PBXFileReference section */
 		09D3A786745B7C6D0D364BF0 /* Pods-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-watchOS/Pods-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		0CE51F0910A76C0B0D8B795E /* Pods-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-Shared-watchOS-metadata.plist"; path = "Pods/Pods-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
+		1100D52024974D6700B1073C /* camera_notification.apns */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = camera_notification.apns; sourceTree = "<group>"; };
 		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
 		113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocationTests.swift"; sourceTree = "<group>"; };
 		113D29E224946F930014067C /* OneShotLocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneShotLocationManager.swift; sourceTree = "<group>"; };
@@ -1438,6 +1439,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1100D5222497578800B1073C /* TestNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				1100D52024974D6700B1073C /* camera_notification.apns */,
+			);
+			path = TestNotifications;
+			sourceTree = "<group>";
+		};
 		29278BB24639BA945D3D86B4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1727,6 +1736,7 @@
 		B627CB0C1D83C87B0057173E /* NotificationContentExtension */ = {
 			isa = PBXGroup;
 			children = (
+				1100D5222497578800B1073C /* TestNotifications */,
 				B678DB351EA9999C0045312F /* MainInterface.storyboard */,
 				B627CB121D83C87B0057173E /* Info.plist */,
 				B689EBCD1D8B91CE0000AECE /* NotificationContentExtension.entitlements */,

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/NotificationContentExtension.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/NotificationContentExtension.xcscheme
@@ -2,7 +2,7 @@
 <Scheme
    LastUpgradeVersion = "1120"
    wasCreatedForAppExtension = "YES"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -59,13 +59,12 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
-      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "2">
+      notificationPayloadFile = "Configuration/push.apns">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/NotificationContentExtension/Camera.swift
+++ b/NotificationContentExtension/Camera.swift
@@ -45,10 +45,30 @@ class CameraViewController: UIView, NotificationCategory {
         }
 
         let imageView = UIImageView()
-        imageView.frame = vc.view.frame
+
+        var aspectRatioConstraint: NSLayoutConstraint?
+
+        func updateAspectRatioConstraint(size: CGSize) {
+            guard size.height > 0 else {
+                return
+            }
+
+            let ratio = size.width/size.height
+
+            guard aspectRatioConstraint?.multiplier != ratio else {
+                return
+            }
+
+            let constraint = imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: ratio)
+            constraint.isActive = true
+            aspectRatioConstraint = constraint
+        }
+
+        // assume we're going to be playing a 16:9 video, and adjust
+        updateAspectRatioConstraint(size: CGSize(width: 16.0, height: 9.0))
+
+        imageView.contentMode = .scaleAspectFit
         imageView.accessibilityIdentifier = "camera_notification_imageview"
-        // imageView.accessibilityLabel = "camera_notification_imageview"
-        imageView.contentMode = .redraw
 
         var frameCount = 0
 
@@ -88,7 +108,16 @@ class CameraViewController: UIView, NotificationCategory {
                         hud.hide(animated: true)
                     })
 
-                    vc.view.addSubview(imageView)
+                    if imageView.superview == nil {
+                        vc.view.addSubview(imageView)
+                        imageView.translatesAutoresizingMaskIntoConstraints = false
+                        NSLayoutConstraint.activate([
+                            imageView.topAnchor.constraint(equalTo: vc.view.topAnchor),
+                            imageView.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
+                            imageView.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
+                            imageView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor)
+                        ])
+                    }
 
                     extensionContext?.mediaPlayingStarted()
                 }
@@ -97,6 +126,8 @@ class CameraViewController: UIView, NotificationCategory {
                     image.accessibilityIdentifier = "camera_notification_image"
                     imageView.image = image
                     imageView.image?.accessibilityIdentifier = image.accessibilityIdentifier
+                    
+                    updateAspectRatioConstraint(size: image.size)
                 }
             }
 

--- a/NotificationContentExtension/TestNotifications/camera_notification.apns
+++ b/NotificationContentExtension/TestNotifications/camera_notification.apns
@@ -1,0 +1,11 @@
+{
+	"aps": {
+		"alert": {
+			"title": "title here",
+			"body": "body here"
+		},
+		"sound": "default",
+		"category": "camera"
+	},
+	"entity_id": "camera.outside"
+}


### PR DESCRIPTION
- Adjusts the constraints on the preview image view while it vends so it isn't stretched. Fixes #513 / #167.
- Adds a sample .apns which can be used to trigger a Camera notification more easily.

Looking through the server code, it looks like we can also grab an HLS stream, which is what the frontend is using for previewing the camera. Refs #596. Created a ticket remember this as #649.

![Simulator Screen Shot - iPhone 11 Pro - 2020-06-15 at 00 24 18](https://user-images.githubusercontent.com/74188/84629756-ad5fef00-ae9f-11ea-903f-3fc4cd42e065.png)
