### PR TITLE
Hide Action Syncing when not available

### DIFF
--- a/HomeAssistant/Utilities/CLKComplication+Strings.swift
+++ b/HomeAssistant/Utilities/CLKComplication+Strings.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-import Shared
 #if os(watchOS)
 import WatchKit
 import ClockKit

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -17,6 +17,7 @@ import Firebase
 import CoreMotion
 import DeviceKit
 import FirebaseMessaging
+import Version
 
 // swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
@@ -325,28 +326,30 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 }
             }
 
-            form +++ RealmSection(
-                header: L10n.SettingsDetails.Actions.ActionsSynced.header,
-                footer: nil,
-                collection: AnyRealmCollection(actions.filter("isServerControlled == true")),
-                emptyRows: [
-                    LabelRow {
-                        $0.title = L10n.SettingsDetails.Actions.ActionsSynced.empty
-                        $0.disabled = true
+            if Current.serverVersion() >= .actionSyncing {
+                form +++ RealmSection(
+                    header: L10n.SettingsDetails.Actions.ActionsSynced.header,
+                    footer: nil,
+                    collection: AnyRealmCollection(actions.filter("isServerControlled == true")),
+                    emptyRows: [
+                        LabelRow {
+                            $0.title = L10n.SettingsDetails.Actions.ActionsSynced.empty
+                            $0.disabled = true
+                        },
+                    ], getter: { [weak self] in self?.getActionRow($0) },
+                    didUpdate: { section, collection in
+                        if collection.isEmpty {
+                            section.footer = HeaderFooterView(
+                                title: L10n.SettingsDetails.Actions.ActionsSynced.footerNoActions
+                            )
+                        } else {
+                            section.footer = HeaderFooterView(
+                                title: L10n.SettingsDetails.Actions.ActionsSynced.footer
+                            )
+                        }
                     }
-                ], getter: { [weak self] in self?.getActionRow($0) },
-                didUpdate: { section, collection in
-                    if collection.isEmpty {
-                        section.footer = HeaderFooterView(
-                            title: L10n.SettingsDetails.Actions.ActionsSynced.footerNoActions
-                        )
-                    } else {
-                        section.footer = HeaderFooterView(
-                            title: L10n.SettingsDetails.Actions.ActionsSynced.footer
-                        )
-                    }
-                }
-            )
+                )
+            }
 
             let scenes = realm.objects(RLMScene.self).sorted(byKeyPath: RLMScene.positionKeyPath)
 

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -335,7 +335,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                         LabelRow {
                             $0.title = L10n.SettingsDetails.Actions.ActionsSynced.empty
                             $0.disabled = true
-                        },
+                        }
                     ], getter: { [weak self] in self?.getActionRow($0) },
                     didUpdate: { section, collection in
                         if collection.isEmpty {

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -397,7 +397,7 @@ public class HomeAssistantAPI {
     }
 
     public func GetMobileAppConfig() -> Promise<MobileAppConfig> {
-        if Current.serverVersion() < Version(major: 0, minor: 200, prerelease: "any0") {
+        if Current.serverVersion() < .actionSyncing {
             return firstly { () -> Promise<MobileAppConfigPush> in
                 requestImmutable(path: "ios/push", callingFunctionName: "\(#function)")
             }.recover { error -> Promise<MobileAppConfigPush> in
@@ -446,7 +446,7 @@ public class HomeAssistantAPI {
 
         var json = Mapper().toJSON(ident)
 
-        if Current.serverVersion() < Version(major: 0, minor: 104) {
+        if Current.serverVersion() < .canSendDeviceID {
             // device_id was added in 0.104, but prior it would error for unknown keys
             json.removeValue(forKey: "device_id")
         }

--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 import RealmSwift
 import ObjectMapper
-import Shared
 
 public final class Action: Object, ImmutableMappable, UpdatableModel {
     public enum PositionOffset: Int {

--- a/Shared/API/Models/WatchComplication.swift
+++ b/Shared/API/Models/WatchComplication.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 import RealmSwift
 import ObjectMapper
-import Shared
 import UIColor_Hex_Swift
 #if os(watchOS)
 import ClockKit

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ObjectMapper
-import Shared
 
 public struct WebhookSensorSetting {
     public enum SettingType {

--- a/Shared/API/Webhook/Sensors/GeocoderSensor.swift
+++ b/Shared/API/Webhook/Sensors/GeocoderSensor.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PromiseKit
-import Shared
 import CoreLocation
 import Contacts
 

--- a/Shared/API/Webhook/Sensors/PedometerSensor.swift
+++ b/Shared/API/Webhook/Sensors/PedometerSensor.swift
@@ -107,13 +107,13 @@ public class PedometerSensor: SensorProvider {
             switch self {
             case .distance: return "mdi:hiking"
             case .floorsAscended:
-                if Current.serverVersion() >= Version(major: 0, minor: 105) {
+                if Current.serverVersion() >= .pedometerIconsAvailable {
                     return "mdi:stairs-up"
                 } else {
                     return "mdi:slope-uphill"
                 }
             case .floorsDescended:
-                if Current.serverVersion() >= Version(major: 0, minor: 105) {
+                if Current.serverVersion() >= .pedometerIconsAvailable {
                     return "mdi:stairs-down"
                 } else {
                     return "mdi:slope-downhill"

--- a/Shared/Common/Extensions/UIImage+Icons.swift
+++ b/Shared/Common/Extensions/UIImage+Icons.swift
@@ -5,7 +5,7 @@
 //  Created by Stephan Vanterpool on 9/15/18.
 //  Copyright © 2018 Robbie Trencheny. All rights reserved.
 //
-import Shared
+
 import UIKit
 
 extension UIImage {

--- a/Shared/Common/SiriIntents+ConvenienceInits.swift
+++ b/Shared/Common/SiriIntents+ConvenienceInits.swift
@@ -10,7 +10,6 @@ import Foundation
 import CoreLocation
 import MapKit
 import Intents
-import Shared
 import UIColor_Hex_Swift
 
 @available(iOS 12, *)

--- a/Shared/Common/Structs/Constants.swift
+++ b/Shared/Common/Structs/Constants.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 import KeychainAccess
-import Shared
+import Version
 
 /// Contains shared constants
 public struct Constants {
@@ -123,4 +123,10 @@ public struct Constants {
     static public var version: String {
         SharedPlistFiles.Info.cfBundleShortVersionString
     }
+}
+
+public extension Version {
+    static var canSendDeviceID: Version = .init(minor: 104)
+    static var pedometerIconsAvailable: Version = .init(minor: 105)
+    static var actionSyncing: Version = .init(minor: 200)
 }


### PR DESCRIPTION
- Moves the server-based Version checking into a central place.
- Adds a version check around showing the Synced Actions section in Actions.
- Fixes some random import warnings that I just introduced.