### PR TITLE
Allow customizing Scene Actions

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -471,7 +471,7 @@
 "settings_details.actions.footer" = "Actions are used in the Apple Watch app, App Icon Actions and the Today widget";
 "settings_details.actions.title" = "Actions";
 "settings_details.actions.scenes.title" = "Scene Actions";
-"settings_details.actions.scenes.footer" = "When enabled, Scenes display alongside actions. When activated, they trigger scene changes.";
+"settings_details.actions.scenes.footer" = "When enabled, Scenes display alongside actions. When performed, they trigger scene changes.";
 "settings_details.actions.scenes.customize_action" = "Customize";
 "settings_details.actions.scenes.empty" = "No Scenes";
 "settings_details.general.app_icon.enum.beta" = "Beta";

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -472,6 +472,7 @@
 "settings_details.actions.title" = "Actions";
 "settings_details.actions.scenes.title" = "Scene Actions";
 "settings_details.actions.scenes.footer" = "When enabled, Scenes display alongside actions. When activated, they trigger scene changes.";
+"settings_details.actions.scenes.customize_action" = "Customize";
 "settings_details.actions.scenes.empty" = "No Scenes";
 "settings_details.general.app_icon.enum.beta" = "Beta";
 "settings_details.general.app_icon.enum.black" = "Black";

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -76,6 +76,9 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
             if !newAction {
                 $0.value = self.action.Name
             }
+            if action.triggerType == .scene {
+                $0.disabled = true
+            }
         }.onChange { row in
             if let value = row.value {
                 self.action.Name = value
@@ -90,110 +93,121 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
             }
         }
 
