### PR TITLE
Fix crash deleting Action, delete Scene Action with Scene

### DIFF
--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -570,6 +570,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
         return [switchRow, configure]
     }
 
+    // swiftlint:disable:next function_body_length
     func getActionRow(_ inputAction: Action?) -> ButtonRowWithPresent<ActionConfigurator> {
         var identifier = UUID().uuidString
         var title = L10n.ActionsConfigurator.title
@@ -584,7 +585,10 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
             $0.tag = identifier
             $0.title = title
             $0.cellStyle = .subtitle
-            $0.displayValueFor = { _ in action?.Text ?? L10n.ActionsConfigurator.Rows.Text.title }
+            $0.displayValueFor = { _ in
+                guard action == nil || action?.isInvalidated == false else { return nil }
+                return action?.Text ?? L10n.ActionsConfigurator.Rows.Text.title
+            }
             $0.cellSetup { cell, _ in
                 if #available(iOS 13, *) {
                     cell.detailTextLabel?.textColor = .secondaryLabel
@@ -593,6 +597,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 }
             }
             $0.cellUpdate { cell, _ in
+                guard action == nil || action?.isInvalidated == false else { return }
                 cell.imageView?.image = MaterialDesignIcons(named: action?.IconName ?? "")
                     .image(ofSize: Self.iconSize, color: .black)
                     .withRenderingMode(.alwaysTemplate)

--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -95,10 +95,14 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         isServerControlled >>> map["isServerControlled"]
     }
 
-    static func didUpdate(objects: [Action]) {
+    static func didUpdate(objects: [Action], realm: Realm) {
         for (idx, object) in objects.enumerated() {
             object.Position = PositionOffset.synced.rawValue + idx
         }
+    }
+
+    static func willDelete(objects: [Action], realm: Realm) {
+
     }
 
     static var updateEligiblePredicate: NSPredicate {

--- a/Shared/API/Models/ModelManager.swift
+++ b/Shared/API/Models/ModelManager.swift
@@ -183,8 +183,9 @@ public final class ModelManager {
             }
 
             realm.add(updatedModels, update: .all)
+            UM.didUpdate(objects: updatedModels, realm: realm)
+            UM.willDelete(objects: Array(deleteObjects), realm: realm)
             realm.delete(deleteObjects)
-            UM.didUpdate(objects: updatedModels)
         }
     }
 }

