### PR TITLE
Add In-Development Updating to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,7 @@ App version:
 <!-- Please give the version number of Home Assistant Core you are running -->
 
 **Describe the bug**
+<!-- For location issues, please specify if using the new "In-Development Updating" option under App Configuration > Location -->
 
 **To Reproduce**
 


### PR DESCRIPTION
Seems like a good idea when people open bug reports to ask whether they're using the "In-Development Updating" option.