### PR TITLE
Allow "redundant" zone events to trigger location updates

### DIFF
--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerIgnoreReason.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerIgnoreReason.swift
@@ -7,7 +7,6 @@ enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
     case unknownRegionState
     case unknownRegion
     case zoneDisabled
-    case zoneStateAgrees
     case ignoredSSID(String)
     case zoneUpdateFailed(NSError) // NSError so Equatable for laziness
     case beaconExitIgnored
@@ -26,8 +25,6 @@ enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
             return "unknown region id"
         case .zoneDisabled:
             return "zone has tracking disabled"
-        case .zoneStateAgrees:
-            return "zone already in state"
         case .ignoredSSID(let ssid):
             return "ignored due to ssid \(ssid)"
         case .zoneUpdateFailed(let error):

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
@@ -112,14 +112,9 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
             return ignore(.ignoredSSID(current))
         }
 
-        let inRegion = state == .inside
-        guard zone.inRegion != inRegion else {
-            return ignore(.zoneStateAgrees)
-        }
-
         do {
             try zone.realm?.reentrantWrite {
-                zone.inRegion = inRegion
+                zone.inRegion = state == .inside
             }
         } catch {
             return ignore(.zoneUpdateFailed(error as NSError))


### PR DESCRIPTION
This is only an issue for zones <100m, and is a logic issue following adding additional monitored regions for smaller zones. Since we are now giving 3 regions to smaller zones, we can't expect a direct "inside region = inside zone" relationship; you can be in 1 of the regions and outside the others but still be in the zone.

What this means is that a user can enter one of the wrapping regions, have their location (albeit outside the zone) updated from there and then when they enter one of the overlapping regions the app chooses not to update the location since it believes they are already inside the zone.

This fixes the issue by not caring if the user is in a zone or not when deciding whether to update location.