### PR TITLE
Extend local logging from ~1.5 hours to ~3 days

### DIFF
--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -141,7 +141,7 @@ public class Environment {
         }
     }
 
-    public var Log: XCGLogger = {
+    public lazy var Log: XCGLogger = {
         if NSClassFromString("XCTest") != nil {
             return XCGLogger()
         }
@@ -170,7 +170,11 @@ public class Environment {
         // Create a file log destination
         let fileDestination = AutoRotatingFileDestination(writeToFile: logPath,
                                                           identifier: "advancedLogger.fileDestination",
-                                                          shouldAppend: true)
+                                                          shouldAppend: true,
+                                                          maxFileSize: 10_485_760,
+                                                          maxTimeInterval: 86400,
+                                                          // archived logs + 1 current, so realy this is -1'd
+                                                          targetMaxLogFiles: isTestFlight ? 8 : 4)
 
         // Optionally set some configuration options
         fileDestination.outputLevel = .verbose


### PR DESCRIPTION
The default values are 10 logs at 600 seconds each with a max file size of 1.5mb, so depending on how active the app is, anything that happened earlier in the day is gone. This extends our maximum logging size from 15mb to 30mb and a much longer duration of time.

Limits are about doubled for TestFlight builds.