### PR TITLE
Fix Battery Sensor in Catalyst; add more info to it

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -164,6 +164,8 @@
 		11C590ED24A832CA0066085D /* YamlSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C590EC24A832CA0066085D /* YamlSection.swift */; };
 		11C65CC0249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */; };
 		11C65CC1249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */; };
+		11C8E8AD24F36535003E7F89 /* DeviceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */; };
+		11C8E8AE24F3778E003E7F89 /* DeviceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */; };
 		11CB98C6249DE15B00B05222 /* LastUpdateSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CB98C5249DE15B00B05222 /* LastUpdateSensor.test.swift */; };
 		11CB98C8249DE24100B05222 /* PedometerSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CB98C7249DE24000B05222 /* PedometerSensor.test.swift */; };
 		11CB98CA249E62E700B05222 /* Version+HA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CB98C9249E62E700B05222 /* Version+HA.swift */; };
@@ -922,6 +924,7 @@
 		11C4629524B19FC700031902 /* URLSessionTask+WebhookPersisted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionTask+WebhookPersisted.swift"; sourceTree = "<group>"; };
 		11C590EC24A832CA0066085D /* YamlSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlSection.swift; sourceTree = "<group>"; };
 		11C65CBF249838EB00D07FC7 /* StreamCameraResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCameraResponse.swift; sourceTree = "<group>"; };
+		11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWrapper.swift; sourceTree = "<group>"; };
 		11CB98C5249DE15B00B05222 /* LastUpdateSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdateSensor.test.swift; sourceTree = "<group>"; };
 		11CB98C7249DE24000B05222 /* PedometerSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PedometerSensor.test.swift; sourceTree = "<group>"; };
 		11CB98C9249E62E700B05222 /* Version+HA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Version+HA.swift"; sourceTree = "<group>"; };
@@ -2519,6 +2522,7 @@
 				D00302BD20D4BEDB004C2CA9 /* Environment.swift */,
 				D03D893A20E0B2E300D4F28D /* Constants.swift */,
 				1101568624D7712F009424C9 /* TagManagerProtocol.swift */,
+				11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -4313,6 +4317,7 @@
 				11AF4D20249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,
 				B67CE8A622200F220034C1D0 /* HAAPI.swift in Sources */,
 				1141182724AF9A0500E6525C /* WebhookManager.swift in Sources */,
+				11C8E8AD24F36535003E7F89 /* DeviceWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4441,6 +4446,7 @@
 				11EE9B5424C62EB300404AF8 /* RealmScene.swift in Sources */,
 				D0EEF322214DE56B00D1D360 /* LocationTrigger.swift in Sources */,
 				D0B25BD62133128800678C2C /* UNNotificationContent+ClientEvent.swift in Sources */,
