### PR TITLE
Improve Connection Settings saving and editing

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1141182A24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141182924AFA10900E6525C /* WebhookResponseHandler.swift */; };
 		1141182B24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141182924AFA10900E6525C /* WebhookResponseHandler.swift */; };
 		114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */; };
+		1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */; };
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
 		117D8A0A24A9381F00580913 /* UIColor+CSSRGB.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0924A9381F00580913 /* UIColor+CSSRGB.test.swift */; };
 		11810D4A249EAF8D00E741A4 /* rainbow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 11810D40249EAF8B00E741A4 /* rainbow@2x.png */; };
@@ -751,6 +752,7 @@
 		1141182924AFA10900E6525C /* WebhookResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseHandler.swift; sourceTree = "<group>"; };
 		114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.test.swift"; sourceTree = "<group>"; };
 		1166363289B5E05B7BAB7204 /* Pods_Shared_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shared_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionURLViewController.swift; sourceTree = "<group>"; };
 		117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.swift"; sourceTree = "<group>"; };
 		117D8A0924A9381F00580913 /* UIColor+CSSRGB.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.test.swift"; sourceTree = "<group>"; };
 		11810D40249EAF8B00E741A4 /* rainbow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "rainbow@2x.png"; sourceTree = "<group>"; };
@@ -1949,6 +1951,7 @@
 				B661FB6E226BCCAD00E541DD /* ConnectionSettingsViewController.swift */,
 				B65C0B512282BA13007E057B /* NotificationSettingsViewController.swift */,
 				11C4629324B189B100031902 /* NotificationRateLimitsAPI.swift */,
+				1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -3922,6 +3925,7 @@
 				B648AE252275918F006972AF /* Segues.swift in Sources */,
 				11ADB13E24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift in Sources */,
 				B657A8EA1CA646EB00121384 /* AppDelegate.swift in Sources */,
+				1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */,
 				B6CDC096228CF5C2009355DD /* RemoteMediaPlayer.swift in Sources */,
 				B661FC88226D478300E541DD /* DiscoverInstancesViewController.swift in Sources */,
 				11A48D8124CA8ADB0021BDD9 /* NotificationCategory+Observation.swift in Sources */,

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -820,4 +820,4 @@ Your actions and local configuration will still be available after logging in.";
 "settings.connection_section.validate_error.title" = "Error Saving URL";
 "settings.connection_section.validate_error.use_anyway" = "Use Anyway";
 "settings.connection_section.validate_error.edit_url" = "Edit URL";
-"settings.connection_section.ssid_permission_message" = "Accessing SSIDs requires 'Always' location permission. Tap here to change your settings.";
+"settings.connection_section.ssid_permission_message" = "Accessing SSIDs in the background requires 'Always' location permission. Tap here to change your settings.";

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "devices_map.map_types.satellite" = "Satellite";
 "devices_map.battery_label" = "Battery";
 "ok_label" = "OK";
+"copy_label" = "Copy";
 "about.title" = "About";
 "about.logo.app_title" = "Home Assistant Companion";
 "about.logo.tagline" = "Awaken Your Home";
@@ -815,3 +816,8 @@ Your actions and local configuration will still be available after logging in.";
 "actions_configurator.visual_section.server_defined" = "The appearance of this action is controlled by the server configuration.";
 "settings_details.actions.actions_synced.header" = "Synced Actions";
 "settings_details.actions.actions_synced.footer" = "Actions defined in .yaml are not editable on device.";
+"settings.connection_section.errors.cannot_remove_last_url" = "You cannot remove only available URL.";
+"settings.connection_section.validate_error.title" = "Error Saving URL";
+"settings.connection_section.validate_error.use_anyway" = "Use Anyway";
+"settings.connection_section.validate_error.edit_url" = "Edit URL";
+"settings.connection_section.ssid_permission_message" = "Accessing SSIDs requires 'Always' location permission. Tap here to change your settings.";

--- a/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
@@ -17,7 +17,6 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
 
     public var onDismissCallback: ((UIViewController) -> Void)?
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -54,12 +53,6 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                 $0.value = Current.settingsStore.authenticatedUser?.Name
             }
 
