### PR TITLE
Handle deleting and reinstalling the app better

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -441,11 +441,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
-        if prefs.object(forKey: "onboarding_complete_newconninfo") == nil {
-            Current.Log.info("requiring onboarding due to onboarding not being finished")
-            return true
-        }
-
         return false
     }
 
@@ -767,8 +762,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         guard let webhookID = prefs.string(forKey: "webhookID") else {
             fatalError("Required fastlane argument 'webhookID' not provided or invalid!")
         }
-
-        prefs.set(true, forKey: "onboarding_complete_newconninfo")
 
         let connectionInfo = ConnectionInfo(externalURL: url, internalURL: nil, cloudhookURL: nil, remoteUIURL: nil,
                                             webhookID: webhookID,

--- a/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
+++ b/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
@@ -60,7 +60,6 @@ class ConnectInstanceViewController: UIViewController {
             self.overallProgress.loopMode = .playOnce
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
-                UserDefaults(suiteName: Constants.AppGroupID)?.set(true, forKey: "onboarding_complete_newconninfo")
                 Current.onboardingComplete?()
                 if let navVC = self.navigationController as? OnboardingNavigationViewController {
                     Current.Log.verbose("Dismissing from permissions")


### PR DESCRIPTION
When the app is deleted, but the keychain values (webhook, auth token) persist, our state looks like:

1. The API, WebhookManager, etc., are all alive and well, talking to the server.
1. The UI shows the onboarding flow.

This is because we control whether onboarding should be displayed based on a UserDefaults entry for whether they've finished it, which is less likely than the keychain to persist across installs. What happens next is:

1. A webhook update is sent, since we're launching
1. If the webhook already existed, it's updated. If it did not, using the auth token that is still around, we re-register and create a new integration.
1. The user finishes onboarding, which creates a _new_ auth token, and registers a new integration.

If the integration that was still around in the keychain was for the same `identifierForVendor` (what we send for `device_id`) this doesn't do anything surprising - it just updates the sensors and registration.

If the integration that was still around, however, is for a different (or none) `device_id` this will create a new integration. Giving us a total of 2 integrations for 1 install.

Fixes #819 by using the keychain values we discover on startup to decide if we're done with onboarding.

I tested 2 scenarios:

1. The keychain values are valid, in which case the app comes back alive and works normally, albeit with most settings reset.

This is fine now because all of the onboarding-related settings are now available in-app; before that was the case, skipping onboarding was potentially bad for location, etc., permission.

2. The keychain values are invalid. When this happens we show the normal app UI until the server rejects our credentials, so it behaves much like auth tokens being revoked on startup.