### PR TITLE
Sensor Settings: fix icon loading

### DIFF
--- a/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
@@ -98,7 +98,7 @@ class SensorListViewController: FormViewController {
 
                     cell.imageView?.image =
                         sensor.Icon
-                            .flatMap(MaterialDesignIcons.init(named:))?
+                            .flatMap({ MaterialDesignIcons(serversideValueNamed: $0) })?
                             .image(ofSize: CGSize(width: 28, height: 28), color: .black)
                             .withRenderingMode(.alwaysTemplate)
                 }

--- a/Shared/Common/Extensions/UIImage+Icons.swift
+++ b/Shared/Common/Extensions/UIImage+Icons.swift
@@ -14,11 +14,27 @@ extension UIImage {
 
         MaterialDesignIcons.register()
 
-        var fixedIconIdentifier = iconIdentifier.replacingOccurrences(of: "mdi:", with: "")
-        fixedIconIdentifier = fixedIconIdentifier.replacingOccurrences(of: ":", with: "-")
-        let mdi = MaterialDesignIcons.init(named: fixedIconIdentifier, fallbackIconName: "help")
+        let mdi = MaterialDesignIcons(named: iconIdentifier.normalizingIconString, fallbackIconName: "help")
 
         return mdi.image(ofSize: CGSize(width: CGFloat(iconWidth), height: CGFloat(iconHeight)), color: color)
     }
+}
 
+public extension MaterialDesignIcons {
+    init(serversideValueNamed value: String, fallbackIcon: String? = nil) {
+        if let fallbackIcon = fallbackIcon {
+            self.init(named: value.normalizingIconString, fallbackIconName: fallbackIcon)
+        } else {
+            self.init(named: value.normalizingIconString)
+        }
+    }
+}
+
+private extension String {
+    var normalizingIconString: String {
+        return self
+            .replacingOccurrences(of: "mdi:", with: "")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: "-", with: "_")
+    }
 }


### PR DESCRIPTION
Uses the actual value for picking which icon to use, and also corrects what is likely an MDI change where `-` is now always `_` in icon names.

![Simulator Screen Shot - iPhone 11 Pro - 2020-06-15 at 22 33 55](https://user-images.githubusercontent.com/74188/84735413-4fdba900-af58-11ea-9213-6b1ad4e280e5.png)
