### PR TITLE
Handle Realm database issues without crashing

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -81,6 +81,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         self.setupSentry()
         self.setupFirebase()
+        self.setupModels()
 
         self.configureLokalise()
 
@@ -118,7 +119,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.finished_launching", eventData: [:])
         connectAPI(reason: .cold)
 
-        setupModels()
         setup14Workaround()
 
         return true
@@ -975,6 +975,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupModels() {
+        // Force Realm migration to happen now
+        _ = Realm.live()
+
         Current.modelManager.cleanup().cauterize()
         Action.setupObserver()
         NotificationCategory.setupObserver()

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -859,3 +859,6 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings_details.actions.actions_synced.footer_no_actions" = "Actions may be also defined in the .yaml configuration.";
 "settings.connection_section.cloud_overrides_external" = "When connecting via Cloud, the External URL will not be used. You do not need to configure one unless you want to disable Cloud.";
 "nfc.generic_tag_read" = "Tag Read";
+"database.problem.title" = "Database Error";
+"database.problem.delete" = "Delete Database & Quit App";
+"database.problem.quit" = "Quit App";

--- a/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Shared/Common/Extensions/Realm+Initialization.swift
@@ -172,6 +172,7 @@ extension Realm {
             alert.addAction(UIAlertAction(title: L10n.Database.Problem.delete, style: .destructive, handler: { _ in
                 // swiftlint:disable:next force_try
                 try! FileManager.default.removeItem(at: storeDirectoryURL)
+                exit(1)
             }))
             alert.addAction(UIAlertAction(title: L10n.Database.Problem.quit, style: .cancel, handler: { _ in
                 exit(1)

--- a/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Shared/Common/Extensions/Realm+Initialization.swift
@@ -27,13 +27,11 @@ extension Realm {
         let storeDirectoryURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: Constants.AppGroupID)?
             .appendingPathComponent("dataStore", isDirectory: true)
 
-        guard let directoryURL = storeDirectoryURL else {
+        if storeDirectoryURL == nil {
             Current.Log.error("Unable to get directory URL! AppGroupID: \(Constants.AppGroupID)")
-            Realm.handleFatalError("Unable to get datastoreURL for Realm!.", HomeAssistantAPI.APIError.unknown)
-            return URL(string: "http://somethingbroke.fake")!
         }
 
-        return directoryURL
+        return storeDirectoryURL ?? URL(fileURLWithPath: NSTemporaryDirectory())
     }
 
     /// The live data store, located in shared storage.
@@ -56,8 +54,11 @@ extension Realm {
                     [FileAttributeKey.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
                 try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true,
                                                 attributes: attributes)
-            } catch let error as NSError {
-                Realm.handleFatalError("Error while attempting to create data store URL", error)
+            } catch {
+                Realm.handleError(
+                    message: "Error while attempting to create data store URL",
+                    error: error
+                )
             }
         }
 
@@ -78,27 +79,36 @@ extension Realm {
             migrationBlock: { migration, oldVersion in
                 if oldVersion < 9 {
                     migration.enumerateObjects(ofType: NotificationAction.className()) { _, newObject in
-                        newObject!["uuid"] = UUID().uuidString
+                        newObject?["uuid"] = UUID().uuidString
                     }
                 }
 
                 if oldVersion < 10 {
                     migration.enumerateObjects(ofType: Action.className()) { _, newObject in
-                        newObject!["isServerControlled"] = false
+                        newObject?["isServerControlled"] = false
                     }
                 }
             },
             deleteRealmIfMigrationNeeded: false
         )
 
-        var configuredRealm: Realm!
         do {
-            configuredRealm = try Realm(configuration: config)
-        } catch let error as NSError {
-            Current.logError?(error)
-            fatalError(error.debugDescription)
+            return try Realm(configuration: config)
+        } catch let error {
+            Current.logError?(error as NSError)
+
+            Realm.handleError(
+                message: error.localizedDescription,
+                error: error
+            )
+
+            do {
+                // temporarily provide an in-memory instance so we don't crash
+                return try Realm(configuration: .init(inMemoryIdentifier: "Fallback"))
+            } catch {
+                fatalError(String(describing: error))
+            }
         }
-        return configuredRealm
     }
 
     /// Backup the Realm database, returning the URL of the backup location.
@@ -136,24 +146,53 @@ extension Realm {
         try? realm.commitWrite()
     }
 
-    private static func handleFatalError(_ message: String, _ error: Swift.Error) {
-        let errMsg = "\(message): \(error)"
-        Current.Log.error(errMsg)
+    private static var hasShownError = false
+
+    private static func handleError(
+        message: String,
+        error: Swift.Error
+    ) {
+        Current.logError?(error as NSError)
+        Current.Log.error([message, error])
+
         #if os(iOS)
-        let alert = UIAlertController(title: "Realm Error!",
-                                      message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Quit App", style: .destructive, handler: { _ in exit(1) }))
+        DispatchQueue.main.async {
+            guard !hasShownError else {
+                return
+            }
 
-        let win = UIWindow(frame: UIScreen.main.bounds)
-        let vc = UIViewController()
-        vc.view.backgroundColor = .clear
-        win.rootViewController = vc
-        win.windowLevel = UIWindow.Level.alert + 1
-        win.makeKeyAndVisible()
-        vc.present(alert, animated: true, completion: nil)
+            hasShownError = true
 
+            let alert = UIAlertController(
+                title: L10n.Database.Problem.title,
+                message: error.localizedDescription,
+                preferredStyle: .alert
+            )
+
+            alert.addAction(UIAlertAction(title: L10n.Database.Problem.delete, style: .destructive, handler: { _ in
+                // swiftlint:disable:next force_try
+                try! FileManager.default.removeItem(at: storeDirectoryURL)
+            }))
+            alert.addAction(UIAlertAction(title: L10n.Database.Problem.quit, style: .cancel, handler: { _ in
+                exit(1)
+            }))
+
+            let win = UIWindow(frame: UIScreen.main.bounds)
+            let vc = UIViewController()
+            vc.view.backgroundColor = .black
+            win.rootViewController = vc
+            win.windowLevel = UIWindow.Level.statusBar
+            win.makeKeyAndVisible()
+            vc.present(alert, animated: true, completion: nil)
+
+            Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true, block: { [win] _ in
+                // we don't know when in the lifecycle this will present, we may get another window on top
+                // this is basically fatal so it isn't really problematic to never, well, stop doing this
+                win.makeKeyAndVisible()
+            })
+        }
         #else
-        fatalError(errMsg)
+        fatalError("\(message) \(error.localizedDescription)")
         #endif
     }
 

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -273,6 +273,17 @@ internal enum L10n {
     }
   }
 
+  internal enum Database {
+    internal enum Problem {
+      /// Delete Database & Quit App
+      internal static let delete = L10n.tr("Localizable", "database.problem.delete")
+      /// Quit App
+      internal static let quit = L10n.tr("Localizable", "database.problem.quit")
+      /// Database Error
+      internal static let title = L10n.tr("Localizable", "database.problem.title")
+    }
+  }
+
   internal enum Device {
     /// Device
     internal static let genericName = L10n.tr("Localizable", "device.generic_name")


### PR DESCRIPTION
If the database isn't able to be read for some reason, show the error message visually and offer delete/quit options. This should achieve 2 things:

1. We'll know about the root cause without trying to inspect logs.
2. The user will have a mechanism to fix it without deleting the app and reinstalling.

![Image](https://user-images.githubusercontent.com/74188/89972627-1a2f0580-dc13-11ea-95c6-6a9f4c4b7321.png)
