### PR TITLE
Dark Mode: Update With Theme, New Tint Color

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -125,7 +125,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupWindow() {
-        let window = UIWindow.init(frame: UIScreen.main.bounds)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.tintColor = Constants.tintColor
         window.restorationIdentifier = StateRestorationKey.mainWindow.rawValue
         window.makeKeyAndVisible()
         self.window = window

--- a/HomeAssistant/Views/Onboarding/OnboardingNavigationViewController.swift
+++ b/HomeAssistant/Views/Onboarding/OnboardingNavigationViewController.swift
@@ -60,11 +60,15 @@ class OnboardingNavigationViewController: UINavigationController, RowControllerT
 
     func styleButton(_ button: MDCButton) {
         let containerScheme = MDCContainerScheme()
-        containerScheme.colorScheme.primaryColor = .white
-        containerScheme.colorScheme.secondaryColor = Constants.blue
+        if #available(iOS 13, *) {
+            containerScheme.colorScheme.primaryColor = .systemBackground
+        } else {
+            containerScheme.colorScheme.primaryColor = .white
+        }
+        containerScheme.colorScheme.secondaryColor = Constants.tintColor
         button.applyContainedTheme(withScheme: containerScheme)
 
-        button.setTitleColor(Constants.blue, for: .normal)
+        button.setTitleColor(Constants.tintColor, for: .normal)
 
         button.isUppercaseTitle = true
 

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -253,7 +253,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         self.urlObserver = nil
     }
 
-    func styleUI() {
+    private func styleUI() {
         precondition(isViewLoaded && webView != nil)
 
         let cachedColors = ThemeColors.cachedThemeColors
@@ -275,6 +275,11 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }
 
         setNeedsStatusBarAppearanceUpdate()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        webView.evaluateJavaScript("notifyThemeColors()", completionHandler: nil)
     }
 
     public func open(inline url: URL) {
@@ -540,127 +545,6 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             Current.Log.info("setting view scale to \(viewScale)")
             webView.setValue(viewScale, forKey: "viewScale")
         }
-    }
-
-    // swiftlint:disable:next function_body_length
-    func showWhatsNew() {
-        if Current.appConfiguration == .FastlaneSnapshot { return }
-        let iconSize = CGSize(width: 100, height: 100)
-        let iconColor = Constants.blue
-        let major = WhatsNew.Version.current().major
-        let minor = WhatsNew.Version.current().minor
-        let whatsNew = WhatsNew(
-            title: L10n.WhatsNew.title("\(major).\(minor)"),
-            items: [
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.Donations.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.Donations.subtitle,
-                    image: MaterialDesignIcons.currencyUsdIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.HomeAssistantCloudSupport.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.HomeAssistantCloudSupport.subtitle,
-                    image: MaterialDesignIcons.cloudIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.ImprovedIntegration.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.ImprovedIntegration.subtitle,
-                    image: MaterialDesignIcons.linkVariantIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.CriticalAlerts.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.CriticalAlerts.subtitle,
-                    image: MaterialDesignIcons.alertIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.InAppNotificationCategoryEditor.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.InAppNotificationCategoryEditor.subtitle,
-                    image: MaterialDesignIcons.bellRingIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.NotificationSounds.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.NotificationSounds.subtitle,
-                    image: MaterialDesignIcons.volumeHighIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.WebViewCleanup.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.WebViewCleanup.subtitle,
-                    image: MaterialDesignIcons.sprayIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.TodayWidget.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.TodayWidget.subtitle,
-                    image: MaterialDesignIcons.widgetsIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.MoreData.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.MoreData.subtitle,
-                    image: MaterialDesignIcons.databaseIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.Themes.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.Themes.subtitle,
-                    image: MaterialDesignIcons.formatPaintIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.AppIcons.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.AppIcons.subtitle,
-                    image: MaterialDesignIcons.imageFilterFramesIcon.image(ofSize: iconSize, color: iconColor)
-                ),
-                WhatsNew.Item(
-                    title: L10n.WhatsNew.TwoDotZero.Items.AndSoMuchMore.title,
-                    subtitle: L10n.WhatsNew.TwoDotZero.Items.AndSoMuchMore.subtitle,
-                    image: MaterialDesignIcons.starCircleIcon.image(ofSize: iconSize, color: iconColor)
-                )
-            ]
-        )
-
-        var config = WhatsNewViewController.Configuration()
-        config.apply(animation: .fade)
-
-        config.titleView.secondaryColor = .init(
-            startIndex: 13,
-            length: 29,
-            color: Constants.blue
-        )
-
-        var detailButton = WhatsNewViewController.DetailButton(
-            title: L10n.WhatsNew.Buttons.ReadMore.title,
-            action: .website(url: "https://companion.home-assistant.io/app/ios/whats-new")
-        )
-
-        detailButton.titleColor = Constants.blue
-        detailButton.hapticFeedback = .impact(.medium)
-
-        config.detailButton = detailButton
-
-        let completionButton = WhatsNewViewController.CompletionButton(
-            title: L10n.WhatsNew.Buttons.Completion.title,
-            action: .custom(action: { [weak self] whatsNewVC in
-                let alert = UIAlertController(title: L10n.WhatsNew.TwoDotZero.ThankYou.title,
-                                              message: L10n.WhatsNew.TwoDotZero.ThankYou.message,
-                                              preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.WhatsNew.TwoDotZero.ThankYou.okButton, style: .default,
-                                              handler: { _ in
-                                                self?.dismiss(animated: true, completion: nil)
-                }))
-                whatsNewVC.present(alert, animated: true, completion: nil)
-                alert.popoverPresentationController?.sourceView = whatsNewVC.view
-            })
-        )
-
-        config.completionButton = completionButton
-
-        config.completionButton.backgroundColor = Constants.blue
-        config.completionButton.hapticFeedback = .impact(.medium)
-
-        let versionStore = KeyValueWhatsNewVersionStore(keyValueable: prefs)
-
-        guard let whatsNewViewController = WhatsNewViewController(whatsNew: whatsNew,
-                                                                  configuration: config,
-                                                                  versionStore: versionStore) else { return }
-
-        self.present(whatsNewViewController, animated: true)
     }
 }
 

