### PR TITLE
Correct invalid-ish location accuracy when exiting zones

### DIFF
--- a/HomeAssistant/Classes/RegionManager.swift
+++ b/HomeAssistant/Classes/RegionManager.swift
@@ -131,7 +131,7 @@ class RegionManager: NSObject {
                 location = CLLocation(
                     coordinate: cachedLocation.coordinate,
                     altitude: cachedLocation.altitude,
-                    horizontalAccuracy: 200.0,
+                    horizontalAccuracy: exitMaximumAccuracy,
                     verticalAccuracy: cachedLocation.verticalAccuracy,
                     course: cachedLocation.course,
                     speed: cachedLocation.speed,


### PR DESCRIPTION
Fixes #661 by setting a ceiling on the accuracy we'll allow for region monitoring exit events.

Alternatives considered:
- Fluff the value in the receiving side. In fact, I went as far as to implement this, but I decided this isn't the right move. We're much more likely to want poor accuracy numbers to _keep_ the user in a zone than to allow them to pull the user out. The fact that we know an exit event is happening is a _lot_ stronger signal than the given accuracy seems.

Apple definitely has heuristics around when to fire region monitoring events, which they suggest are something like 200m at minimum:

> The specific threshold distances are determined by the hardware and the location technologies that are currently available. For example, if Wi-Fi is disabled, region monitoring is significantly less accurate. However, for testing purposes, you can assume that the minimum distance is approximately 200 meters.

- Fire the GPS up and get a better location when exiting. This may still be the right thing to do, this will need to evolve a bit with user feedback about how accurate these changes are.

I think firing up GPS for exit and enter events is likely fine - they don't happen often and it won't be on for more than a few seconds, if the results of #623 show - the system is very likely to give us an actually-valid accuracy a few seconds later.

This truly does feel like an iOS 13.4/13.5 bug and not intended accuracy numbers.