### PR TITLE
Prefer monitoring closer regions over further

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		11CD94BB24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */; };
 		11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
+		11EF62DA24C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */; };
 		11F3D74C2495377B00C05BBA /* SensorListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3D74B2495377B00C05BBA /* SensorListViewController.swift */; };
 		11F3D7512495434C00C05BBA /* SensorDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3D7502495434C00C05BBA /* SensorDetailViewController.swift */; };
 		28F97CE2A585EB2423FB7003 /* Pods_Shared_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81EFBEA503010FAE577D0269 /* Pods_Shared_watchOS.framework */; };
@@ -876,6 +877,7 @@
 		11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseServiceCall.test.swift; sourceTree = "<group>"; };
 		11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUnhandled.test.swift; sourceTree = "<group>"; };
 		11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+BackgroundTask.swift"; sourceTree = "<group>"; };
+		11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerRegionFilter.test.swift; sourceTree = "<group>"; };
 		11F3D74B2495377B00C05BBA /* SensorListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorListViewController.swift; sourceTree = "<group>"; };
 		11F3D7502495434C00C05BBA /* SensorDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDetailViewController.swift; sourceTree = "<group>"; };
 		1C5332DAFA7CC79107B5429E /* Pods-Shared-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-iOS/Pods-Shared-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -1637,6 +1639,7 @@
 				11A71C8C24A593A800D9565F /* ZoneManagerCollector.test.swift */,
 				11A71C8E24A5946B00D9565F /* FakeCLLocationManager.swift */,
 				11A71C9024A598AB00D9565F /* ZoneManagerProcessor.test.swift */,
+				11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */,
 			);
 			path = ZoneManager;
 			sourceTree = "<group>";
@@ -4250,6 +4253,7 @@
 				117D8A0A24A9381F00580913 /* UIColor+CSSRGB.test.swift in Sources */,
 				11A71C9124A598AB00D9565F /* ZoneManagerProcessor.test.swift in Sources */,
 				11A71C8F24A5946B00D9565F /* FakeCLLocationManager.swift in Sources */,
+				11EF62DA24C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift in Sources */,
 				11A71C8724A5074E00D9565F /* ZoneManager.test.swift in Sources */,
 				11A71C8D24A593A800D9565F /* ZoneManagerCollector.test.swift in Sources */,
 				11A71C7324A4FC8A00D9565F /* ZoneManagerEquatableRegion.test.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		11A71C8D24A593A800D9565F /* ZoneManagerCollector.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C8C24A593A800D9565F /* ZoneManagerCollector.test.swift */; };
 		11A71C8F24A5946B00D9565F /* FakeCLLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C8E24A5946B00D9565F /* FakeCLLocationManager.swift */; };
 		11A71C9124A598AB00D9565F /* ZoneManagerProcessor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A71C9024A598AB00D9565F /* ZoneManagerProcessor.test.swift */; };
+		11ADB13E24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADB13D24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift */; };
 		11AF4D13249C7E08006C74C0 /* ActivitySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */; };
 		11AF4D14249C7E09006C74C0 /* ActivitySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */; };
 		11AF4D16249C8083006C74C0 /* With.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D15249C8082006C74C0 /* With.swift */; };
@@ -842,6 +843,7 @@
 		11A71C8C24A593A800D9565F /* ZoneManagerCollector.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerCollector.test.swift; sourceTree = "<group>"; };
 		11A71C8E24A5946B00D9565F /* FakeCLLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCLLocationManager.swift; sourceTree = "<group>"; };
 		11A71C9024A598AB00D9565F /* ZoneManagerProcessor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerProcessor.test.swift; sourceTree = "<group>"; };
+		11ADB13D24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerRegionFilter.swift; sourceTree = "<group>"; };
 		11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitySensor.swift; sourceTree = "<group>"; };
 		11AF4D15249C8082006C74C0 /* With.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = With.swift; sourceTree = "<group>"; };
 		11AF4D18249C8253006C74C0 /* PedometerSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PedometerSensor.swift; sourceTree = "<group>"; };
@@ -1621,6 +1623,7 @@
 				11A71C7024A4648000D9565F /* ZoneManagerEquatableRegion.swift */,
 				11A71C8824A5844300D9565F /* ZoneManagerCollector.swift */,
 				11A71C8A24A5848B00D9565F /* ZoneManagerProcessor.swift */,
