### PR TITLE
Minor Xcode project changes

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -2882,7 +2882,7 @@
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Original;
 				LastSwiftUpdateCheck = 1150;
-				LastUpgradeCheck = 1120;
+				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = "Robbie Trencheny";
 				TargetAttributes = {
 					B627CB061D83C87B0057173E = {
@@ -4769,7 +4769,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant${BUNDLE_ID_SUFFIX}";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -5069,6 +5069,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -5091,7 +5092,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant${BUNDLE_ID_SUFFIX}";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -5145,7 +5146,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant${BUNDLE_ID_SUFFIX}";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/APNSAttachmentService.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/APNSAttachmentService.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Beta.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Beta.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -64,7 +64,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      disableMainThreadChecker = "YES"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/HomeAssistantUITests.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/HomeAssistantUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/NotificationContentExtension.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/NotificationContentExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    wasCreatedForAppExtension = "YES"
    version = "1.3">
    <BuildAction

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-iOS.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-watchOS.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/SiriIntents.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/SiriIntents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/TodayWidget.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/TodayWidget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Complication).xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Complication).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- Lets Xcode run the latest migrator, disallows it to turn back on the New Build System.
- Sets the debug output as non-dSYM DWARF, so it doesn't need to create an additional file on build.
- Turns on some of the runtime sanitization in the Debug scheme.