### PR TITLE
Fix infinite loop syncing Actions to watch

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		119385A4249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A5249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A6249E9F930097F497 /* StorageSensor.test.swift */; };
+		119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C9B1E24A448A600308A54 /* ZoneManager.swift */; };
 		119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */; };
 		119DC15824B6A33F00AAB204 /* ZeroLatitude.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */; };
@@ -499,7 +500,6 @@
 		B6C09153215206BB00A326DC /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
 		B6CC5D862159D10D00833E5D /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6CC5D842159D10D00833E5D /* Interface.storyboard */; };
 		B6CC5D882159D10E00833E5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B6CC5D872159D10E00833E5D /* Assets.xcassets */; };
-		B6CC5D8F2159D10E00833E5D /* WatchAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B6CC5D942159D10E00833E5D /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CC5D932159D10E00833E5D /* InterfaceController.swift */; };
 		B6CC5D962159D10E00833E5D /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CC5D952159D10E00833E5D /* ExtensionDelegate.swift */; };
 		B6CC5D982159D10E00833E5D /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CC5D972159D10E00833E5D /* ComplicationController.swift */; };
@@ -578,6 +578,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		119A172624D74DA800D1B66D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B6CC5D8D2159D10E00833E5D;
+			remoteInfo = WatchAppExtension;
+		};
 		B627CB131D83C87B0057173E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
@@ -627,13 +634,6 @@
 			remoteGlobalIDString = B6AAD7A01D827DD40090B220;
 			remoteInfo = APNSAttachmentService;
 		};
-		B6CC5D902159D10E00833E5D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B6CC5D8D2159D10E00833E5D;
-			remoteInfo = "WatchApp Extension";
-		};
 		B6CC5D9C2159D10F00833E5D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
@@ -665,6 +665,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		119A172824D74DA800D1B66D /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B61DA2A7221E8D8F00AADEDD /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -686,17 +697,6 @@
 				B627CB151D83C87B0057173E /* NotificationContentExtension.appex in Embed App Extensions */,
 				B66F9F2E216B1E61000CAA0F /* TodayWidget.appex in Embed App Extensions */,
 				B66C58AC215086F0004AB261 /* SiriIntents.appex in Embed App Extensions */,
-			);
-			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B6CC5DA42159D10F00833E5D /* Embed App Extensions */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
-			files = (
-				B6CC5D8F2159D10E00833E5D /* WatchAppExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2721,13 +2721,13 @@
 			buildConfigurationList = B6CC5DA52159D10F00833E5D /* Build configuration list for PBXNativeTarget "WatchApp" */;
 			buildPhases = (
 				B6CC5D802159D10D00833E5D /* Resources */,
-				B6CC5DA42159D10F00833E5D /* Embed App Extensions */,
 				93C44648FF2FAE89B2ED8FC9 /* Frameworks */,
+				119A172824D74DA800D1B66D /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				B6CC5D912159D10E00833E5D /* PBXTargetDependency */,
+				119A172724D74DA800D1B66D /* PBXTargetDependency */,
 			);
 			name = WatchApp;
 			productName = WatchApp;
@@ -4230,6 +4230,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		119A172724D74DA800D1B66D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B6CC5D8D2159D10E00833E5D /* WatchAppExtension */;
+			targetProxy = 119A172624D74DA800D1B66D /* PBXContainerItemProxy */;
+		};
 		B627CB141D83C87B0057173E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B627CB061D83C87B0057173E /* NotificationContentExtension */;
@@ -4264,11 +4269,6 @@
 			isa = PBXTargetDependency;
 			target = B6AAD7A01D827DD40090B220 /* APNSAttachmentService */;
 			targetProxy = B6AAD7A61D827DD40090B220 /* PBXContainerItemProxy */;
-		};
-		B6CC5D912159D10E00833E5D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B6CC5D8D2159D10E00833E5D /* WatchAppExtension */;
-			targetProxy = B6CC5D902159D10E00833E5D /* PBXContainerItemProxy */;
 		};
 		B6CC5D9D2159D10F00833E5D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4827,7 +4827,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Beta;
@@ -5526,7 +5525,6 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -5562,7 +5560,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -74,7 +74,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Notification).xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Notification).xcscheme
@@ -54,7 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "32">
+      launchAutomaticallySubstyle = "8"
+      notificationPayloadFile = "NotificationContentExtension/TestNotifications/map_notification.apns">
       <RemoteRunnable
          runnableDebuggingMode = "2"
          BundleIdentifier = "com.apple.Carousel"
@@ -74,7 +75,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      launchAutomaticallySubstyle = "32">
+      launchAutomaticallySubstyle = "8"
+      notificationPayloadFile = "NotificationContentExtension/TestNotifications/map_notification.apns">
       <RemoteRunnable
          runnableDebuggingMode = "2"
          BundleIdentifier = "com.apple.Carousel"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1160"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
       </Testables>
    </TestAction>
