### PR TITLE
Clean up old database entries on disk on startup

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11EE9B4624C4E01500404AF8 /* SharedPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4524C4E01500404AF8 /* SharedPlist.swift */; };
 		11EE9B4724C4E01500404AF8 /* SharedPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4524C4E01500404AF8 /* SharedPlist.swift */; };
+		11EE9B4924C5116F00404AF8 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4824C5116F00404AF8 /* ModelManager.swift */; };
+		11EE9B4A24C5116F00404AF8 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4824C5116F00404AF8 /* ModelManager.swift */; };
+		11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */; };
 		11EF62DA24C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */; };
 		11F3B85724C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
 		11F3B85824C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
@@ -803,6 +806,8 @@
 		11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUnhandled.test.swift; sourceTree = "<group>"; };
 		11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+BackgroundTask.swift"; sourceTree = "<group>"; };
 		11EE9B4524C4E01500404AF8 /* SharedPlist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedPlist.swift; sourceTree = "<group>"; };
+		11EE9B4824C5116F00404AF8 /* ModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.swift; sourceTree = "<group>"; };
+		11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.test.swift; sourceTree = "<group>"; };
 		11EF62D924C3687D00BABB64 /* ZoneManagerRegionFilter.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerRegionFilter.test.swift; sourceTree = "<group>"; };
 		11F3B85524C4279700642676 /* Entity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		11F3B85624C4279700642676 /* Zone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone.swift; sourceTree = "<group>"; };
@@ -2309,6 +2314,7 @@
 				11CB98CC249E637300B05222 /* Version+HA.test.swift */,
 				11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */,
 				11883CC624C131EE0036A6C6 /* RealmZone.test.swift */,
+				11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -2359,6 +2365,7 @@
 				B62CD2A4225B099C008DF3C5 /* WebhookSensor.swift */,
 				11F3B85524C4279700642676 /* Entity.swift */,
 				11F3B85624C4279700642676 /* Zone.swift */,
+				11EE9B4824C5116F00404AF8 /* ModelManager.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4103,6 +4110,7 @@
 				11AF4D1D249C8AA0006C74C0 /* BatterySensor.swift in Sources */,
 				B67CE8A922200F220034C1D0 /* SettingsStore.swift in Sources */,
 				11AF4D26249D1931006C74C0 /* LastUpdateSensor.swift in Sources */,
+				11EE9B4A24C5116F00404AF8 /* ModelManager.swift in Sources */,
 				B67CE8B622200F220034C1D0 /* UIColor+HA.swift in Sources */,
 				B67CE89722200F220034C1D0 /* PushRegistrationResponse.swift in Sources */,
 				B67CE8B522200F220034C1D0 /* String+HA.swift in Sources */,
@@ -4219,6 +4227,7 @@
 				11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */,
 				B6B74CBD228399AB00D58A68 /* Action.swift in Sources */,
 				11CB98CA249E62E700B05222 /* Version+HA.swift in Sources */,
+				11EE9B4924C5116F00404AF8 /* ModelManager.swift in Sources */,
 				D0EEF31A214DD7A400D1D360 /* PushConfiguration.swift in Sources */,
 				D0C3DC142134CD4E000C9EE1 /* CMMotion+StringExtensions.swift in Sources */,
 				D0EEF31B214DD7A400D1D360 /* Services.swift in Sources */,
@@ -4286,6 +4295,7 @@
 				1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */,
 				119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */,
 				11CD94B724B2CC7400BA801D /* WebhookResponseLocation.test.swift in Sources */,
+				11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */,
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
 				11CB98CD249E637300B05222 /* Version+HA.test.swift in Sources */,

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -112,6 +112,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.finished_launching", eventData: [:])
         connectAPI(reason: .cold)
 
+        ModelManager.cleanup().cauterize()
+
         return true
     }
 

