### PR TITLE
Show logged out reason for post-team migration

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -800,3 +800,8 @@ Thank you.\
 "settings_details.actions.scenes.footer" = "When enabled, Scenes display alongside actions. When performed, they trigger scene changes.";
 "settings_details.actions.scenes.title" = "Scene Actions";
 "settings_details.actions.scenes.empty" = "No Scenes";
+"onboarding.logged_out_from_move.title" = "You've been logged out :(";
+"onboarding.logged_out_from_move.body" = "The Home Assistant iOS app recently moved organizations on the App Store. This move, unfortunately, required logging you out.\n\nYour actions and local configuration will still be available after logging in.";
+"onboarding.logged_out_from_move.learn_more" = "Learn more about the move.";
+"onboarding.logged_out_from_move.duplicate_warning" = "To avoid duplicate entities, you must remove the existing mobile_app integration for this device in your browser before logging in.";
+"onboarding.logged_out_from_move.continue" = "Continue";

--- a/HomeAssistant/Utilities/Utils.swift
+++ b/HomeAssistant/Utilities/Utils.swift
@@ -11,6 +11,7 @@ import KeychainAccess
 import Shared
 import RealmSwift
 import SafariServices
+import Version
 
 func resetStores() {
     do {
@@ -71,6 +72,15 @@ func showAlert(title: String, message: String) {
 }
 
 func setDefaults() {
+    // before we reset the value, read in the last version number -- if it's pre-team migration, save that
+    if let previous = prefs.string(forKey: "lastInstalledShortVersion"),
+        let version = try? Version(hassVersion: previous),
+        version <= Version(major: 2020, minor: 4, patch: 1),
+        HomeAssistantAPI.authenticatedAPI() == nil {
+        Current.Log.info("going to show migration message")
+        prefs.set(true, forKey: "onboardingShouldShowMigrationMessage")
+    }
+
     prefs.set(Constants.build, forKey: "lastInstalledBundleVersion")
     prefs.set(Constants.version, forKey: "lastInstalledShortVersion")
 

--- a/HomeAssistant/Views/Onboarding/WelcomeViewController.swift
+++ b/HomeAssistant/Views/Onboarding/WelcomeViewController.swift
@@ -12,12 +12,15 @@ import Eureka
 import MaterialComponents.MaterialButtons
 import Lottie
 import Reachability
+import RealmSwift
 
-class WelcomeViewController: UIViewController {
+class WelcomeViewController: UIViewController, UITextViewDelegate {
 
     @IBOutlet weak var animationView: AnimationView!
     @IBOutlet weak var continueButton: MDCButton!
     @IBOutlet weak var wifiWarningLabel: UILabel!
+
+    private var loggedOutView: UIView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,6 +35,10 @@ class WelcomeViewController: UIViewController {
         self.animationView.animation = Animation.named("ha-loading")
         self.animationView.loopMode = .playOnce
         self.animationView.play(toMarker: "Circles Formed")
+
+        if prefs.bool(forKey: "onboardingShouldShowMigrationMessage") || true {
+            setupLoggedOutView()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -74,4 +81,147 @@ class WelcomeViewController: UIViewController {
         Current.Log.verbose("Reachability changed to \(reachability.connection.description)")
         self.wifiWarningLabel.isHidden = (reachability.connection == .wifi)
     }
+}
+
+// logged out from app store migration handling
+extension WelcomeViewController {
+    // swiftlint:disable:next function_body_length
+    private func setupLoggedOutView() {
+        let scrollView = with(UIScrollView()) {
+            $0.contentInsetAdjustmentBehavior = .always
+            $0.alwaysBounceVertical = true
+            $0.backgroundColor = view.backgroundColor
+        }
+
+        let container = with(UIStackView()) {
+            $0.axis = .vertical
+            $0.spacing = 24.0
+            $0.directionalLayoutMargins = .init(top: 32, leading: 32, bottom: 32, trailing: 32)
+            $0.isLayoutMarginsRelativeArrangement = true
+        }
+        container.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(container)
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            container.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            container.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            container.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            container.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor),
+            container.heightAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.heightAnchor)
+        ])
+
+        func textView() -> UITextView {
+            with(UITextView()) {
+                $0.textContainer.lineFragmentPadding = 0
+                $0.textContainerInset = .zero
+                $0.contentInset = .zero
+                $0.backgroundColor = .clear
+                $0.adjustsFontForContentSizeCategory = true
+                $0.textColor = .white
+                $0.isScrollEnabled = false
+                $0.isEditable = false
+            }
+        }
+
+        container.addArrangedSubview(with(UILabel()) {
+            $0.font = UIFont.preferredFont(forTextStyle: .title1)
+            $0.adjustsFontForContentSizeCategory = true
+            $0.numberOfLines = 0
+            $0.textColor = .white
+            $0.text = L10n.Onboarding.LoggedOutFromMove.title
+        })
+
+        container.addArrangedSubview(with(textView()) {
+            $0.font = UIFont.preferredFont(forTextStyle: .body)
+            $0.textColor = .white
+            $0.text = L10n.Onboarding.LoggedOutFromMove.body
+        })
+
+        container.addArrangedSubview(with(UIButton(type: .system)) {
+            $0.contentHorizontalAlignment = .leading
+            $0.setAttributedTitle(NSAttributedString(string: L10n.Onboarding.LoggedOutFromMove.learnMore, attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .body),
+                .foregroundColor: UIColor.white,
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]), for: .normal)
+            $0.addTarget(self, action: #selector(learnMoreAboutMove), for: .touchUpInside)
+        })
+
+        container.addArrangedSubview(with(UIView()) {
+            $0.setContentHuggingPriority(.defaultLow, for: .vertical)
+        })
+
+        let showDuplicateWarning: Bool = {
+            guard let values = try? Realm.storeDirectoryURL.resourceValues(forKeys: [.creationDateKey]) else {
+                Current.Log.info("not showing duplicate warning - can't read creation date")
+                return false
+            }
+
+            guard let creationDate = values.creationDate else {
+                Current.Log.info("not showing duplicate warning - no creation date")
+                return false
+            }
+
+            // 2020.1 was released on 6/12/2020 and it was the first version to send device_id to integration
+            guard let testDate = Calendar.current.date(from: .init(year: 2020, month: 6, day: 12)) else {
+                Current.Log.info("not showing duplicate warning - calendars are broken")
+                return false
+            }
+
+            return creationDate < testDate
+        }()
+
+        if showDuplicateWarning {
+            Current.Log.info("showing duplicate warning")
+            container.addArrangedSubview(with(textView()) {
+                $0.font = UIFont.preferredFont(forTextStyle: .body)
+                $0.text = L10n.Onboarding.LoggedOutFromMove.duplicateWarning
+                $0.backgroundColor = UIColor(red: 255.0/255.0, green: 255.0/255.0, blue: 219.0/255.0, alpha: 1.0)
+                $0.textColor = .black
+                $0.textContainerInset = .init(top: 8, left: 8, bottom: 8, right: 8)
+            })
+        } else {
+            Current.Log.info("not showing duplicate warning")
+        }
+
+        container.addArrangedSubview(with(UIButton(type: .system)) {
+            $0.setTitle(L10n.Onboarding.LoggedOutFromMove.continue, for: .normal)
+            $0.setTitleColor(view.backgroundColor, for: .normal)
+            $0.setBackgroundImage(.init(size: CGSize(width: 1, height: 1), color: .white), for: .normal)
+            $0.contentEdgeInsets = .init(top: 16, left: 8, bottom: 16, right: 8)
+            $0.titleLabel?.font = .preferredFont(forTextStyle: .callout)
+            $0.titleLabel?.baselineAdjustment = .alignCenters
+            $0.titleLabel?.adjustsFontSizeToFitWidth = true
+            $0.titleLabel?.adjustsFontForContentSizeCategory = true
+            $0.layer.cornerRadius = 12.0
+            $0.layer.masksToBounds = true
+
+            $0.addTarget(self, action: #selector(continueFromLoggedOut), for: .touchUpInside)
+        })
+
+        loggedOutView = scrollView
+    }
+
+    @objc private func learnMoreAboutMove() {
+        openURLInBrowser(URL(string: "https://companion.home-assistant.io/app/ios/about-the-move")!, self)
+    }
+
+    @objc private func dismissLearnMore() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @objc private func continueFromLoggedOut() {
+        prefs.removeObject(forKey: "onboardingShouldShowMigrationMessage")
+        loggedOutView?.removeFromSuperview()
+    }
+
 }

--- a/Shared/Common/Extensions/Version+HA.swift
+++ b/Shared/Common/Extensions/Version+HA.swift
@@ -9,7 +9,7 @@ extension Version {
         ]
     }
 
-    init(hassVersion: String) throws {
+    public init(hassVersion: String) throws {
         let sanitized = try Self.replacements().reduce(into: hassVersion) { result, pair in
             result = pair.regex.stringByReplacingMatches(
                 in: result,

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -643,6 +643,18 @@ internal enum L10n {
         }
       }
     }
+    internal enum LoggedOutFromMove {
+      /// The Home Assistant iOS app recently moved organizations on the App Store. This move, unfortunately, required logging you out.\n\nYour actions and local configuration will still be available after logging in.
+      internal static let body = L10n.tr("Localizable", "onboarding.logged_out_from_move.body")
+      /// Continue
+      internal static let `continue` = L10n.tr("Localizable", "onboarding.logged_out_from_move.continue")
+      /// To avoid duplicate entities, you must remove the existing mobile_app integration for this device in your browser before logging in.
+      internal static let duplicateWarning = L10n.tr("Localizable", "onboarding.logged_out_from_move.duplicate_warning")
+      /// Learn more about the move.
+      internal static let learnMore = L10n.tr("Localizable", "onboarding.logged_out_from_move.learn_more")
+      /// You've been logged out :(
+      internal static let title = L10n.tr("Localizable", "onboarding.logged_out_from_move.title")
+    }
     internal enum ManualSetup {
       internal enum CouldntMakeUrl {
         /// The value '%@' was not a valid URL.


### PR DESCRIPTION
- When the user is logged out and was last running 2020.4.1, shows a warning about why the user got logged out.
- If the user's Realm was created before 2020.1 went out and started sending device_id, shows a warning that the integration will be duplicated.

Fixes #820.

Shows the message until they press continue, so e.g. launching in the background won't cause them to not see it. Once they press continue, it'll show again for any reason.

Learn more goes to [https://companion.home-assistant.io/app/ios/about-the-move](https://companion.home-assistant.io/app/ios/about-the-move), which right now redirects to the blog post.

# No warning
![Image 19](https://user-images.githubusercontent.com/74188/89001276-9c800700-d2ae-11ea-9adc-ee2f0e468c28.png)

# Warning
![Image 20](https://user-images.githubusercontent.com/74188/89001336-cf29ff80-d2ae-11ea-83da-78738ab90db7.png)

