### PR TITLE
Updates for region monitoring

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		119DC15824B6A33F00AAB204 /* ZeroLatitude.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */; };
 		119EC3C724D5119300617D51 /* MobileAppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119EC3C624D5119300617D51 /* MobileAppConfig.swift */; };
 		119EC3C824D5119300617D51 /* MobileAppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119EC3C624D5119300617D51 /* MobileAppConfig.swift */; };
+		11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A3F08B24ECE88C0018D84F /* WebhookUpdateLocation.test.swift */; };
 		11A48D7B24CA7D7F0021BDD9 /* NotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DAC736215F06B100727D2A /* NotificationAction.swift */; };
 		11A48D7C24CA7D7F0021BDD9 /* NotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DAC736215F06B100727D2A /* NotificationAction.swift */; };
 		11A48D7D24CA7E4E0021BDD9 /* NotificationCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DAC734215F069300727D2A /* NotificationCategory.swift */; };
@@ -852,6 +853,7 @@
 		119EC3D824D5395B00617D51 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Onboarding.strings"; sourceTree = "<group>"; };
 		119EC3D924D5395B00617D51 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		119EC3DA24D5395C00617D51 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		11A3F08B24ECE88C0018D84F /* WebhookUpdateLocation.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookUpdateLocation.test.swift; sourceTree = "<group>"; };
 		11A48D8024CA8ADB0021BDD9 /* NotificationCategory+Observation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCategory+Observation.swift"; sourceTree = "<group>"; };
 		11A48D8224CA9D010021BDD9 /* RealmSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmSection.swift; sourceTree = "<group>"; };
 		11A71C6A24A463FC00D9565F /* ZoneManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerState.swift; sourceTree = "<group>"; };
@@ -1670,6 +1672,7 @@
 				11CD94B624B2CC7400BA801D /* WebhookResponseLocation.test.swift */,
 				11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */,
 				11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */,
+				11A3F08B24ECE88C0018D84F /* WebhookUpdateLocation.test.swift */,
 			);
 			path = Webhook;
 			sourceTree = "<group>";
@@ -4352,6 +4355,7 @@
 				11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */,
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
+				11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */,
 				11CB98CD249E637300B05222 /* Version+HA.test.swift in Sources */,
 				11AF4D2E249DA5AF006C74C0 /* GeocoderSensor.test.swift in Sources */,
 				114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */,

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -94,6 +94,16 @@ class ZoneManager {
         }
     }
 
+    private func fire(event: ZoneManagerEvent) {
+        guard let eventInfo = event.asFirableEvent() else {
+            return
+        }
+
+        Current.api()?
+            .CreateEvent(eventType: eventInfo.eventType, eventData: eventInfo.eventData)
+            .cauterize()
+    }
+
     private func sync(zones: AnyCollection<RLMZone>) {
         let currentRegions = locationManager.monitoredRegions
         let desiredRegions = regionFilter.regions(
@@ -155,6 +165,7 @@ extension ZoneManager: ZoneManagerCollectorDelegate {
     }
 
     func collector(_ collector: ZoneManagerCollector, didCollect event: ZoneManagerEvent) {
+        fire(event: event)
         perform(event: event)
     }
 }

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -139,11 +139,12 @@ class ZoneManager {
         )
 
         Current.Log.info {
-            [
+            let info = [
                 "monitoring \(expected.count) (\(counts))",
                 "started \(needsAddition.count)",
                 "ended \(needsRemoval.count)"
-            ].joined(separator: ", ")
+            ]
+            return info.joined(separator: ", ")
         }
     }
 }

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerEvent.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerEvent.swift
@@ -84,6 +84,14 @@ struct ZoneManagerEvent: Equatable, CustomStringConvertible {
         }()
     }
 
