### PR TITLE
Storage Sensor: More system-like % available

### DIFF
--- a/Shared/API/Webhook/Sensors/StorageSensor.swift
+++ b/Shared/API/Webhook/Sensors/StorageSensor.swift
@@ -96,7 +96,7 @@ public class StorageSensor: SensorProvider {
 
         func availablePercent() -> String {
             precondition(total > 0, "init should prevent this")
-            let percent = Decimal(availableOverall) / Decimal(total) * Decimal(100.0)
+            let percent = Decimal(availableOpportunistic) / Decimal(total) * Decimal(100.0)
             return String(format: "%.02lf", Double(truncating: percent as NSNumber))
         }
 

--- a/SharedTests/Sensors/StorageSensor.test.swift
+++ b/SharedTests/Sensors/StorageSensor.test.swift
@@ -62,7 +62,7 @@ class StorageSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].Name, "Storage")
         XCTAssertEqual(sensors[0].UniqueID, "storage")
         XCTAssertEqual(sensors[0].Icon, "mdi:database")
-        XCTAssertEqual(sensors[0].State as? String, "20.00")
+        XCTAssertEqual(sensors[0].State as? String, "22.00")
         XCTAssertEqual(sensors[0].UnitOfMeasurement, "% available")
         XCTAssertEqual(sensors[0].Attributes?["Total"] as? String, "100.00 GB")
         XCTAssertEqual(sensors[0].Attributes?["Available"] as? String, "20.00 GB")


### PR DESCRIPTION
Sets the numerator for the percentage as the opportunistic space value, rather than the pre-purgable-data available space. Fixes #736.