-            form +++ TextRow("text") {
-                $0.title = L10n.ActionsConfigurator.Rows.Text.title
-                $0.value = self.action.Text
-                $0.placeholder = L10n.ActionsConfigurator.Rows.Text.title
-            }.onChange { row in
-                if let value = row.value {
-                    self.action.Text = value
-                    self.updatePreviews()
-                }
+        form +++ TextRow("text") {
+            $0.title = L10n.ActionsConfigurator.Rows.Text.title
+            $0.value = self.action.Text
+            $0.placeholder = L10n.ActionsConfigurator.Rows.Text.title
+            $0.add(rule: RuleRequired())
+            if action.triggerType == .scene {
+                $0.hidden = true
             }
-
-            <<< InlineColorPickerRow("text_color") {
-                    $0.title = L10n.ActionsConfigurator.Rows.TextColor.title
-                    $0.isCircular = true
-                    $0.showsPaletteNames = true
-                    $0.value = UIColor(hex: self.action.TextColor)
-            }.onChange { row in
-                if let value = row.value {
-                    self.action.TextColor = value.hexString()
-                    self.updatePreviews()
-                }
+        }.onChange { row in
+            if let value = row.value {
+                self.action.Text = value
+                self.updatePreviews()
             }
+        }
 
-            <<< InlineColorPickerRow("background_color") {
-                $0.title = L10n.ActionsConfigurator.Rows.BackgroundColor.title
+        <<< InlineColorPickerRow("text_color") {
+                $0.title = L10n.ActionsConfigurator.Rows.TextColor.title
                 $0.isCircular = true
                 $0.showsPaletteNames = true
-                $0.value = UIColor(hex: self.action.BackgroundColor)
-                }.onChange { row in
-                    if let value = row.value {
-                        self.action.BackgroundColor = value.hexString()
-                        self.updatePreviews()
-                    }
-            }
-
-            <<< SearchPushRow<String> {
-                    $0.options = MaterialDesignIcons.allCases.map({ $0.name })
-                    $0.selectorTitle = L10n.ActionsConfigurator.Rows.Icon.title
-                    $0.tag = "icon"
-                    $0.title = L10n.ActionsConfigurator.Rows.Icon.title
-                    $0.value = self.action.IconName
-                }.cellUpdate({ (cell, row) in
-                    if let value = row.value {
-                        let theIcon = MaterialDesignIcons(named: value)
-                        if let iconColorRow = self.form.rowBy(tag: "icon_color") as? InlineColorPickerRow {
-                            cell.imageView?.image = theIcon.image(ofSize: CGSize(width: CGFloat(30),
-                                                                                 height: CGFloat(30)),
-                                                                  color: iconColorRow.value)
-                        }
-                    }
-                }).onPresent { _, to in
-                    to.selectableRowCellSetup = {cell, row in
-                        if let value = row.selectableValue {
-                            let theIcon = MaterialDesignIcons(named: value)
-                            cell.imageView?.image = theIcon.image(ofSize: CGSize(width: CGFloat(30),
-                                                                                 height: CGFloat(30)),
-                                                                  color: .systemGray)
-                        }
-                    }
-                    to.selectableRowCellUpdate = { cell, row in
-                        cell.textLabel?.text = row.selectableValue!
-                    }
-                }.onChange { row in
-                    if let value = row.value {
-                        self.action.IconName = value
-                        self.updatePreviews()
-                    }
-            }
-
-            <<< InlineColorPickerRow("icon_color") {
-                    $0.title = L10n.ActionsConfigurator.Rows.IconColor.title
-                    $0.isCircular = true
-                    $0.showsPaletteNames = true
-                    $0.value = UIColor.green
-                    $0.value = UIColor(hex: self.action.IconColor)
-                }.onChange { (picker) in
-                    Current.Log.verbose("icon color: \(picker.value!.hexString(false))")
-
-                    self.action.IconColor = picker.value!.hexString()
-
-                    self.updatePreviews()
-                    if let iconRow = self.form.rowBy(tag: "icon") as? PushRow<String> {
-                        if let value = iconRow.value {
-                            let theIcon = MaterialDesignIcons(named: value)
-                            iconRow.cell.imageView?.image = theIcon.image(ofSize: CGSize(width: CGFloat(30),
-                                                                                         height: CGFloat(30)),
-                                                                          color: picker.value)
-                        }
-                    }
-            }
-
-            +++ ViewRow<ActionPreview>("preview").cellSetup { (cell, _) in
-                cell.backgroundColor = UIColor.clear
-                cell.preservesSuperviewLayoutMargins = false
+                $0.value = UIColor(hex: self.action.TextColor)
+        }.onChange { row in
+            if let value = row.value {
+                self.action.TextColor = value.hexString()
                 self.updatePreviews()
-                cell.view = self.preview
             }
+        }
 
-            +++ YamlSection(
-                tag: "exampleTrigger",
-                header: L10n.ActionsConfigurator.TriggerExample.title,
-                yamlGetter: { [action] in action.exampleTrigger },
-                present: { [weak self] controller in self?.present(controller, animated: true, completion: nil) }
-            )
+        <<< InlineColorPickerRow("background_color") {
+            $0.title = L10n.ActionsConfigurator.Rows.BackgroundColor.title
+            $0.isCircular = true
+            $0.showsPaletteNames = true
+            $0.value = UIColor(hex: self.action.BackgroundColor)
+            }.onChange { row in
+                if let value = row.value {
+                    self.action.BackgroundColor = value.hexString()
+                    self.updatePreviews()
+                }
+        }
+
+        <<< SearchPushRow<String> {
+            $0.options = MaterialDesignIcons.allCases.map({ $0.name })
+            $0.selectorTitle = L10n.ActionsConfigurator.Rows.Icon.title
+            $0.tag = "icon"
+            $0.title = L10n.ActionsConfigurator.Rows.Icon.title
+            $0.value = self.action.IconName
+
+            if action.triggerType == .scene {
+                $0.hidden = true
+            }
+        }.cellUpdate({ (cell, row) in
+            if let value = row.value {
+                let theIcon = MaterialDesignIcons(named: value)
+                if let iconColorRow = self.form.rowBy(tag: "icon_color") as? InlineColorPickerRow {
+                    cell.imageView?.image = theIcon.image(
+                        ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
+                        color: iconColorRow.value
+                    )
+                }
+            }
+        }).onPresent { _, to in
+            to.selectableRowCellSetup = {cell, row in
+                if let value = row.selectableValue {
+                    let theIcon = MaterialDesignIcons(named: value)
+                    cell.imageView?.image = theIcon.image(
+                        ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
+                        color: .systemGray
+                    )
+                }
+            }
+            to.selectableRowCellUpdate = { cell, row in
+                cell.textLabel?.text = row.selectableValue!
+            }
+        }.onChange { row in
+            if let value = row.value {
+                self.action.IconName = value
+                self.updatePreviews()
+            }
+        }
+
+        <<< InlineColorPickerRow("icon_color") {
+            $0.title = L10n.ActionsConfigurator.Rows.IconColor.title
+            $0.isCircular = true
+            $0.showsPaletteNames = true
+            $0.value = UIColor.green
+            $0.value = UIColor(hex: self.action.IconColor)
+        }.onChange { (picker) in
+            Current.Log.verbose("icon color: \(picker.value!.hexString(false))")
+
+            self.action.IconColor = picker.value!.hexString()
+
+            self.updatePreviews()
+            if let iconRow = self.form.rowBy(tag: "icon") as? PushRow<String> {
+                if let value = iconRow.value {
+                    let theIcon = MaterialDesignIcons(named: value)
+                    iconRow.cell.imageView?.image = theIcon.image(
+                        ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
+                        color: picker.value
+                    )
+                }
+            }
+        }
+
+        +++ ViewRow<ActionPreview>("preview").cellSetup { (cell, _) in
+            cell.backgroundColor = UIColor.clear
+            cell.preservesSuperviewLayoutMargins = false
+            self.updatePreviews()
+            cell.view = self.preview
+        }
+
+        +++ YamlSection(
+            tag: "exampleTrigger",
+            header: L10n.ActionsConfigurator.TriggerExample.title,
+            yamlGetter: { [action] in action.exampleTrigger },
+            present: { [weak self] controller in self?.present(controller, animated: true, completion: nil) }
+        )
     }
 
     override func didReceiveMemoryWarning() {

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -536,9 +536,8 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                         .withRenderingMode(.alwaysTemplate)
             }
             $0.onChange { row in
-                let realm = Current.realm()
                 do {
-                    try realm.write {
+                    try rlmScene.realm?.write {
                         rlmScene.actionEnabled = row.value ?? true
                     }
 

--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -92,20 +92,39 @@ public class Action: Object, Mappable, NSCoding {
     }
 
     public var exampleTrigger: String {
-        let data = HomeAssistantAPI.actionEvent(actionID: ID, actionName: Name, source: .Preview)
-        let eventDataStrings = data.eventData.map { $0 + ": " + $1 }.sorted()
-        let sourceStrings = HomeAssistantAPI.ActionSource.allCases.map { $0.description }.sorted()
+        switch triggerType {
+        case .event:
+            let data = HomeAssistantAPI.actionEvent(actionID: ID, actionName: Name, source: .Preview)
+            let eventDataStrings = data.eventData.map { $0 + ": " + $1 }.sorted()
+            let sourceStrings = HomeAssistantAPI.ActionSource.allCases.map { $0.description }.sorted()
 
-        let indentation = "\n    "
+            let indentation = "\n    "
 
-        return """
-        - platform: event
-          event_type: \(data.eventType)
-          event_data:
-            # source may be one of:
-            # - \(sourceStrings.joined(separator: indentation + "# - "))
-            \(eventDataStrings.joined(separator: indentation))
-        """
+            return """
+            - platform: event
+              event_type: \(data.eventType)
+              event_data:
+                # source may be one of:
+                # - \(sourceStrings.joined(separator: indentation + "# - "))
+                \(eventDataStrings.joined(separator: indentation))
+            """
+        case .scene:
+            let data = HomeAssistantAPI.actionScene(actionID: ID, source: .Preview)
+            let eventDataStrings = data.serviceData.map { $0 + ": " + $1 }.sorted()
+
+            let indentation = "\n      "
+
+            return """
+            # you can watch for the scene change
+            - platform: event
+              event_type: call_service
+              event_data:
+                domain: \(data.serviceDomain)
+                service: \(data.serviceName)
+                service_data:
+                  \(eventDataStrings.joined(separator: indentation))
+            """
+        }
     }
 }
 

--- a/Shared/API/Models/RealmScene.swift
+++ b/Shared/API/Models/RealmScene.swift
@@ -99,6 +99,9 @@ public final class RLMScene: Object, UpdatableModel {
         let action = actions.first ?? Action()
         if action.realm == nil {
             action.ID = identifier
+            action.BackgroundColor = "#FFFFFF"
+            action.TextColor = "#000000"
+            action.IconColor = "#000000"
         } else {
             precondition(action.ID == identifier)
         }
@@ -106,9 +109,6 @@ public final class RLMScene: Object, UpdatableModel {
         action.Position = position
         action.Name = scene.FriendlyName ?? identifier
         action.Text = scene.FriendlyName ?? identifier
-        action.BackgroundColor = "#FFFFFF"
-        action.TextColor = "#000000"
-        action.IconColor = "#000000"
         action.Scene = self
         realm?.add(action, update: .all)
     }

--- a/Shared/Common/Extensions/UIImage+Icons.swift
+++ b/Shared/Common/Extensions/UIImage+Icons.swift
@@ -9,6 +9,21 @@ import Iconic
 import UIKit
 
 extension UIImage {
+    public convenience init(size: CGSize, color: UIColor) {
+        // why is UIGraphicsImageRenderer not available on watchOS?
+        var alpha: CGFloat = 1
+        color.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+
+        UIGraphicsBeginImageContextWithOptions(size, alpha == 1.0, 0)
+        color.setFill()
+        UIRectFill(CGRect(origin: .zero, size: size))
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+
+        self.init(cgImage: image.cgImage!, scale: image.scale, orientation: image.imageOrientation)
+    }
+
     public static func iconForIdentifier(_ iconIdentifier: String, iconWidth: Double,
                                          iconHeight: Double, color: UIColor) -> UIImage {
 

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1299,6 +1299,8 @@ internal enum L10n {
       /// Actions
       internal static let title = L10n.tr("Localizable", "settings_details.actions.title")
       internal enum Scenes {
+        /// Customize
+        internal static let customizeAction = L10n.tr("Localizable", "settings_details.actions.scenes.customize_action")
         /// No Scenes
         internal static let empty = L10n.tr("Localizable", "settings_details.actions.scenes.empty")
         /// When enabled, Scenes display alongside actions. When activated, they trigger scene changes.

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1303,7 +1303,7 @@ internal enum L10n {
         internal static let customizeAction = L10n.tr("Localizable", "settings_details.actions.scenes.customize_action")
         /// No Scenes
         internal static let empty = L10n.tr("Localizable", "settings_details.actions.scenes.empty")
-        /// When enabled, Scenes display alongside actions. When activated, they trigger scene changes.
+        /// When enabled, Scenes display alongside actions. When performed, they trigger scene changes.
         internal static let footer = L10n.tr("Localizable", "settings_details.actions.scenes.footer")
         /// Scene Actions
         internal static let title = L10n.tr("Localizable", "settings_details.actions.scenes.title")


### PR DESCRIPTION
Add configure row underneath each Scene, which exposes:
- Colors of scene actions, which are the only fields not synced down.
- Add to Siri button.
- An example trigger to watch the service call for the scene.

Also updates the appearance of regular actions to include their icon and text.

![Image 13](https://user-images.githubusercontent.com/74188/88486834-68ff4e80-cf35-11ea-8d32-f8613f5d2dda.png)
