### PR TITLE
ZoneManager: Don't Region Monitor Untracked Zones

### DIFF
--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -66,6 +66,7 @@ class ZoneManager {
         let expected = Set(
             Current.realm()
                 .objects(RLMZone.self)
+                .filter { $0.TrackingEnabled }
                 .map { $0.region() }
                 .map(ZoneManagerEquatableRegion.init(region:))
         )


### PR DESCRIPTION
Although the old region management did allow tracking, but didn't observe them, this instead doesn't do anything special about them.