### PR TITLE
Allow specifying Scene Action colors via Scene attributes

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -797,3 +797,4 @@ Thank you.\
 "sensors.geocoded_location.setting.use_zones" = "Use Zone Name";
 "settings_sensors.settings.header" = "Settings";
 "settings_sensors.settings.footer" = "Changes will be applied on the next update.";
+"actions_configurator.visual_section.scene_hint_footer" = "You can also change these by customizing the Scene attributes: %@";

--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -32,6 +32,23 @@ public class Action: Object, Mappable, NSCoding {
         self.init()
     }
 
+    public func canConfigure(_ keyPath: PartialKeyPath<Action>) -> Bool {
+        switch keyPath {
+        case \Action.BackgroundColor:
+            return Scene == nil || Scene?.scene.backgroundColor == nil
+        case \Action.TextColor:
+            return Scene == nil || Scene?.scene.textColor == nil
+        case \Action.IconColor:
+            return Scene == nil || Scene?.scene.iconColor == nil
+        case \Action.IconName,
+             \Action.Name,
+             \Action.Text:
+            return Scene == nil || Scene == nil
+        default:
+            return true
+        }
+    }
+
     // NSCoding
     public func encode(with aCoder: NSCoder) {
         let jsonString = self.toJSONString() ?? ""

--- a/Shared/API/Models/RealmScene.swift
+++ b/Shared/API/Models/RealmScene.swift
@@ -110,6 +110,19 @@ public final class RLMScene: Object, UpdatableModel {
         action.Name = scene.FriendlyName ?? identifier
         action.Text = scene.FriendlyName ?? identifier
         action.Scene = self
+
+        if let backgroundColor = scene.backgroundColor {
+            action.BackgroundColor = backgroundColor
+        }
+
+        if let textColor = scene.textColor {
+            action.TextColor = textColor
+        }
+
+        if let iconColor = scene.iconColor {
+            action.IconColor = iconColor
+        }
+
         realm?.add(action, update: .all)
     }
 }

--- a/Shared/API/Models/Scene.swift
+++ b/Shared/API/Models/Scene.swift
@@ -3,9 +3,19 @@ import ObjectMapper
 
 public class Scene: Entity {
     @objc dynamic var entityIDs = [String]()
+    @objc dynamic var backgroundColor: String?
+    @objc dynamic var textColor: String?
+    @objc dynamic var iconColor: String?
+
+    public static let backgroundColorKey = "background_color"
+    public static let textColorKey = "text_color"
+    public static let iconColorKey = "icon_color"
 
     public override func mapping(map: Map) {
         super.mapping(map: map)
         entityIDs <- map["attributes.entity_id"]
+        backgroundColor <- map["attributes." + Self.backgroundColorKey]
+        textColor <- map["attributes." + Self.textColorKey]
+        iconColor <- map["attributes." + Self.iconColorKey]
     }
 }

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -141,6 +141,12 @@ internal enum L10n {
       /// Example Trigger
       internal static let title = L10n.tr("Localizable", "actions_configurator.trigger_example.title")
     }
+    internal enum VisualSection {
+      /// You can also change these by customizing the Scene attributes: %@
+      internal static func sceneHintFooter(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "actions_configurator.visual_section.scene_hint_footer", String(describing: p1))
+      }
+    }
   }
 
   internal enum Alerts {


### PR DESCRIPTION
Adds parsing for `icon_color`, `text_color` and `background_color` as read from the Scene. Whenever these are set in the config, we hide the corresponding row when configuring its action.

![Image 14](https://user-images.githubusercontent.com/74188/88512652-c0d0a080-cf9b-11ea-8dc4-f9865743b883.png)