### PR TITLE
Prevent using background session on Catalyst

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -71,7 +71,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         setDefaults()
-        Current.isBackgroundRequestsImmediate = { application.applicationState != .background }
+        Current.isBackgroundRequestsImmediate = {
+            if Current.isCatalyst {
+                return false
+            } else {
+                return application.applicationState != .background
+            }
+        }
 
         #if targetEnvironment(simulator)
         Current.tags = SimulatorTagManager()


### PR DESCRIPTION
Unless the app is in the foreground, background sessions appear broken -- I see `urlsessiond` logging about the network requests:

```
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> uploadTaskWithRequest: <private> fromFile: <private>
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<396> is for <<private>>.<<private>>.<396>
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> enqueueing
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> resumeTaskWithIdentifier, props <private>
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> resuming, QOS(0x19)
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> resuming
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> has not requested a begin delay
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> skipping delayed request callback - delegate not implemented
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> will begin
Task <B22D34D2-4EEB-475E-B233-AC2F67086EC4>.<489> resuming, QOS(0x19) Voucher <private>
```

…but this task will never be referenced again in any log, the delegate methods won't be invoked, etc. Foregrounding the app, changing power state…nothing seems to kick-start it into issuing the requests. I must therefor conclude there's something broken either in our implementation specifically on Catalyst or a bug in the framework itself. TBD, but easier to fix this way than let it stay broken, since the Mac app is unlikely to be bouncing in/out of background mode anyway.

Refs #934.