### PR TITLE
Handle webhook error status, add more detailed logging

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -36,6 +36,7 @@ public class HomeAssistantAPI {
         case mobileAppComponentNotLoaded
         case webhookGone
         case mustUpgradeHomeAssistant(Version)
+        case unacceptableStatusCode(Int)
         case unknown
     }
 
@@ -673,7 +674,7 @@ extension HomeAssistantAPI.APIError: LocalizedError {
         case .mustUpgradeHomeAssistant(let current):
             return L10n.HaApi.ApiError.mustUpgradeHomeAssistant(current.description,
                                                                 HomeAssistantAPI.minimumRequiredVersion.description)
-        case .unknown:
+        case .unknown, .unacceptableStatusCode:
             return L10n.HaApi.ApiError.unknown
         }
     }

--- a/Shared/Networking/BackgroundTask.swift
+++ b/Shared/Networking/BackgroundTask.swift
@@ -40,10 +40,11 @@ public enum HomeAssistantBackgroundTask {
 
         let promise = Promise<Void> { seal in
             (identifier, remaining) = beginBackgroundTask(name) {
+                Current.Log.error("out of time for background task \(name) \(describe(identifier))")
                 seal.reject(BackgroundTaskError.outOfTime)
             }
 
-            Current.Log.info("started background task \(name) (\(describe(identifier)))")
+            Current.Log.debug("started background task \(name) (\(describe(identifier)))")
 
             finished = {
                 seal.fulfill(())
@@ -52,7 +53,7 @@ public enum HomeAssistantBackgroundTask {
             guard let endableIdentifier = identifier else { return }
 
             let endBackgroundTask = {
-                Current.Log.info("ending background task \(name) (\(describe(endableIdentifier)))")
+                Current.Log.debug("ending background task \(name) (\(describe(endableIdentifier)))")
                 endBackgroundTask(endableIdentifier)
                 identifier = nil
             }


### PR DESCRIPTION
- Handles status code 400 which we were silently treating as successful. This ties to the "invalid JSON" that we've seen in server logs but don't know what's triggering it.
- Ups the logging to match debug builds; these don't leave the device and oh boy they are more useful this way. Now that the logs don't have very small limits this shouldn't be too bad.
- Lowers the logging level for background tasks. We still are logging it to disk, but we can change that too.