### PR TITLE
Fix a few action editing rough edges

### DIFF
--- a/HomeAssistant/Classes/Action.swift
+++ b/HomeAssistant/Classes/Action.swift
@@ -19,7 +19,7 @@ public class Action: Object, Mappable, NSCoding {
     @objc dynamic public var BackgroundColor: String = UIColor.randomColor().hexString()
     @objc dynamic public var IconName: String = MaterialDesignIcons.allCases.randomElement()!.name
     @objc dynamic public var IconColor: String = UIColor.randomColor().hexString()
-    @objc dynamic public var Text: String = "Action"
+    @objc dynamic public var Text: String = ""
     @objc dynamic public var TextColor: String = UIColor.randomColor().hexString()
     @objc dynamic public var CreatedAt = Date()
 

--- a/HomeAssistant/Utilities/SearchPushRow.swift
+++ b/HomeAssistant/Utilities/SearchPushRow.swift
@@ -13,10 +13,16 @@ import Eureka
 // swiftlint:disable type_name line_length
 open class _SearchSelectorViewController<Row: SelectableRowType, OptionsRow: OptionsProviderRow>: SelectorViewController<OptionsRow>, UISearchResultsUpdating where Row.Cell.Value: SearchItem {
 
+    private var notificationCenterObservers: [AnyObject] = []
+
     let searchController = UISearchController(searchResultsController: nil)
 
     var originalOptions = [ListCheckRow<Row.Cell.Value>]()
     var currentOptions = [ListCheckRow<Row.Cell.Value>]()
+
+    deinit {
+        notificationCenterObservers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
 
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,19 +30,22 @@ open class _SearchSelectorViewController<Row: SelectableRowType, OptionsRow: Opt
         searchController.searchResultsUpdater = self
         searchController.dimsBackgroundDuringPresentation = false
 
-        definesPresentationContext = true
-
-        navigationItem.searchController = searchController
-    }
-
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         navigationItem.hidesSearchBarWhenScrolling = false
-    }
+        navigationItem.searchController = searchController
 
-    open override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        navigationItem.hidesSearchBarWhenScrolling = true
+        notificationCenterObservers.append(NotificationCenter.default.addObserver(
+            forName: UIApplication.keyboardWillChangeFrameNotification,
+            object: nil,
+            queue: .main
+        ) { [tableView] note in
+            guard let tableView = tableView, let screenFrameValue = note.userInfo?[UIApplication.keyboardFrameEndUserInfoKey] as? NSValue else {
+                return
+            }
+
+            let overlap = tableView.convert(screenFrameValue.cgRectValue, from: nil).intersection(tableView.bounds)
+            tableView.contentInset.bottom = overlap.height
+            tableView.scrollIndicatorInsets.bottom = overlap.height
+        })
     }
 
     public func updateSearchResults(for searchController: UISearchController) {

--- a/HomeAssistant/Utilities/SearchPushRow.swift
+++ b/HomeAssistant/Utilities/SearchPushRow.swift
@@ -38,7 +38,8 @@ open class _SearchSelectorViewController<Row: SelectableRowType, OptionsRow: Opt
             object: nil,
             queue: .main
         ) { [tableView] note in
-            guard let tableView = tableView, let screenFrameValue = note.userInfo?[UIApplication.keyboardFrameEndUserInfoKey] as? NSValue else {
+            guard let tableView = tableView,
+                let screenFrameValue = note.userInfo?[UIApplication.keyboardFrameEndUserInfoKey] as? NSValue else {
                 return
             }
 

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -69,6 +69,7 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
             +++ TextRow {
                     $0.tag = "name"
                     $0.title = L10n.ActionsConfigurator.Rows.Name.title
+                    $0.placeholder = L10n.ActionsConfigurator.Rows.Name.title
                     $0.add(rule: RuleRequired())
                     if !newAction {
                         $0.value = self.action.Name
@@ -83,6 +84,7 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
             +++ TextRow("text") {
                 $0.title = L10n.ActionsConfigurator.Rows.Text.title
                 $0.value = self.action.Text
+                $0.placeholder = L10n.ActionsConfigurator.Rows.Text.title
             }.onChange { row in
                 if let value = row.value {
                     self.action.Text = value

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -536,11 +536,10 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
         super.tableView(tableView, willBeginReorderingRowAtIndexPath: indexPath)
     }
 
-    @objc public func tableView(_ tableView: UITableView, didEndReorderingRowAtIndexPath indexPath: IndexPath) {
-        guard let rowTag = form[indexPath].tag, let row = reorderingRows[rowTag],
-            let actionsSection = row.section as? MultivaluedSection else { return }
-
-        Current.Log.verbose("Setting action \(row) to position \(indexPath.row)")
+    private func updatePositions() {
+        guard let actionsSection = form.sectionBy(tag: "actions") as? MultivaluedSection else {
+            return
+        }
 
         let rowsDict = actionsSection.allRows.enumerated().compactMap { (entry) -> (String, Int)? in
             // Current.Log.verbose("Map \(entry.element.indexPath) \(entry.element.tag)")
@@ -560,8 +559,15 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
         }
 
         try? realm.commitWrite()
+    }
 
-        reorderingRows[rowTag] = nil
+    @objc public func tableView(_ tableView: UITableView, didEndReorderingRowAtIndexPath indexPath: IndexPath) {
+        let row = form[indexPath]
+        Current.Log.verbose("Setting action \(row) to position \(indexPath.row)")
+
+        updatePositions()
+
+        reorderingRows[row.tag ?? ""] = nil
     }
 
     @objc func tableView(_ tableView: UITableView, didCancelReorderingRowAtIndexPath indexPath: IndexPath) {
@@ -604,7 +610,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
     func getActionRow(_ inputAction: Action?) -> ButtonRowWithPresent<ActionConfigurator> {
         var identifier = UUID().uuidString
         var title = L10n.ActionsConfigurator.title
-        let action = inputAction
+        var action = inputAction
 
         if let passedAction = inputAction {
             identifier = passedAction.ID
@@ -616,7 +622,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
             $0.title = title
             $0.presentationMode = .show(controllerProvider: ControllerProvider.callback {
                 return ActionConfigurator(action: action)
-            }, onDismiss: { vc in
+            }, onDismiss: { [weak self] vc in
                 _ = vc.navigationController?.popViewController(animated: true)
 
                 if let vc = vc as? ActionConfigurator {
@@ -625,6 +631,8 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                         return
                     }
 
+                    action = vc.action
+                    vc.row.tag = vc.action.ID
                     vc.row.title = vc.action.Name
                     vc.row.updateCell()
 
@@ -636,6 +644,8 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                         try realm.write {
                             realm.add(vc.action, update: .all)
                         }
+
+                        self?.updatePositions()
                     } catch let error as NSError {
                         Current.Log.error("Error while saving to Realm!: \(error)")
                     }


### PR DESCRIPTION
- Fixes keyboard overlapping icons when searching icons. Fixes #795.
- Fixes translucency of navigation bar when searching icons. Fixes #794.
- Fixes incorrect sort location (both initial and if drag/dropped before closing screen) of new actions. Fixes #796.
- Fixes initial value of text behaving like entered value instead of a placeholder. Refs half of #422.
- Fixes editing a just-created action (like #603 did for notification categories & actions).