### PR TITLE
Minor FCM improvements

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -295,6 +295,8 @@ public class HomeAssistantAPI {
 
             Current.setUserProperty?(config.Version, "HA_Version")
 
+            Current.subscribeFCMTopic?("ha_version_\(config.Version)")
+
             return Promise.value(config)
         }
     }

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -107,6 +107,8 @@ public class Environment {
 
     public var setUserProperty: ((String?, String) -> Void)?
 
+    public var subscribeFCMTopic: ((String) -> Void)?
+
     public func updateWith(authenticatedAPI: HomeAssistantAPI) {
         self.tokenManager = authenticatedAPI.tokenManager
         self.settingsStore.connectionInfo = authenticatedAPI.connectionInfo


### PR DESCRIPTION
Based on learnings during the account migration, this PR does two things:

1. Subscribes users to the following FCM topics:

- `everyone`
- `app_version_<VERSION_NUMBER>` e.g. `app_version_2020.4.1`
- `app_version_build_<VERSION_NUMBER>_<BUILD_NUMBER>` e.g. `app_version_build_2020.4.1_1`
- `ha_version_<HA_VERSION>` e.g. `ha_version_0.112.1`
- `locale_<USER_APP_FIRST_LOCALE>` e.g. `locale_en-US`

This way, we can target users via topic instead of having to use the limited functionality FCM composer.

2. If `fcm_options.image` is set in a notification payload, use that as the attachment, ignoring anything else. This way, if we do have to use the limited functionality FCM composer we can still set an image.