### PR TITLE
Add space between sensor value and unit

### DIFF
--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -70,7 +70,7 @@ public class WebhookSensor: Mappable {
 
     public var StateDescription: String? {
         if let value = State {
-            return String(describing: value) +  (UnitOfMeasurement.flatMap { " " + $0 } ?? "")
+            return String(describing: value) + (UnitOfMeasurement.flatMap { " " + $0 } ?? "")
         } else {
             return nil
         }

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -70,7 +70,7 @@ public class WebhookSensor: Mappable {
 
     public var StateDescription: String? {
         if let value = State {
-            return String(describing: value) + " " + (UnitOfMeasurement ?? "")
+            return String(describing: value) +  (UnitOfMeasurement.flatMap { " " + $0 } ?? "")
         } else {
             return nil
         }

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -70,7 +70,7 @@ public class WebhookSensor: Mappable {
 
     public var StateDescription: String? {
         if let value = State {
-            return String(describing: value) + (UnitOfMeasurement ?? "")
+            return String(describing: value) + " " + (UnitOfMeasurement ?? "")
         } else {
             return nil
         }


### PR DESCRIPTION
Add a space between the sensor value and the unit in the sensor settings pages. Fixes #660
