### PR TITLE
Fix WebhookManager issue during login

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -427,12 +427,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         completionHandler: @escaping () -> Void
     ) {
         if identifier == WebhookManager.URLSessionIdentifier {
-            if let webhookManager = HomeAssistantAPI.authenticatedAPI()?.webhookManager {
-                webhookManager.handleBackground(for: identifier, completionHandler: completionHandler)
-            } else {
-                Current.Log.error("couldn't find webhookmanager for background events")
-                completionHandler()
-            }
+            Current.webhooks.handleBackground(for: identifier, completionHandler: completionHandler)
         } else {
             Current.Log.error("couldn't find appropriate session for for \(identifier)")
             completionHandler()

--- a/HomeAssistant/Utilities/WatchHelpers.swift
+++ b/HomeAssistant/Utilities/WatchHelpers.swift
@@ -132,7 +132,7 @@ extension HomeAssistantAPI {
         }
 
         return firstly { () -> Promise<Any> in
-            webhookManager.sendEphemeral(request: .init(type: "render_template", data: payload))
+            Current.webhooks.sendEphemeral(request: .init(type: "render_template", data: payload))
         }.then { (respJSON: Any) -> Promise<[WatchComplication]> in
             Current.Log.verbose("Got JSON \(respJSON)")
             guard let jsonDict = respJSON as? [String: String] else {

--- a/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
@@ -16,13 +16,7 @@ class SensorListViewController: FormViewController, SensorObserver {
         tableView.refreshControl = refreshControl
         refreshControl.beginRefreshing()
 
-        HomeAssistantAPI
-            .authenticatedAPIPromise
-            .done { [weak self] api in
-                guard let self = self else { return }
-                // triggers a refreesh
-                api.sensors.register(observer: self)
-            }.cauterize()
+        Current.sensors.register(observer: self)
 
         tableView.alwaysBounceVertical = true
 

--- a/Shared/API/Webhook/Request&Response/WebhookResponseUpdateSensors.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookResponseUpdateSensors.swift
@@ -44,13 +44,13 @@ struct WebhookResponseUpdateSensors: WebhookResponseHandler {
             if keys.isEmpty == false {
                 Current.Log.info("need to register \(keys)")
             }
-        }.then { [api] needsRegistering -> Promise<Void> in
+        }.then { needsRegistering -> Promise<Void> in
             guard needsRegistering.isEmpty == false else {
                 return .value(())
             }
 
             return firstly { () -> Guarantee<[WebhookSensor]> in
-                api.sensors.sensors(request: .init(reason: .registration))
+                Current.sensors.sensors(request: .init(reason: .registration))
             }.filterValues { sensor in
                 if let uniqueID = sensor.UniqueID {
                     return needsRegistering.contains(uniqueID)
@@ -60,7 +60,7 @@ struct WebhookResponseUpdateSensors: WebhookResponseHandler {
             }.get { sensors in
                 Current.Log.info("registering \(sensors.map { $0.UniqueID })")
             }.thenMap { sensor in
-                api.webhookManager.send(request: .init(type: "register_sensor", data: sensor.toJSON()))
+                Current.webhooks.send(request: .init(type: "register_sensor", data: sensor.toJSON()))
             }.asVoid()
         }
 

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -58,6 +58,23 @@ public class Environment {
 
     public var settingsStore = SettingsStore()
 
+    public var webhooks = with(WebhookManager()) {
+        // ^ because background url session identifiers cannot be reused, this must be a singleton-ish
+        $0.register(responseHandler: WebhookResponseUpdateSensors.self, for: .updateSensors)
+        $0.register(responseHandler: WebhookResponseLocation.self, for: .location)
+        $0.register(responseHandler: WebhookResponseServiceCall.self, for: .serviceCall)
+    }
+
+    public var sensors = with(SensorContainer()) {
+        $0.register(provider: ActivitySensor.self)
+        $0.register(provider: PedometerSensor.self)
+        $0.register(provider: BatterySensor.self)
+        $0.register(provider: StorageSensor.self)
+        $0.register(provider: ConnectivitySensor.self)
+        $0.register(provider: GeocoderSensor.self)
+        $0.register(provider: LastUpdateSensor.self)
+    }
+
     public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
 
     #if os(iOS)

--- a/SharedTests/Webhook/WebhookResponseUpdateSensors.test.swift
+++ b/SharedTests/Webhook/WebhookResponseUpdateSensors.test.swift
@@ -5,6 +5,8 @@ import XCTest
 
 class WebhookResponseUpdateSensorsTests: XCTestCase {
     private var api: FakeHomeAssistantAPI!
+
+    private var previousWebhookManager: WebhookManager!
     private var webhookManager: FakeWebhookManager!
 
     override func setUp() {
@@ -26,7 +28,14 @@ class WebhookResponseUpdateSensorsTests: XCTestCase {
             )
         )
         webhookManager = FakeWebhookManager()
-        api.webhookManager = webhookManager
+        previousWebhookManager = Current.webhooks
+        Current.webhooks = webhookManager
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        Current.webhooks = previousWebhookManager
     }
 
     func testReplacement() throws {
@@ -73,7 +82,7 @@ class WebhookResponseUpdateSensorsTests: XCTestCase {
     func testUpdatedRequiringRegistration() throws {
         // it's probably too much work to mock out the sensors here, so this implicitly
         // depends on one of the registered sensors. to make this more obvious, grab one.
-        let sensors = try hang(Promise(api.sensors.sensors(request: .init(reason: .registration))))
+        let sensors = try hang(Promise(Current.sensors.sensors(request: .init(reason: .registration))))
         let handler = WebhookResponseUpdateSensors(api: api)
         let request = WebhookRequest(type: "update_sensor_states", data: [:])
 


### PR DESCRIPTION
- Make WebhookManager & SensorContainer a singleton in Environment. The system really does not like the background session identifiers being reused, which happens during login as HomeAssistantAPI instances are created and destroyed.
- Adds a mutex around the state handling coming back from URLSession delegate methods and enqueueing. This doesn't seem to be a problem, but better safe than sorry.

Fixes #759.