### PR TITLE
Fix Notifications Help Link

### DIFF
--- a/HomeAssistant/Views/NotificationCategoryConfigurator.swift
+++ b/HomeAssistant/Views/NotificationCategoryConfigurator.swift
@@ -277,7 +277,7 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
 
     @objc
     func getInfoAction(_ sender: Any) {
-        Current.Log.verbose("getInfoAction hit, open docs page!")
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/docs/notifications/actionable-notifications")!)
     }
 
     @objc


### PR DESCRIPTION
Currently the help link in the notification category configurator does nothing from a user's perspective (it does actually fire a log entry). 

Replace log entry with link to actionable notifications part of the docs. Ditched the log as none of the other help links seem to use them.

Fixes #434
