### PR TITLE
Add quality thresholds to location results

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A6249E9F930097F497 /* StorageSensor.test.swift */; };
 		119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C9B1E24A448A600308A54 /* ZoneManager.swift */; };
 		119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */; };
+		119DC15824B6A33F00AAB204 /* ZeroLatitude.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */; };
 		11A71C6B24A463FC00D9565F /* ZoneManagerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C6A24A463FC00D9565F /* ZoneManagerState.swift */; };
 		11A71C6D24A4641600D9565F /* ZoneManagerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C6C24A4641600D9565F /* ZoneManagerEvent.swift */; };
 		11A71C6F24A4644A00D9565F /* ZoneManagerIgnoreReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C6E24A4644A00D9565F /* ZoneManagerIgnoreReason.swift */; };
@@ -822,6 +823,7 @@
 		119385A6249E9F930097F497 /* StorageSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.test.swift; sourceTree = "<group>"; };
 		119C9B1E24A448A600308A54 /* ZoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManager.swift; sourceTree = "<group>"; };
 		119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+BackgroundTask.swift"; sourceTree = "<group>"; };
+		119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = ZeroLatitude.gpx; sourceTree = "<group>"; };
 		11A71C6A24A463FC00D9565F /* ZoneManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerState.swift; sourceTree = "<group>"; };
 		11A71C6C24A4641600D9565F /* ZoneManagerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerEvent.swift; sourceTree = "<group>"; };
 		11A71C6E24A4644A00D9565F /* ZoneManagerIgnoreReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerIgnoreReason.swift; sourceTree = "<group>"; };
@@ -2034,6 +2036,7 @@
 				B657A90B1CA646EB00121384 /* HomeAssistantUITests.swift */,
 				B657A90D1CA646EB00121384 /* Info.plist */,
 				B699339B1E2338960054453D /* SnapshotHelper.swift */,
+				119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */,
 				B63CCDDE21649AE400123C50 /* BayArea.gpx */,
 			);
 			path = HomeAssistantUITests;
@@ -3415,6 +3418,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				119DC15824B6A33F00AAB204 /* ZeroLatitude.gpx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -900,6 +900,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Analytics.logEvent(eventName, parameters: params)
         }
 
+        Current.logError = { error in
+            // crashlytics itself controlled by the crashlytics key, but this is more like analytics
+            guard prefs.bool(forKey: "analyticsEnabled") else { return }
+
+            Current.Log.error("logging error: \(error.debugDescription)")
+            Crashlytics.crashlytics().record(error: error)
+        }
+
         Current.setUserProperty = { (value: String?, name: String) -> Void in
             Current.Log.verbose("Setting user property \(name) to \(String(describing: value))")
             Analytics.setUserProperty(value, forName: name)

--- a/HomeAssistantUITests/ZeroLatitude.gpx
+++ b/HomeAssistantUITests/ZeroLatitude.gpx
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Xcode">
+
+    <!--
+     Provide one or more waypoints containing a latitude/longitude pair. If you provide one
+     waypoint, Xcode will simulate that specific location. If you provide multiple waypoints,
+     Xcode will simulate a route visiting each waypoint.
+     -->
+    <wpt lat="0" lon="-122.358050">
+        <name>Zero Latitude</name>
+
+        <!--
+         Optionally provide a time element for each waypoint. Xcode will interpolate movement
+         at a rate of speed based on the time elapsed between each waypoint. If you do not provide
+         a time element, then Xcode will use a fixed rate of speed.
+
+         Waypoints must be sorted by time in ascending order.
+         -->
+        <time>2014-09-24T14:55:37Z</time>
+    </wpt>
+
+</gpx>

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -102,6 +102,7 @@ public class Environment {
     public var isPerformingSingleShotLocationQuery = false
 
     public var logEvent: ((String, [String: Any]?) -> Void)?
+    public var logError: ((NSError) -> Void)?
 
     public var setUserProperty: ((String?, String) -> Void)?
 


### PR DESCRIPTION
This requires locations we're considering as updates to:

- Not have a longitude or latitude of exactly 0. I'm not sure why this is happening, and it almost certainly is not something we're doing (I can't find any reason why it would be) but at least we can detect it. Fixes #684.
- Not have an accuracy that exceeds 1500m or be older than 600s. Refs #298. These are numbers that can be tuned in the future, too.

The tradeoff here is that we may be disregarding poor location information when entering and exiting monitored regions. We may need to write some compensating "zone enters/exits are not location-based" logic if this proves to be the case.

This also bumps up our requested accuracy level from 200m to "Best." I'm guessing in practice there may be no difference in the poor results iOS seems to be sending us.