### PR TITLE
Per-sensor settings; use Zones for Geocoded Location

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -589,6 +589,7 @@
 "sensors.activity.attributes.confidence" = "Confidence";
 "sensors.activity.attributes.types" = "Types";
 "sensors.geocoded_location.name" = "Geocoded Location";
+"sensors.geocoded_location.setting.use_zones" = "Use Zone Name";
 "sensors.geocoded_location.attributes.administrative_area" = "AdministrativeArea";
 "sensors.geocoded_location.attributes.areas_of_interest" = "AreasOfInterest";
 "sensors.geocoded_location.attributes.country" = "Country";
@@ -757,6 +758,8 @@ Thank you.\
 "settings_details.location.background_refresh.disabled" = "Disabled";
 "settings_details.general.restoration.title" = "Remember Last Page";
 "settings_sensors.title" = "Sensors";
+"settings_sensors.settings.header" = "Settings";
+"settings_sensors.settings.footer" = "Changes will be applied on the next update.";
 "settings_sensors.loading_error.title" = "Failed to load sensors";
 "settings_sensors.detail.unique_id" = "Unique ID";
 "settings_sensors.detail.state" = "State";

--- a/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
@@ -51,6 +51,28 @@ class SensorDetailViewController: FormViewController {
 
         form +++ baseSection
 
+        if sensor.Settings.isEmpty == false {
+            let settingsSection = Section(
+                header: L10n.SettingsSensors.Settings.header,
+                footer: L10n.SettingsSensors.Settings.footer
+            )
+
+            settingsSection.append(contentsOf: sensor.Settings.map { setting -> BaseRow in
+                switch setting.type {
+                case .switch(let getter, let setter):
+                    return SwitchRow {
+                        $0.title = setting.title
+                        $0.value = getter()
+                        $0.onChange { row in
+                            setter(row.value ?? false)
+                        }
+                    }
+                }
+            })
+
+            form.append(settingsSection)
+        }
+
         if let attributes = sensor.Attributes {
             let attributesSection = Section(header: L10n.SettingsSensors.Detail.attributes, footer: nil)
             let attributeRows = attributes

--- a/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
@@ -61,9 +61,13 @@ class SensorListViewController: FormViewController, SensorObserver {
 
         firstly {
             HomeAssistantAPI.authenticatedAPIPromise
-        }.then { api in
+        }.then { api -> Promise<Void> in
             return UIApplication.shared.backgroundTask(withName: "manual-location-update-settings") { _ in
-                return api.UpdateSensors(trigger: .Manual)
+                if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState) {
+                    return api.GetAndSendLocation(trigger: .Manual).asVoid()
+                } else {
+                    return api.UpdateSensors(trigger: .Manual).asVoid()
+                }
             }
         }.ensure { [refreshControl] in
             refreshControl.endRefreshing()

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -418,44 +418,31 @@ public class HomeAssistantAPI {
     public func storeZones(zones: [Zone]) {
         let realm = Current.realm()
 
-        let existingZoneIDs: [String] = realm.objects(RLMZone.self).map { $0.ID }
+        do {
+            try realm.write {
+                let existingIDs = Set(realm.objects(RLMZone.self).map(\.ID))
+                let incomingIDs = Set(zones.map(\.ID))
+                let deletedIDs = existingIDs.subtracting(incomingIDs)
 
-        var seenZoneIDs: [String] = []
+                for zone in zones {
+                    let updatingZone: RLMZone
 
-        for zone in zones {
-            seenZoneIDs.append(zone.ID)
-            if let existingZone = realm.object(ofType: RLMZone.self, forPrimaryKey: zone.ID) {
-                // swiftlint:disable:next force_try
-                try! realm.write {
-                    HomeAssistantAPI.updateZone(existingZone, withZoneEntity: zone)
+                    if let existing = realm.object(ofType: RLMZone.self, forPrimaryKey: zone.ID) {
+                        updatingZone = existing
+                    } else {
+                        Current.Log.verbose("creating \(zone.ID)")
+                        updatingZone = RLMZone()
+                    }
+
+                    updatingZone.update(with: zone)
+                    realm.add(updatingZone, update: .all)
                 }
-            } else {
-                // swiftlint:disable:next force_try
-                try! realm.write {
-                    realm.add(RLMZone(zone: zone), update: .all)
-                }
+
+                realm.delete(realm.objects(RLMZone.self).filter("ID in %@", deletedIDs))
             }
+        } catch {
+            Current.Log.error("failed to update zones: \(error)")
         }
-
-        // Now remove zones that aren't in HA anymore
-        let zoneIDsToDelete = existingZoneIDs.filter { zoneID -> Bool in
-            return seenZoneIDs.contains(zoneID) == false
-        }
-
-        // swiftlint:disable:next force_try
-        try! realm.write {
-            realm.delete(realm.objects(RLMZone.self).filter("ID IN %@", zoneIDsToDelete))
-        }
-    }
-
-    private static func updateZone(_ storeableZone: RLMZone, withZoneEntity zone: Zone) {
-        storeableZone.Latitude = zone.Latitude
-        storeableZone.Longitude = zone.Longitude
-        storeableZone.Radius = zone.Radius
-        storeableZone.TrackingEnabled = zone.TrackingEnabled
-        storeableZone.BeaconUUID = zone.UUID
-        storeableZone.BeaconMajor.value = zone.Major
-        storeableZone.BeaconMinor.value = zone.Minor
     }
 
     public func SubmitLocation(updateType: LocationUpdateTrigger,

--- a/Shared/API/Models/Components/Zone.swift
+++ b/Shared/API/Models/Components/Zone.swift
@@ -18,6 +18,7 @@ public class Zone: Entity {
     @objc public dynamic var TrackingEnabled = true
     @objc public dynamic var enterNotification = true
     @objc public dynamic var exitNotification = true
+    @objc public dynamic var isPassive = false
 
     // Beacons
     @objc public dynamic var UUID: String?
@@ -40,6 +41,7 @@ public class Zone: Entity {
         Minor              <- map["attributes.beacon.minor"]
         SSIDTrigger        <- map["attributes.ssid_trigger"]
         SSIDFilter         <- map["attributes.ssid_filter"]
+        isPassive          <- map["attributes.passive"]
     }
 
     public func locationCoordinates() -> CLLocationCoordinate2D {

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -10,6 +10,15 @@ import Foundation
 import ObjectMapper
 import Iconic
 
+public struct WebhookSensorSetting {
+    public enum SettingType {
+        case `switch`(getter: () -> Bool, setter: (Bool) -> Void)
+    }
+
+    public let type: SettingType
+    public let title: String
+}
+
 public class WebhookSensor: Mappable {
     public var Attributes: [String: Any]?
     public var DeviceClass: DeviceClass?
@@ -19,6 +28,8 @@ public class WebhookSensor: Mappable {
     public var `Type`: String = "sensor"
     public var UniqueID: String?
     public var UnitOfMeasurement: String?
+
+    public var Settings: [WebhookSensorSetting] = []
 
     init() {}
 

--- a/Shared/API/Webhook/Sensors/GeocoderSensor.swift
+++ b/Shared/API/Webhook/Sensors/GeocoderSensor.swift
@@ -9,7 +9,7 @@ public class GeocoderSensor: SensorProvider {
         case noLocation
     }
 
-    private enum UserDefaultsKeys: String {
+    internal enum UserDefaultsKeys: String {
         case geocodeUseZone = "geocoded_location_use_zone"
 
         var title: String {
@@ -71,8 +71,7 @@ public class GeocoderSensor: SensorProvider {
                     .filter { $0 != "" }
 
                 if let zone = insideZones.first,
-                    Current.settingsStore.prefs.bool(forKey: UserDefaultsKeys.geocodeUseZone.rawValue)
-                {
+                    Current.settingsStore.prefs.bool(forKey: UserDefaultsKeys.geocodeUseZone.rawValue) {
                     // only override if there's something to set, and only if the user wants us to do so
                     sensor.State = zone
                 }

--- a/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Shared/Common/Extensions/Realm+Initialization.swift
@@ -68,9 +68,10 @@ extension Realm {
         #endif
 
         // 5 - 2020-07-08 v2020.4
+        // 6 - 2020-07-12 v2020.4
         let config = Realm.Configuration(
             fileURL: storeURL,
-            schemaVersion: 5,
+            schemaVersion: 6,
             migrationBlock: nil,
             deleteRealmIfMigrationNeeded: false
         )

--- a/Shared/Location/RealmZone.swift
+++ b/Shared/Location/RealmZone.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ObjectMapper
 import CoreLocation
 import RealmSwift
 
@@ -22,6 +21,7 @@ public class RLMZone: Object {
     @objc public dynamic var enterNotification = true
     @objc public dynamic var exitNotification = true
     @objc public dynamic var inRegion = false
+    @objc public dynamic var isPassive = false
 
     // Beacons
     @objc public dynamic var BeaconUUID: String?
@@ -32,27 +32,12 @@ public class RLMZone: Object {
     public var SSIDTrigger = List<String>()
     public var SSIDFilter = List<String>()
 
-    public func mapping(map: Map) {
-        ID                       <- map["entity_id"]
-
-        FriendlyName             <- map["attributes.friendly_name"]
-
-        Latitude                 <- map["attributes.latitude"]
-        Longitude                <- map["attributes.longitude"]
-        Radius                   <- map["attributes.radius"]
-        TrackingEnabled          <- map["attributes.track_ios"]
-
-        BeaconUUID               <- map["attributes.beacon.uuid"]
-        BeaconMajor.value        <- map["attributes.beacon.major"]
-        BeaconMinor.value        <- map["attributes.beacon.minor"]
-
-        SSIDTrigger              <- map["attributes.ssid_trigger"]
-        SSIDFilter               <- map["attributes.ssid_filter"]
-    }
-
-    convenience init(zone: Zone) {
-        self.init()
-        self.ID = zone.ID
+    func update(with zone: Zone) {
+        if realm == nil {
+            self.ID = zone.ID
+        } else {
+            precondition(zone.ID == ID)
+        }
         self.Latitude = zone.Latitude
         self.Longitude = zone.Longitude
         self.Radius = zone.Radius
@@ -60,9 +45,13 @@ public class RLMZone: Object {
         self.BeaconUUID = zone.UUID
         self.BeaconMajor.value = zone.Major
         self.BeaconMinor.value = zone.Minor
+        self.isPassive = zone.isPassive
+
+        self.SSIDTrigger.removeAll()
         if let ssidTrigger = zone.SSIDTrigger {
             self.SSIDTrigger.append(objectsIn: ssidTrigger)
         }
+        self.SSIDFilter.removeAll()
         if let ssidFilter = zone.SSIDFilter {
             self.SSIDFilter.append(objectsIn: ssidFilter)
         }

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -874,6 +874,10 @@ internal enum L10n {
         /// TimeZone
         internal static let timeZone = L10n.tr("Localizable", "sensors.geocoded_location.attributes.time_zone")
       }
+      internal enum Setting {
+        /// Use Zone Name
+        internal static let useZones = L10n.tr("Localizable", "sensors.geocoded_location.setting.use_zones")
+      }
     }
     internal enum Pedometer {
       internal enum AverageActivePace {
@@ -1775,6 +1779,12 @@ internal enum L10n {
       internal static let off = L10n.tr("Localizable", "settings_sensors.periodic_update.off")
       /// Periodic Update
       internal static let title = L10n.tr("Localizable", "settings_sensors.periodic_update.title")
+    }
+    internal enum Settings {
+      /// Changes will be applied on the next update.
+      internal static let footer = L10n.tr("Localizable", "settings_sensors.settings.footer")
+      /// Settings
+      internal static let header = L10n.tr("Localizable", "settings_sensors.settings.header")
     }
   }
 


### PR DESCRIPTION
- Adds a method for declaring settings per-sensor
- Adds a setting to the Geocoded Location sensor to replace the state value with the best-match Zone name for that location. Fixes #347.
- Adds a `Zones` attribute to the Geocoded Location sensor which are the Zones that the location is inside of in the order of consideration of the state choice. This particular one ignores the setting.

![Image 6](https://user-images.githubusercontent.com/74188/87265310-5423b500-c477-11ea-8894-b77a252ee47f.png)