-            /* <<< ButtonRow("logout") {
-                $0.title = L10n.Settings.ConnectionSection.logOut
-            }.cellUpdate { cell, _ in
-                cell.textLabel?.textColor = .red
-            } */
-
             +++ Section(L10n.Settings.ConnectionSection.details)
             <<< LabelRow("connectionPath") {
                 $0.title = L10n.Settings.ConnectionSection.connectingVia
@@ -73,7 +66,10 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
             }.onCellSelection { cell, _ in
                 guard let url = Current.settingsStore.connectionInfo?.remoteUIURL else { return }
                 let alert = UIAlertController(title: nil, message: url.absoluteString, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
+                alert.addAction(UIAlertAction(title: L10n.copyLabel, style: .default, handler: { _ in
+                    UIPasteboard.general.url = url
+                }))
+                alert.addAction(UIAlertAction(title: L10n.okLabel, style: .cancel, handler: nil))
                 self.present(alert, animated: true, completion: nil)
                 alert.popoverPresentationController?.sourceView = cell.contentView
             }
@@ -85,9 +81,9 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
             }.onChange { row in
                 guard let value = row.value else { return }
                 if value == false {
-                    guard let externalURLRow = self.form.rowBy(tag: "externalURL") as? URLRow else { return }
-
-                    if externalURLRow.value == nil {
+                    if Current.settingsStore.connectionInfo?.externalURL == nil,
+                        Current.settingsStore.connectionInfo?.internalURL == nil {
+                        // no other url is available, can't allow turning it off
                         row.value = true
                         row.updateCell()
 
@@ -103,106 +99,28 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                 Current.settingsStore.connectionInfo?.useCloud = value
             }
 
-            <<< URLRow("internalURL") {
-                $0.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
-                $0.value = Current.settingsStore.connectionInfo?.internalURL
-                $0.placeholder = L10n.Settings.ConnectionSection.InternalBaseUrl.placeholder
-            }.onCellHighlightChanged { (cell, row) in
-                if !row.isHighlighted {
-                    guard let newURL = row.value else {
-                        Current.settingsStore.connectionInfo?.setAddress(nil, .internal)
-                        return
-                    }
-
-                    if let host = newURL.host, host.contains("nabu.casa") {
-                        let alert = UIAlertController(title: L10n.errorLabel, message: L10n.Errors.noRemoteUiUrl,
-                                                      preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-                        self.present(alert, animated: true, completion: nil)
-                        alert.popoverPresentationController?.sourceView = cell.contentView
-                        return
-                    }
-                    self.confirmURL(newURL).done { _ in
-                        Current.settingsStore.connectionInfo?.setAddress(newURL, .internal)
-                    }.catch { error in
-                        row.value = Current.settingsStore.connectionInfo?.internalURL
-                        row.updateCell()
-                        let alert = UIAlertController(title: L10n.errorLabel, message: error.localizedDescription,
-                                                      preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-                        self.present(alert, animated: true, completion: nil)
-                        alert.popoverPresentationController?.sourceView = cell.contentView
-                    }
-                }
+            <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
+                row.cellStyle = .value1
+                row.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
+                row.displayValueFor = { _ in Current.settingsStore.connectionInfo?.internalURL?.absoluteString }
+                row.presentationMode = .show(controllerProvider: .callback(builder: {
+                    ConnectionURLViewController(urlType: .internal, row: row)
+                }), onDismiss: { [navigationController] _ in
+                    row.updateCell()
+                    navigationController?.popViewController(animated: true)
+                })
             }
 
-            <<< URLRow("externalURL") {
-                $0.title = L10n.Settings.ConnectionSection.ExternalBaseUrl.title
-                $0.value = Current.settingsStore.connectionInfo?.externalURL
-                $0.placeholder = L10n.Settings.ConnectionSection.ExternalBaseUrl.placeholder
-            }.onCellHighlightChanged { (cell, row) in
-                if !row.isHighlighted {
-                    guard let newURL = row.value else {
-
-                        if Current.settingsStore.connectionInfo?.remoteUIURL != nil {
-                            Current.settingsStore.connectionInfo?.setAddress(nil, .external)
-                            guard let useCloudRow = self.form.rowBy(tag: "useCloud") as? SwitchRow else { return }
-                            useCloudRow.value = true
-                            useCloudRow.updateCell()
-                        } else {
-                            let alert = UIAlertController(title: L10n.errorLabel,
-                                                          // swiftlint:disable:next line_length
-                                                          message: L10n.Settings.ConnectionSection.Errors.noCloudExternalUrlRequired,
-                                                          preferredStyle: .alert)
-                            alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-                            self.present(alert, animated: true, completion: nil)
-                            alert.popoverPresentationController?.sourceView = cell.contentView
-                        }
-                        return
-                    }
-                    if let host = newURL.host, host.contains("nabu.casa") {
-                        let alert = UIAlertController(title: L10n.errorLabel, message: L10n.Errors.noRemoteUiUrl,
-                                                      preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-                        self.present(alert, animated: true, completion: nil)
-                        alert.popoverPresentationController?.sourceView = cell.contentView
-                    }
-                    self.confirmURL(newURL).done { _ in
-                        Current.settingsStore.connectionInfo?.setAddress(newURL, .external)
-                    }.catch { error in
-                        row.value = Current.settingsStore.connectionInfo?.externalURL
-                        row.updateCell()
-                        let alert = UIAlertController(title: L10n.errorLabel, message: error.localizedDescription,
-                                                      preferredStyle: .alert)
-                        alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-                        self.present(alert, animated: true, completion: nil)
-                        alert.popoverPresentationController?.sourceView = cell.contentView
-                    }
-                }
-            }
-
-            +++ MultivaluedSection(multivaluedOptions: [.Insert, .Delete],
-                                   header: L10n.Settings.ConnectionSection.InternalUrlSsids.header,
-                                   footer: L10n.Settings.ConnectionSection.InternalUrlSsids.footer) {
-                $0.tag = "internalSSIDs"
-                $0.addButtonProvider = { _ in
-                    return ButtonRow {
-                        $0.title = L10n.Settings.ConnectionSection.InternalUrlSsids.addNewSsid
-                    }.cellUpdate { cell, _ in
-                        cell.textLabel?.textAlignment = .left
-                    }
-                }
-
-                $0.multivaluedRowToInsertAt = { index in
-                    return TextRow {
-                        $0.placeholder = L10n.Settings.ConnectionSection.InternalUrlSsids.placeholder
-                        $0.value = self.currentSSID
-                    }.onCellHighlightChanged { self.addSSID($1.value) }
-                }
-
-                $0.append(contentsOf: Current.settingsStore.connectionInfo?.internalSSIDs?.map { ssid in
-                    return TextRow { $0.value = ssid }.onCellHighlightChanged { self.addSSID($1.value) }
-                } ?? [TextRow]())
+            <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
+                row.cellStyle = .value1
+                row.title = L10n.Settings.ConnectionSection.ExternalBaseUrl.title
+                row.displayValueFor = { _ in Current.settingsStore.connectionInfo?.externalURL?.absoluteString }
+                row.presentationMode = .show(controllerProvider: .callback(builder: {
+                    ConnectionURLViewController(urlType: .external, row: row)
+                }), onDismiss: { [navigationController] _ in
+                    row.updateCell()
+                    navigationController?.popViewController(animated: true)
+                })
             }
     }
 
@@ -212,60 +130,6 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
         // Detect when your view controller is popped and invoke the callback
         if !isMovingToParent {
             onDismissCallback?(self)
-        }
-    }
-
-    /// currentSSID returns the currently connected SSID if it hasn't been stored already or if no SSIDs are stored.
-    var currentSSID: String? {
-        // First, ensure we are connected to a network
-        guard let currentSSID = ConnectionInfo.CurrentWiFiSSID else { return nil }
-
-        // Next, ensure SSIDs have been previously stored. If not, then we should show the row
-        guard let storedSSIDs = Current.settingsStore.connectionInfo?.internalSSIDs else { return currentSSID }
-
-        // Finally, check to see if the current SSID is stored in the existing SSID list
-        guard storedSSIDs.contains(currentSSID) == false else { return currentSSID }
-
-        // Okay, the SSID must have been in the list so lets return nothing so the row wont appear
-        return currentSSID
-    }
-
-    override func rowsHaveBeenRemoved(_ rows: [BaseRow], at indexes: [IndexPath]) {
-        super.rowsHaveBeenRemoved(rows, at: indexes)
-        let values = rows.compactMap { $0.baseValue as? String }
-        Current.settingsStore.connectionInfo?.internalSSIDs?.removeAll { values.contains($0) }
-    }
-
-    func addSSID(_ ssid: String?) {
-        guard let value = ssid else { return }
-        guard let ssids = Current.settingsStore.connectionInfo?.internalSSIDs else { return }
-        if !ssids.contains(value) {
-            Current.settingsStore.connectionInfo?.internalSSIDs?.append(value)
-        }
-    }
-
-    func confirmURL(_ connectionURL: URL) -> Promise<Void> {
-        return Promise { seal in
-            guard let webhookID = Current.settingsStore.connectionInfo?.webhookID else {
-                seal.reject(HomeAssistantAPI.APIError.cantBuildURL)
-                return
-            }
-            let url = connectionURL.appendingPathComponent("api/webhook/\(webhookID)")
-            Current.Log.verbose("Confirming URL at \(url)")
-
-            let request = WebhookRequest(type: "get_config", data: [:])
-            let requestJSON = Mapper<WebhookRequest>(context: WebhookRequestContext.server).toJSON(request)
-
-            Alamofire.request(url, method: .post, parameters: requestJSON,
-                              encoding: JSONEncoding.default).validate().responseJSON { resp in
-                switch resp.result {
-                case .success:
-                    seal.fulfill_()
-                case .failure(let error):
-                    Current.Log.error("Received error \(error)")
-                    seal.reject(error)
-                }
-            }
         }
     }
 

--- a/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
@@ -180,9 +180,9 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
                 multivaluedOptions: [.Insert, .Delete],
                 header: L10n.Settings.ConnectionSection.InternalUrlSsids.header,
                 footer: L10n.Settings.ConnectionSection.InternalUrlSsids.footer
-            ) {
-                $0.tag = RowTag.ssids.rawValue
-                $0.addButtonProvider = { _ in
+            ) { section in
+                section.tag = RowTag.ssids.rawValue
+                section.addButtonProvider = { _ in
                     return ButtonRow {
                         $0.title = L10n.Settings.ConnectionSection.InternalUrlSsids.addNewSsid
                     }.cellUpdate { cell, _ in
@@ -197,12 +197,18 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
                     }
                 }
 
-                $0.multivaluedRowToInsertAt = { _ in
-                    row(for: ConnectionInfo.CurrentWiFiSSID)
+                section.multivaluedRowToInsertAt = { _ in
+                    let current = ConnectionInfo.CurrentWiFiSSID
+
+                    if section.allRows.contains(where: { ($0 as? TextRow)?.value == current }) {
+                        return row(for: nil)
+                    } else {
+                        return row(for: current)
+                    }
                 }
 
                 let existing = Current.settingsStore.connectionInfo?.internalSSIDs ?? []
-                $0.append(contentsOf: existing.map { row(for: $0) })
+                section.append(contentsOf: existing.map { row(for: $0) })
             }
         }
     }

--- a/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
@@ -245,6 +245,7 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
             $0.title = L10n.Settings.ConnectionSection.ssidPermissionMessage
 
             $0.cellUpdate { cell, _ in
+                cell.accessibilityTraits.insert(.button)
                 cell.selectionStyle = .default
                 cell.textLabel?.numberOfLines = 0
 

--- a/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Eureka
+import Shared
+import PromiseKit
+import CoreLocation
+
+final class ConnectionURLViewController: FormViewController, TypedRowControllerType {
+    typealias RowValue = ConnectionURLViewController
+    var row: RowOf<RowValue>!
+    var onDismissCallback: ((UIViewController) -> Void)?
+    let urlType: ConnectionInfo.URLType
+
+    init(urlType: ConnectionInfo.URLType, row: RowOf<RowValue>) {
+        self.urlType = urlType
+        self.row = row
+
+        if #available(iOS 13, *) {
+            super.init(style: .insetGrouped)
+        } else {
+            super.init(style: .grouped)
+        }
+
+        self.title = urlType.description
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    enum SaveError: LocalizedError {
+        case nabuCasa
+        case lastURL
+
+        var errorDescription: String? {
+            switch self {
+            case .nabuCasa: return L10n.Errors.noRemoteUiUrl
+            case .lastURL: return L10n.Settings.ConnectionSection.Errors.cannotRemoveLastUrl
+            }
+        }
+
+        var isFinal: Bool {
+            switch self {
+            case .nabuCasa: return true
+            case .lastURL: return true
+            }
+        }
+    }
+
+    private func check(url: URL?) throws {
+        if url?.host?.contains("nabu.casa") == true {
+            throw SaveError.nabuCasa
+        }
+
+        if url == nil, let existingInfo = Current.settingsStore.connectionInfo {
+            let other: ConnectionInfo.URLType = urlType == .internal ? .external : .internal
+            if !existingInfo.useCloud, existingInfo.address(for: other) == nil {
+                throw SaveError.lastURL
+            }
+        }
+    }
+
+    @objc private func cancel() {
+        onDismissCallback?(self)
+    }
+
+    @objc private func save() {
+        let givenURL = (form.rowBy(tag: RowTag.url.rawValue) as? URLRow)?.value
+
+        func commit() {
+            Current.settingsStore.connectionInfo?.setAddress(givenURL, urlType)
+
+            if let section = form.sectionBy(tag: RowTag.ssids.rawValue) as? MultivaluedSection {
+                Current.settingsStore.connectionInfo?.internalSSIDs = section.allRows
+                    .compactMap { $0 as? TextRow }
+                    .compactMap { $0.value }
+            }
+
+            onDismissCallback?(self)
+        }
+
+        updateNavigationItems(isChecking: true)
+
+        firstly { () -> Promise<Void> in
+            try check(url: givenURL)
+
+            if let givenURL = givenURL {
+                return Current.webhooks.sendTest(baseURL: givenURL)
+            }
+
+            return .value(())
+        }.ensure {
+            self.updateNavigationItems(isChecking: false)
+        }.done {
+            commit()
+        }.catch { error in
+            let alert = UIAlertController(
+                title: L10n.Settings.ConnectionSection.ValidateError.title,
+                message: error.localizedDescription,
+                preferredStyle: .alert
+            )
+
+            let canCommit: Bool
+
+            if let error = error as? SaveError {
+                canCommit = !error.isFinal
+            } else {
+                canCommit = true
+            }
+
+            if canCommit {
+                alert.addAction(UIAlertAction(
+                    title: L10n.Settings.ConnectionSection.ValidateError.useAnyway,
+                    style: .default,
+                    handler: { _ in commit() }
+                ))
+            }
+
+            alert.addAction(UIAlertAction(
+                title: L10n.Settings.ConnectionSection.ValidateError.editUrl,
+                style: .cancel,
+                handler: nil
+            ))
+            self.present(alert, animated: true, completion: nil)
+        }
+    }
+
+    private enum RowTag: String {
+        case url
+        case ssids
+    }
+
+    private func updateNavigationItems(isChecking: Bool) {
+        navigationItem.leftBarButtonItems = [
+            UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
+        ]
+
+        if isChecking {
+            let activityIndicator: UIActivityIndicatorView
+
+            if #available(iOS 13, *) {
+                activityIndicator = .init(style: .medium)
+            } else {
+                activityIndicator = .init(style: .gray)
+            }
+
+            activityIndicator.startAnimating()
+
+            navigationItem.rightBarButtonItems = [
+                UIBarButtonItem(customView: activityIndicator)
+            ]
+        } else {
+            navigationItem.rightBarButtonItems = [
+                UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(save))
+            ]
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        updateNavigationItems(isChecking: false)
+
+        form +++ Section()
+        <<< URLRow(RowTag.url.rawValue) {
+            $0.value = Current.settingsStore.connectionInfo?.address(for: urlType)
+            $0.placeholder = { () -> String? in
+                switch urlType {
+                case .internal: return L10n.Settings.ConnectionSection.InternalBaseUrl.placeholder
+                case .external: return L10n.Settings.ConnectionSection.ExternalBaseUrl.placeholder
+                case .remoteUI: return nil
+                }
+            }()
+        }
+
+        if urlType.isAffectedBySSID {
+            form +++ locationPermissionSection()
+
+            form +++ MultivaluedSection(
+                multivaluedOptions: [.Insert, .Delete],
+                header: L10n.Settings.ConnectionSection.InternalUrlSsids.header,
+                footer: L10n.Settings.ConnectionSection.InternalUrlSsids.footer
+            ) {
+                $0.tag = RowTag.ssids.rawValue
+                $0.addButtonProvider = { _ in
+                    return ButtonRow {
+                        $0.title = L10n.Settings.ConnectionSection.InternalUrlSsids.addNewSsid
+                    }.cellUpdate { cell, _ in
+                        cell.textLabel?.textAlignment = .natural
+                    }
+                }
+
+                func row(for value: String?) -> TextRow {
+                    TextRow {
+                        $0.placeholder = L10n.Settings.ConnectionSection.InternalUrlSsids.placeholder
+                        $0.value = value
+                    }
+                }
+
+                $0.multivaluedRowToInsertAt = { _ in
+                    row(for: ConnectionInfo.CurrentWiFiSSID)
+                }
+
+                let existing = Current.settingsStore.connectionInfo?.internalSSIDs ?? []
+                $0.append(contentsOf: existing.map { row(for: $0) })
+            }
+        }
+    }
+
+    private func locationPermissionSection() -> Section {
+        // swiftlint:disable:next nesting
+        class PermissionWatchingDelegate: NSObject, CLLocationManagerDelegate {
+            let section: Section
+
+            init(section: Section) {
+                self.section = section
+            }
+
+            func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+                section.evaluateHidden()
+            }
+        }
+
+        let section = Section {
+            $0.hidden = .function([], { _ in CLLocationManager.authorizationStatus() == .authorizedAlways })
+        }
+        section.evaluateHidden()
+        var locationManager: CLLocationManager? = CLLocationManager()
+        var permissionDelegate: PermissionWatchingDelegate? = PermissionWatchingDelegate(section: section)
+        locationManager?.delegate = permissionDelegate
+
+        after(life: self).done {
+            // we're keeping these lifetimes around longer so they update
+            locationManager = nil
+            permissionDelegate = nil
+        }
+
+        section <<< LabelRow {
+            $0.title = L10n.Settings.ConnectionSection.ssidPermissionMessage
+
+            $0.cellUpdate { cell, _ in
+                cell.selectionStyle = .default
+                cell.textLabel?.numberOfLines = 0
+
+                if #available(iOS 13, *) {
+                    cell.textLabel?.textColor = .secondaryLabel
+                } else {
+                    cell.textLabel?.textColor = .gray
+                }
+            }
+
+            $0.onCellSelection { _, _ in
+                if CLLocationManager.authorizationStatus() == .notDetermined {
+                    locationManager?.requestAlwaysAuthorization()
+                } else {
+                    UIApplication.shared.open(
+                        URL(string: UIApplication.openSettingsURLString)!,
+                        options: [:],
+                        completionHandler: nil
+                    )
+                }
+            }
+        }
+
+        return section
+    }
+
+}

--- a/Shared/Networking/ConnectionInfo.swift
+++ b/Shared/Networking/ConnectionInfo.swift
@@ -156,6 +156,13 @@ public class ConnectionInfo: Codable {
                 return L10n.Settings.ConnectionSection.ExternalBaseUrl.title
             }
         }
