### PR TITLE
Use the same User-Agent in Webhooks as elsewhere

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		11CD94BB24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */; };
 		11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
+		11EE9B4624C4E01500404AF8 /* SharedPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4524C4E01500404AF8 /* SharedPlist.swift */; };
+		11EE9B4724C4E01500404AF8 /* SharedPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4524C4E01500404AF8 /* SharedPlist.swift */; };
 		11EF62DA24C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */; };
 		11F3B85724C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
 		11F3B85824C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
@@ -800,6 +802,7 @@
 		11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseServiceCall.test.swift; sourceTree = "<group>"; };
 		11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUnhandled.test.swift; sourceTree = "<group>"; };
 		11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+BackgroundTask.swift"; sourceTree = "<group>"; };
+		11EE9B4524C4E01500404AF8 /* SharedPlist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedPlist.swift; sourceTree = "<group>"; };
 		11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerRegionFilter.test.swift; sourceTree = "<group>"; };
 		11F3B85524C4279700642676 /* Entity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		11F3B85624C4279700642676 /* Zone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone.swift; sourceTree = "<group>"; };
@@ -2427,6 +2430,7 @@
 		D0EEF31E214DDD9B00D1D360 /* Swiftgen */ = {
 			isa = PBXGroup;
 			children = (
+				11EE9B4524C4E01500404AF8 /* SharedPlist.swift */,
 				D0EEF31F214DE3B300D1D360 /* Strings.swift */,
 			);
 			path = Swiftgen;
@@ -4075,6 +4079,7 @@
 			files = (
 				B6A258492232539900ADD202 /* WebhookUpdateLocation.swift in Sources */,
 				11C4628324B053A800031902 /* WebhookResponseUpdateSensors.swift in Sources */,
+				11EE9B4724C4E01500404AF8 /* SharedPlist.swift in Sources */,
 				B67CE8AB22200F220034C1D0 /* TokenInfo.swift in Sources */,
 				B67CE87722200F220034C1D0 /* Strings.swift in Sources */,
 				B67CE8AE22200F220034C1D0 /* TokenManager.swift in Sources */,
@@ -4190,6 +4195,7 @@
 			files = (
 				1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */,
 				1141182A24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */,
+				11EE9B4624C4E01500404AF8 /* SharedPlist.swift in Sources */,
 				D0EEF327214DF31D00D1D360 /* Notifications.swift in Sources */,
 				1110836824AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */,
 				D0C88464211F33CE00CCB501 /* TokenManager.swift in Sources */,

--- a/HomeAssistant/Utilities/Bonjour.swift
+++ b/HomeAssistant/Utilities/Bonjour.swift
@@ -87,28 +87,23 @@ public class Bonjour {
 
     private func buildPublishDict() -> [String: Data] {
         var publishDict: [String: Data] = [:]
-        if let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") {
-            if let stringedBundleVersion = bundleVersion as? String {
-                if let data = stringedBundleVersion.data(using: .utf8) {
-                    publishDict["buildNumber"] = data
-                }
-            }
+
+        if let data = Constants.build.data(using: .utf8) {
+            publishDict["buildNumber"] = data
         }
-        if let versionNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") {
-            if let stringedVersionNumber = versionNumber as? String {
-                if let data = stringedVersionNumber.data(using: .utf8) {
-                    publishDict["versionNumber"] = data
-                }
-            }
+
+        if let data = Constants.version.data(using: .utf8) {
+            publishDict["versionNumber"] = data
         }
+
         if let permanentID = Constants.PermanentID.data(using: .utf8) {
             publishDict["permanentID"] = permanentID
         }
-        if let bundleIdentifier = Bundle.main.bundleIdentifier {
-            if let data = bundleIdentifier.data(using: .utf8) {
-                publishDict["bundleIdentifier"] = data
-            }
+
+        if let data = Constants.BundleID.data(using: .utf8) {
+            publishDict["bundleIdentifier"] = data
         }
+
         return publishDict
     }
 

--- a/HomeAssistant/Utilities/OpenInChromeController.swift
+++ b/HomeAssistant/Utilities/OpenInChromeController.swift
@@ -30,6 +30,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import UIKit
+import Shared
 
 private let googleChromeHTTPScheme: String = "googlechrome:"
 private let googleChromeHTTPSScheme: String = "googlechromes:"

--- a/HomeAssistant/Utilities/Utils.swift
+++ b/HomeAssistant/Utilities/Utils.swift
@@ -71,15 +71,8 @@ func showAlert(title: String, message: String) {
 }
 
 func setDefaults() {
-    if let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion"),
-        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString"),
-        let stringedShortVersion = shortVersion as? String,
-        let stringedBundleVersion = bundleVersion as? String {
-        let combined = "\(stringedShortVersion) (\(stringedBundleVersion))"
-        prefs.set(stringedBundleVersion, forKey: "lastInstalledBundleVersion")
-        prefs.set(stringedShortVersion, forKey: "lastInstalledShortVersion")
-        prefs.set(combined, forKey: "lastInstalledVersion")
-    }
+    prefs.set(Constants.build, forKey: "lastInstalledBundleVersion")
+    prefs.set(Constants.version, forKey: "lastInstalledShortVersion")
 
     if prefs.object(forKey: "openInBrowser") == nil {
         if prefs.bool(forKey: "openInChrome") {

--- a/HomeAssistant/Views/AboutViewController.swift
+++ b/HomeAssistant/Views/AboutViewController.swift
@@ -45,7 +45,7 @@ class AboutViewController: FormViewController {
                                                                                   bundle: nil))
                 logoHeader.onSetupView = { view, _ in
                     view.AppTitle.text = L10n.About.Logo.appTitle
-                    view.Version.text = prefs.string(forKey: "lastInstalledVersion")
+                    view.Version.text = HomeAssistantAPI.clientVersionDescription
                     view.Tagline.text = L10n.About.Logo.tagline
                     view.addGestureRecognizer(UITapGestureRecognizer(target: self,
                                                                      action: #selector(self.tapAbout(_:))))

--- a/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
+++ b/HomeAssistant/Views/Onboarding/AuthenticationViewController.swift
@@ -142,7 +142,7 @@ class AuthenticationViewController: UIViewController {
     private func testConnection(_ baseURL: URL) -> Promise<DiscoveredHomeAssistant> {
         let discoveryURL = baseURL.appendingPathComponent("api/discovery_info")
         return Promise { seal in
-            let sessionManager = Alamofire.SessionManager.default
+            let sessionManager = HomeAssistantAPI.unauthenticatedManager
             let delegate: Alamofire.SessionDelegate = sessionManager.delegate
             delegate.taskDidReceiveChallengeWithCompletion = { session, task, challenge, completion in
                 let method = challenge.protectionSpace.authenticationMethod

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -149,7 +149,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }
 
         config.userContentController = userContentController
-        config.applicationNameForUserAgent = SessionManager.defaultHTTPHeaders["User-Agent"]
+        config.applicationNameForUserAgent = HomeAssistantAPI.userAgent
 
         self.webView = WKWebView(frame: self.view!.frame, configuration: config)
         self.webView.isOpaque = false

--- a/Shared/Common/Structs/Constants.swift
+++ b/Shared/Common/Structs/Constants.swift
@@ -102,4 +102,12 @@ public struct Constants {
 
         return newID
     }
+
+    static public var build: String {
+        SharedPlistFiles.Info.cfBundleVersion
+    }
+
+    static public var version: String {
+        SharedPlistFiles.Info.cfBundleShortVersionString
+    }
 }

--- a/Shared/Resources/Swiftgen/SharedPlist.swift
+++ b/Shared/Resources/Swiftgen/SharedPlist.swift
@@ -1,0 +1,65 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum SharedPlistFiles {
+  internal enum Info {
+    private static let _document = PlistDocument(path: "Info.plist")
+    internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
+    internal static let cfBundleExecutable: String = _document["CFBundleExecutable"]
+    internal static let cfBundleIdentifier: String = _document["CFBundleIdentifier"]
+    internal static let cfBundleInfoDictionaryVersion: String = _document["CFBundleInfoDictionaryVersion"]
+    internal static let cfBundleName: String = _document["CFBundleName"]
+    internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
+    internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+    internal static let cfBundleVersion: String = _document["CFBundleVersion"]
+    internal static let nsPrincipalClass: String = _document["NSPrincipalClass"]
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  let bundle = BundleToken.bundle
+  guard let url = bundle.url(forResource: path, withExtension: nil),
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    let bundle = BundleToken.bundle
+    guard let url = bundle.url(forResource: path, withExtension: nil),
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -23,3 +23,12 @@ colors:
   outputs:
     templateName: swift5
     output: HomeAssistant/Resources/Colors.swift
+plist:
+  inputs:
+  - Shared/Info.plist
+  outputs:
+  - templateName: runtime-swift5
+    output: Shared/Resources/SwiftGen/SharedPlist.swift
+    params: 
+      enumName: SharedPlistFiles
+      forceFileNameEnum: true


### PR DESCRIPTION
- Uses SwiftGen to generate Shared Info.plist dictionary accessors, wraps them in Constants and uses them for version/build numbers.
- Generates and uses a User-Agent string in the API class and uses that within Webhooks, uses the same everywhere else.
- Avoids issuing a REST API call for config every time we load it from webhooks, since creating the Promise also issues the network request.
- Combines the Ephemeral and Non-Background sessions in WebhookManager; they're the same now, no reason to keep 'em separate.

Fixes #806.