### PR TITLE
Add "Reload Page" & "Update Sensors" menu items for Catalyst

### DIFF
--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -875,3 +875,5 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "menu.application.about" = "About %@";
 "menu.application.preferences" = "Preferences…";
 "menu.help.help" = "%@ Help";
+"menu.view.reload_page" = "Reload Page";
+"menu.file.update_sensors" = "Update Sensors";

--- a/HomeAssistant/Utilities/MenuManager.swift
+++ b/HomeAssistant/Utilities/MenuManager.swift
@@ -7,6 +7,8 @@ import Shared
 private extension UIMenu.Identifier {
     static var haActions: Self { .init(rawValue: "ha.actions") }
     static var haHelp: Self { .init(rawValue: "ha.help") }
+    static var haWebViewActions: Self { .init(rawValue: "ha.webViewActions") }
+    static var haFile: Self { .init(rawValue: "ha.file") }
 }
 
 @available(iOS 13, *)
@@ -48,6 +50,8 @@ class MenuManager {
         builder.insertSibling(preferencesMenu(), afterMenu: .about)
         builder.replaceChildren(ofMenu: .help) { _ in helpMenus() }
         builder.insertSibling(actionsMenu(), beforeMenu: .window)
+        builder.insertSibling(webViewActionsMenu(), beforeMenu: .fullscreen)
+        builder.insertChild(fileMenu(), atStartOfMenu: .file)
     }
 
     private func aboutMenu() -> UIMenu {
@@ -144,4 +148,44 @@ class MenuManager {
             children: Array(children)
         )
     }
+
+    private func webViewActionsMenu() -> UIMenu {
+        UIMenu(
+            title: "",
+            image: nil,
+            identifier: .haWebViewActions,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: L10n.Menu.View.reloadPage,
+                    image: nil,
+                    action: #selector(refresh),
+                    input: "R",
+                    modifierFlags: [.command]
+                )
+            ]
+        )
+    }
+
+    private func fileMenu() -> UIMenu {
+        UIMenu(
+            title: "",
+            image: nil,
+            identifier: .haFile,
+            options: .displayInline,
+            children: [
+                UIKeyCommand(
+                    title: L10n.Menu.File.updateSensors,
+                    image: nil,
+                    action: #selector(updateSensors),
+                    input: "R",
+                    modifierFlags: [.command, .shift]
+                )
+            ]
+        )
+    }
+
+    // selectors that use responder chain
+    @objc private func refresh() {}
+    @objc private func updateSensors() {}
 }

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -496,11 +496,19 @@ internal enum L10n {
       /// Preferences…
       internal static let preferences = L10n.tr("Localizable", "menu.application.preferences")
     }
+    internal enum File {
+      /// Update Sensors
+      internal static let updateSensors = L10n.tr("Localizable", "menu.file.update_sensors")
+    }
     internal enum Help {
       /// %@ Help
       internal static func help(_ p1: Any) -> String {
         return L10n.tr("Localizable", "menu.help.help", String(describing: p1))
       }
+    }
+    internal enum View {
+      /// Reload Page
+      internal static let reloadPage = L10n.tr("Localizable", "menu.view.reload_page")
     }
   }
 


### PR DESCRIPTION
Removes pull-to-refresh on Catalyst in favor of these menu choices. Not 100% certain on the keyboard shortcuts here:

- Reload Page: ⌘R
- Update Sensors: ⇧⌘R

I chose to keep them related to each other because they currently are in functionality, and R works entirely on the left hand in the English keyboard.

<img width="418" alt="image" src="https://user-images.githubusercontent.com/74188/91242276-dac8e480-e6fb-11ea-948f-c7b7939f6d63.png">
<img width="264" alt="image" src="https://user-images.githubusercontent.com/74188/91242281-ddc3d500-e6fb-11ea-8738-ccc7a11bb80d.png">
