### PR TITLE
ZoneManager: Ignore Old Location Updates

### DIFF
--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerIgnoreReason.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerIgnoreReason.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
     case duringOneShot
+    case locationUpdateTooOld
     case locationMissingEntries
     case unknownRegionState
     case unknownRegion
@@ -17,6 +18,8 @@ enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
             return "ignoring during one shot"
         case .locationMissingEntries:
             return "location update missing evennts"
+        case .locationUpdateTooOld:
+            return "location update from the past"
         case .unknownRegionState:
             return "unknown region state"
         case .unknownRegion:

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
@@ -82,7 +82,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
             return ignore(.locationMissingEntries)
         }
 
-        if let lastLocation = locations.last, Current.date().timeIntervalSince(lastLocation.timestamp) > 10.0 {
+        if let lastLocation = locations.last, Current.date().timeIntervalSince(lastLocation.timestamp) > 30.0 {
             // if we're just being tangentially told about locations because of creating the location manager,
             // we want to ignore it in favor if manually getting location in a non-this-class code path
             return ignore(.locationUpdateTooOld)

--- a/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
@@ -118,14 +118,14 @@ class ZoneManagerProcessorTests: XCTestCase {
                 altitude: 3.45,
                 horizontalAccuracy: 1.25,
                 verticalAccuracy: 0.36,
-                timestamp: now.addingTimeInterval(-30.0)
+                timestamp: now.addingTimeInterval(-61.0)
             ),
             CLLocation(
                 coordinate: .init(latitude: 123, longitude: 1.23),
                 altitude: 3.45,
                 horizontalAccuracy: 1.25,
                 verticalAccuracy: 0.36,
-                timestamp: now.addingTimeInterval(-11.0)
+                timestamp: now.addingTimeInterval(-31.0)
             ),
         ]
         let promise = processor.perform(event: ZoneManagerEvent(eventType: .locationChange(locations)))

--- a/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
@@ -108,6 +108,31 @@ class ZoneManagerProcessorTests: XCTestCase {
         XCTAssertEqual(try hangForIgnoreReason(promise), .locationMissingEntries)
     }
 
+    func testLocationTooOld() throws {
+        let now = Date()
+        Current.date = { now }
+
+        let locations = [
+            CLLocation(
+                coordinate: .init(latitude: 123, longitude: 1.23),
+                altitude: 3.45,
+                horizontalAccuracy: 1.25,
+                verticalAccuracy: 0.36,
+                timestamp: now.addingTimeInterval(-30.0)
+            ),
+            CLLocation(
+                coordinate: .init(latitude: 123, longitude: 1.23),
+                altitude: 3.45,
+                horizontalAccuracy: 1.25,
+                verticalAccuracy: 0.36,
+                timestamp: now.addingTimeInterval(-11.0)
+            ),
+        ]
+        let promise = processor.perform(event: ZoneManagerEvent(eventType: .locationChange(locations)))
+
+        XCTAssertEqual(try hangForIgnoreReason(promise), .locationUpdateTooOld)
+    }
+
     func testPerformingZoneStateBad() throws {
         let promise = processor.perform(event: ZoneManagerEvent(eventType: .region(circularRegion, .unknown)))
 


### PR DESCRIPTION
Resolves forcing a round of location updates due to stale location data being available on startup, matching behavior.