### PR TITLE
Actionable Notifications: Per-Action URL, example YAML

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		11B7FD742493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */; };
+		11C590ED24A832CA0066085D /* YamlSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C590EC24A832CA0066085D /* YamlSection.swift */; };
 		11C65CC0249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */; };
 		11C65CC1249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */; };
 		11CB98C6249DE15B00B05222 /* LastUpdateSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CB98C5249DE15B00B05222 /* LastUpdateSensor.test.swift */; };
@@ -821,6 +822,7 @@
 		11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivitySensor.test.swift; sourceTree = "<group>"; };
 		11B7FD732493225200E60ED9 /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
 		11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.test.swift; sourceTree = "<group>"; };
+		11C590EC24A832CA0066085D /* YamlSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlSection.swift; sourceTree = "<group>"; };
 		11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCameraResponse.swift; sourceTree = "<group>"; };
 		11CB98C5249DE15B00B05222 /* LastUpdateSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdateSensor.test.swift; sourceTree = "<group>"; };
 		11CB98C7249DE24000B05222 /* PedometerSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PedometerSensor.test.swift; sourceTree = "<group>"; };
@@ -2148,6 +2150,7 @@
 				B661FB6B226BCC8500E541DD /* Settings */,
 				B661FB72226C10AE00E541DD /* Onboarding */,
 				B6D48E6022B9FEE0009F9131 /* DonateViewController.swift */,
+				11C590EC24A832CA0066085D /* YamlSection.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -4105,6 +4108,7 @@
 				B6393F861CB255F200503916 /* EurekaLocationRow.swift in Sources */,
 				11A71C7124A4648000D9565F /* ZoneManagerEquatableRegion.swift in Sources */,
 				B60221FA226D9BC200E8DBFE /* PermissionLineItemView.swift in Sources */,
+				11C590ED24A832CA0066085D /* YamlSection.swift in Sources */,
 				D0EEF331214E41F700D1D360 /* HomeAssistantAPI+Notifications.swift in Sources */,
 				B6DAC735215F069300727D2A /* NotificationCategory.swift in Sources */,
 				B6DA3C7122690B1F00DE811C /* NotificationSoundsViewController.swift in Sources */,

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -969,7 +969,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                           completionHandler: nil)
             }
         }