@@ -53,7 +54,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      notificationPayloadFile = "NotificationContentExtension/TestNotifications/map_notification.apns">
       <RemoteRunnable
          runnableDebuggingMode = "2"
          BundleIdentifier = "com.apple.Carousel"

--- a/HomeAssistant/Views/SettingsViewController.swift
+++ b/HomeAssistant/Views/SettingsViewController.swift
@@ -121,11 +121,7 @@ class SettingsViewController: FormViewController {
                 view.detailGroup = "actions"
                 return view
             }, onDismiss: { _ in
-                _ = HomeAssistantAPI.SyncWatchContext()
 
-                let storedActions = Realm.live().objects(Action.self).sorted(byKeyPath: "Position")
-
-                UIApplication.shared.shortcutItems = storedActions.map { $0.uiShortcut }
             })
         }
 
@@ -140,16 +136,6 @@ class SettingsViewController: FormViewController {
                 _ = HomeAssistantAPI.authenticatedAPI()?.updateComplications()
             })
         }
-
-//        <<< ButtonRow("siriShortcuts") {
-//            $0.hidden = Condition(booleanLiteral: UIDevice.current.systemVersion == "12")
-//            $0.title = L10n.Settings.DetailsSection.SiriShortcutsRow.title
-//            $0.presentationMode = .show(controllerProvider: ControllerProvider.callback {
-//                let view = SettingsDetailViewController()
-//                view.detailGroup = "siri"
-//                return view
-//            }, onDismiss: nil)
-//        }
 
         +++ ButtonRow("privacy") {
             $0.title = L10n.SettingsDetails.Privacy.title

--- a/Shared/API/Models/WatchComplication.swift
+++ b/Shared/API/Models/WatchComplication.swift
@@ -17,7 +17,7 @@ import ClockKit
 #endif
 
 // swiftlint:disable:next type_body_length
-public class WatchComplication: Object, Mappable {
+public class WatchComplication: Object, ImmutableMappable {
     @objc private dynamic var rawFamily: String = ""
     public var Family: ComplicationGroupMember {
         get {
@@ -79,27 +79,24 @@ public class WatchComplication: Object, Mappable {
         return ["RenderedData", "Family", "Template"]
     }
 
-    required convenience public init?(map: Map) {
-        self.init()
+    public required init() {
+
+    }
+
+    public required init(map: Map) throws {
+        // this is used for watch<->app syncing
+        self.CreatedAt = try map.value("CreatedAt", using: DateTransform())
+        super.init()
+        self.Template  = try map.value("Template")
+        self.Data      = try map.value("Data")
+        self.Family    = try map.value("Family")
     }
 
     public func mapping(map: Map) {
-        let realm = Realm.live()
-        let isWriteRequired = realm.isInWriteTransaction == false
-        isWriteRequired ? realm.beginWrite() : ()
-
-        Template  <- map["Template"]
-        Data      <- map["Data"]
-        CreatedAt <- map["CreatedAt"]
-
-        if map.mappingType == .toJSON {
-            var family = self.Family
-            family <- map["Family"]
-        } else {
-            Family <- map["Family"]
-        }
-
-        isWriteRequired ? try? realm.commitWrite() : ()
+        Template  >>> map["Template"]
+        Data      >>> map["Data"]
+        CreatedAt >>> (map["CreatedAt"], DateTransform())
+        Family    >>> map["Family"]
     }
 
     #if os(watchOS)

--- a/WatchAppExtension/ExtensionDelegate.swift
+++ b/WatchAppExtension/ExtensionDelegate.swift
@@ -178,7 +178,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             }
 
             if let actionsDictionary = context.content["actions"] as? [[String: Any]] {
-                let actions = actionsDictionary.compactMap { Action(JSON: $0) }
+                let actions = actionsDictionary.compactMap { try? Action(JSON: $0) }
 
                 Current.Log.verbose("Updating actions from context \(actions)")
 
@@ -189,7 +189,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             }
 
             if let complicationsDictionary = context.content["complications"] as? [[String: Any]] {
-                let complications = complicationsDictionary.compactMap { WatchComplication(JSON: $0) }
+                let complications = complicationsDictionary.compactMap { try? WatchComplication(JSON: $0) }
 
                 Current.Log.verbose("Updating complications from context \(complications)")
 


### PR DESCRIPTION
This happens because the Mappable-variant encode/decode of an Action requires a write transaction (since ObjectMapper's mapping is `inout`, which triggers the "only set in a write transaction" check in Realm) which then, directly, caused a new update to the Watch.

Worked around this by making Action and WatchComplication sync via ImmutableMappable which does not do anything inout, and thus doesn't require a write transaction.

Fixes a few more issues:
- Setting shortcutItems and syncing to watch is now done entirely in the Actions observer; removed from Settings.
- Fix iPhone-not-connected action sending for Scene-synced Actions, which don't have their RLMScene synced to the watch.
- Fixed the empty state label not hiding if actions go in or out of 0-count after initially.