### PR TITLE
Change UI links to target companion.home-assistant.io

### DIFF
--- a/HomeAssistant/Views/AboutViewController.swift
+++ b/HomeAssistant/Views/AboutViewController.swift
@@ -58,7 +58,7 @@ class AboutViewController: FormViewController {
              +++ ButtonRow {
                    $0.title = L10n.About.Donate.patreon
                }.onCellSelection { _, _  in
-                   let urlStr = "https://patreon.com/robbiet480/"
+                   let urlStr = "https://companion.home-assistant.io/app/ios/patreon"
                    openURLInBrowser(urlToOpen: URL(string: urlStr)!)
                }
 
@@ -66,7 +66,7 @@ class AboutViewController: FormViewController {
                     $0.title = L10n.About.Beta.title
                     $0.disabled = Condition(booleanLiteral: Current.appConfiguration == .Beta)
                 }.onCellSelection { _, _  in
-                    let urlStr = "https://home-assistant.io/ios/beta/"
+                    let urlStr = "https://companion.home-assistant.io/app/ios/beta"
                     UIApplication.shared.open(URL(string: urlStr)!, options: [:], completionHandler: nil)
                 }
 
@@ -82,14 +82,14 @@ class AboutViewController: FormViewController {
             <<< ButtonRow {
                     $0.title = L10n.About.Review.title
                 }.onCellSelection { _, _  in
-                    let urlStr = "https://itunes.apple.com/app/id1099568401?action=write-review&mt=8"
+                    let urlStr = "https://companion.home-assistant.io/app/ios/review"
                     UIApplication.shared.open(URL(string: urlStr)!, options: [:], completionHandler: nil)
                 }
 
             <<< ButtonRow {
                 $0.title = L10n.About.HelpLocalize.title
                 }.onCellSelection { _, _  in
-                    let urlStr = "https://developers.home-assistant.io/docs/en/internationalization_translation.html"
+                    let urlStr = "https://companion.home-assistant.io/app/ios/translate"
                     openURLInBrowser(urlToOpen: URL(string: urlStr)!)
             }
 
@@ -108,13 +108,13 @@ class AboutViewController: FormViewController {
             <<< ButtonRow {
                     $0.title = L10n.About.Chat.title
                 }.onCellSelection { _, _  in
-                    openURLInBrowser(urlToOpen: URL(string: "https://discord.gg/C7fXPmt")!)
+                    openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/chat")!)
                 }
 
             <<< ButtonRow {
                     $0.title = L10n.About.Documentation.title
                 }.onCellSelection { _, _  in
-                    openURLInBrowser(urlToOpen: URL(string: "https://www.home-assistant.io/docs/ecosystem/ios/")!)
+                    openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io")!)
                 }
 
             <<< ButtonRow {
@@ -134,14 +134,14 @@ class AboutViewController: FormViewController {
             <<< ButtonRow {
                     $0.title = L10n.About.Github.title
                 }.onCellSelection { _, _  in
-                    openURLInBrowser(urlToOpen: URL(string: "https://github.com/home-assistant/home-assistant-iOS")!)
+                    openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/repo")!)
                 }
 
             <<< ButtonRow {
                     $0.title = L10n.About.GithubIssueTracker.title
                 }.onCellSelection { _, _ in
                     openURLInBrowser(urlToOpen:
-                        URL(string: "https://github.com/home-assistant/home-assistant-iOS/issues")!)
+                        URL(string: "https://companion.home-assistant.io/app/ios/issues")!)
                 }
     }
 

--- a/HomeAssistant/Views/NotificationCategoryConfigurator.swift
+++ b/HomeAssistant/Views/NotificationCategoryConfigurator.swift
@@ -277,7 +277,7 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
 
     @objc
     func getInfoAction(_ sender: Any) {
-        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/docs/notifications/actionable-notifications")!)
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/actionable-notifications")!)
     }
 
     @objc

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -515,15 +515,15 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
     }
 
     @objc func firebasePrivacy(_ sender: Any) {
-        openURLInBrowser(urlToOpen: URL(string: "https://firebase.google.com/support/privacy/")!)
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/firebase-privacy")!)
     }
 
     @objc func actionsHelp(_ sender: Any) {
-        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/docs/core/actions")!)
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/actions")!)
     }
 
     @objc func watchHelp(_ sender: Any) {
-        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/next/integrations/apple-watch")!)
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/apple-watch")!)
     }
 
     override func tableView(_ tableView: UITableView, willBeginReorderingRowAtIndexPath indexPath: IndexPath) {

--- a/HomeAssistant/Views/WatchComplicationConfigurator.swift
+++ b/HomeAssistant/Views/WatchComplicationConfigurator.swift
@@ -304,7 +304,7 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
 
     @objc
     func getInfoAction(_ sender: Any) {
-        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/next/integrations/apple-watch")!)
+        openURLInBrowser(urlToOpen: URL(string: "https://companion.home-assistant.io/app/ios/apple-watch")!)
     }
 
     func renderTemplateForRow(rowTag: String) {

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -632,7 +632,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         var detailButton = WhatsNewViewController.DetailButton(
             title: L10n.WhatsNew.Buttons.ReadMore.title,
-            action: .website(url: "https://home-assistant.io/ios/whats-new")
+            action: .website(url: "https://companion.home-assistant.io/app/ios/whats-new")
         )
 
         detailButton.titleColor = Constants.blue
@@ -909,7 +909,7 @@ extension WebViewController: UIScrollViewDelegate {
 extension ConnectionInfo {
     func webviewURL() -> URL? {
         if Current.appConfiguration == .FastlaneSnapshot, prefs.object(forKey: "useDemo") != nil {
-            return URL(string: "https://demo.home-assistant.io")!
+            return URL(string: "https://companion.home-assistant.io/app/ios/demo")!
         }
         guard var components = URLComponents(url: self.activeURL, resolvingAgainstBaseURL: true) else {
             return nil


### PR DESCRIPTION
This changes the UI links to target <http://companion.home-assistant.io/app/ios/**> from where they are redirected by Netlify. This means we can quickly fix any links that become dead without the need to go through review with Apple. Currently this only deals with UI links, could expand this to cover all web resources used during run time.

Counterpart PR on the companion docs repo for the redirects: home-assistant/companion.home-assistant#248