### PR TITLE
Event Log improvements

### DIFF
--- a/HomeAssistant/ClientEvents/ViewControllers/ClientEventPayloadViewController.swift
+++ b/HomeAssistant/ClientEvents/ViewControllers/ClientEventPayloadViewController.swift
@@ -18,7 +18,18 @@ class ClientEventPayloadViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share(_:)))
+        ]
         self.textView.text = self.jsonString
+    }
+
+    @objc private func share(_ sender: UIBarButtonItem) {
+        let controller = UIActivityViewController(activityItems: [jsonString ?? "?"], applicationActivities: nil)
+        with(controller.popoverPresentationController) {
+            $0?.barButtonItem = sender
+        }
+        present(controller, animated: true, completion: nil)
     }
 
     func showEvent(_ event: ClientEvent) {

--- a/HomeAssistant/Resources/Scenes.swift
+++ b/HomeAssistant/Resources/Scenes.swift
@@ -12,6 +12,11 @@ import UIKit
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
+  internal enum ClientEvents: StoryboardType {
+    internal static let storyboardName = "ClientEvents"
+
+    internal static let clientEventsList = SceneType<HomeAssistant.ClientEventTableViewController>(storyboard: ClientEvents.self, identifier: "clientEventsList")
+  }
   internal enum Onboarding: StoryboardType {
     internal static let storyboardName = "Onboarding"
 

--- a/HomeAssistant/Resources/Segues.swift
+++ b/HomeAssistant/Resources/Segues.swift
@@ -12,6 +12,9 @@ import UIKit
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardSegue {
+  internal enum ClientEvents: String, SegueType {
+    case showPayload
+  }
   internal enum Onboarding: String, SegueType {
     case chooseDiscoveredInstance
     case continueManually

--- a/HomeAssistant/Views/SettingsViewController.swift
+++ b/HomeAssistant/Views/SettingsViewController.swift
@@ -161,9 +161,15 @@ class SettingsViewController: FormViewController {
 
         +++ ButtonRow("eventLog") {
             $0.title = L10n.Settings.EventLog.title
-            let controllerProvider = ControllerProvider.storyBoard(storyboardId: "clientEventsList",
-                                                                   storyboardName: "ClientEvents",
-                                                                   bundle: Bundle.main)
+
+            let scene = StoryboardScene.ClientEvents.self
+
+            let controllerProvider = ControllerProvider.storyBoard(
+                storyboardId: scene.clientEventsList.identifier,
+                storyboardName: scene.storyboardName,
+                bundle: Bundle.main
+            )
+
             $0.presentationMode = .show(controllerProvider: controllerProvider, onDismiss: { vc in
                 _ = vc.navigationController?.popViewController(animated: true)
             })

--- a/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
@@ -213,7 +213,7 @@ class ZoneManagerTests: XCTestCase {
         }
 
         XCTAssertTrue(loggedEvent.type == .locationUpdate)
-        XCTAssertTrue(loggedEvent.text.contains("Failed updating"))
+        XCTAssertTrue(loggedEvent.text.contains("Didn't update"))
         XCTAssertEqual(loggedEvent.jsonPayload?["start_ssid"] as? String, "wifi_name")
         XCTAssertEqual(loggedEvent.jsonPayload?["event"] as? String, event.description)
     }

--- a/Shared/Authentication/TokenManager.swift
+++ b/Shared/Authentication/TokenManager.swift
@@ -202,9 +202,6 @@ public class TokenManager: RequestAdapter, RequestRetrier {
             throw TokenError.expired
         }
 
-        let urlText = self.loggableString(for: url)
-        let networkEvent = ClientEvent(text: urlText, type: .networkRequest)
-        Current.clientEventStore.addEvent(networkEvent)
         newRequest.setValue("Bearer \(tokenInfo.accessToken)", forHTTPHeaderField: "Authorization")
         return newRequest
     }

--- a/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -23,9 +23,14 @@ public struct ClientEventStore {
         Current.Log.info(event)
     }
 
-    public var getEvents: () -> Results<ClientEvent> = {
+    public func getEvents(filter: String? = nil) -> AnyRealmCollection<ClientEvent> {
         let realm = Current.realm()
-        return realm.objects(ClientEvent.self).sorted(byKeyPath: "date", ascending: false)
+        let objects = realm.objects(ClientEvent.self).sorted(byKeyPath: "date", ascending: false)
+        if let filter = filter, filter.isEmpty == false {
+            return AnyRealmCollection(objects.filter(NSPredicate(format: "text contains[c] %@", filter)))
+        } else {
+            return AnyRealmCollection(objects)
+        }
     }
 
     public var clearAllEvents: () -> Void = {

--- a/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -189,9 +189,6 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
         if let cachedLocation = locationManager.location {
             let potentialLocation = PotentialLocation(location: cachedLocation)
             potentialLocations.append(potentialLocation)
-
-            let message = "Cached potential one-shot location of \(potentialLocation)"
-            Current.clientEventStore.addEvent(ClientEvent(text: message, type: .locationUpdate))
         }
     }
 

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -5,7 +5,9 @@ strings:
     - templateName: structured-swift5
       output: Shared/Resources/SwiftGen/Strings.swift
 ib:
-  inputs: HomeAssistant/Resources/Base.lproj/Onboarding.storyboard
+  inputs:
+    - HomeAssistant/Resources/Base.lproj/Onboarding.storyboard
+    - HomeAssistant/ClientEvents/Resources/ClientEvents.storyboard
   outputs:
     - templateName: scenes-swift5
       output: HomeAssistant/Resources/Scenes.swift


### PR DESCRIPTION
- Stops logging the rare REST API calls that we do, aka getting the config.
- Adds a share/action button to the JSON detail screen.
- Adds some extra information to some events, removes some from others.
- Adds a search bar to the event log. Refs #395.
- (Likely) fixes a crash on iOS 14. Please verify! Refs #733.
- Switches to using SwiftGen for the storyboard interactions.

![Image 4](https://user-images.githubusercontent.com/74188/87254700-39325000-c439-11ea-82ef-0a8ce34f3f97.png)