### PR TITLE
Wrap webhook networking in background tasks

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		11CD94B724B2CC7400BA801D /* WebhookResponseLocation.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD94B624B2CC7400BA801D /* WebhookResponseLocation.test.swift */; };
 		11CD94B924B2D16F00BA801D /* WebhookResponseServiceCall.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */; };
 		11CD94BB24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */; };
+		11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
+		11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11F3D74C2495377B00C05BBA /* SensorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3D74B2495377B00C05BBA /* SensorListViewController.swift */; };
 		11F3D7512495434C00C05BBA /* SensorDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3D7502495434C00C05BBA /* SensorDetailViewController.swift */; };
 		28F97CE2A585EB2423FB7003 /* Pods_Shared_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81EFBEA503010FAE577D0269 /* Pods_Shared_watchOS.framework */; };
@@ -867,6 +869,7 @@
 		11CD94B624B2CC7400BA801D /* WebhookResponseLocation.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseLocation.test.swift; sourceTree = "<group>"; };
 		11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseServiceCall.test.swift; sourceTree = "<group>"; };
 		11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUnhandled.test.swift; sourceTree = "<group>"; };
+		11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+BackgroundTask.swift"; sourceTree = "<group>"; };
 		11F3D74B2495377B00C05BBA /* SensorListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorListViewController.swift; sourceTree = "<group>"; };
 		11F3D7502495434C00C05BBA /* SensorDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDetailViewController.swift; sourceTree = "<group>"; };
 		1C5332DAFA7CC79107B5429E /* Pods-Shared-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-iOS/Pods-Shared-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -2591,6 +2594,7 @@
 			children = (
 				D014EEA82128E192008EA6F5 /* ConnectionInfo.swift */,
 				11B7FD732493225200E60ED9 /* BackgroundTask.swift */,
+				11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -4310,6 +4314,7 @@
 				1110836924AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */,
 				B67CE8AF22200F220034C1D0 /* ObjectMapperTransformers.swift in Sources */,
 				11AF4D13249C7E08006C74C0 /* ActivitySensor.swift in Sources */,
+				11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */,
 				B67CE88822200F220034C1D0 /* Zone.swift in Sources */,
 				11AF4D1D249C8AA0006C74C0 /* BatterySensor.swift in Sources */,
 				B67CE8A922200F220034C1D0 /* SettingsStore.swift in Sources */,
@@ -4452,6 +4457,7 @@
 				B6C091442151F93D00A326DC /* Light.swift in Sources */,
 				D0BE440E210437F900C74314 /* AuthenticationRoutes.swift in Sources */,
 				B6C0914E2151F93D00A326DC /* Thermostat.swift in Sources */,
+				11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */,
 				B6B74CBD228399AB00D58A68 /* Action.swift in Sources */,
 				11CB98CA249E62E700B05222 /* Version+HA.swift in Sources */,
 				D0EEF31A214DD7A400D1D360 /* PushConfiguration.swift in Sources */,

