### PR TITLE
Minor Settings Cleanup

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		119385A4249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A5249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A6249E9F930097F497 /* StorageSensor.test.swift */; };
+		11948E8924DA5D50006F5657 /* InfoLabelRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11948E8824DA5D50006F5657 /* InfoLabelRow.swift */; };
 		119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C9B1E24A448A600308A54 /* ZoneManager.swift */; };
 		119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */; };
@@ -779,6 +780,7 @@
 		11883CC624C131EE0036A6C6 /* RealmZone.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmZone.test.swift; sourceTree = "<group>"; };
 		119385A3249E8E360097F497 /* StorageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.swift; sourceTree = "<group>"; };
 		119385A6249E9F930097F497 /* StorageSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.test.swift; sourceTree = "<group>"; };
+		11948E8824DA5D50006F5657 /* InfoLabelRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabelRow.swift; sourceTree = "<group>"; };
 		119C9B1E24A448A600308A54 /* ZoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManager.swift; sourceTree = "<group>"; };
 		119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+BackgroundTask.swift"; sourceTree = "<group>"; };
 		119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = ZeroLatitude.gpx; sourceTree = "<group>"; };
@@ -2137,6 +2139,7 @@
 				11C590EC24A832CA0066085D /* YamlSection.swift */,
 				11A48D8224CA9D010021BDD9 /* RealmSection.swift */,
 				11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */,
+				11948E8824DA5D50006F5657 /* InfoLabelRow.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3924,6 +3927,7 @@
 				11A71C8924A5844300D9565F /* ZoneManagerCollector.swift in Sources */,
 				B6093CE4228CFB0A0079E661 /* RemotePlayerState.swift in Sources */,
 				119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */,
+				11948E8924DA5D50006F5657 /* InfoLabelRow.swift in Sources */,
 				B68EDD09215F45EB00DD6B28 /* NotificationIdentifierEurekaRow.swift in Sources */,
 				B6B6B14A215B137C003DE2DD /* WatchComplicationConfigurator.swift in Sources */,
 				B6DD5E6A24940F6F003A0154 /* OpenInFirefoxControllerSwift.swift in Sources */,

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -822,6 +822,7 @@ Your actions and local configuration will still be available after logging in.";
 "settings.connection_section.validate_error.use_anyway" = "Use Anyway";
 "settings.connection_section.validate_error.edit_url" = "Edit URL";
 "settings.connection_section.ssid_permission_message" = "Accessing SSIDs in the background requires 'Always' location permission. Tap here to change your settings.";
+"settings.connection_section.cloud_overrides_external" = "When connecting via Cloud, the External URL will not be used. You do not need to configure one unless you want to disable Cloud.";
 "device.generic_name" = "Device";
 "nfc.list.title" = "NFC Tags";
 "nfc.list.description" = "NFC tags written by the app will show a notification when you bring your device near them. Activating the notification will launch the app and fire an event.\

--- a/HomeAssistant/Views/ActionConfigurator.swift
+++ b/HomeAssistant/Views/ActionConfigurator.swift
@@ -32,6 +32,11 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
 
     convenience init(action: Action?) {
         self.init()
+
+        if #available(iOS 13, *) {
+            self.isModalInPresentation = true
+        }
+
         if let action = action {
             self.action = Action(value: action)
             self.newAction = false
@@ -198,22 +203,13 @@ class ActionConfigurator: FormViewController, TypedRowControllerType {
         }
 
         if visuals.isEmpty {
-            form +++ LabelRow {
+            form +++ InfoLabelRow {
                 switch action.triggerType {
                 case .event:
                     // TODO: when actions sync from config
                     $0.title = ""
                 case .scene:
                     $0.title = L10n.ActionsConfigurator.VisualSection.sceneDefined
-                }
-                $0.cellUpdate { cell, _ in
-                    cell.textLabel?.numberOfLines = 0
-
-                    if #available(iOS 13, *) {
-                        cell.textLabel?.textColor = .secondaryLabel
-                    } else {
-                        cell.textLabel?.textColor = .gray
-                    }
                 }
             }
         } else {

--- a/HomeAssistant/Views/InfoLabelRow.swift
+++ b/HomeAssistant/Views/InfoLabelRow.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Eureka
+
+final class InfoLabelRow: _LabelRow, RowType {
+    enum DisplayType {
+        case primary
+        case secondary
+
+        var textColor: UIColor {
+            switch self {
+            case .primary:
+                if #available(iOS 13, *) {
+                    return .label
+                } else {
+                    return .black
+                }
+            case .secondary:
+                if #available(iOS 13, *) {
+                    return .secondaryLabel
+                } else {
+                    return .gray
+                }
+            }
+        }
+    }
+
+    var displayType: DisplayType = .secondary
+
+    override func updateCell() {
+        super.updateCell()
+
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.textColor = displayType.textColor
+    }
+}

