### PR TITLE
Retry "Unable to connect" frontend error automatically

### DIFF
--- a/HomeAssistant/Resources/WebSocketBridge.js
+++ b/HomeAssistant/Resources/WebSocketBridge.js
@@ -27,6 +27,14 @@ const waitForHassConnection = () => {
     });
 }
 
+const checkForMissingHassConnectionAndReload = () => {
+    // this is invoked when we think connect status is changed, to avoid the user needing to tap reload
+    window.hassConnection.catch(() => {
+        // this is the action taken by the frontend when the user taps, anyway -- we're just doing it for them
+        location.reload();
+    });
+};
+
 waitForHassConnection().then(({ conn }) => {
     conn.sendMessagePromise({type: 'auth/current_user'}).then((user) => {
         window.webkit.messageHandlers.currentUser.postMessage(user);

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -422,6 +422,8 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         guard webView.url == nil || webView.url?.baseIsEqual(to: desiredURL) == false else {
             Current.Log.info("not changing webview url - we're okay with what we have")
+            // we also tell the webview -- maybe it failed to connect itself? -- to refresh if needed
+            webView.evaluateJavaScript("checkForMissingHassConnectionAndReload()", completionHandler: nil)
             return
         }
 


### PR DESCRIPTION
Similar to #653 which did this for a completely-unloaded state, I also found I could get the frontend to think it initially failed to connect, which we can detect in some cases too.