+    func asFirableEvent() -> (eventType: String, eventData: [String: Any])? {
+        guard case .region(let region, let state) = eventType, let zone = associatedZone else {
+            return nil
+        }
+
+        return HomeAssistantAPI.zoneStateEvent(region: region, state: state, zone: zone)
+    }
+
     func asTrigger() -> LocationUpdateTrigger {
         switch eventType {
         case .region(let region, let state):

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -537,6 +537,7 @@
 "ha_api.api_error.webhook_gone" = "mobile_app integration has been deleted, you must reconfigure the app.";
 "ha_api.api_error.must_upgrade_home_assistant" = "Your Home Assistant version (%@) is too old, you must upgrade to at least version %@ to use the app.";
 "ha_api.api_error.unknown" = "An unknown error occurred.";
+"ha_api.api_error.update_not_possible" = "Operation could not be performed.";
 "sensors.unknown_state" = "Unknown";
 "sensors.not_available_state" = "N/A";
 "sensors.battery.state.charging" = "Charging";

--- a/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
@@ -51,6 +51,7 @@ class ZoneManagerTests: XCTestCase {
         Current.realm = { self.realm }
         Current.clientEventStore.addEvent = { self.loggedEvents.append($0) }
         Current.api = { [api] in api }
+        Current.location.oneShotLocation = { _ in .value(.init(latitude: 0, longitude: 0)) }
         collector = FakeCollector()
         processor = FakeProcessor()
         regionFilter = FakeRegionFilter()
@@ -252,7 +253,9 @@ class ZoneManagerTests: XCTestCase {
             eventType: .locationChange([CLLocation(latitude: 1.23, longitude: 4.56)])
         ))
 
-        wait(for: [expectation], timeout: 10)
+        let expectation2 = self.expectation(for: .init(format: "monitoredRegions.@count == 1"), evaluatedWith: locationManager, handler: nil)
+
+        wait(for: [expectation, expectation2], timeout: 10)
 
         XCTAssertEqual(locationManager.monitoredRegions.count, 1)
         XCTAssertEqual(locationManager.monitoredRegions, Set([expectedReplacement]))

--- a/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
@@ -388,7 +388,7 @@ class FakeZoneManagerProcessorDelegate: ZoneManagerProcessorDelegate {
     }
 }
 
-class FakeHassAPI: HomeAssistantAPI {
+private class FakeHassAPI: HomeAssistantAPI {
     var getAndSendPromise: Promise<Void>?
     var getAndSendInvocation: (
         trigger: LocationUpdateTrigger?,

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -527,13 +527,10 @@ public class HomeAssistantAPI {
         }
         Current.Log.verbose("getAndSendLocation called via \(String(describing: updateTrigger))")
 
-        Current.isPerformingSingleShotLocationQuery = true
         return firstly { () -> Promise<CLLocation> in
             return CLLocationManager.oneShotLocation(
                 timeout: updateTrigger.oneShotTimeout(maximum: maximumBackgroundTime)
             )
-        }.ensure {
-            Current.isPerformingSingleShotLocationQuery = false
         }.then { location in
             self.SubmitLocation(updateType: updateTrigger, location: location, zone: zone)
         }.asVoid()

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -33,6 +33,7 @@ public class HomeAssistantAPI {
         case invalidResponse
         case cantBuildURL
         case notConfigured
+        case updateNotPossible
         case mobileAppComponentNotLoaded
         case webhookGone
         case mustUpgradeHomeAssistant(Version)
@@ -481,6 +482,12 @@ public class HomeAssistantAPI {
                 location: location,
                 zone: zone
             ))
+        }.map { (update: WebhookUpdateLocation?) -> WebhookUpdateLocation in
+            if let update = update {
+                return update
+            } else {
+                throw HomeAssistantAPI.APIError.updateNotPossible
+            }
         }.map { payload -> [String: Any] in
             let realm = Current.realm()
             // swiftlint:disable:next force_try
@@ -727,6 +734,8 @@ extension HomeAssistantAPI.APIError: LocalizedError {
             return L10n.HaApi.ApiError.cantBuildUrl
         case .notConfigured:
             return L10n.HaApi.ApiError.notConfigured
+        case .updateNotPossible:
+            return L10n.HaApi.ApiError.updateNotPossible
         case .mobileAppComponentNotLoaded:
             return L10n.HaApi.ApiError.mobileAppComponentNotLoaded
         case .webhookGone:

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -629,6 +629,24 @@ public class HomeAssistantAPI {
         return (eventType: "tag_scanned", eventData: eventData)
     }
 
+    @available(watchOS, unavailable)
+    public class func zoneStateEvent(
+        region: CLRegion,
+        state: CLRegionState,
+        zone: RLMZone
+    ) -> (eventType: String, eventData: [String: Any]) {
+        var eventData: [String: Any] = sharedEventDeviceInfo
+        eventData["zone"] = zone.ID
+        if region.identifier.contains("@"), let subId = region.identifier.split(separator: "@").last {
+            eventData["multi_region_zone_id"] = String(subId)
+        }
+        if state == .inside {
+            return (eventType: "ios.zone_entered", eventData: eventData)
+        } else {
+            return (eventType: "ios.zone_exited", eventData: eventData)
+        }
+    }
+
     public func HandleAction(actionID: String, source: ActionSource) -> Promise<Void> {
         return Promise { seal in
             guard let api = HomeAssistantAPI.authenticatedAPI() else {

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -12,13 +12,6 @@ import CoreLocation
 import CoreMotion
 import DeviceKit
 
-public enum UpdateTypes: String {
-    case GlobalPositioningSystem = "gps"
-    case Router = "router"
-    case Bluetooth = "bluetooth"
-    case BluetoothLowEnergy = "bluetooth_le"
-}
-
 public enum LocationNames: String {
     case Home = "home"
     case NotHome = "not_home"
@@ -47,13 +40,12 @@ public class WebhookUpdateLocation: Mappable {
         self.init()
 
         self.Trigger = trigger
-        self.Battery = Device.current.batteryLevel ?? 0
+        self.Battery = Current.device.batteryLevel()
 
         let useLocation: Bool
 
         switch trigger {
         case .BeaconRegionExit, .BeaconRegionEnter:
-            // never use location for beacons
             useLocation = false
         default:
             useLocation = true
@@ -63,6 +55,8 @@ public class WebhookUpdateLocation: Mappable {
             self.SetLocation(location: location)
         } else if let zone = zone {
             self.SetZone(zone: zone)
+        } else {
+            return nil
         }
     }
 
@@ -91,7 +85,7 @@ public class WebhookUpdateLocation: Mappable {
             }
         } else {
             switch self.Trigger {
-            case .BeaconRegionEnter:
+            case .BeaconRegionEnter where !zone.isPassive:
                 self.LocationName = zone.Name
             case .BeaconRegionExit:
                 self.ClearLocation()

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -43,7 +43,7 @@ public class WebhookUpdateLocation: Mappable {
 
     public required init?(map: Map) {}
 
-    public convenience init(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
+    public convenience init?(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
         self.init()
 
         self.Trigger = trigger

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -255,6 +255,14 @@ public class Environment {
     }
     public var geocoder = Geocoder()
 
+    /// Wrapper around One Shot
+    public struct Location {
+        public lazy var oneShotLocation: (_ timeout: TimeInterval) -> Promise<CLLocation> = {
+            CLLocationManager.oneShotLocation(timeout: $0)
+        }
+    }
+    public var location = Location()
+
     /// Wrapper around CoreTelephony, Reachability
     public struct Connectivity {
         public var currentWiFiSSID: () -> String? = { ConnectionInfo.CurrentWiFiSSID }

--- a/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -130,6 +130,8 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
         (self.promise, self.seal) = Promise<CLLocation>.pending()
         self.locationManager = locationManager
 
+        Current.isPerformingSingleShotLocationQuery = true
+
         super.init()
 
         locationManager.allowsBackgroundLocationUpdates = true
@@ -142,6 +144,8 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
             locationManager.stopUpdatingLocation()
             locationManager.delegate = nil
             self.selfRetain = nil
+
+            Current.isPerformingSingleShotLocationQuery = false
         }
 
         timeout.done(on: workQueue) { [weak self] in

--- a/Shared/Location/LocationTrigger.swift
+++ b/Shared/Location/LocationTrigger.swift
@@ -37,7 +37,7 @@ public enum LocationUpdateTrigger: String, CaseIterable {
     case Periodic = "Periodic"
     case Unknown = "Unknown"
 
-    func oneShotTimeout(maximum: TimeInterval?) -> TimeInterval {
+    public func oneShotTimeout(maximum: TimeInterval?) -> TimeInterval {
         if let maximum = maximum {
             // the system appears to have given us a reasonable baseline, leave some time for network call
             return max(maximum - 5.0, 1.0)

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -380,6 +380,8 @@ internal enum L10n {
       internal static let notConfigured = L10n.tr("Localizable", "ha_api.api_error.not_configured")
       /// An unknown error occurred.
       internal static let unknown = L10n.tr("Localizable", "ha_api.api_error.unknown")
+      /// Operation could not be performed.
+      internal static let updateNotPossible = L10n.tr("Localizable", "ha_api.api_error.update_not_possible")
       /// mobile_app integration has been deleted, you must reconfigure the app.
       internal static let webhookGone = L10n.tr("Localizable", "ha_api.api_error.webhook_gone")
     }


### PR DESCRIPTION
- Fires `ios.zone_entered` and `ios.zone_exited` directly from monitored regions. This will include keys `"zone" = zone.xyz"` and sometimes `"multi_region_zone_id" = "180"` when the zone (<100m at the time of writing this) require multiple regions. Refs #924 which asked for this.
- Fixes passive beacon zones being sent up as definite zones, rather than GPS producers. I'm not sure when this regressed, this behavior looks the same to my eye to before it was reported broken, but it's an easy fix. Fixes #924.
- Fixes cases where a region monitoring enter event might not produce an in-region location update when the accuracy and position do not show the current location as being in the region. When this occurs, we fudge the accuracy to be larger than given such that the GPS location is inside the region. Fixes #841.