### PR TITLE
Fix motion sensors not checking authorization status

### DIFF
--- a/Shared/API/Webhook/Sensors/WebhookSensor+Activity.swift
+++ b/Shared/API/Webhook/Sensors/WebhookSensor+Activity.swift
@@ -4,6 +4,7 @@ import CoreMotion
 
 extension WebhookSensor {
     public enum ActivityError: Error {
+        case unauthorized
         case unavailable
         case noData
     }
@@ -26,6 +27,11 @@ extension WebhookSensor {
     }
 
     private static func latestMotionActivity() -> Promise<CMMotionActivity> {
+        guard Current.motion.isAuthorized() else {
+            Current.Log.warning("Activity is not authorized")
+            return .init(error: ActivityError.unauthorized)
+        }
+
         guard Current.motion.isActivityAvailable() else {
             Current.Log.warning("Activity is not available")
             return .init(error: ActivityError.unavailable)

--- a/Shared/API/Webhook/Sensors/WebhookSensor+Pedometer.swift
+++ b/Shared/API/Webhook/Sensors/WebhookSensor+Pedometer.swift
@@ -5,6 +5,7 @@ import Version
 
 extension WebhookSensor {
     public enum PedometerError: Error {
+        case unauthorized
         case unavailable
         case noData
     }
@@ -26,8 +27,13 @@ extension WebhookSensor {
     }
 
     private static func latestPedometerData() -> Promise<CMPedometerData> {
+        guard Current.pedometer.isAuthorized() else {
+            Current.Log.warning("Pedometer is not authorized")
+            return .init(error: PedometerError.unauthorized)
+        }
+
         guard Current.pedometer.isStepCountingAvailable() else {
-            Current.Log.warning("Step counting is not available")
+            Current.Log.warning("Pedometer is not available")
             return .init(error: PedometerError.unavailable)
         }
 

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -178,6 +178,13 @@ public class Environment {
     /// Wrapper around CMMotionActivityManager
     public struct Motion {
         private let underlyingManager = CMMotionActivityManager()
+        public var isAuthorized: () -> Bool = {
+            if #available(iOS 11, *) {
+                return CMMotionActivityManager.authorizationStatus() == .authorized
+            } else {
+                return true
+            }
+        }
         public var isActivityAvailable: () -> Bool = CMMotionActivityManager.isActivityAvailable
         public lazy var queryStartEndOnQueueHandler: (
             Date, Date, OperationQueue, @escaping CMMotionActivityQueryHandler
@@ -190,6 +197,14 @@ public class Environment {
     /// Wrapper around CMPedometeer
     public struct Pedometer {
         private let underlyingPedometer = CMPedometer()
+        public var isAuthorized: () -> Bool = {
+            if #available(iOS 11, *) {
+                return CMPedometer.authorizationStatus() == .authorized
+            } else {
+                return true
+            }
+        }
+
         public var isStepCountingAvailable: () -> Bool = CMPedometer.isStepCountingAvailable
         public lazy var queryStartEndHandler: (
             Date, Date, @escaping CMPedometerHandler

--- a/SharedTests/WebhookSensor/WebhookSensor+Activity.test.swift
+++ b/SharedTests/WebhookSensor/WebhookSensor+Activity.test.swift
@@ -13,11 +13,20 @@ class WebhookSensorActivityTests: XCTestCase {
         super.setUp()
 
         // start by assuming nothing is enabled/available
+        Current.motion.isAuthorized = { false  }
         Current.motion.isActivityAvailable = { false }
         Current.motion.queryStartEndOnQueueHandler = { _, _, _, handler in handler([], nil) }
     }
 
+    func testUnauthorizedReturnsError() {
+        let promise = WebhookSensor.activity()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? WebhookSensor.ActivityError, .unauthorized)
+        }
+    }
+
     func testUnavailableReturnsError() {
+        Current.motion.isAuthorized = { true }
         let promise = WebhookSensor.activity()
         XCTAssertThrowsError(try hang(promise)) { error in
             XCTAssertEqual(error as? WebhookSensor.ActivityError, .unavailable)
@@ -25,6 +34,7 @@ class WebhookSensorActivityTests: XCTestCase {
     }
 
     func testNoDataReturnsError() {
+        Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
         let promise = WebhookSensor.activity()
         XCTAssertThrowsError(try hang(promise)) { error in
@@ -33,6 +43,7 @@ class WebhookSensorActivityTests: XCTestCase {
     }
 
     func testQueryReturnsContractuallyImpossibleErrorReturnsError() {
+        Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
         Current.motion.queryStartEndOnQueueHandler = { _, _, _, handler in handler(nil, nil) }
 
@@ -43,6 +54,7 @@ class WebhookSensorActivityTests: XCTestCase {
     }
 
     func testQueryErrorsReturnsError() {
+        Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
         Current.motion.queryStartEndOnQueueHandler = { _, _, _, hand in hand(nil, TestError.someError) }
 
@@ -57,6 +69,7 @@ class WebhookSensorActivityTests: XCTestCase {
             $0.walking = true
         }
 
+        Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
         Current.motion.queryStartEndOnQueueHandler = { _, _, _, hand in hand([anyActivity], nil) }
 
@@ -68,6 +81,7 @@ class WebhookSensorActivityTests: XCTestCase {
     }
 
     func testQueryActivitiesReturnSensors() throws {
+        Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
 
         // swiftlint:disable opening_brace

--- a/SharedTests/WebhookSensor/WebhookSensor+Pedometer.test.swift
+++ b/SharedTests/WebhookSensor/WebhookSensor+Pedometer.test.swift
@@ -14,11 +14,20 @@ class WebhookSensorPedometerTests: XCTestCase {
         super.setUp()
 
         // start by assuming nothing is enabled/available
+        Current.pedometer.isAuthorized = { false }
         Current.pedometer.isStepCountingAvailable = { false }
         Current.pedometer.queryStartEndHandler = { _, _, handler in handler(nil, nil) }
     }
 
+    func testUnauthorizedReturnsError() {
+        let promise = WebhookSensor.pedometer()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? WebhookSensor.PedometerError, .unauthorized)
+        }
+    }
+
     func testUnavailableReturnsError() {
+        Current.pedometer.isAuthorized = { true }
         let promise = WebhookSensor.pedometer()
         XCTAssertThrowsError(try hang(promise)) { error in
             XCTAssertEqual(error as? WebhookSensor.PedometerError, .unavailable)
@@ -26,6 +35,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testNoDataReturnsError() {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         let promise = WebhookSensor.pedometer()
         XCTAssertThrowsError(try hang(promise)) { error in
@@ -34,6 +44,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testQueryErrorsReturnsError() {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in hand(nil, TestError.someError) }
 
@@ -44,6 +55,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testWithOnlyRequiredSteps() throws {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in hand(FakePedometerData(), nil) }
 
@@ -59,6 +71,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testWithDistance() throws {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -80,6 +93,7 @@ class WebhookSensorPedometerTests: XCTestCase {
 
     func testWithFloorsAscendedBefore105() throws {
         Current.serverVersion = { Version(major: 0, minor: 104) }
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -101,6 +115,7 @@ class WebhookSensorPedometerTests: XCTestCase {
 
     func testWithFloorsAscendedAfter105() throws {
         Current.serverVersion = { Version(major: 0, minor: 105) }
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -122,6 +137,7 @@ class WebhookSensorPedometerTests: XCTestCase {
 
     func testWithFloorsDescendedBefore105() throws {
         Current.serverVersion = { Version(major: 0, minor: 104) }
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -143,6 +159,7 @@ class WebhookSensorPedometerTests: XCTestCase {
 
     func testWithFloorsDescendedAfter105() throws {
         Current.serverVersion = { Version(major: 0, minor: 105) }
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -163,6 +180,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testWithAverageActivePace() throws {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -183,6 +201,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testWithCurrentPace() throws {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {
@@ -203,6 +222,7 @@ class WebhookSensorPedometerTests: XCTestCase {
     }
 
     func testWithCurrentCadence() throws {
+        Current.pedometer.isAuthorized = { true }
         Current.pedometer.isStepCountingAvailable = { true }
         Current.pedometer.queryStartEndHandler = { _, _, hand in
             hand(with(FakePedometerData()) {


### PR DESCRIPTION
When refactoring this, I noted but forgot that SettingStore was checking this authorization status on behalf of the sensor code. This pulls it into the sensors so they can avoid causing a permission prompt.