### PR TITLE
Fix crash when switching off internal address can't happen

### DIFF
--- a/Shared/Networking/ConnectionInfo.swift
+++ b/Shared/Networking/ConnectionInfo.swift
@@ -182,6 +182,9 @@ public class ConnectionInfo: Codable {
                         self.activeURLType = .remoteUI
                     } else if self.externalURL != nil {
                         self.activeURLType = .external
+                    } else {
+                        // no change - we don't have one to switch to
+                        return url
                     }
                     return self.activeURL
                 }


### PR DESCRIPTION
If we think we're not on the internal network -- but there is no external URL to reach -- don't reset to external which doesn't exist, just keep using internal. This avoids an infinite loop.

Fixes #894.