### PR TITLE
Fix sim_1 vs. cellular_provider on pre-multiple-SIM devices

### DIFF
--- a/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
+++ b/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
@@ -91,8 +91,7 @@ public class ConnectivitySensor: SensorProvider {
                 carrierSensor(
                     carrier: $0.value,
                     radioTech: radioTech?[$0.key],
-                    key: $0.key,
-                    hasMultiple: networkInfo.count > 1
+                    key: $0.key
                 )
             })
         } else {
@@ -103,13 +102,12 @@ public class ConnectivitySensor: SensorProvider {
     private func carrierSensor(
         carrier: CTCarrier,
         radioTech: String?,
-        key: String,
-        hasMultiple: Bool
+        key: String?
     ) -> Guarantee<WebhookSensor> {
         let sensor: WebhookSensor
 
-        if hasMultiple, let id = key.last {
-            // the user has multiple, so break them into numbered
+        if let id = key?.last {
+            // the user has multiple, or could have multiple, so break them into numbered
             sensor = WebhookSensor(
                 name: "SIM \(id)",
                 uniqueID: "connectivity_sim_\(id)",
@@ -127,7 +125,7 @@ public class ConnectivitySensor: SensorProvider {
 
         sensor.State = carrier.carrierName ?? "N/A"
         sensor.Attributes = [
-            "Carrier ID": hasMultiple ? key : "N/A",
+            "Carrier ID": key ?? "N/A",
             "Carrier Name": carrier.carrierName ?? "N/A",
             "Mobile Country Code": carrier.mobileCountryCode ?? "N/A",
             "Mobile Network Code": carrier.mobileNetworkCode ?? "N/A",

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -248,21 +248,21 @@ public class Environment {
         public var simpleNetworkType: () -> NetworkType = Reachability.getSimpleNetworkType
         public var cellularNetworkType: () -> NetworkType = Reachability.getNetworkType
 
-        public var telephonyCarriers: () -> [String: CTCarrier]? = {
+        public var telephonyCarriers: () -> [String?: CTCarrier]? = {
             let info = CTTelephonyNetworkInfo()
 
             if #available(iOS 12, *) {
                 return info.serviceSubscriberCellularProviders
             } else {
-                return info.subscriberCellularProvider.flatMap { ["1": $0] }
+                return info.subscriberCellularProvider.flatMap { [nil: $0] }
             }
         }
-        public var telephonyRadioAccessTechnology: () -> [String: String]? = {
+        public var telephonyRadioAccessTechnology: () -> [String?: String]? = {
             let info = CTTelephonyNetworkInfo()
             if #available(iOS 12, *) {
                 return info.serviceCurrentRadioAccessTechnology
             } else {
-                return info.currentRadioAccessTechnology.flatMap { ["1": $0] }
+                return info.currentRadioAccessTechnology.flatMap { [nil: $0] }
             }
         }
         #endif


### PR DESCRIPTION
Fixes #731. I mistook the old codepaths to have collapsed single-SIM devices into one sensor; instead, it isn't pre-multiple-SIM devices that get collapsed, it's just iOS 10/11.

This is my first ever somewhat-legitimate use of a `Dictionary<Optional<T>, *>`.