### PR TITLE
ZoneManager: Directly observe Realm for syncing

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -90,7 +90,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Current.syncMonitoredRegions = {
             self.regionManager?.syncMonitoredRegions()
-            self.zoneManager?.syncZones().cauterize()
+            // zoneManager observes the realm collection directly
         }
 
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
@@ -118,7 +118,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
         }
 
         do {
-            try zone.realm?.write {
+            try zone.realm?.reentrantWrite {
                 zone.inRegion = inRegion
             }
         } catch {

--- a/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
@@ -91,7 +91,8 @@ class ZoneManagerTests: XCTestCase {
             zones[1].Latitude += 0.02
             addedRegions.append(zones[1].region())
         }
-        try hang(manager.syncZones())
+
+        realm.refresh()
 
         XCTAssertEqual(locationManager.monitoredRegions, currentRegions)
         XCTAssertEqual(locationManager.stopMonitoringRegions.hackilySorted(), removedRegions.hackilySorted())
@@ -104,10 +105,13 @@ class ZoneManagerTests: XCTestCase {
             realm.delete(toRemove)
         }
 
-        try hang(manager.syncZones())
+        realm.refresh()
+
         XCTAssertEqual(locationManager.monitoredRegions, currentRegions)
         XCTAssertEqual(locationManager.stopMonitoringRegions.hackilySorted(), removedRegions.hackilySorted())
         XCTAssertEqual(locationManager.startMonitoringRegions.hackilySorted(), addedRegions.hackilySorted())
+
+        withExtendedLifetime(manager) { /* silences unused variable */ }
     }
 
     func testStartingWithZoneButNoneWanted() throws {
@@ -123,9 +127,12 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertEqual(locationManager.stopMonitoringRegions, [startRegion])
         XCTAssertTrue(locationManager.monitoredRegions.isEmpty)
 
-        try hang(manager.syncZones())
+        realm.refresh()
+
         XCTAssertEqual(locationManager.stopMonitoringRegions, [startRegion])
         XCTAssertTrue(locationManager.monitoredRegions.isEmpty)
+
+        withExtendedLifetime(manager) { /* silences unused variable */ }
     }
 
     func testTrackingDisabledNotMonitored() throws {
@@ -153,15 +160,19 @@ class ZoneManagerTests: XCTestCase {
             zones[0].TrackingEnabled = true
         }
 
-        try hang(manager.syncZones())
+        realm.refresh()
+
         XCTAssertEqual(Set(locationManager.monitoredRegions.map { $0.identifier }), Set(["work" ,"home"]))
 
         try realm.write {
             zones[1].TrackingEnabled = false
         }
 
-        try hang(manager.syncZones())
+        realm.refresh()
+
         XCTAssertEqual(Set(locationManager.monitoredRegions.map { $0.identifier }), Set(["home"]))
+
+        withExtendedLifetime(manager) { /* silences unused variable */ }
     }
 
     func testBasicStartup() {

--- a/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -13,7 +13,7 @@ public struct ClientEventStore {
     public var addEvent: (ClientEvent) -> Void = { event in
         let realm = Current.realm()
         do {
-            try realm.write {
+            try realm.reentrantWrite {
                 realm.add(event)
             }
         } catch {
@@ -32,7 +32,7 @@ public struct ClientEventStore {
         let realm = Current.realm()
 
         do {
-            try realm.write {
+            try realm.reentrantWrite {
                 realm.delete(realm.objects(ClientEvent.self))
             }
         } catch {

--- a/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Shared/Common/Extensions/Realm+Initialization.swift
@@ -133,4 +133,15 @@ extension Realm {
         fatalError(errMsg)
         #endif
     }
+
+    public func reentrantWrite<Result>(
+        withoutNotifying tokens: [NotificationToken] = [],
+        _ block: (() throws -> Result)
+    ) throws -> Result {
+        if isInWriteTransaction {
+            return try block()
+        } else {
+            return try write(withoutNotifying: tokens, block)
+        }
+    }
 }


### PR DESCRIPTION
Instead of needing to wire up locations that are mutating zones into the manager, this makes the manager observe for any changes and sync them as a result.

One tough thing here: Realm, for some unbelievable reason, notifies about changes in the transaction that is mutating them. This means that anything which is observing the changes and may perform its own write in response needs to make sure it doesn't start a new write transaction, which also unbelievably crashes.