### PR TITLE
Fix importing notification categories showing duplicates

### DIFF
--- a/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/NotificationSettingsViewController.swift
@@ -143,7 +143,9 @@ class NotificationSettingsViewController: FormViewController {
 
                     alert.popoverPresentationController?.sourceView = cell.contentView
 
-                    let rows = cats.map { self.getNotificationCategoryRow($0) }
+                    let rows = cats
+                        .filter { self.form.rowBy(tag: $0.Identifier) == nil }
+                        .map { self.getNotificationCategoryRow($0) }
                     var section = self.form.sectionBy(tag: "notification_categories")
                     section?.insert(contentsOf: rows, at: 0)
                 }


### PR DESCRIPTION
Although the underlying models were not duplicated (because of primary key), they were always inserted which gave the visual impression that they were duplicated. Fixes #317.