### PR TITLE
Fix window background color on iOS 13+

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -109,7 +109,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func setupWindow() {
         let window = UIWindow.init(frame: UIScreen.main.bounds)
         window.restorationIdentifier = StateRestorationKey.mainWindow.rawValue
-        window.backgroundColor = UIColor(red: 0.90, green: 0.90, blue: 0.90, alpha: 1.0)
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -99,8 +99,6 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         view.addSubview(statusBarView)
 
-        self.styleUI()
-
         statusBarView.topAnchor.constraint(equalTo: self.view.topAnchor).isActive = true
         statusBarView.leftAnchor.constraint(equalTo: self.view.leftAnchor).isActive = true
         statusBarView.rightAnchor.constraint(equalTo: self.view.rightAnchor).isActive = true
@@ -200,6 +198,8 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             object: nil
         )
         updateWebViewSettings()
+
+        styleUI()
     }
 
     public func showSettingsViewController() {
@@ -252,6 +252,8 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
     }
 
     func styleUI() {
+        precondition(isViewLoaded && webView != nil)
+
         let cachedColors = ThemeColors.cachedThemeColors
 
         self.webView?.backgroundColor = cachedColors[.primaryBackgroundColor]


### PR DESCRIPTION
Changing the Window color affected the loading look of the WebView because its background wasn't being set because the WebView didn't exist yet. This moves the styling to later in the initialization (so it can style it) and removes the background color from the Window.

![IMG_6621](https://user-images.githubusercontent.com/74188/84841272-b31c1880-aff6-11ea-9836-be29028d3708.png)
