### PR TITLE
Use more accurate location when entering and exiting regions

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -527,6 +527,7 @@ public class HomeAssistantAPI {
 
     public func GetAndSendLocation(
         trigger: LocationUpdateTrigger?,
+        zone: RLMZone? = nil,
         maximumBackgroundTime: TimeInterval? = nil
     ) -> Promise<Void> {
         var updateTrigger: LocationUpdateTrigger = .Manual
@@ -547,7 +548,7 @@ public class HomeAssistantAPI {
         }.ensure {
             Current.isPerformingSingleShotLocationQuery = false
         }.then { location in
-            self.SubmitLocation(updateType: updateTrigger, location: location, zone: nil)
+            self.SubmitLocation(updateType: updateTrigger, location: location, zone: zone)
         }.asVoid()
     }
 

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -37,8 +37,21 @@ public class WebhookUpdateLocation: Mappable {
         self.SourceType = (self.Trigger == .BeaconRegionEnter || self.Trigger == .BeaconRegionExit
             ? .BluetoothLowEnergy : .GlobalPositioningSystem)
 
-        if let location = location, (
-            trigger != .BeaconRegionEnter && trigger != .BeaconRegionExit && trigger != .GPSRegionEnter) {
+        let useLocation: Bool
+
+        switch trigger {
+        case .BeaconRegionExit, .BeaconRegionEnter:
+            // never use location for beacons
+            useLocation = false
+        case .GPSRegionEnter where Current.settingsStore.useNewOneShotLocation == false:
+            // don't use location for gps enter when not using a one-shot to get location
+            // new one-shot flag controls whether we do a one-shot during region updates
+            useLocation = false
+        default:
+            useLocation = true
+        }
+
+        if let location = location, useLocation {
             self.SetLocation(location: location)
         } else if let zone = zone {
             self.SetZone(zone: zone)


### PR DESCRIPTION
This is gated by the 'Use In-Development Updating' flag as well.

Fixes #661 but I'd like people to validate it in the beta before we totally switch everything over.
Refs #404 - as this no longer forces the location to be the centroid of the region when entering.