--- a/Shared/API/Models/ModelManager.swift
+++ b/Shared/API/Models/ModelManager.swift
@@ -1,0 +1,79 @@
+import Foundation
+import RealmSwift
+import PromiseKit
+
+public final class ModelManager {
+    public struct CleanupDefinition {
+        var model: Object.Type
+        var createdKey: String
+        var duration: Measurement<UnitDuration>
+
+        public init(
+            model: Object.Type,
+            createdKey: String,
+            duration: Measurement<UnitDuration> = .init(value: 256, unit: .hours)
+        ) {
+            self.model = model
+            self.createdKey = createdKey
+            self.duration = duration
+        }
+
+        public static var defaults: [Self] = [
+            CleanupDefinition(
+                model: LocationHistoryEntry.self,
+                createdKey: #keyPath(LocationHistoryEntry.CreatedAt)
+            ),
+            CleanupDefinition(
+                model: LocationError.self,
+                createdKey: #keyPath(LocationError.CreatedAt)
+            ),
+            CleanupDefinition(
+                model: ClientEvent.self,
+                createdKey: #keyPath(ClientEvent.date)
+            )
+        ]
+    }
+
+    public static func cleanup(
+        definitions: [CleanupDefinition] = CleanupDefinition.defaults,
+        on queue: DispatchQueue = .global(qos: .utility)
+    ) -> Promise<Void> {
+        let (promise, seal) = Promise<Void>.pending()
+
+        queue.async {
+            do {
+                for definition in definitions {
+                    try autoreleasepool {
+                        let realm = Current.realm()
+                        try realm.write {
+                            cleanup(using: definition, realm: realm)
+                        }
+                    }
+                }
+
+                seal.fulfill(())
+            } catch {
+                Current.Log.error("failed to remove: \(error)")
+                seal.reject(error)
+            }
+        }
+
+        return promise
+    }
+
+    private static func cleanup(
+        using definition: CleanupDefinition,
+        realm: Realm
+    ) {
+        let duration = definition.duration.converted(to: .seconds).value
+        let date = Current.date().addingTimeInterval(-duration)
+        let objects = realm
+            .objects(definition.model)
+            .filter("%K < %@", definition.createdKey, date)
+
+        if objects.isEmpty == false {
+            Current.Log.info("\(definition.model): \(objects.count)")
+            realm.delete(objects)
+        }
+    }
+}

