### PR TITLE
Fix MJPEG streaming errorring when token is expired

### DIFF
--- a/Shared/API/MJPEGStreamer.swift
+++ b/Shared/API/MJPEGStreamer.swift
@@ -41,7 +41,6 @@ public class MJPEGStreamer {
                     callback(nil, error)
                 }
             })
-        self.request?.resume()
 
         request?.stream { [weak self] buffer in
             guard let this = self else {


### PR DESCRIPTION
When we experience an error in the HLS or MJPEG streaming paths introduced in 2020.3, we continue down until we run out of available ways to play the camera. In this situation, we are receiving the error about the expired token _long_ before we've even gone to fetch a refresh token.

Surface bug: the completion handler is being invoked when we don't expect it to, and new error handling is making it error out when it would silently fail before.

So why exactly is the completion handler being invoked here? We haven't finished retrying it. The completion handler for the request in Alamofire is run on an `OperationQueue` which remains suspended until the network request finishes. So when you call…

```swift
dataRequest.response(completionHandler: …)
```

…the block parameter `completionHandler` is added to the operation queue via some wrapping code. When the queue is unsuspended, the wrapping code grabs the current state (`Data`, `Error`, etc.) and invokes the `completionHandler` with it.

This operation queue is suspended in exactly 2 places in Alamofire:

1. When a `didCompleteWithError` (which is both success and error; bad API naming) comes back, indicating the request is done including retries if desired.
1. When calling `resume()` on a `DataRequest` which doesn't have a `URLSessionTask`.

This failure mode is clearly not a URL connection failing, because we're receiving expired token errors explicitly typed to the kind the TokenManager throws when it's got an expired-by-time token. It's not an HTTP error.

So that leaves the second one, and presents us with some questions:

- Why is the task `nil`?

The task is `nil` because the initial attempt to create it failed because of the token being expired. Asynchronously, it's waiting for the refresh token callback to occur before it retries the request, which will create its first task.

- Why are we calling `resume()` in this situation?

We have no reason to do so.

Removed.