### PR TITLE
Fix actions on Watch App not configuring in dev

### DIFF
--- a/WatchAppExtension/InterfaceController.swift
+++ b/WatchAppExtension/InterfaceController.swift
@@ -46,6 +46,7 @@ class InterfaceController: WKInterfaceController {
         self.noActionsLabel.setText(L10n.Watch.Labels.noAction)
 
         let actions = realm.objects(Action.self).sorted(byKeyPath: "Position")
+        self.actions = actions
 
         notificationToken = actions.observe { (changes: RealmCollectionChange) in
             guard let tableView = self.tableView else { return }


### PR DESCRIPTION
This fixes showing just empty "Label" rows on the Watch because it was never able to configure the rows with their actions.