### PR TITLE
Remove current error and analytics logs

### DIFF
--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerRegionFilter.swift
@@ -143,12 +143,6 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
         strippedZones: AnyCollection<RLMZone>,
         decisionSource: String
     ) {
-        Current.logError?(ReportedError(
-            code: .exceededRegionCount,
-            regionCount: (beacon: counts.beacon, circular: counts.circular, zone: allZones.count),
-            decisionSource: decisionSource
-        ).asNsError())
-
         Current.clientEventStore.addEvent(ClientEvent(
             text: "Exceeded maximum monitored regions",
             type: .locationUpdate, payload: [
@@ -159,26 +153,5 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
                 "stripped_decision": decisionSource
             ]
         ))
-    }
-}
-
-private struct ReportedError {
-    enum Code: Int {
-        case exceededRegionCount = 0
-    }
-
-    private static let domain = "ZoneManagerRegionFilterError"
-
-    let code: Code
-    let regionCount: (beacon: Int, circular: Int, zone: Int)
-    let decisionSource: String
-
-    func asNsError() -> NSError {
-        return NSError(domain: Self.domain, code: code.rawValue, userInfo: [
-            "count_beacon": regionCount.beacon,
-            "count_circular": regionCount.circular,
-            "count_zone": regionCount.zone,
-            "decision": decisionSource
-        ])
     }
 }

--- a/Shared/API/Webhook/Request&Response/WebhookResponseLocation.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookResponseLocation.swift
@@ -65,8 +65,6 @@ struct WebhookResponseLocation: WebhookResponseHandler {
                 throw HandleError.missingLocalMetadata
             }
 
-            Current.logEvent?("location_update", ["trigger": localMetadata.trigger.rawValue])
-
             let notificationOptions = localMetadata.trigger.notificationOptionsFor(zoneName: localMetadata.zoneName)
 
             Current.clientEventStore.addEvent(ClientEvent(

--- a/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -27,40 +27,6 @@ enum OneShotError: Error, Equatable {
     }
 }
 
-private struct ReportedError {
-    enum Code: Int {
-        case invalidLatitudeOrLongitude = 0
-        case invalidAgeOrAccuracy = 1
-    }
-
-    private static let domain = "OneShotLocationError"
-
-    let code: Code
-    let location: CLLocation
-
-    func asNsError() -> NSError {
-        // technically this doesn't have to be Double but it's really easy to accidentally send a bad value type here
-        var userInfo: [String: Double] = [
-            "location_coord_lat": location.coordinate.latitude,
-            "location_coord_lng": location.coordinate.longitude,
-            "location_altitude": location.altitude,
-            "location_floor": Double(location.floor?.level ?? -1),
-            "location_speed": location.speed,
-            "location_course": location.course,
-            "location_acc_horiz": location.horizontalAccuracy,
-            "location_acc_vert": location.verticalAccuracy,
-            "location_acc_speed": location.speedAccuracy,
-            "location_age": location.timestamp.timeIntervalSinceNow
-        ]
-
-        if #available(iOS 13.4, watchOS 6.2, *) {
-            userInfo["location_acc_course"] = location.courseAccuracy
-        }
-
-        return NSError(domain: Self.domain, code: code.rawValue, userInfo: userInfo)
-    }
-}
-
 internal struct PotentialLocation: Comparable, CustomStringConvertible {
     static var desiredAccuracy: CLLocationAccuracy { 100.0 }
     static var invalidAccuracyThreshold: CLLocationAccuracy { 1500.0 }
@@ -83,8 +49,6 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
             // iOS 13.5? seems to occasionally report 0 lat/long, so ignore these locations
             Current.Log.error("Location \(location.coordinate) was super duper invalid")
             quality = .invalid
-
-            Current.logError?(ReportedError(code: .invalidLatitudeOrLongitude, location: location).asNsError())
         } else {
             // now = 0 seconds ago
             // timestamp = 100 seconds ago
@@ -94,7 +58,6 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
                 quality = .perfect
             } else if location.horizontalAccuracy > Self.invalidAccuracyThreshold || age > Self.invalidAgeThreshold {
                 quality = .invalid
-                Current.logError?(ReportedError(code: .invalidAgeOrAccuracy, location: location).asNsError())
             } else {
                 quality = .meh
             }


### PR DESCRIPTION
We have a good handle on the location errors (and they fire a _lot_) and we don't need to report verbose analytics into Sentry for now. At the current rate this would have logged around 5-10m events/month, which is a lot of noise.