### PR TITLE
Fix background crash on iOS 14 beta in our beta

### DIFF
--- a/SharedTests/Webhook/WebhookManager.test.swift
+++ b/SharedTests/Webhook/WebhookManager.test.swift
@@ -61,6 +61,11 @@ class WebhookManagerTests: XCTestCase {
         XCTAssertTrue(didInvokeCompletion)
     }
 
+    func testUnbalancedBackgroundHandlingDoesntCrash() {
+        // not the best test: this will crash the test execution if it fails
+        manager.urlSessionDidFinishEvents(forBackgroundURLSession: manager.backgroundUrlSession)
+    }
+
     func testSendingEphemeralFailsEntirely() {
         let expectedError = URLError(.timedOut)
         let expectedRequest = WebhookRequest(type: "webhook_name", data: ["json": true])


### PR DESCRIPTION
iOS 14 is sending `urlSessionDidFinishEvents` without the paired `handleEventsForBackgroundURLSession` to start it, which means we're trying to `.leave()` a group we did not `.enter()` which causes DispatchGroup to assert.