### PR TITLE
Avoid unnecessary escaping slashes in Event Logs

### DIFF
--- a/HomeAssistant/ClientEvents/ViewControllers/ClientEventPayloadViewController.swift
+++ b/HomeAssistant/ClientEvents/ViewControllers/ClientEventPayloadViewController.swift
@@ -33,16 +33,6 @@ class ClientEventPayloadViewController: UIViewController {
     }
 
     func showEvent(_ event: ClientEvent) {
-        guard let payloadObject = event.jsonPayload else {
-            return
-        }
-
-        do {
-            let data: Data = try JSONSerialization.data(withJSONObject: payloadObject as Any,
-                                                        options: .prettyPrinted)
-            self.jsonString  = String(data: data, encoding: .utf8)
-        } catch _ {
-            Current.Log.error("Error printing event")
-        }
+        jsonString = event.jsonPayloadDescription
     }
 }

--- a/Shared/ClientEvents/Model/ClientEvent.swift
+++ b/Shared/ClientEvents/Model/ClientEvent.swift
@@ -51,7 +51,13 @@ public class ClientEvent: Object {
             }
 
             do {
-                jsonData = try JSONSerialization.data(withJSONObject: payload, options: .prettyPrinted)
+                var writeOptions: JSONSerialization.WritingOptions = [.prettyPrinted]
+
+                if #available(iOS 13, *) {
+                    writeOptions.insert(.withoutEscapingSlashes)
+                }
+
+                jsonData = try JSONSerialization.data(withJSONObject: payload, options: writeOptions)
             } catch {
                 Current.Log.error("Error serializing json payload: \(error)")
             }
@@ -66,6 +72,10 @@ public class ClientEvent: Object {
 
             return dictionary
         }
+    }
+
+    public var jsonPayloadDescription: String? {
+        jsonData.flatMap { String(data: $0, encoding: .utf8) }
     }
 
     override public static func indexedProperties() -> [String] {


### PR DESCRIPTION
Fixes #815. Also avoids Data -> JSON -> Data -> String in favor of Data -> String when showing the payload. Does not apply retroactively.

![Simulator Screen Shot - iPhone 11 Pro - 2020-07-27 at 18 25 34](https://user-images.githubusercontent.com/74188/88608418-91bb3d00-d036-11ea-96a8-e394b5e35ff7.png)