--- a/Shared/API/Models/NotificationCategory.swift
+++ b/Shared/API/Models/NotificationCategory.swift
@@ -104,7 +104,11 @@ final public class NotificationCategory: Object, UpdatableModel {
         """
     }
 
-    static func didUpdate(objects: [NotificationCategory]) {
+    static func didUpdate(objects: [NotificationCategory], realm: Realm) {
+
+    }
+
+    static func willDelete(objects: [NotificationCategory], realm: Realm) {
 
     }
 

--- a/Shared/API/Models/RealmPersistable.swift
+++ b/Shared/API/Models/RealmPersistable.swift
@@ -3,7 +3,10 @@ import RealmSwift
 
 protocol UpdatableModel {
     associatedtype Source: UpdatableModelSource
-    static func didUpdate(objects: [Self])
+
+    static func didUpdate(objects: [Self], realm: Realm)
+    static func willDelete(objects: [Self], realm: Realm)
+
     static func primaryKey() -> String? // from realm, we use
     static var updateEligiblePredicate: NSPredicate { get }
     func update(with object: Source, using realm: Realm)

--- a/Shared/API/Models/RealmScene.swift
+++ b/Shared/API/Models/RealmScene.swift
@@ -63,7 +63,7 @@ public final class RLMScene: Object, UpdatableModel {
         #keyPath(identifier)
     }
 
-    static func didUpdate(objects: [RLMScene]) {
+    static func didUpdate(objects: [RLMScene], realm: Realm) {
         let sorted = objects.sorted { lhs, rhs in
             let lhsText = lhs.scene.FriendlyName ?? lhs.scene.ID
             let rhsText = rhs.scene.FriendlyName ?? rhs.scene.ID
@@ -73,6 +73,13 @@ public final class RLMScene: Object, UpdatableModel {
         for (idx, object) in sorted.enumerated() {
             object.position = Action.PositionOffset.scene.rawValue + idx
         }
+    }
+
+    static func willDelete(objects: [RLMScene], realm: Realm) {
+        // also delete our paired actions if they exist
+        let actions = realm.objects(Action.self).filter("ID in %@", objects.map(\.identifier))
+        Current.Log.info("deleting actions \(Array(actions.map(\.ID)))")
+        realm.delete(actions)
     }
 
     func update(with object: Scene, using realm: Realm) {

--- a/Shared/API/Models/RealmZone.swift
+++ b/Shared/API/Models/RealmZone.swift
@@ -36,7 +36,11 @@ public final class RLMZone: Object, UpdatableModel {
         ID == "zone.home"
     }
 
-    static func didUpdate(objects: [RLMZone]) {
+    static func didUpdate(objects: [RLMZone], realm: Realm) {
+
+    }
+
+    static func willDelete(objects: [RLMZone], realm: Realm) {
 
     }
 

--- a/SharedTests/ModelManager.test.swift
+++ b/SharedTests/ModelManager.test.swift
@@ -47,6 +47,7 @@ class ModelManagerTests: XCTestCase {
 
         Current.realm = Realm.live
         TestStoreModel1.lastDidUpdate = []
+        TestStoreModel1.lastWillDeleteIds = []
     }
 
     func testObserve() throws {
@@ -311,6 +312,12 @@ class ModelManagerTests: XCTestCase {
             XCTAssertEqual(models[2].value, "start_val1-2")
             XCTAssertEqual(models[3].identifier, "start_id2")
             XCTAssertEqual(models[3].value, "start_val2-2")
+
+            // deleted
+            XCTAssertEqual(Set(TestStoreModel1.lastWillDeleteIds), Set([
+                "start_id3",
+                "start_id4",
+            ]))
         }
     }
 
@@ -411,8 +418,12 @@ class TestDeleteModel3: Object {
 
 final class TestStoreModel1: Object, UpdatableModel {
     static var lastDidUpdate: [TestStoreModel1] = []
-    static func didUpdate(objects: [TestStoreModel1]) {
+    static var lastWillDeleteIds: [String] = []
+    static func didUpdate(objects: [TestStoreModel1], realm: Realm) {
         lastDidUpdate = objects
+    }
+    static func willDelete(objects: [TestStoreModel1], realm: Realm) {
+        lastWillDeleteIds = objects.compactMap(\.identifier)
     }
 
     @objc dynamic var identifier: String?
@@ -443,7 +454,11 @@ struct TestStoreSource1: UpdatableModelSource {
 }
 
 final class TestStoreModel2: Object, UpdatableModel {
-    static func didUpdate(objects: [TestStoreModel2]) {
+    static func didUpdate(objects: [TestStoreModel2], realm: Realm) {
+
+    }
+
+    static func willDelete(objects: [TestStoreModel2], realm: Realm) {
 
     }
 
@@ -469,7 +484,11 @@ struct TestStoreSource2: UpdatableModelSource {
 }
 
 final class TestStoreModel3: Object, UpdatableModel {
-    static func didUpdate(objects: [TestStoreModel3]) {
+    static func didUpdate(objects: [TestStoreModel3], realm: Realm) {
+
+    }
+
+    static func willDelete(objects: [TestStoreModel3], realm: Realm) {
 
     }
 


### PR DESCRIPTION
- Adds to ModelManager a hook to tell a class when models of its type are being deleted, so it can do any secondary cleanup necessary.
- Fixes a few Eureka issues where it would re-query for the cell update of a row as it's being deleted/removed from the table view, which Realm really would prefer you not do.

Fixes #891.