### PR TITLE
Sensor Settings: Periodic Update

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -759,3 +759,6 @@ Thank you.\
 "settings_sensors.detail.attributes" = "Attributes";
 "settings_sensors.detail.device_class" = "Device Class";
 "settings_sensors.detail.icon" = "Icon";
+"settings_sensors.periodic_update.title" = "Periodic Update";
+"settings_sensors.periodic_update.description" = "When enabled, these sensors will update after the app has been continually open for this long.";
+"settings_sensors.periodic_update.off" = "Off";

--- a/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
@@ -15,6 +15,37 @@ class SensorListViewController: FormViewController {
         title = L10n.SettingsSensors.title
 
         updateSensors(section: sensorSection)
+        form +++ Section(header: nil, footer: L10n.SettingsSensors.PeriodicUpdate.description)
+        <<< PushRow<TimeInterval?> {
+            $0.title =  L10n.SettingsSensors.PeriodicUpdate.title
+            $0.options = {
+                var options: [TimeInterval?] = [nil, 20, 60, 120, 300, 600, 900, 1800, 3600]
+
+                if Current.appConfiguration == .Debug {
+                    options.insert(contentsOf: [2, 5], at: 1)
+                }
+
+                return options
+            }()
+            $0.value = Current.settingsStore.periodicUpdateInterval
+            $0.onChange { row in
+                // this looks silly but value is actually `Optional<Optional<TimeInterval>>`
+                Current.settingsStore.periodicUpdateInterval = row.value ?? nil
+            }
+
+            let formatter = DateComponentsFormatter()
+            formatter.unitsStyle = .full
+
+            $0.displayValueFor = { value in
+                switch value {
+                case .some(.none), .none:
+                    return L10n.SettingsSensors.PeriodicUpdate.off
+                case .some(.some(let interval)):
+                    return formatter.string(from: interval)
+                }
+            }
+        }
+
         form +++ sensorSection
 
         tableView.addSubview(refreshControl)

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1701,6 +1701,14 @@ internal enum L10n {
       /// Failed to load sensors
       internal static let title = L10n.tr("Localizable", "settings_sensors.loading_error.title")
     }
+    internal enum PeriodicUpdate {
+      /// When enabled, these sensors will update after the app has been continually open for this long.
+      internal static let description = L10n.tr("Localizable", "settings_sensors.periodic_update.description")
+      /// Off
+      internal static let off = L10n.tr("Localizable", "settings_sensors.periodic_update.off")
+      /// Periodic Update
+      internal static let title = L10n.tr("Localizable", "settings_sensors.periodic_update.title")
+    }
   }
 
   internal enum SiriShortcuts {

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -272,6 +272,25 @@ public class SettingsStore {
         }
     }
 
+    public var periodicUpdateInterval: TimeInterval? {
+        get {
+            if prefs.object(forKey: "periodicUpdateInterval") == nil {
+                return 300.0
+            } else {
+                let doubleValue = prefs.double(forKey: "periodicUpdateInterval")
+                return doubleValue > 0 ? doubleValue : nil
+            }
+        }
+        set {
+            if let newValue = newValue {
+                precondition(newValue > 0)
+                prefs.set(newValue, forKey: "periodicUpdateInterval")
+            } else {
+                prefs.set(-1, forKey: "periodicUpdateInterval")
+            }
+        }
+    }
+
     // MARK: - Private helpers
 
     private var hasMigratedConnection: Bool {


### PR DESCRIPTION
Updates sensors at a regular time interval while the app is in the foreground. Likely useful for e.g. wall tablets.

Fixes #644. Fixes #499. At least to the best of our abilities; if the app is not running, it cannot update outside of being woken up by e.g. background fetch or push notifications.

(Options in non-debug don't include 2 or 5 seconds.)

![IMG_6616](https://user-images.githubusercontent.com/74188/84733106-37689000-af52-11ea-991d-5b6e2eb70630.png)