--- a/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
+++ b/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
@@ -11,8 +11,8 @@ extension UIApplication {
         HomeAssistantBackgroundTask.execute(
             withName: name,
             beginBackgroundTask: { name, expirationHandler in
-                let identifier = self.beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
-                let remaining = self.backgroundTimeRemaining < 100 ? self.backgroundTimeRemaining : nil
+                let identifier = beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
+                let remaining = backgroundTimeRemaining < 100 ? backgroundTimeRemaining : nil
 
                 Current.Log.info {
                     if let remaining = remaining {

--- a/Shared/API/Webhook/Request&Response/WebhookManager.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookManager.swift
@@ -208,6 +208,7 @@ public class WebhookManager: NSObject {
 
     // MARK: - Sending Persistent
 
+    // swiftlint:disable:next function_body_length
     public func send(
         identifier: WebhookResponseIdentifier = .unhandled,
         request: WebhookRequest
@@ -223,7 +224,7 @@ public class WebhookManager: NSObject {
         // this is important because we may be woken up later and asked to continue the same request, even if timed out
         // since, you know, background execution and whatnot
         ProcessInfo.processInfo.backgroundTask(withName: "webhook-send") { _ in promise }.cauterize()
-        
+
         firstly {
             Self.urlRequest(for: request)
         }.done(on: dataQueue) { [currentBackgroundSessionInfo] urlRequest, data in

--- a/Shared/Networking/BackgroundTask.swift
+++ b/Shared/Networking/BackgroundTask.swift
@@ -12,7 +12,7 @@ public enum BackgroundTaskError: Error {
 public enum HomeAssistantBackgroundTask {
     public static func execute<ReturnType, IdentifierType>(
         withName name: String,
-        beginBackgroundTask: @escaping (String, @escaping () -> Void) -> (IdentifierType?, TimeInterval?),
+        beginBackgroundTask: (String, @escaping () -> Void) -> (IdentifierType?, TimeInterval?),
         endBackgroundTask: @escaping (IdentifierType) -> Void,
         wrapping: (TimeInterval?) -> Promise<ReturnType>
     ) -> Promise<ReturnType> {

--- a/Shared/Networking/ProcessInfo+BackgroundTask.swift
+++ b/Shared/Networking/ProcessInfo+BackgroundTask.swift
@@ -14,17 +14,13 @@ extension ProcessInfo {
             beginBackgroundTask: { name, expirationHandler -> (UUID?, TimeInterval?) in
                 performExpiringActivity(withReason: name) { expire in
                     if expire {
-                        Current.Log.info("expiring \(identifier) [\(name)]")
                         expirationHandler()
                     } else {
-                        Current.Log.info("start blocking \(identifier) [\(name)]")
                         semaphore.wait()
-                        Current.Log.info("end blocking \(identifier) [\(name)]")
                     }
                 }
                 return (identifier, nil)
-            }, endBackgroundTask: { identifier in
-                Current.Log.info("signaling \(identifier) [\(name)]")
+            }, endBackgroundTask: { _ in
                 semaphore.signal()
             }, wrapping: wrapping
         )

--- a/Shared/Networking/ProcessInfo+BackgroundTask.swift
+++ b/Shared/Networking/ProcessInfo+BackgroundTask.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PromiseKit
+
+extension ProcessInfo {
+    func backgroundTask<PromiseValue>(
+        withName name: String,
+        wrapping: (TimeInterval?) -> Promise<PromiseValue>
+    ) -> Promise<PromiseValue> {
+        let identifier = UUID()
+        let semaphore = DispatchSemaphore(value: 0)
+
+        return HomeAssistantBackgroundTask.execute(
+            withName: name,
+            beginBackgroundTask: { name, expirationHandler -> (UUID?, TimeInterval?) in
+                self.performExpiringActivity(withReason: name) { expire in
+                    if expire {
+                        Current.Log.info("expiring \(identifier) [\(name)]")
+                        expirationHandler()
+                    } else {
+                        Current.Log.info("start blocking \(identifier) [\(name)]")
+                        semaphore.wait()
+                        Current.Log.info("end blocking \(identifier) [\(name)]")
+                    }
+                }
+                return (identifier, nil)
+            }, endBackgroundTask: { identifier in
+                Current.Log.info("signaling \(identifier) [\(name)]")
+                semaphore.signal()
+            }, wrapping: wrapping
+        )
+    }
+}

--- a/Shared/Networking/ProcessInfo+BackgroundTask.swift
+++ b/Shared/Networking/ProcessInfo+BackgroundTask.swift
@@ -12,7 +12,7 @@ extension ProcessInfo {
         return HomeAssistantBackgroundTask.execute(
             withName: name,
             beginBackgroundTask: { name, expirationHandler -> (UUID?, TimeInterval?) in
-                self.performExpiringActivity(withReason: name) { expire in
+                performExpiringActivity(withReason: name) { expire in
                     if expire {
                         Current.Log.info("expiring \(identifier) [\(name)]")
                         expirationHandler()


### PR DESCRIPTION
I have a few theories about #777:

1. The system isn't bothering to execute the background request because we've exhausted the background allotment that it wants for us. This is [somewhat documented (descriptively)](https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background?language=objc):

> When the system resumes or relaunches your app, it uses a rate limiter to prevent abuse of background downloads. When your app starts a new download task while in the background, the task doesn't begin until the delay expires. The delay increases each time the system resumes or relaunches your app.

If this is what's happening, this fix won't do anything; the real fix will be to try to send ephemerally and drop to using a background request if that fails or times out.

I don't like this solution because it's gross! But, it'll be the next thing to try.

2. We're executing the actions but since we're allowing ourselves to be suspended right away the system doesn't consider it worth actually executing. Like, is this a heuristic maybe?

If this is the case, and I hope it is, then wrapping things in a background task will resolve this problem. It doesn't seem like this is it, but it's nice to do anyway, so let's give it a try.

----

Since this is adding a new failure mode to the register->re-integrate flow, adds another check to make sure we don't accidentally re-register when we don't need to.