-
     }
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse,
@@ -999,7 +998,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             open(urlString: openURLRaw)
         } else if let openURLDictionary = userInfo["url"] as? [String: String] {
             let url = openURLDictionary.compactMap { key, value -> String? in
-                if key.lowercased() == response.actionIdentifier.lowercased() {
+                if response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+                    key.lowercased() == NotificationCategory.FallbackActionIdentifier {
+                    return value
+                } else if key.lowercased() == response.actionIdentifier.lowercased() {
                     return value
                 } else {
                     return nil
@@ -1008,7 +1010,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
             if let url = url {
                 open(urlString: url)
+            } else {
+                Current.Log.error(
+                    "couldn't make openable url out of \(openURLDictionary) for \(response.actionIdentifier)"
+                )
             }
+        } else if let someUrl = userInfo["url"] {
+            Current.Log.error(
+                "couldn't make openable url out of \(type(of: someUrl)): \(String(describing: someUrl))"
+            )
         }
 
         firstly {

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -971,6 +971,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse,
                                        withCompletionHandler completionHandler: @escaping () -> Void) {
         if Current.appConfiguration == .FastlaneSnapshot &&

--- a/HomeAssistant/Classes/NotificationAction.swift
+++ b/HomeAssistant/Classes/NotificationAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import RealmSwift
+import Shared
 import UserNotifications
 
 public class NotificationAction: Object {
@@ -50,5 +51,28 @@ public class NotificationAction: Object {
         }
 
         return UNNotificationAction(identifier: self.Identifier, title: self.Title, options: self.options)
+    }
+
+    public class func exampleTrigger(
+        identifier: String,
+        category: String?,
+        textInput: Bool
+    ) -> String {
+        let data = HomeAssistantAPI.notificationActionEvent(
+            identifier: identifier,
+            category: category,
+            actionData: "# value of action_data in notify call",
+            textInput: textInput ? "# text you input" : nil
+        )
+        let eventDataStrings = data.eventData.map { $0 + ": " + String(describing: $1) }.sorted()
+
+        let indentation = "\n    "
+
+        return """
+        - platform: event
+          event_type: \(data.eventType)
+          event_data:
+            \(eventDataStrings.joined(separator: indentation))
+        """
     }
 }

--- a/HomeAssistant/Classes/NotificationCategory.swift
+++ b/HomeAssistant/Classes/NotificationCategory.swift
@@ -63,7 +63,7 @@ public class NotificationCategory: Object {
                                               hiddenPreviewsBodyPlaceholder: placeholder,
                                               options: self.options)
             } else {
-                return UNNotificationCategory(identifier: self.Identifier.uppercased(), actions: allActions,
+                return UNNotificationCategory(identifier: anIdentifier, actions: allActions,
                                               intentIdentifiers: [], options: self.options)
             }
         }

--- a/HomeAssistant/Classes/NotificationCategory.swift
+++ b/HomeAssistant/Classes/NotificationCategory.swift
@@ -13,6 +13,8 @@ import DeviceKit
 import UserNotifications
 
 public class NotificationCategory: Object {
+    static let FallbackActionIdentifier = "_"
+
     @objc dynamic var Name: String = ""
     @objc dynamic var Identifier: String = ""
     // iOS 11+ only
@@ -81,20 +83,22 @@ public class NotificationCategory: Object {
             category: \(Identifier.uppercased())
           action_data:
             # see example trigger in action
-            # value will be in action trigger event
+            # value will be in fired event
 
-          # url can be absolute path like this
+          # url can be absolute path like:
           # "http://example.com/url"
-          # or relative like this
+          # or relative like:
           # "/lovelace/dashboard"
 
-          # pick one of the following url types:
+          # pick one of the following styles:
 
-          # always open when activating the category
+          # always open when opening notification
           url: "/lovelace/dashboard"
 
-          # open a different url based on action
+          # open a different url per action
+          # use "\(Self.FallbackActionIdentifier)" as key for no action chosen
           url:
+          - "\(Self.FallbackActionIdentifier)": "http://example.com/fallback"
           - \(urlStrings.joined(separator: indentation + "- "))
         """
     }

--- a/HomeAssistant/Notifications/HomeAssistantAPI+Notifications.swift
+++ b/HomeAssistant/Notifications/HomeAssistantAPI+Notifications.swift
@@ -13,31 +13,30 @@ import Shared
 import UserNotifications
 
 extension HomeAssistantAPI {
-
-    func handlePushAction(identifier: String, userInfo: [AnyHashable: Any], userInput: String?) -> Promise<Bool> {
+    func handlePushAction(
+        identifier: String,
+        category: String?,
+        userInfo: [AnyHashable: Any],
+        userInput: String?
+    ) -> Promise<Void> {
         return Promise { seal in
             guard let api = HomeAssistantAPI.authenticatedAPI() else {
                 throw APIError.notConfigured
             }
 
-            let device = Device.current
-            var eventData: [String: Any] = ["actionName": identifier,
-                                            "sourceDevicePermanentID": Constants.PermanentID,
-                                            "sourceDeviceName": device.name ?? "Unknown",
-                                            "sourceDeviceID": Current.settingsStore.deviceID]
-            if let dataDict = userInfo["homeassistant"] {
-                eventData["action_data"] = dataDict
-            }
-            if let textInput = userInput {
-                eventData["response_info"] = textInput
-                eventData["textInput"] = textInput
-            }
+            let action = Self.notificationActionEvent(
+                identifier: identifier,
+                category: category,
+                actionData: userInfo["homeassistant"],
+                textInput: userInput
+            )
 
-            let eventType = "ios.notification_action_fired"
-            api.CreateEvent(eventType: eventType, eventData: eventData).done { _ -> Void in
-                seal.fulfill(true)
-                }.catch {error in
-                    seal.reject(error)
+            Current.Log.verbose("Sending action: \(action.eventType) payload: \(action.eventData)")
+
+            api.CreateEvent(eventType: action.eventType, eventData: action.eventData).done { _ -> Void in
+                seal.fulfill(())
+            }.catch {error in
+                seal.reject(error)
             }
         }
     }

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "notifications_configurator.category.rows.hidden_preview_placeholder.footer" = "This text is only displayed if you have notification previews hidden. Use '%%u' for the number of messages with the same thread identifier.";
 "notifications_configurator.identifier" = "Identifier";
 "notifications_configurator.new_action.title" = "New Action";
+"notifications_configurator.category.example_call.title" = "Example Service Call";
 "notifications_configurator.settings.header" = "Settings";
 "notifications_configurator.settings.footer" = "Identifier must contain only letters and underscores and be uppercase. It must be globally unique to the app.";
 "notifications_configurator.settings.footer.id_set" = "Identifier can not be changed after creation. You must delete and recreate the action to change the identifier.";

--- a/HomeAssistant/Utilities/Notifications.swift
+++ b/HomeAssistant/Utilities/Notifications.swift
@@ -15,18 +15,22 @@ import PromiseKit
 extension HomeAssistantAPI {
     public static func ProvideNotificationCategoriesToSystem() {
         let realm = Current.realm()
-        var categories = Set<UNNotificationCategory>(realm.objects(NotificationCategory.self).map({ $0.category }))
+        var categories = Set(realm.objects(NotificationCategory.self).flatMap({ $0.categories }))
 
         if Current.appConfiguration == .FastlaneSnapshot {
-            let cameraCat = UNNotificationCategory(identifier: "camera",
-                                                   actions: [],
-                                                   intentIdentifiers: [],
-                                                   options: UNNotificationCategoryOptions([.customDismissAction]))
-            let mapCat = UNNotificationCategory(identifier: "map",
-                                                actions: [],
-                                                intentIdentifiers: [],
-                                                options: UNNotificationCategoryOptions([.customDismissAction]))
-            categories.formUnion([cameraCat, mapCat])
+            let cameraCategories = ["camera", "CAMERA"].map {
+                UNNotificationCategory(identifier: $0,
+                                       actions: [],
+                                       intentIdentifiers: [],
+                                       options: UNNotificationCategoryOptions([.customDismissAction]))
+            }
+            let mapCategories = ["map", "MAP"].map {
+                UNNotificationCategory(identifier: $0,
+                                       actions: [],
+                                       intentIdentifiers: [],
+                                       options: UNNotificationCategoryOptions([.customDismissAction]))
+            }
+            categories.formUnion([cameraCategories, mapCategories].flatMap { $0 })
         }
 
         Current.Log.verbose("Providing \(categories.count) categories to system: \(categories)")

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -177,37 +177,12 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
                 cell.view = self.preview
             }
 
-            +++ Section(header: L10n.ActionsConfigurator.TriggerExample.title, footer: nil)
-
-            <<< TextAreaRow("trigger-yaml") { row in
-                row.value = "test"
-                row.textAreaHeight = .dynamic(initialTextViewHeight: 100)
-
-                row.cellSetup { cell, _ in
-                    // a little smaller than the body size
-                    let baseSize = UIFont.preferredFont(forTextStyle: .body).pointSize - 2.0
-                    cell.textView.font = {
-                        if #available(iOS 13, *) {
-                            return UIFont.monospacedSystemFont(ofSize: baseSize, weight: .regular)
-                        } else {
-                            return UIFont(name: "Menlo", size: baseSize)
-                        }
-                    }()
-                }
-            }
-
-            <<< ButtonRow { row in
-                row.title = L10n.ActionsConfigurator.TriggerExample.share
-
-                row.onCellSelection { _, _ in
-                    // although this could be done via presentationMode, we want to preserve the 'button' look
-                    let value = (self.form.rowBy(tag: "trigger-yaml") as? TextAreaRow)?.value
-                        ?? self.action.exampleTrigger
-                    let controller = UIActivityViewController(activityItems: [ value ], applicationActivities: [])
-                    self.present(controller, animated: true, completion: nil)
-                }
-            }
-
+            +++ YamlSection(
+                tag: "exampleTrigger",
+                header: L10n.ActionsConfigurator.TriggerExample.title,
+                yamlGetter: { [action] in action.exampleTrigger },
+                present: { [weak self] controller in self?.present(controller, animated: true, completion: nil) }
+            )
     }
 
     override func didReceiveMemoryWarning() {
@@ -251,9 +226,8 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
 
         preview.setup(action)
 
-        if let row = form.rowBy(tag: "trigger-yaml") as? TextAreaRow {
-            row.value = action.exampleTrigger
-            row.updateCell()
+        if let section = form.sectionBy(tag: "exampleTrigger") as? YamlSection {
+            section.update()
         }
     }
 }

--- a/HomeAssistant/Views/NotificationActionConfigurator.swift
+++ b/HomeAssistant/Views/NotificationActionConfigurator.swift
@@ -17,17 +17,24 @@ class NotificationActionConfigurator: FormViewController, TypedRowControllerType
     /// A closure to be called when the controller disappears.
     public var onDismissCallback: ((UIViewController) -> Void)?
 
+    private let category: NotificationCategory
     var newAction: Bool = true
     var action: NotificationAction = NotificationAction()
 
     private let realm = Current.realm()
 
-    convenience init(action: NotificationAction?) {
-        self.init()
+    init(category: NotificationCategory, action: NotificationAction?) {
+        self.category = category
+        super.init(style: .grouped)
         if let action = action {
             self.action = action
             self.newAction = false
         }
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -155,6 +162,22 @@ class NotificationActionConfigurator: FormViewController, TypedRowControllerType
                 }
             }
 
+        +++ YamlSection(
+            tag: "exampleTrigger",
+            header: L10n.ActionsConfigurator.TriggerExample.title,
+            yamlGetter: { [weak form, category] in
+                guard let form = form else { return "" }
+
+                let formVals = form.values(includeHidden: true)
+
+                return NotificationAction.exampleTrigger(
+                    identifier: formVals["identifier"] as? String ?? "",
+                    category: category.Identifier,
+                    textInput: formVals["textInput"] as? Bool ?? false
+                )
+            },
+            present: { [weak self] controller in self?.present(controller, animated: true, completion: nil) }
+        )
     }
 
     override func didReceiveMemoryWarning() {
@@ -209,4 +232,11 @@ class NotificationActionConfigurator: FormViewController, TypedRowControllerType
         Current.Log.verbose("Preview hit")
     }
 
+    override func valueHasBeenChanged(for row: BaseRow, oldValue: Any?, newValue: Any?) {
+        super.valueHasBeenChanged(for: row, oldValue: oldValue, newValue: newValue)
+
+        if let section = form.sectionBy(tag: "exampleTrigger") as? YamlSection, row.section != section {
+            section.update()
+        }
+    }
 }

--- a/HomeAssistant/Views/NotificationCategoryConfigurator.swift
+++ b/HomeAssistant/Views/NotificationCategoryConfigurator.swift
@@ -210,6 +210,13 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
                         section <<< self.getActionRow(action)
                     }
                 }
+
+        form +++ YamlSection(
+            tag: "exampleServiceCall",
+            header: L10n.NotificationsConfigurator.Category.ExampleCall.title,
+            yamlGetter: { [category] in category.exampleServiceCall },
+            present: { [weak self] controller in self?.present(controller, animated: true, completion: nil) }
+        )
     }
 
     override func didReceiveMemoryWarning() {
@@ -233,6 +240,24 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
                 self.addButtonRow.hidden = false
                 self.addButtonRow.evaluateHidden()
             }
+
+            self.updatePreview()
+        }
+    }
+
+    private func updatePreview() {
+        if let section = form.sectionBy(tag: "exampleServiceCall") as? YamlSection {
+            DispatchQueue.main.async {
+                section.update()
+            }
+        }
+    }
+
+    override func valueHasBeenChanged(for row: BaseRow, oldValue: Any?, newValue: Any?) {
+        super.valueHasBeenChanged(for: row, oldValue: oldValue, newValue: newValue)
+
+        if row.section?.tag != "exampleServiceCall" {
+            updatePreview()
         }
     }
 
@@ -251,8 +276,8 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
             row.tag = identifier
             row.title = title
 
-            row.presentationMode = PresentationMode.show(controllerProvider: ControllerProvider.callback {
-                return NotificationActionConfigurator(action: action)
+            row.presentationMode = PresentationMode.show(controllerProvider: ControllerProvider.callback { [category] in
+                return NotificationActionConfigurator(category: category, action: action)
             }, onDismiss: { vc in
                 vc.navigationController?.popViewController(animated: true)
 
@@ -269,8 +294,9 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
                         self.realm.add(vc.action, update: .all)
                         self.category.Actions.append(vc.action)
                     }
-                }
 
+                    self.updatePreview()
+                }
             })
         }
     }

--- a/HomeAssistant/Views/YamlSection.swift
+++ b/HomeAssistant/Views/YamlSection.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Eureka
+import UIKit
+
+final public class YamlSection: Section {
+    private let yamlRow = TextAreaRow { row in
+        row.value = ""
+        row.textAreaHeight = .dynamic(initialTextViewHeight: 100)
+
+        row.cellSetup { cell, _ in
+            // a little smaller than the body size
+            let baseSize = UIFont.preferredFont(forTextStyle: .body).pointSize - 2.0
+            cell.textView.font = {
+                if #available(iOS 13, *) {
+                    return UIFont.monospacedSystemFont(ofSize: baseSize, weight: .regular)
+                } else {
+                    return UIFont(name: "Menlo", size: baseSize)
+                }
+            }()
+        }
+    }
+
+    private let yamlGetter: () -> String
+
+    public init(
+        tag: String,
+        header: String,
+        yamlGetter: @escaping () -> String,
+        present: @escaping (UIViewController) -> Void
+    ) {
+        self.yamlGetter = yamlGetter
+
+        super.init(
+            header: header,
+            footer: nil
+        )
+
+        self.tag = tag
+
+        self
+            <<< yamlRow
+            <<< ButtonRow { row in
+                row.title = L10n.ActionsConfigurator.TriggerExample.share
+
+                row.onCellSelection { [yamlRow, present, yamlGetter] _, _ in
+                    // although this could be done via presentationMode, we want to preserve the 'button' look
+                    let value = yamlRow.value ?? yamlGetter()
+                    let controller = UIActivityViewController(activityItems: [ value ], applicationActivities: [])
+                    present(controller)
+                }
+            }
+
+        yamlRow.value = yamlGetter()
+    }
+
+    @available(*, unavailable)
+    required init<S>(_ elements: S) where S: Sequence, S.Element == BaseRow {
+        fatalError("init(_:) has not been implemented")
+    }
+
+    @available(*, unavailable)
+    required init() {
+        fatalError("init() has not been implemented")
+    }
+
+    public func update() {
+        yamlRow.value = yamlGetter()
+        yamlRow.updateCell()
+    }
+}

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -601,6 +601,34 @@ public class HomeAssistantAPI {
         }
     }
 
+    public class func notificationActionEvent(
+        identifier: String,
+        category: String?,
+        actionData: Any?,
+        textInput: String?
+    ) -> (eventType: String, eventData: [String: Any]) {
+        let device = Device.current
+        var eventData: [String: Any] = [
+            "actionName": identifier,
+            "sourceDevicePermanentID": Constants.PermanentID,
+            "sourceDeviceName": device.name ?? "Unknown",
+            "sourceDeviceID": Current.settingsStore.deviceID
+        ]
+
+        if let category = category {
+            eventData["categoryName"] = category
+        }
+        if let actionData = actionData {
+            eventData["action_data"] = actionData
+        }
+        if let textInput = textInput {
+            eventData["response_info"] = textInput
+            eventData["textInput"] = textInput
+        }
+
+        return (eventType: "ios.notification_action_fired", eventData: eventData)
+    }
+
     public class func actionEvent(
         actionID: String,
         actionName: String,

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -489,6 +489,10 @@ internal enum L10n {
       }
     }
     internal enum Category {
+      internal enum ExampleCall {
+        /// Example Service Call
+        internal static let title = L10n.tr("Localizable", "notifications_configurator.category.example_call.title")
+      }
       internal enum NavigationBar {
         /// Category Configurator
         internal static let title = L10n.tr("Localizable", "notifications_configurator.category.navigation_bar.title")


### PR DESCRIPTION
- Added `categoryName` to the contents of the event for activating a notification.
- Makes the acceptable case of categories both uppercase and lowercase. Refs #329.
- Copy/paste of an example service call for a category named TEST, which demonstrates per-action URLs:

```yaml
service: notify.mobile_app_#name_here
data:
  push:
    category: TEST
  action_data:
    # see example trigger in action
    # value will be in fired event

  # url can be absolute path like:
  # "http://example.com/url"
  # or relative like:
  # "/lovelace/dashboard"

  # pick one of the following styles:

  # always open when opening notification
  url: "/lovelace/dashboard"

  # open a different url per action
  # use "_" as key for no action chosen
  url:
  - "_": "http://example.com/fallback"
  - "THING": "http://example.com/url"
  - "OTHER": "http://example.com/url"
```

Fixes #643.

![IMG_6666](https://user-images.githubusercontent.com/74188/85937593-e6458e00-b8b9-11ea-8c2e-41c1ebebc12a.png)
