### PR TITLE
Fix authentication delay when WebView forces a token refresh

### DIFF
--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -711,9 +711,10 @@ extension WebViewController: WKScriptMessageHandler {
         } else if message.name == "updateThemeColors" {
             self.handleThemeUpdate(messageBody)
         } else if message.name == "getExternalAuth", let callbackName = messageBody["callback"] {
+            let force = messageBody["force"] as? Bool ?? false
             if let tokenManager = Current.tokenManager {
-                Current.Log.verbose("getExternalAuth called")
-                tokenManager.authDictionaryForWebView.done { dictionary in
+                Current.Log.verbose("getExternalAuth called, forced: \(force)")
+                tokenManager.authDictionaryForWebView(forceRefresh: force).done { dictionary in
                     let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: [])
                     if let jsonString = String(data: jsonData!, encoding: .utf8) {
                         // swiftlint:disable:next line_length


### PR DESCRIPTION
Refs #592. I believe the issue is that the referenced module in the frontend is refreshing the token itself, and that's causing our expiration logic to be incorrect -- we think we have a valid token, but it's actually been replaced.

We do eventually recover when one of our own network requests yields an invalid token response, but that's _after_ we've already told the WebView about the token we believed was valid. The frontend will then retry in 10 seconds, but not before considering the token we provided as an invalid login attempt and throwing a log.

This also resolves some threading issues with the cache wrapping refresh token, whose goal was to avoid issuing more than one request at once. Since the WebView callbacks were happening on the on the main queue, and the Alamofire responses on the utility queue, it was possible for both to mutate and kick off refreshes at once, which would also log login failures.

This also adds some logs to try and understand the issues that may be happening in that ticket if this doesn't resolve them.