--- a/HomeAssistant/Views/NotificationActionConfigurator.swift
+++ b/HomeAssistant/Views/NotificationActionConfigurator.swift
@@ -26,6 +26,11 @@ class NotificationActionConfigurator: FormViewController, TypedRowControllerType
     init(category: NotificationCategory, action: NotificationAction?) {
         self.category = category
         super.init(style: .grouped)
+
+        if #available(iOS 13, *) {
+            self.isModalInPresentation = true
+        }
+
         if let action = action {
             self.action = action
             self.newAction = false

--- a/HomeAssistant/Views/NotificationCategoryConfigurator.swift
+++ b/HomeAssistant/Views/NotificationCategoryConfigurator.swift
@@ -31,6 +31,11 @@ class NotificationCategoryConfigurator: FormViewController, TypedRowControllerTy
 
     convenience init(category: NotificationCategory?) {
         self.init()
+
+        if #available(iOS 13, *) {
+            self.isModalInPresentation = true
+        }
+
         if let category = category {
             self.category = category
             if self.category.isServerControlled {

--- a/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionURLViewController.swift
@@ -21,6 +21,10 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
         }
 
         self.title = urlType.description
+
+        if #available(iOS 13, *) {
+            self.isModalInPresentation = true
+        }
     }
 
     @available(*, unavailable)
@@ -173,6 +177,12 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
             }()
         }
 
+        if urlType.isAffectedByCloud, Current.settingsStore.connectionInfo?.useCloud == true {
+            form +++ InfoLabelRow {
+                $0.title = L10n.Settings.ConnectionSection.cloudOverridesExternal
+            }
+        }
+
         if urlType.isAffectedBySSID {
             form +++ locationPermissionSection()
 
@@ -241,19 +251,12 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
             permissionDelegate = nil
         }
 
-        section <<< LabelRow {
+        section <<< InfoLabelRow {
             $0.title = L10n.Settings.ConnectionSection.ssidPermissionMessage
 
             $0.cellUpdate { cell, _ in
                 cell.accessibilityTraits.insert(.button)
                 cell.selectionStyle = .default
-                cell.textLabel?.numberOfLines = 0
-
-                if #available(iOS 13, *) {
-                    cell.textLabel?.textColor = .secondaryLabel
-                } else {
-                    cell.textLabel?.textColor = .gray
-                }
             }
 
             $0.onCellSelection { _, _ in

--- a/HomeAssistant/Views/Settings/NFC/NFCListViewController.swift
+++ b/HomeAssistant/Views/Settings/NFC/NFCListViewController.swift
@@ -24,11 +24,9 @@ class NFCListViewController: FormViewController {
         super.viewDidLoad()
 
         form +++ Section()
-        <<< LabelRow {
+        <<< InfoLabelRow {
             $0.title = L10n.Nfc.List.description
-            $0.cellUpdate { cell, _ in
-                cell.textLabel?.numberOfLines = 0
-            }
+            $0.displayType = .primary
         }
         <<< ButtonRow {
             $0.title = L10n.Nfc.List.learnMore

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -495,9 +495,9 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 cell.textLabel?.textAlignment = .natural
                 cell.imageView?.image = UIImage(size: iconSize, color: .clear)
                 if #available(iOS 13, *) {
-                    cell.textLabel?.textColor = row.isDisabled == false ? cell.tintColor : .tertiaryLabel
+                    cell.textLabel?.textColor = row.isDisabled == false ? Constants.tintColor : .tertiaryLabel
                 } else {
-                    cell.textLabel?.textColor = row.isDisabled == false ? cell.tintColor : .gray
+                    cell.textLabel?.textColor = row.isDisabled == false ? Constants.tintColor : .gray
                 }
             }
 

--- a/Shared/Networking/ConnectionInfo.swift
+++ b/Shared/Networking/ConnectionInfo.swift
@@ -163,6 +163,13 @@ public class ConnectionInfo: Codable {
             case .remoteUI, .external: return false
             }
         }
+
+        public var isAffectedByCloud: Bool {
+            switch self {
+            case .internal: return false
+            case .remoteUI, .external: return true
+            }
+        }
     }
 
     /// Returns the url that should be used at this moment to access the Home Assistant instance.

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -1076,6 +1076,8 @@ internal enum L10n {
     internal enum ConnectionSection {
       /// Cloud Available
       internal static let cloudAvailable = L10n.tr("Localizable", "settings.connection_section.cloud_available")
+      /// When connecting via Cloud, the External URL will not be used. You do not need to configure one unless you want to disable Cloud.
+      internal static let cloudOverridesExternal = L10n.tr("Localizable", "settings.connection_section.cloud_overrides_external")
       /// Cloudhook Available
       internal static let cloudhookAvailable = L10n.tr("Localizable", "settings.connection_section.cloudhook_available")
       /// Connected via


### PR DESCRIPTION
- Makes the screens with 'cancel' (configuration things) not pull-down-to-dismissable.
- Adds a note about External URL not being used when Cloud is enabled.