### PR TITLE
Increase network connections' timeout duration

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -80,7 +80,6 @@ public class HomeAssistantAPI {
 
     private static func configureSessionManager(urlConfig: URLSessionConfiguration = .default) -> SessionManager {
         let configuration = urlConfig
-        configuration.timeoutIntervalForRequest = 10 // seconds
         return Alamofire.SessionManager(configuration: configuration)
     }
 


### PR DESCRIPTION
Instead of specifying 10 seconds as a timeout (which is 1/6th the default), allow the default to be inherited. This should improve situations where e.g. a very high-data-required API call during onboarding fails and doesn't allow the user to progress.

Fixes #580.