### PR TITLE
Generate more compatible random colors for Actions

### DIFF
--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -147,13 +147,10 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
                 $0.value = self.action.IconName
             }.cellUpdate({ (cell, row) in
                 if let value = row.value {
-                    let theIcon = MaterialDesignIcons(named: value)
-                    if let iconColorRow = self.form.rowBy(tag: "icon_color") as? InlineColorPickerRow {
-                        cell.imageView?.image = theIcon.image(
-                            ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
-                            color: iconColorRow.value
-                        )
-                    }
+                    cell.imageView?.image = MaterialDesignIcons(named: value).image(
+                        ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
+                        color: .black
+                    ).withRenderingMode(.alwaysTemplate)
                 }
             }).onPresent { _, to in
                 to.selectableRowCellSetup = {cell, row in
@@ -162,7 +159,7 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
                         cell.imageView?.image = theIcon.image(
                             ofSize: CGSize(width: CGFloat(30), height: CGFloat(30)),
                             color: .systemGray
-                        )
+                        ).withRenderingMode(.alwaysTemplate)
                     }
                 }
                 to.selectableRowCellUpdate = { cell, row in

--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -15,17 +15,29 @@ import Iconic
 public class Action: Object, Mappable, NSCoding {
     @objc dynamic public var ID: String = UUID().uuidString
     @objc dynamic public var Name: String = ""
-    @objc dynamic public var Position: Int = 0
-    @objc dynamic public var BackgroundColor: String = UIColor.randomColor().hexString()
-    @objc dynamic public var IconName: String = MaterialDesignIcons.allCases.randomElement()!.name
-    @objc dynamic public var IconColor: String = UIColor.randomColor().hexString()
     @objc dynamic public var Text: String = ""
-    @objc dynamic public var TextColor: String = UIColor.randomColor().hexString()
+    @objc dynamic public var IconName: String = MaterialDesignIcons.allCases.randomElement()!.name
+    @objc dynamic public var BackgroundColor: String
+    @objc dynamic public var IconColor: String
+    @objc dynamic public var TextColor: String
+    @objc dynamic public var Position: Int = 0
     @objc dynamic public var CreatedAt = Date()
     @objc dynamic public var Scene: RLMScene?
 
     override public static func primaryKey() -> String? {
         return "ID"
+    }
+
+    public required init() {
+        let background = UIColor.randomBackgroundColor()
+        BackgroundColor = background.hexString()
+        if background.isLight {
+            TextColor = UIColor.black.hexString()
+            IconColor = UIColor.black.hexString()
+        } else {
+            TextColor = UIColor.white.hexString()
+            IconColor = UIColor.white.hexString()
+        }
     }
 
     required convenience public init?(map: Map) {
@@ -146,8 +158,16 @@ public class Action: Object, Mappable, NSCoding {
 }
 
 extension UIColor {
-    public static func randomColor() -> UIColor {
-        let random = {CGFloat(arc4random_uniform(255)) / 255.0}
-        return UIColor(red: random(), green: random(), blue: random(), alpha: 1)
+    public static func randomBackgroundColor() -> UIColor {
+        // avoiding:
+        // - super gray (low saturation)
+        // - super black (low brightness)
+        // - super white (high brightness)
+        UIColor(
+            hue: CGFloat.random(in: 0...1.0),
+            saturation: CGFloat.random(in: 0.5...1.0),
+            brightness: CGFloat.random(in: 0.25...0.75),
+            alpha: 1.0
+        )
     }
 }


### PR DESCRIPTION
Fixes #422. This aims to create background colors that are:

1. Any hue (e.g. red, green, blue)
2. Saturation between 50% and 100% (avoiding super gray colors)
3. Brightness between 25% and 75% (avoiding blacks and whites)

It'll then set both the text and icon color to the same pairing we use for calculating whether to use a light or dark status bar color, sticking to white or black.

Examples:

![Image 16](https://user-images.githubusercontent.com/74188/88604051-7139b580-d02b-11ea-9dc3-f21e73364f1d.png)
![Image 17](https://user-images.githubusercontent.com/74188/88604081-86164900-d02b-11ea-82b4-d26d1fad4e2c.png)
![Image 18](https://user-images.githubusercontent.com/74188/88604134-975f5580-d02b-11ea-968c-367b62760097.png)