+				11C8E8AE24F3778E003E7F89 /* DeviceWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HomeAssistant/Notifications/HomeAssistantAPI+Notifications.swift
+++ b/HomeAssistant/Notifications/HomeAssistantAPI+Notifications.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 Robbie Trencheny. All rights reserved.
 //
 
-import DeviceKit
 import Foundation
 import PromiseKit
 import Shared

--- a/HomeAssistant/Utilities/Bonjour.swift
+++ b/HomeAssistant/Utilities/Bonjour.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 Robbie Trencheny. All rights reserved.
 //
 
-import DeviceKit
 import Foundation
 import Shared
 
@@ -79,10 +78,13 @@ public class Bonjour {
     public var publishIsRunning: Bool = false
 
     public init() {
-        let device = Device.current
         self.nsb = NetServiceBrowser()
-        self.nsp = NetService(domain: "local", type: "_hass-mobile-app._tcp.", name: device.name ?? "Unknown",
-                              port: 65535)
+        self.nsp = NetService(
+            domain: "local",
+            type: "_hass-mobile-app._tcp.",
+            name: Current.device.deviceName(),
+            port: 65535
+        )
     }
 
     private func buildPublishDict() -> [String: Data] {

--- a/HomeAssistant/Utilities/WatchHelpers.swift
+++ b/HomeAssistant/Utilities/WatchHelpers.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Communicator
-import DeviceKit
 import ObjectMapper
 import PromiseKit
 import RealmSwift
@@ -47,7 +46,7 @@ extension HomeAssistantAPI {
         }
 
         content["activeFamilies"] = activeFamilies
-        content["watchModel"] = Device.identifier
+        content["watchModel"] = Current.device.systemModel()
 
         #endif
 

--- a/HomeAssistant/Views/Settings/NFC/NFCReader.swift
+++ b/HomeAssistant/Views/Settings/NFC/NFCReader.swift
@@ -30,7 +30,7 @@ class NFCReader: NSObject, NFCTagReaderSessionDelegate {
             delegate: self,
             queue: nil
         )
-        readerSession.alertMessage = L10n.Nfc.Read.startMessage(Current.device.model())
+        readerSession.alertMessage = L10n.Nfc.Read.startMessage(Current.device.inspecificModel())
         readerSession.begin()
     }
 

--- a/HomeAssistant/Views/Settings/NFC/NFCWriter.swift
+++ b/HomeAssistant/Views/Settings/NFC/NFCWriter.swift
@@ -37,7 +37,7 @@ class NFCWriter: NSObject, NFCNDEFReaderSessionDelegate {
             queue: nil,
             invalidateAfterFirstRead: false
         )
-        readerSession.alertMessage = L10n.Nfc.Write.startMessage(Current.device.model())
+        readerSession.alertMessage = L10n.Nfc.Write.startMessage(Current.device.inspecificModel())
         readerSession.begin()
     }
 

--- a/HomeAssistant/Views/SettingsDetailViewController.swift
+++ b/HomeAssistant/Views/SettingsDetailViewController.swift
@@ -15,7 +15,6 @@ import PromiseKit
 import RealmSwift
 import Firebase
 import CoreMotion
-import DeviceKit
 import FirebaseMessaging
 import Version
 
@@ -70,7 +69,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 +++ Section()
                 <<< TextRow {
                     $0.title = L10n.SettingsDetails.General.DeviceName.title
-                    $0.placeholder = Device.current.name
+                    $0.placeholder = Current.device.deviceName()
                     $0.value = Current.settingsStore.overrideDeviceName
                     $0.onChange { row in
                         Current.settingsStore.overrideDeviceName = row.value

--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,6 @@ ENV['CUSTOM_FONT_NAME'] = 'MaterialDesignIcons'
 def shared_pods
     pod 'Alamofire', '~> 4.0'
     pod 'Communicator', '~> 3.3.0'
-    pod 'DeviceKit'
     #pod 'Iconic', :git => 'https://github.com/home-assistant/Iconic.git', :branch => 'master'
     pod 'KeychainAccess'
     pod 'ObjectMapper', :git => 'https://github.com/tristanhimmelman/ObjectMapper.git', :branch => 'master'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
   - Communicator (3.3.0):
     - TABObserverSet (~> 2)
   - CPDAcknowledgements (1.0.0)
-  - DeviceKit (3.2.0)
   - EMTLoadingIndicator (4.0.0)
   - Eureka (5.2.1)
   - Firebase/CoreOnly (6.30.0):
@@ -128,7 +127,6 @@ DEPENDENCIES:
   - ColorPickerRow (from `https://github.com/EurekaCommunity/ColorPickerRow`, branch `master`)
   - Communicator (~> 3.3.0)
   - CPDAcknowledgements (from `https://github.com/CocoaPods/CPDAcknowledgements`, branch `master`)
-  - DeviceKit
   - EMTLoadingIndicator (from `https://github.com/hirokimu/EMTLoadingIndicator`, branch `master`)
   - Eureka (from `https://github.com/xmartlabs/Eureka.git`, branch `xcode12`)
   - Firebase/Messaging
@@ -157,7 +155,6 @@ SPEC REPOS:
     - Alamofire
     - CallbackURLKit
     - Communicator
-    - DeviceKit
     - Firebase
     - FirebaseCore
     - FirebaseCoreDiagnostics
@@ -240,7 +237,6 @@ SPEC CHECKSUMS:
   ColorPickerRow: 409acc262ca04283eb56f54e813e775d2e99741e
   Communicator: d870b95ca54965412790334620e2f188c68f2462
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
-  DeviceKit: d081659419cce07c0b5239dbc9fb39ed7413c7fe
   EMTLoadingIndicator: 0d3256b0de3e6ba5ab17048acc7aa93af34e48d3
   Eureka: c883105488e05bc65539f583246ecf9657cabbfe
   Firebase: 210f41ca352067d83b1ba4fd2e7fb49a0c017397
@@ -276,6 +272,6 @@ SPEC CHECKSUMS:
   XCGLogger: 1943831ef907df55108b0b18657953f868de973b
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 4947112bc9a2d81df28eceb617901de5a7e48ce5
+PODFILE CHECKSUM: 9b8a817a320499f97e8a3adcee67159c468abf09
 
 COCOAPODS: 1.10.0.beta.2

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -73,7 +73,7 @@ public class HomeAssistantAPI {
             let version = ProcessInfo.processInfo.operatingSystemVersion
             let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
 
-            var notCircularReferenceWrapper = DeviceWrapper()
+            let notCircularReferenceWrapper = DeviceWrapper()
             let osName = notCircularReferenceWrapper.systemName()
             return "\(osName) \(versionString)"
         }()

--- a/Shared/API/Models/NotificationCategory.swift
+++ b/Shared/API/Models/NotificationCategory.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import RealmSwift
-import DeviceKit
 import UserNotifications
 
 final public class NotificationCategory: Object, UpdatableModel {

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -10,7 +10,6 @@ import Foundation
 import ObjectMapper
 import CoreLocation
 import CoreMotion
-import DeviceKit
 
 public enum LocationNames: String {
     case Home = "home"

--- a/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -8,14 +8,11 @@ public class BatterySensor: SensorProvider {
     }
 
     public func sensors() -> Promise<[WebhookSensor]> {
-        var level = Current.device.batteryLevel()
-        if level == -100 { // simulator fix
-            level = 100
-        }
-
+        let level = Current.device.batteryLevel()
         var state = "Unknown"
         var icon = "mdi:battery"
 
+        let batteryAttributes = Current.device.verboseBatteryInfo()
         let batState = Current.device.batteryState()
         let isLowPowerMode = Current.device.isLowPowerMode()
 
@@ -41,7 +38,7 @@ public class BatterySensor: SensorProvider {
             $0.Attributes = [
                 "Battery State": state,
                 "Low Power Mode": isLowPowerMode
-            ]
+            ].merging(batteryAttributes, uniquingKeysWith: { a, _ in a })
             $0.UnitOfMeasurement = "%"
         }
 
@@ -56,7 +53,7 @@ public class BatterySensor: SensorProvider {
             $0.Attributes = [
                 "Battery Level": level,
                 "Low Power Mode": isLowPowerMode
-            ]
+            ].merging(batteryAttributes, uniquingKeysWith: { a, _ in a })
         }
 
         return .value([levelSensor, stateSensor])

--- a/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -20,10 +20,10 @@ public class BatterySensor: SensorProvider {
         let isLowPowerMode = Current.device.isLowPowerMode()
 
         switch batState {
-        case .charging(let level):
+        case .charging:
             state = "Charging"
             icon = Self.chargingIcon(level: level)
-        case .unplugged(let level):
+        case .unplugged:
             state = "Not Charging"
             icon = Self.unpluggedIcon(level: level)
         case .full:

--- a/Shared/API/Webhook/Sensors/StorageSensor.swift
+++ b/Shared/API/Webhook/Sensors/StorageSensor.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PromiseKit
-import DeviceKit
 
 public class StorageSensor: SensorProvider {
     public enum StorageError: Error, Equatable {

--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -139,7 +139,11 @@ public class DeviceWrapper {
         #if os(iOS)
             return UIDevice.current.identifierForVendor?.uuidString
         #elseif os(watchOS)
-            return WKInterfaceDevice.current().identifierForVendor?.uuidString
+            if #available(watchOS 6.2, *) {
+                return WKInterfaceDevice.current().identifierForVendor?.uuidString
+            } else {
+                return nil
+            }
         #endif
     }
 

--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -1,0 +1,151 @@
+import Foundation
+#if os(iOS)
+import UIKit
+#elseif os(watchOS)
+import WatchKit
+#endif
+
+/// Wrapper around UIDevice/WKInterfaceDevice
+public struct DeviceWrapper {
+    public lazy var batteryLevel: () -> Int = {
+        #if os(iOS)
+        let isMonitoringEnabled = UIDevice.current.isBatteryMonitoringEnabled
+        defer {
+            UIDevice.current.isBatteryMonitoringEnabled = isMonitoringEnabled
+        }
+        return Int(round(UIDevice.current.batteryLevel * 100))
+        #elseif os(watchOS)
+        let isMonitoringEnabled = WKInterfaceDevice.current().isBatteryMonitoringEnabled
+        defer {
+            WKInterfaceDevice.current().isBatteryMonitoringEnabled = isMonitoringEnabled
+        }
+        return Int(round(WKInterfaceDevice.current().batteryLevel * 100))
+        #endif
+    }
+
+    public enum BatteryState {
+        case charging
+        case unplugged
+        case full
+
+        #if os(iOS)
+        init(state: UIDevice.BatteryState) {
+            switch state {
+            case .charging: self = .charging
+            case .full: self = .full
+            case .unplugged: self = .unplugged
+            case .unknown: self = .full
+            @unknown default: self = .full
+            }
+        }
+        #endif
+
+        #if os(watchOS)
+        init(state: WKInterfaceDeviceBatteryState) {
+            switch state {
+            case .charging: self = .charging
+            case .full: self = .full
+            case .unplugged: self = .unplugged
+            case .unknown: self = .full
+            @unknown default: self = .full
+            }
+        }
+        #endif
+    }
+
+    public lazy var batteryState: () -> BatteryState = {
+        #if os(iOS)
+        let isMonitoringEnabled = UIDevice.current.isBatteryMonitoringEnabled
+        defer {
+            UIDevice.current.isBatteryMonitoringEnabled = isMonitoringEnabled
+        }
+        return .init(state: UIDevice.current.batteryState)
+        #elseif os(watchOS)
+        let isMonitoringEnabled = WKInterfaceDevice.current().isBatteryMonitoringEnabled
+        defer {
+            WKInterfaceDevice.current().isBatteryMonitoringEnabled = isMonitoringEnabled
+        }
+        return .init(state: WKInterfaceDevice.current().batteryState)
+        #endif
+    }
+
+    public lazy var isLowPowerMode: () -> Bool = {
+        ProcessInfo.processInfo.isLowPowerModeEnabled
+    }
+
+    public lazy var volumes: () -> [URLResourceKey: Int64]? = {
+        #if os(iOS)
+            return try? URL(fileURLWithPath: NSHomeDirectory()).resourceValues(forKeys: [
+                .volumeAvailableCapacityForImportantUsageKey,
+                .volumeAvailableCapacityKey,
+                .volumeAvailableCapacityForOpportunisticUsageKey,
+                .volumeTotalCapacityKey
+            ]).allValues.mapValues {
+                if let int = $0 as? Int64 {
+                    return int
+                }
+                if let int = $0 as? Int {
+                    return Int64(int)
+                }
+                return 0
+            }
+        #elseif os(watchOS)
+            return nil
+        #endif
+    }
+
+    @available(iOS 7.0, watchOS 6.2, *)
+    public lazy var identifierForVendor: () -> String? = {
+        #if os(iOS)
+            return UIDevice.current.identifierForVendor?.uuidString
+        #elseif os(watchOS)
+            return WKInterfaceDevice.current().identifierForVendor?.uuidString
+        #endif
+    }
+
+    public lazy var inspecificModel: () -> String = {
+        #if os(iOS)
+            return UIDevice.current.model
+        #elseif os(watchOS)
+            return WKInterfaceDevice.current().model
+        #endif
+    }
+
+    public lazy var deviceName: () -> String = {
+        #if os(iOS)
+        return UIDevice.current.name
+        #elseif os(watchOS)
+        return WKInterfaceDevice.current().name
+        #endif
+    }
+
+    public lazy var systemName: () -> String = {
+        #if os(iOS)
+        // iOS
+        return UIDevice.current.systemName
+        #elseif os(watchOS)
+        // watchOS
+        return WKInterfaceDevice.current().systemName
+        #endif
+    }
+
+    public lazy var systemVersion: () -> String = {
+        #if os(iOS)
+        return UIDevice.current.systemVersion
+        #elseif os(watchOS)
+        return WKInterfaceDevice.current().systemVersion
+        #endif
+    }
+
+    public lazy var systemModel: () -> String = {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let mirror = Mirror(reflecting: systemInfo.machine)
+
+        let identifier = mirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }
+}

--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -36,7 +36,11 @@ public class DeviceWrapper {
         defer {
             UIDevice.current.isBatteryMonitoringEnabled = isMonitoringEnabled
         }
-        return Int(round(UIDevice.current.batteryLevel * 100))
+        #if targetEnvironment(simulator)
+            return 100
+        #else
+            return Int(round(UIDevice.current.batteryLevel * 100))
+        #endif
         #elseif os(watchOS)
         let isMonitoringEnabled = WKInterfaceDevice.current().isBatteryMonitoringEnabled
         defer {

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -11,7 +11,6 @@ import PromiseKit
 import RealmSwift
 import XCGLogger
 import CoreMotion
-import DeviceKit
 import CoreLocation
 import Version
 #if os(iOS)
@@ -242,20 +241,6 @@ public class Environment {
     }
     public var pedometer = Pedometer()
 
-    /// Wrapper around DeviceKit
-    public struct DeviceWrapper {
-        public lazy var batteryLevel: () -> Int = { Device.current.batteryLevel ?? 0 }
-        public lazy var batteryState: () -> Device.BatteryState = { Device.current.batteryState ?? .full }
-        public lazy var isLowPowerMode: () -> Bool = { Device.current.batteryState?.lowPowerMode ?? false }
-        public lazy var volumes: () -> [URLResourceKey: Int64]? = {
-            #if os(iOS)
-                return Device.volumes
-            #else
-                return nil
-            #endif
-        }
-        public lazy var model: () -> String = { Device.current.model ?? L10n.Device.genericName }
-    }
     public var device = DeviceWrapper()
 
     /// Wrapper around CLGeocoder

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -8,15 +8,10 @@
 
 import Foundation
 import KeychainAccess
-import DeviceKit
 import CoreLocation
 import CoreMotion
 import Version
-#if os(iOS)
 import UIKit
-#elseif os(watchOS)
-import WatchKit
-#endif
 
 // swiftlint:disable:next type_body_length
 public class SettingsStore {
@@ -134,15 +129,11 @@ public class SettingsStore {
     public var integrationDeviceID: String {
         let baseString: String
 
-        #if os(iOS)
-            baseString = UIDevice.current.identifierForVendor?.uuidString ?? deviceID
-        #elseif os(watchOS)
-            if #available(watchOS 6.2, *) {
-                baseString = WKInterfaceDevice.current().identifierForVendor?.uuidString ?? deviceID
-            } else {
-                baseString = deviceID
-            }
-        #endif
+        if #available(iOS 7, watchOS 6.2, *) {
+            baseString = Current.device.identifierForVendor() ?? deviceID
+        } else {
+            baseString = deviceID
+        }
 
         switch Current.appConfiguration {
         case .Beta:
@@ -353,7 +344,7 @@ public class SettingsStore {
     }
 
     private var defaultDeviceID: String {
-        let baseID = self.removeSpecialCharsFromString(text: Device.current.name ?? "Unknown")
+        let baseID = self.removeSpecialCharsFromString(text: Current.device.deviceName())
             .replacingOccurrences(of: " ", with: "_")
             .lowercased()
 

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -127,13 +127,7 @@ public class SettingsStore {
     }
 
     public var integrationDeviceID: String {
-        let baseString: String
-
-        if #available(iOS 7, watchOS 6.2, *) {
-            baseString = Current.device.identifierForVendor() ?? deviceID
-        } else {
-            baseString = deviceID
-        }
+        let baseString = Current.device.identifierForVendor() ?? deviceID
 
         switch Current.appConfiguration {
         case .Beta:

--- a/SharedTests/CLLocationManager+OneShotLocationTests.swift
+++ b/SharedTests/CLLocationManager+OneShotLocationTests.swift
@@ -556,18 +556,26 @@ class OneShotLocationTests: XCTestCase {
 
                 if testCase.hasPerfect {
                     XCTAssertTrue(promise.isFulfilled, file: testCase.file, line: testCase.line)
+
+                    XCTAssertEqual(
+                        promise.value,
+                        testCase.winnerLocation,
+                        testCase.reason,
+                        file: testCase.file,
+                        line: testCase.line
+                    )
                 } else {
                     XCTAssertFalse(promise.isFulfilled, file: testCase.file, line: testCase.line)
                     timeoutSeal(())
-                }
 
-                XCTAssertEqual(
-                    try hang(promise),
-                    testCase.winnerLocation,
-                    testCase.reason,
-                    file: testCase.file,
-                    line: testCase.line
-                )
+                    XCTAssertEqual(
+                        try hang(promise),
+                        testCase.winnerLocation,
+                        testCase.reason,
+                        file: testCase.file,
+                        line: testCase.line
+                    )
+                }
             }
         }
     }

--- a/SharedTests/Sensors/BatterySensor.test.swift
+++ b/SharedTests/Sensors/BatterySensor.test.swift
@@ -2,7 +2,6 @@ import Foundation
 @testable import Shared
 import PromiseKit
 import XCTest
-import DeviceKit
 
 class BatterySensorTests: XCTestCase {
     func testBattery0() throws {


### PR DESCRIPTION
Switches from UIDevice to (available on Mac) `IOKit` and its Power Sources module. This gives us a lot more granular information about batteries, like cycle counts and other fun things. Given the volume of [available keys](https://developer.apple.com/documentation/iokit/iopskeys_h/defines) I've decided to just use the existing, gross, developer-ish key as the attribute. May clean this up in the future, may say "meh" since we're going to be hard-coding English as well anyway.

Removes DeviceKit; it wasn't updated for Catalyst (so it called every Mac a 'Simulator') and I didn't feel like trying to pull it into the Catalyst era manually since our use of it is pretty slim. Most of the methods were already something I had shimmed for easier testing.

Refs #934.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/74188/91009280-1a28f100-e595-11ea-9620-fcee34250501.png">