+
+        public var isAffectedBySSID: Bool {
+            switch self {
+            case .internal: return true
+            case .remoteUI, .external: return false
+            }
+        }
     }
 
     /// Returns the url that should be used at this moment to access the Home Assistant instance.
@@ -166,7 +173,7 @@ public class ConnectionInfo: Codable {
                 guard self.isOnInternalNetwork else {
                     if self.useCloud && self.remoteUIURL != nil {
                         self.activeURLType = .remoteUI
-                    } else {
+                    } else if self.externalURL != nil {
                         self.activeURLType = .external
                     }
                     return self.activeURL
@@ -255,7 +262,19 @@ public class ConnectionInfo: Codable {
             return cloudURL
         }
 
-        return self.activeURL.appendingPathComponent("api/webhook/\(self.webhookID)", isDirectory: false)
+        return self.activeURL.appendingPathComponent(webhookPath, isDirectory: false)
+    }
+
+    public var webhookPath: String {
+        "api/webhook/\(self.webhookID)"
+    }
+
+    public func address(for addressType: URLType) -> URL? {
+        switch addressType {
+        case .internal: return internalURL
+        case .external: return externalURL
+        case .remoteUI: return remoteUIURL
+        }
     }
 
     /// Updates the stored address for the given addressType.

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -14,6 +14,8 @@ internal enum L10n {
   internal static let addButtonLabel = L10n.tr("Localizable", "addButtonLabel")
   /// Cancel
   internal static let cancelLabel = L10n.tr("Localizable", "cancel_label")
+  /// Copy
+  internal static let copyLabel = L10n.tr("Localizable", "copy_label")
   /// Delete
   internal static let delete = L10n.tr("Localizable", "delete")
   /// Error
@@ -1002,6 +1004,8 @@ internal enum L10n {
       internal static let nabuCasaCloud = L10n.tr("Localizable", "settings.connection_section.nabu_casa_cloud")
       /// Remote UI Available
       internal static let remoteUiAvailable = L10n.tr("Localizable", "settings.connection_section.remote_ui_available")
+      /// Accessing SSIDs requires 'Always' location permission. Tap here to change your settings.
+      internal static let ssidPermissionMessage = L10n.tr("Localizable", "settings.connection_section.ssid_permission_message")
       internal enum ApiPasswordRow {
         /// password
         internal static let placeholder = L10n.tr("Localizable", "settings.connection_section.api_password_row.placeholder")
@@ -1045,6 +1049,8 @@ internal enum L10n {
         internal static let title = L10n.tr("Localizable", "settings.connection_section.error_enabling_notifications.title")
       }
       internal enum Errors {
+        /// You cannot remove only available URL.
+        internal static let cannotRemoveLastUrl = L10n.tr("Localizable", "settings.connection_section.errors.cannot_remove_last_url")
         /// External URL must be set to disable cloud
         internal static let cantDisableCloud = L10n.tr("Localizable", "settings.connection_section.errors.cant_disable_cloud")
         /// Home Assistant Cloud is not set up, you can not remove external URL
@@ -1109,6 +1115,14 @@ internal enum L10n {
       internal enum UseLegacyAuth {
         /// Use legacy authentication
         internal static let title = L10n.tr("Localizable", "settings.connection_section.use_legacy_auth.title")
+      }
+      internal enum ValidateError {
+        /// Edit URL
+        internal static let editUrl = L10n.tr("Localizable", "settings.connection_section.validate_error.edit_url")
+        /// Error Saving URL
+        internal static let title = L10n.tr("Localizable", "settings.connection_section.validate_error.title")
+        /// Use Anyway
+        internal static let useAnyway = L10n.tr("Localizable", "settings.connection_section.validate_error.use_anyway")
       }
     }
     internal enum DetailsSection {


### PR DESCRIPTION
Moves setting an internal or external URL into a sub-screen which has cancel/save buttons and an explicit lifecycle around whether the save is successful:

- When successful, pops off and shows the new value.
- When unsuccessful for connectivity reasons, allows the user to ignore the error and persist the URL change anyway.
- When unsuccessful because we reject the URL as being Nabu Casa or trying to clear the last one, we tell the user we can't save.

This also allows clearing external if internal is set and fixes trying to reset to external when there is no external.

Improves how and when we persist SSIDs in the list to be the same save button next to internal URL and adds a warning if location permission suggests we won't be able to determine SSID information.

Fixes #717.

![Image 22](https://user-images.githubusercontent.com/74188/89108257-abb89f00-d3eb-11ea-84cc-fe3cca6fa8fd.png)
![Image 23](https://user-images.githubusercontent.com/74188/89108270-ca1e9a80-d3eb-11ea-912e-8a6a1c5bab62.png)