+				11ADB13D24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift */,
 			);
 			path = ZoneManager;
 			sourceTree = "<group>";
@@ -4211,6 +4214,7 @@
 				B648AE252275918F006972AF /* Segues.swift in Sources */,
 				B6022215226DB0E500E8DBFE /* UIFontOverride.swift in Sources */,
 				B624DE181CB8369200F413CE /* DevicesMapViewController.swift in Sources */,
+				11ADB13E24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift in Sources */,
 				B657A8EA1CA646EB00121384 /* AppDelegate.swift in Sources */,
 				B6CDC096228CF5C2009355DD /* RemoteMediaPlayer.swift in Sources */,
 				B661FC88226D478300E541DD /* DiscoverInstancesViewController.swift in Sources */,

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -69,7 +69,7 @@ class ZoneManager {
         // let's be very confident that we're not going to miss out on an update due to being suspended
         UIApplication.shared.backgroundTask(withName: "zone-manager-perform-event") { _ in
             processor.perform(event: event)
-        }.get { [weak self] _ in
+        }.tap { [weak self] _ in
             // a location change means we should consider changing our monitored regions
             guard let self = self else { return }
             self.sync(zones: AnySequence(self.zones))

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -69,8 +69,9 @@ class ZoneManager {
         // let's be very confident that we're not going to miss out on an update due to being suspended
         UIApplication.shared.backgroundTask(withName: "zone-manager-perform-event") { _ in
             processor.perform(event: event)
-        }.tap { [weak self] _ in
+        }.get { [weak self] _ in
             // a location change means we should consider changing our monitored regions
+            // ^ not tap for this side effect because we don't want to do this on failure
             guard let self = self else { return }
             self.sync(zones: AnyCollection(self.zones))
         }.done {

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -9,6 +9,7 @@ class ZoneManager {
     let locationManager: CLLocationManager
     let collector: ZoneManagerCollector
     let processor: ZoneManagerProcessor
+    let regionFilter: ZoneManagerRegionFilter
     let zones: AnyRealmCollection<RLMZone>
 
     private var notificationTokens = [NotificationToken]()
@@ -16,10 +17,12 @@ class ZoneManager {
     init(
         locationManager: CLLocationManager = .init(),
         collector: ZoneManagerCollector = ZoneManagerCollectorImpl(),
-        processor: ZoneManagerProcessor = ZoneManagerProcessorImpl()
+        processor: ZoneManagerProcessor = ZoneManagerProcessorImpl(),
+        regionFilter: ZoneManagerRegionFilter = ZoneManagerRegionFilterImpl()
     ) {
         self.collector = collector
         self.processor = processor
+        self.regionFilter = regionFilter
         self.zones = AnyRealmCollection(
             Current.realm()
             .objects(RLMZone.self)
@@ -66,6 +69,10 @@ class ZoneManager {
         // let's be very confident that we're not going to miss out on an update due to being suspended
         UIApplication.shared.backgroundTask(withName: "zone-manager-perform-event") { _ in
             processor.perform(event: event)
+        }.get { [weak self] _ in
+            // a location change means we should consider changing our monitored regions
+            guard let self = self else { return }
+            self.sync(zones: AnySequence(self.zones))
         }.done {
             Current.clientEventStore.addEvent(ClientEvent(
                 text: "Updated location",
@@ -88,8 +95,7 @@ class ZoneManager {
 
     private func sync(zones: AnySequence<RLMZone>) {
         let expected = Set(
-            zones
-                .flatMap { $0.regionsForMonitoring }
+            regionFilter.regions(for: zones, lastLocation: locationManager.location)
                 .map(ZoneManagerEquatableRegion.init(region:))
         )
         let actual = Set(
@@ -131,21 +137,6 @@ class ZoneManager {
             zone: Set(zones).count
         )
 
-        if counts.beacon > 20 || counts.circular > 20 {
-            Current.logError?(ReportedError(
-                code: .exceededRegionCount,
-                regionCount: counts
-            ).asNsError())
-            Current.clientEventStore.addEvent(ClientEvent(
-                text: "Exceeded maximum monitored regions",
-                type: .locationUpdate, payload: [
-                    "beacon": counts.beacon,
-                    "circular": counts.circular,
-                    "zones": counts.zone
-                ]
-            ))
-        }
-
         Current.Log.info {
             [
                 "monitoring \(expected.count) (\(counts))",
@@ -169,25 +160,5 @@ extension ZoneManager: ZoneManagerCollectorDelegate {
 extension ZoneManager: ZoneManagerProcessorDelegate {
     func processor(_ processor: ZoneManagerProcessor, didLog state: ZoneManagerState) {
         log(state: state)
-    }
-}
-
-private struct ReportedError {
-    enum Code: Int {
-        case exceededRegionCount = 0
-    }
-
-    private static let domain = "ZoneManagerError"
-
-    let code: Code
-    // swiftlint:disable:next large_tuple
-    let regionCount: (beacon: Int, circular: Int, zone: Int)
-
-    func asNsError() -> NSError {
-        return NSError(domain: Self.domain, code: code.rawValue, userInfo: [
-            "count_beacon": regionCount.beacon,
-            "count_circular": regionCount.circular,
-            "count_zone": regionCount.zone
-        ])
     }
 }

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
@@ -3,7 +3,7 @@ import CoreLocation
 import Shared
 
 protocol ZoneManagerRegionFilter {
-    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> Set<CLRegion>
+    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> [CLRegion]
 }
 
 class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
@@ -60,7 +60,7 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
         self.limits = limits
     }
 
-    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> Set<CLRegion> {
+    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> [CLRegion] {
         var segmented = Dictionary(uniqueKeysWithValues: zones.map { ($0, $0.regionsForMonitoring) })
 
         let startRegions = segmented.values.flatMap({ $0 })
@@ -68,7 +68,7 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
 
         if startCounts < limits {
             // We're starting out with a small enough count
-            return Set(startRegions)
+            return startRegions
         }
 
         // We've exceeded the limit, so we need to start reducing.
@@ -101,7 +101,7 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
 
         logError(counts: startCounts, allZones: Array(zones), strippedZones: strippedZones)
 
-        return Set(segmented.values.flatMap { $0 })
+        return segmented.values.flatMap { $0 }
     }
 
     private func logError(counts: Counts, allZones: [RLMZone], strippedZones: [RLMZone]) {

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
@@ -1,0 +1,143 @@
+import Foundation
+import CoreLocation
+import Shared
+
+protocol ZoneManagerRegionFilter {
+    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> Set<CLRegion>
+}
+
+class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
+    struct Counts: Comparable {
+        var beacon: Int
+        var circular: Int
+
+        static func < (lhs: Counts, rhs: Counts) -> Bool {
+            lhs.beacon < rhs.beacon && lhs.circular < rhs.circular
+        }
+
+        init(beacon: Int, circular: Int) {
+            self.beacon = beacon
+            self.circular = circular
+        }
+
+        init<T: Sequence>(_ sequence: T) where T.Element == CLRegion {
+            let counts = sequence.reduce(into: (beacon: 0, circular: 0)) { counts, region in
+                if region is CLCircularRegion {
+                    counts.circular += 1
+                } else if region is CLBeaconRegion {
+                    counts.beacon += 1
+                } else {
+                    // what is it like in the future?
+                    Current.Log.error("unknown region type: \(type(of: region))")
+                }
+            }
+
+            self.beacon = counts.beacon
+            self.circular = counts.circular
+        }
+
+        func shouldReduce(option: Self, comparedTo limit: Self) -> Bool {
+            if option.beacon > 0, limit.beacon < beacon {
+                return true
+            }
+
+            if option.circular > 0, limit.circular < circular {
+                return true
+            }
+
+            return false
+        }
+
+        var eventPayload: [String: String] { [
+            "beacon": String(beacon),
+            "circular": String(circular)
+        ] }
+    }
+
+    let limits: Counts
+
+    init(limits: Counts = Counts(beacon: 20, circular: 20)) {
+        self.limits = limits
+    }
+
+    func regions(for zones: AnySequence<RLMZone>, lastLocation: CLLocation?) -> Set<CLRegion> {
+        var segmented = Dictionary(uniqueKeysWithValues: zones.map { ($0, $0.regionsForMonitoring) })
+
+        let startRegions = segmented.values.flatMap({ $0 })
+        let startCounts = Counts(startRegions)
+
+        if startCounts < limits {
+            // We're starting out with a small enough count
+            return Set(startRegions)
+        }
+
+        // We've exceeded the limit, so we need to start reducing.
+        // We aim to clip off the ones that are further away.
+        let sourceLocation = lastLocation ?? zones.first(where: \.isHome)?.location
+
+        let sorted = segmented.sorted { lhs, rhs in
+            if let sourceLocation = sourceLocation {
+                // We have a location to compare against, so do distance
+                return lhs.key.location.distance(from: sourceLocation) < rhs.key.location.distance(from: sourceLocation)
+            } else {
+                // We have neither a location nor a home zone, so just like...strip the bigger ones?
+                return lhs.key.Radius < rhs.key.Radius
+            }
+        }
+
+        // just used for logging
+        var strippedZones = [RLMZone]()
+
+        for option in sorted.reversed() {
+            let currentCount = Counts(segmented.values.flatMap { $0 })
+            let optionCount = Counts(option.value)
+
+            if currentCount.shouldReduce(option: optionCount, comparedTo: limits) {
+                // We strip off entire zones at a time if they contain any region which exceeds the count.
+                strippedZones.append(option.key)
+                segmented[option.key] = nil
+            }
+        }
+
+        logError(counts: startCounts, allZones: Array(zones), strippedZones: strippedZones)
+
+        return Set(segmented.values.flatMap { $0 })
+    }
+
+    private func logError(counts: Counts, allZones: [RLMZone], strippedZones: [RLMZone]) {
+        Current.logError?(ReportedError(
+            code: .exceededRegionCount,
+            regionCount: (beacon: counts.beacon, circular: counts.circular, zone: allZones.count)
+        ).asNsError())
+
+        Current.clientEventStore.addEvent(ClientEvent(
+            text: "Exceeded maximum monitored regions",
+            type: .locationUpdate, payload: [
+                "counts": counts.eventPayload,
+                "limits": limits.eventPayload,
+                "total_zones": allZones.count,
+                "stripped_zones": strippedZones.map { $0.ID }
+            ]
+        ))
+    }
+}
+
+private struct ReportedError {
+    enum Code: Int {
+        case exceededRegionCount = 0
+    }
+
+    private static let domain = "ZoneManagerRegionFilterError"
+
+    let code: Code
+    // swiftlint:disable:next large_tuple
+    let regionCount: (beacon: Int, circular: Int, zone: Int)
+
+    func asNsError() -> NSError {
+        return NSError(domain: Self.domain, code: code.rawValue, userInfo: [
+            "count_beacon": regionCount.beacon,
+            "count_circular": regionCount.circular,
+            "count_zone": regionCount.zone
+        ])
+    }
+}

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -198,7 +198,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     }
                     <<< LocationRow {
                         $0.title = L10n.SettingsDetails.Location.Zones.Location.title
-                        $0.value = zone.location()
+                        $0.value = zone.location
                     }
                     <<< LabelRow {
                         $0.title = L10n.SettingsDetails.Location.Zones.Radius.title

--- a/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
@@ -1,4 +1,4 @@
- import CoreLocation
+import CoreLocation
 import Foundation
 import XCTest
 import PromiseKit

--- a/HomeAssistantTests/ZoneManager/ZoneManagerRegionFilter.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerRegionFilter.test.swift
@@ -1,0 +1,169 @@
+import CoreLocation
+import Foundation
+import XCTest
+import PromiseKit
+import RealmSwift
+@testable import Shared
+@testable import HomeAssistant
+
+class ZoneManagerRegionFilterTests: XCTestCase {
+    private var filter: ZoneManagerRegionFilterImpl!
+    private var locationInStart: CLLocation!
+    private var locationNearStart: CLLocation!
+    private var beaconZones: [RLMZone]!
+    private var beaconRegions: [CLRegion]!
+    private var circularZones: [RLMZone]!
+    private var circularRegions: [CLRegion]!
+
+    override func setUp() {
+        super.setUp()
+
+        // limits are smaller for tests for stability/ease of tests - can hold 2x
+        filter = ZoneManagerRegionFilterImpl(limits: .init(beacon: 3, circular: 3))
+
+        // inside home
+        locationInStart = CLLocation(latitude: 37.766220, longitude: -122.393261)
+        // starbucks near home, 130m from zone
+        locationNearStart = CLLocation(latitude: 37.7662222, longitude: -122.3943928)
+
+        // sorted by distance
+        beaconZones = [
+            with(RLMZone()) {
+                $0.ID = "zone.b_little_skillet"
+                $0.BeaconUUID = UUID().uuidString
+                $0.Latitude = 37.7796508
+                $0.Longitude = -122.3933569
+                $0.Radius = 1
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.b_castro_theater"
+                $0.BeaconUUID = UUID().uuidString
+                $0.Latitude = 37.7622557
+                $0.Longitude = -122.4330972
+                $0.Radius = 2
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.b_nopa"
+                $0.BeaconUUID = UUID().uuidString
+                $0.Latitude = 37.7727871
+                $0.Longitude = -122.4410906
+                $0.Radius = 3
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.b_dmv"
+                $0.BeaconUUID = UUID().uuidString
+                $0.Latitude = 37.7739364
+                $0.Longitude = -122.4435184
+                $0.Radius = 4
+            }
+        ]
+
+        // sorted by distance
+        circularZones = [
+            with(RLMZone()) {
+                $0.ID = "zone.home" // dropbox
+                $0.Latitude = 37.7660435
+                $0.Longitude = -122.3952834
+                $0.Radius = 100
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.oracle_park"
+                $0.Latitude = 37.7806336
+                $0.Longitude = -122.3946727
+                $0.Radius = 140
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.philz_coffee"
+                $0.Latitude = 37.7909037
+                $0.Longitude = -122.3973968
+                $0.Radius = 101
+            },
+            with(RLMZone()) {
+                $0.ID = "zone.ferrybuilding"
+                $0.Latitude = 37.795571
+                $0.Longitude = -122.393572
+                $0.Radius = 120
+            }
+        ]
+    }
+
+    private func monitoredRegions(for zones: AnyCollection<RLMZone>) -> Set<CLRegion> {
+        Set(zones.flatMap { $0.regionsForMonitoring })
+    }
+
+    func testNoZonesProducesNoRegions() {
+        let result = filter.regions(from: AnyCollection([]), currentRegions: AnyCollection([]), lastLocation: nil)
+        XCTAssertEqual(Set(result), Set())
+    }
+
+    func testAtCountProducesSameRegardlessOfLocatio() {
+        let zones = AnyCollection(beaconZones[0..<3] + circularZones[0..<3])
+        let regions = monitoredRegions(for: zones)
+
+        let resultNoLocation = filter.regions(
+            from: zones,
+            currentRegions: AnyCollection([]),
+            lastLocation: nil
+        )
+        let resultInLocation = filter.regions(
+            from: zones,
+            currentRegions: AnyCollection([]),
+            lastLocation: locationInStart
+        )
+        let resultNearLocation = filter.regions(
+            from: zones,
+            currentRegions: AnyCollection([]),
+            lastLocation: locationNearStart
+        )
+
+        XCTAssertEqual(Set(resultNoLocation), regions)
+        XCTAssertEqual(Set(resultInLocation), regions)
+        XCTAssertEqual(Set(resultNearLocation), regions)
+    }
+
+    func testBeaconExceeds() {
+        let zones = AnyCollection(beaconZones + circularZones[0..<3])
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + circularZones[0..<3]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: locationInStart)
+        XCTAssertEqual(Set(result), regions)
+    }
+
+    func testCircularExceeds() {
+        let zones = AnyCollection(beaconZones[0..<3] + circularZones)
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + circularZones[0..<3]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: locationInStart)
+        XCTAssertEqual(Set(result), regions)
+    }
+
+    func testBothExceed() {
+        let zones = AnyCollection(beaconZones + circularZones)
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + circularZones[0..<3]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: locationInStart)
+        XCTAssertEqual(regions, Set(result))
+    }
+    
+    func testBothExceedWithoutLocation() {
+        let zones = AnyCollection(beaconZones + circularZones)
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + circularZones[0..<3]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: nil)
+        XCTAssertEqual(Set(result), regions)
+    }
+
+    func testBothExceedWithOutsideHomeLocation() {
+        let zones = AnyCollection(beaconZones + circularZones)
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + circularZones[0..<3]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: locationNearStart)
+        XCTAssertEqual(Set(result), regions)
+    }
+
+    func testBothExceedWithoutHomeAndWithoutLocation() {
+        circularZones[0].ID = "zone.not_home_lol"
+
+        let zones = AnyCollection(beaconZones + circularZones)
+        let regions = monitoredRegions(for: AnyCollection(beaconZones[0..<3] + [
+            circularZones[0], circularZones[2], circularZones[3]
+        ]))
+        let result = filter.regions(from: zones, currentRegions: AnyCollection([]), lastLocation: nil)
+        XCTAssertEqual(Set(regions.map { $0.identifier }), Set(result.map { $0.identifier }))
+    }
+}

--- a/Shared/API/Models/LocationHistory.swift
+++ b/Shared/API/Models/LocationHistory.swift
@@ -26,7 +26,7 @@ public class LocationHistoryEntry: Object {
         if let location = location {
             loc = location
         } else if let zone = zone {
-            loc = zone.location()
+            loc = zone.location
         }
 
         self.Accuracy = loc.horizontalAccuracy

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -66,7 +66,7 @@ public class WebhookUpdateLocation: Mappable {
         }
         #endif
 
-        if zone.ID == "zone.home" {
+        if zone.isHome {
             switch self.Trigger {
             case .RegionEnter, .GPSRegionEnter, .BeaconRegionEnter:
                 self.LocationName = LocationNames.Home.rawValue

--- a/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -20,7 +20,7 @@ public struct ClientEventStore {
             Current.Log.error("Error writing client event: \(error)")
         }
 
-        Current.Log.info(event)
+        Current.Log.info("\(event.type): \(event.text) \(event.jsonPayload ?? [:])")
     }
 
     public func getEvents(filter: String? = nil) -> AnyRealmCollection<ClientEvent> {

--- a/Shared/Location/RealmZone.swift
+++ b/Shared/Location/RealmZone.swift
@@ -32,6 +32,10 @@ public class RLMZone: Object {
     public var SSIDTrigger = List<String>()
     public var SSIDFilter = List<String>()
 
+    public var isHome: Bool {
+        ID == "zone.home"
+    }
+
     func update(with zone: Zone) {
         if realm == nil {
             self.ID = zone.ID
@@ -64,7 +68,7 @@ public class RLMZone: Object {
         )
     }
 
-    public func location() -> CLLocation {
+    public var location: CLLocation {
         return CLLocation(coordinate: center,
                           altitude: 0,
                           horizontalAccuracy: self.Radius,


### PR DESCRIPTION
Even without increasing the monitored regions in #785 we can still exceed the number of monitored region which causes a few fun things:

1. We try to add a new monitored region every single time we syncs zones, which produces an error from CL and bad logs
2. Depending on the order of execution, we may stop monitoring e.g. the home zone when we're next to it!

We want to focus on the monitored regions which can do the most for us, so we need to make sure we only monitor those that are most relevant.