### PR TITLE
Fix battery  icon at 19%

### DIFF
--- a/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -7,7 +7,6 @@ public class BatterySensor: SensorProvider {
         self.request = request
     }
 
-    // swiftlint:disable:next function_body_length
     public func sensors() -> Promise<[WebhookSensor]> {
         var level = Current.device.batteryLevel()
         if level == -100 { // simulator fix
@@ -63,6 +62,7 @@ public class BatterySensor: SensorProvider {
         return .value([levelSensor, stateSensor])
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     static func chargingIcon(level: Int) -> String {
         switch level {
         case 100...: return "mdi:battery-charging-100"
@@ -79,6 +79,7 @@ public class BatterySensor: SensorProvider {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     static func unpluggedIcon(level: Int) -> String {
         switch level {
         case 100...: return "mdi:battery"

--- a/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -23,24 +23,10 @@ public class BatterySensor: SensorProvider {
         switch batState {
         case .charging(let level):
             state = "Charging"
-            if level >= 100 {
-                icon = "mdi:battery-charging-100"
-            } else if level > 10 {
-                let rounded = Int(round(Double(level / 20) - 0.01)) * 20
-                icon = "mdi:battery-charging-\(rounded)"
-            } else {
-                icon = "mdi:battery-outline"
-            }
+            icon = Self.chargingIcon(level: level)
         case .unplugged(let level):
             state = "Not Charging"
-            if level >= 100 {
-                icon = "mdi:battery"
-            } else if level < 10 {
-                icon = "mdi:battery-outline"
-            } else if level >= 10 {
-                let rounded = Int(round(Double(level / 10) - 0.01)) * 10
-                icon = "mdi:battery-\(rounded)"
-            }
+            icon = Self.unpluggedIcon(level: level)
         case .full:
             state = "Full"
         }
@@ -75,5 +61,37 @@ public class BatterySensor: SensorProvider {
         }
 
         return .value([levelSensor, stateSensor])
+    }
+
+    static func chargingIcon(level: Int) -> String {
+        switch level {
+        case 100...: return "mdi:battery-charging-100"
+        case 90...:  return "mdi:battery-charging-80"
+        case 80...:  return "mdi:battery-charging-80"
+        case 70...:  return "mdi:battery-charging-60"
+        case 60...:  return "mdi:battery-charging-60"
+        case 50...:  return "mdi:battery-charging-40"
+        case 40...:  return "mdi:battery-charging-40"
+        case 30...:  return "mdi:battery-charging-20"
+        case 20...:  return "mdi:battery-charging-20"
+        case 10...:  return "mdi:battery-outline"
+        default:     return "mdi:battery-outline"
+        }
+    }
+
+    static func unpluggedIcon(level: Int) -> String {
+        switch level {
+        case 100...: return "mdi:battery"
+        case 90...:  return "mdi:battery-90"
+        case 80...:  return "mdi:battery-80"
+        case 70...:  return "mdi:battery-70"
+        case 60...:  return "mdi:battery-60"
+        case 50...:  return "mdi:battery-50"
+        case 40...:  return "mdi:battery-40"
+        case 30...:  return "mdi:battery-30"
+        case 20...:  return "mdi:battery-20"
+        case 10...:  return "mdi:battery-10"
+        default:     return "mdi:battery-outline"
+        }
     }
 }

--- a/SharedTests/Sensors/BatterySensor.test.swift
+++ b/SharedTests/Sensors/BatterySensor.test.swift
@@ -33,6 +33,19 @@ class BatterySensorTests: XCTestCase {
         XCTAssertEqual(cState.State as? String, "Charging")
     }
 
+    func testBattery19() throws {
+        let (uLevel, uState, cLevel, cState) = try sensors(level: 19)
+        XCTAssertEqual(uLevel.Icon, "mdi:battery-10")
+        XCTAssertEqual(uState.Icon, "mdi:battery-10")
+        XCTAssertEqual(uLevel.State as? Int, 19)
+        XCTAssertEqual(uState.State as? String, "Not Charging")
+
+        XCTAssertEqual(cLevel.Icon, "mdi:battery-outline")
+        XCTAssertEqual(cState.Icon, "mdi:battery-outline")
+        XCTAssertEqual(cLevel.State as? Int, 19)
+        XCTAssertEqual(cState.State as? String, "Charging")
+    }
+
     func testBattery20() throws {
         let (uLevel, uState, cLevel, cState) = try sensors(level: 20)
         XCTAssertEqual(uLevel.Icon, "mdi:battery-20")


### PR DESCRIPTION
Pulls out the battery icon math into a switch statement. There's only a few buckets and I feel like this is easier to read.