--- a/SharedTests/ModelManager.test.swift
+++ b/SharedTests/ModelManager.test.swift
@@ -1,0 +1,185 @@
+import Foundation
+@testable import Shared
+import RealmSwift
+import XCTest
+import PromiseKit
+
+// swiftlint:disable function_body_length
+
+class ModelManagerTests: XCTestCase {
+    var realm: Realm!
+    var testQueue: DispatchQueue!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        testQueue = DispatchQueue(label: #file)
+
+        let executionIdentifier = UUID().uuidString
+        try testQueue.sync {
+            realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier), queue: testQueue)
+            Current.realm = { self.realm }
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        Current.realm = Realm.live
+    }
+
+    func testCleanupWithoutItems() {
+        let promise = ModelManager.cleanup(definitions: [])
+        XCTAssertNoThrow(try hang(promise))
+    }
+
+    func testNoneToCleanUp() throws {
+        let now = Date()
+        Current.date = { now }
+
+        let models = [
+            TestDeleteModel1(now.addingTimeInterval(-1)),
+            TestDeleteModel1(now.addingTimeInterval(-2)),
+            TestDeleteModel1(now.addingTimeInterval(-3))
+        ]
+
+        try testQueue.sync {
+            try realm.write {
+                realm.add(models)
+            }
+        }
+
+        XCTAssertTrue(models.allSatisfy { $0.realm != nil })
+
+        let promise = ModelManager.cleanup(
+            definitions: [
+                .init(
+                    model: TestDeleteModel1.self,
+                    createdKey: #keyPath(TestDeleteModel1.createdAt),
+                    duration: .init(value: 100, unit: .seconds)
+                )
+            ],
+            on: testQueue
+        )
+
+        XCTAssertNoThrow(try hang(promise))
+        XCTAssertTrue(models.allSatisfy { !$0.isInvalidated })
+    }
+
+    func testCleanupRemovesOnlyOlder() throws {
+        let now = Date()
+
+        let deletedTimeInterval1: TimeInterval = 100
+        let deletedTimeInterval2: TimeInterval = 1000
+
+        let deletedLimit1 = Date(timeIntervalSinceNow: -deletedTimeInterval1)
+        let deletedLimit2 = Date(timeIntervalSinceNow: -deletedTimeInterval2)
+
+        Current.date = { now }
+
+        let (expectedExpired, expectedAlive) = try testQueue.sync { () -> (expired: [Object], alive: [Object]) in
+            let expired = [
+                TestDeleteModel1(deletedLimit1.addingTimeInterval(-1)),
+                TestDeleteModel1(deletedLimit1.addingTimeInterval(-100)),
+                TestDeleteModel1(deletedLimit1.addingTimeInterval(-1000)),
+                TestDeleteModel2(deletedLimit2.addingTimeInterval(-1)),
+                TestDeleteModel2(deletedLimit2.addingTimeInterval(-100)),
+                TestDeleteModel2(deletedLimit2.addingTimeInterval(-1000))
+            ]
+
+            let alive = [
+                // shouldn't be deleted due to time
+                TestDeleteModel1(deletedLimit1),
+                TestDeleteModel1(deletedLimit1.addingTimeInterval(10)),
+                TestDeleteModel1(deletedLimit1.addingTimeInterval(100)),
+                TestDeleteModel2(deletedLimit2),
+                TestDeleteModel2(deletedLimit2.addingTimeInterval(10)),
+                TestDeleteModel2(deletedLimit2.addingTimeInterval(100)),
+                // shouldn't be deleted due to not being requested
+                TestDeleteModel3(now.addingTimeInterval(-10000))
+            ]
+
+            try realm.write {
+                realm.add(expired)
+                realm.add(alive)
+            }
+
+            return (expired, alive)
+        }
+
+        XCTAssertTrue(expectedExpired.allSatisfy { $0.realm != nil })
+        XCTAssertTrue(expectedAlive.allSatisfy { $0.realm != nil })
+
+        let promise = ModelManager.cleanup(
+            definitions: [
+                .init(
+                    model: TestDeleteModel1.self,
+                    createdKey: #keyPath(TestDeleteModel1.createdAt),
+                    duration: .init(value: deletedTimeInterval1, unit: .seconds)
+                ),
+                .init(
+                    model: TestDeleteModel2.self,
+                    createdKey: #keyPath(TestDeleteModel2.createdAt),
+                    duration: .init(value: deletedTimeInterval2, unit: .seconds)
+                )
+            ],
+            on: testQueue
+        )
+
+        XCTAssertNoThrow(try hang(promise))
+        XCTAssertTrue(expectedExpired.allSatisfy { $0.isInvalidated })
+        XCTAssertTrue(expectedAlive.allSatisfy { !$0.isInvalidated })
+    }
+}
+
+class TestDeleteModel1: Object {
+    @objc dynamic var identifier: String = UUID().uuidString
+    @objc dynamic var createdAt: Date
+
+    init(_ createdAt: Date) {
+        self.createdAt = createdAt
+    }
+
+    required init() {
+        self.createdAt = Date()
+    }
+
+    override class func primaryKey() -> String? {
+        return #keyPath(TestDeleteModel1.identifier)
+    }
+}
+
+class TestDeleteModel2: Object {
+    @objc dynamic var identifier: String = UUID().uuidString
+    @objc dynamic var createdAt: Date
+
+    init(_ createdAt: Date) {
+        self.createdAt = createdAt
+    }
+
+    required init() {
+        self.createdAt = Date()
+    }
+
+    override class func primaryKey() -> String? {
+        return #keyPath(TestDeleteModel2.identifier)
+    }
+}
+
+
+class TestDeleteModel3: Object {
+    @objc dynamic var identifier: String = UUID().uuidString
+    @objc dynamic var createdAt: Date
+
+    init(_ createdAt: Date) {
+        self.createdAt = createdAt
+    }
+
+    required init() {
+        self.createdAt = Date()
+    }
+
+    override class func primaryKey() -> String? {
+        return #keyPath(TestDeleteModel3.identifier)
+    }
+}

--- a/SharedTests/ModelManager.test.swift
+++ b/SharedTests/ModelManager.test.swift
@@ -166,7 +166,6 @@ class TestDeleteModel2: Object {
     }
 }
 
-
 class TestDeleteModel3: Object {
     @objc dynamic var identifier: String = UUID().uuidString
     @objc dynamic var createdAt: Date


### PR DESCRIPTION
Removes old location sucess/failure and other client event logs after a not-so-cautiously-decided 256 hours (~10 days).

Refs #797 but does nothing to address whatever mysterious disk usage creep is happening there.