--- a/Shared/Common/Structs/Constants.swift
+++ b/Shared/Common/Structs/Constants.swift
@@ -14,8 +14,21 @@ import Iconic
 /// Contains shared constants
 public struct Constants {
     /// Home Assistant Blue
-    public static var blue: UIColor {
-        return #colorLiteral(red: 0.01, green: 0.66, blue: 0.96, alpha: 1.0)
+    public static var tintColor: UIColor {
+        let light = UIColor(hue: 199.0/360.0, saturation: 0.99, brightness: 0.96, alpha: 1.0)
+        let dark = UIColor(hue: 199.0/360.0, saturation: 0.99, brightness: 0.67, alpha: 1.0)
+
+        #if os(iOS)
+        if #available(iOS 13, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                return traitCollection.userInterfaceStyle == .dark ? light : dark
+            }
+        } else {
+            return dark
+        }
+        #else
+        return light
+        #endif
     }
 
     /// Help icon UIBarButtonItem


### PR DESCRIPTION
Handles the new Dark Mode in the front end -- when it transitions due to media query we need to query the visible colors we use.

Updates the tint color: in dark mode, use the HA blue. In light mode, use a darker version of the same color. Both colors pass WCAG 2.1 Level AA at [4.56](https://contrast-ratio.com/#%230175aa-on-%23f2f2f7) and [5.29](https://contrast-ratio.com/#%2303a9f4-on-%232c2c2e) on the e.g. the navigation bar in each mode.

Tint color change:

![Image 27](https://user-images.githubusercontent.com/74188/89259210-abccc080-d5de-11ea-9dfe-9a3cc8e29c47.png)
![Image 28](https://user-images.githubusercontent.com/74188/89259422-209ffa80-d5df-11ea-8971-bb38254cb9ac.png)

Transitioning in the WebView (wish GitHub supported video):

![Image 29](https://user-images.githubusercontent.com/74188/89259590-7bd1ed00-d5df-11ea-96e2-6aaadf6b68ba.png)

https://www.dropbox.com/s/l9hsw4447qgq9jv/Screen%20Recording%202020-08-03%20at%2023.08.37.mov?dl=0