### PR TITLE
Add macOS camera state sensor

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -37,14 +37,14 @@
 		111858DA24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A5D9F4215233EC0013963F /* SiriIntents+ConvenienceInits.swift */; };
 		111858DB24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A5D9F4215233EC0013963F /* SiriIntents+ConvenienceInits.swift */; };
 		111858DF24CB83DF00B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
-		111D294224F2F6AE00C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294124F2F6AE00C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294424F2F6AE00C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294324F2F6AE00C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294624F2F6B600C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294524F2F6B600C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294824F2F6B600C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294724F2F6B600C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294B24F2F6CD00C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294A24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294D24F2F6CD00C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294C24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */; };
-		111D294F24F2F6D900C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294E24F2F6D900C8A7D1 /* SwiftPackageProductDependency */; };
-		111D295124F2F6D900C8A7D1 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 111D295024F2F6D900C8A7D1 /* SwiftPackageProductDependency */; };
+		111D294224F2F6AE00C8A7D1 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294124F2F6AE00C8A7D1 /* Realm */; };
+		111D294424F2F6AE00C8A7D1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294324F2F6AE00C8A7D1 /* RealmSwift */; };
+		111D294624F2F6B600C8A7D1 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294524F2F6B600C8A7D1 /* Realm */; };
+		111D294824F2F6B600C8A7D1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294724F2F6B600C8A7D1 /* RealmSwift */; };
+		111D294B24F2F6CD00C8A7D1 /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294A24F2F6CD00C8A7D1 /* Clibsodium */; };
+		111D294D24F2F6CD00C8A7D1 /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294C24F2F6CD00C8A7D1 /* Sodium */; };
+		111D294F24F2F6D900C8A7D1 /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294E24F2F6D900C8A7D1 /* Clibsodium */; };
+		111D295124F2F6D900C8A7D1 /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = 111D295024F2F6D900C8A7D1 /* Sodium */; };
 		111D295624F30E2400C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
@@ -369,6 +369,8 @@
 		B60616BA1D1F117800249C11 /* US-EN-Daisy-Refrigerator-Leak.wav in Resources */ = {isa = PBXBuildFile; fileRef = B60615B91D1F117700249C11 /* US-EN-Daisy-Refrigerator-Leak.wav */; };
 		B60616BB1D1F117800249C11 /* US-EN-Daisy-Water-Heater-Leak.wav in Resources */ = {isa = PBXBuildFile; fileRef = B60615BA1D1F117700249C11 /* US-EN-Daisy-Water-Heater-Leak.wav */; };
 		B6093CE4228CFB0A0079E661 /* RemotePlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6093CE3228CFB0A0079E661 /* RemotePlayerState.swift */; };
+		B613936924F728F8002B8C5D /* MacCameraSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B613936824F728F8002B8C5D /* MacCameraSensor.swift */; };
+		B613936A24F728F8002B8C5D /* MacCameraSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B613936824F728F8002B8C5D /* MacCameraSensor.swift */; };
 		B616B299227ED68E00828165 /* Bonjour.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B25BCC2130CAB400678C2C /* Bonjour.swift */; };
 		B616B29A227ED69300828165 /* InternetAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616B28F227EAFFB00828165 /* InternetAddress.swift */; };
 		B616B29B227ED69500828165 /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616B291227EB00D00828165 /* DNSResolver.swift */; };
@@ -1169,6 +1171,7 @@
 		B60615B91D1F117700249C11 /* US-EN-Daisy-Refrigerator-Leak.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = "US-EN-Daisy-Refrigerator-Leak.wav"; sourceTree = "<group>"; };
 		B60615BA1D1F117700249C11 /* US-EN-Daisy-Water-Heater-Leak.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = "US-EN-Daisy-Water-Heater-Leak.wav"; sourceTree = "<group>"; };
 		B6093CE3228CFB0A0079E661 /* RemotePlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePlayerState.swift; sourceTree = "<group>"; };
+		B613936824F728F8002B8C5D /* MacCameraSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacCameraSensor.swift; sourceTree = "<group>"; };
 		B616B28F227EAFFB00828165 /* InternetAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetAddress.swift; sourceTree = "<group>"; };
 		B616B291227EB00D00828165 /* DNSResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
 		B6221F6122266C4000502A30 /* WebhookRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookRequest.swift; sourceTree = "<group>"; };
@@ -1579,10 +1582,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				111D295124F2F6D900C8A7D1 /* BuildFile in Frameworks */,
-				111D294824F2F6B600C8A7D1 /* BuildFile in Frameworks */,
-				111D294F24F2F6D900C8A7D1 /* BuildFile in Frameworks */,
-				111D294624F2F6B600C8A7D1 /* BuildFile in Frameworks */,
+				111D295124F2F6D900C8A7D1 /* Sodium in Frameworks */,
+				111D294824F2F6B600C8A7D1 /* RealmSwift in Frameworks */,
+				111D294F24F2F6D900C8A7D1 /* Clibsodium in Frameworks */,
+				111D294624F2F6B600C8A7D1 /* Realm in Frameworks */,
 				28F97CE2A585EB2423FB7003 /* Pods_Shared_watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1611,11 +1614,11 @@
 			files = (
 				D0EEF301214D8EAB00D1D360 /* CoreLocation.framework in Frameworks */,
 				D0B25BD7213312AE00678C2C /* UserNotifications.framework in Frameworks */,
-				111D294224F2F6AE00C8A7D1 /* BuildFile in Frameworks */,
-				111D294424F2F6AE00C8A7D1 /* BuildFile in Frameworks */,
-				111D294D24F2F6CD00C8A7D1 /* BuildFile in Frameworks */,
+				111D294224F2F6AE00C8A7D1 /* Realm in Frameworks */,
+				111D294424F2F6AE00C8A7D1 /* RealmSwift in Frameworks */,
+				111D294D24F2F6CD00C8A7D1 /* Sodium in Frameworks */,
 				AE8183AD1524FA72946974B8 /* Pods_Shared_iOS.framework in Frameworks */,
-				111D294B24F2F6CD00C8A7D1 /* BuildFile in Frameworks */,
+				111D294B24F2F6CD00C8A7D1 /* Clibsodium in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1763,6 +1766,7 @@
 				11AF4D18249C8253006C74C0 /* PedometerSensor.swift */,
 				119385A3249E8E360097F497 /* StorageSensor.swift */,
 				1109F81E24A1C011002590F2 /* SensorProvider.swift */,
+				B613936824F728F8002B8C5D /* MacCameraSensor.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -2963,10 +2967,10 @@
 			);
 			name = "Shared-watchOS";
 			packageProductDependencies = (
-				111D294524F2F6B600C8A7D1 /* SwiftPackageProductDependency */,
-				111D294724F2F6B600C8A7D1 /* SwiftPackageProductDependency */,
-				111D294E24F2F6D900C8A7D1 /* SwiftPackageProductDependency */,
-				111D295024F2F6D900C8A7D1 /* SwiftPackageProductDependency */,
+				111D294524F2F6B600C8A7D1 /* Realm */,
+				111D294724F2F6B600C8A7D1 /* RealmSwift */,
+				111D294E24F2F6D900C8A7D1 /* Clibsodium */,
+				111D295024F2F6D900C8A7D1 /* Sodium */,
 			);
 			productName = "Shared-watchOS";
 			productReference = B67CE82422200D420034C1D0 /* Shared.framework */;
@@ -3045,10 +3049,10 @@
 			);
 			name = "Shared-iOS";
 			packageProductDependencies = (
-				111D294124F2F6AE00C8A7D1 /* SwiftPackageProductDependency */,
-				111D294324F2F6AE00C8A7D1 /* SwiftPackageProductDependency */,
-				111D294A24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */,
-				111D294C24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */,
+				111D294124F2F6AE00C8A7D1 /* Realm */,
+				111D294324F2F6AE00C8A7D1 /* RealmSwift */,
+				111D294A24F2F6CD00C8A7D1 /* Clibsodium */,
+				111D294C24F2F6CD00C8A7D1 /* Sodium */,
 			);
 			productName = Shared;
 			productReference = D03D891720E0A85200D4F28D /* Shared.framework */;
@@ -3282,8 +3286,8 @@
 			);
 			mainGroup = B657A8DD1CA646EB00121384;
 			packageReferences = (
-				111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */,
-				111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */,
+				111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
+				111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */,
 			);
 			productRefGroup = B657A8E71CA646EB00121384 /* Products */;
 			projectDirPath = "";
@@ -4251,6 +4255,7 @@
 				B67CE8B522200F220034C1D0 /* String+HA.swift in Sources */,
 				B672334B225DDF410031D629 /* Event.swift in Sources */,
 				B6872E642226841400C475D1 /* MobileAppRegistrationRequest.swift in Sources */,
+				B613936A24F728F8002B8C5D /* MacCameraSensor.swift in Sources */,
 				B67CE8B422200F220034C1D0 /* URL+Extensions.swift in Sources */,
 				11C4629724B19FC800031902 /* URLSessionTask+WebhookPersisted.swift in Sources */,
 				1109F82024A1C011002590F2 /* SensorProvider.swift in Sources */,
@@ -4380,6 +4385,7 @@
 				D0EEF31B214DD7A400D1D360 /* Services.swift in Sources */,
 				B6872E662226842100C475D1 /* MobileAppRegistrationResponse.swift in Sources */,
 				D0EEF305214DD0D400D1D360 /* UIColor+HA.swift in Sources */,
+				B613936924F728F8002B8C5D /* MacCameraSensor.swift in Sources */,
 				11C4629624B19FC700031902 /* URLSessionTask+WebhookPersisted.swift in Sources */,
 				11AF4D1C249C8AA0006C74C0 /* BatterySensor.swift in Sources */,
 				D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */,
@@ -4951,6 +4957,7 @@
 				CODE_SIGN_ENTITLEMENTS = "HomeAssistant/Resources/HomeAssistant Beta.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "HomeAssistant/Resources/HomeAssistant Beta-catalyst.entitlements";
 				CURRENT_PROJECT_VERSION = 6;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENV_URL_HANDLER = "homeassistant-beta";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = HomeAssistant/Resources/Info.plist;
@@ -5357,6 +5364,7 @@
 				CODE_SIGN_ENTITLEMENTS = "HomeAssistant/Resources/HomeAssistant Development.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "HomeAssistant/Resources/HomeAssistant Development-catalyst.entitlements";
 				CURRENT_PROJECT_VERSION = 6;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENV_URL_HANDLER = "homeassistant-dev";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = HomeAssistant/Resources/Info.plist;
@@ -5404,6 +5412,7 @@
 				CODE_SIGN_ENTITLEMENTS = HomeAssistant/Resources/HomeAssistant.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "HomeAssistant/Resources/HomeAssistant-catalyst.entitlements";
 				CURRENT_PROJECT_VERSION = 6;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENV_URL_HANDLER = homeassistant;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = HomeAssistant/Resources/Info.plist;
@@ -6226,7 +6235,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */ = {
+		111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-cocoa";
 			requirement = {
@@ -6234,7 +6243,7 @@
 				minimumVersion = 5.3.5;
 			};
 		};
-		111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */ = {
+		111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jedisct1/swift-sodium";
 			requirement = {
@@ -6245,44 +6254,44 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		111D294124F2F6AE00C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294124F2F6AE00C8A7D1 /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = Realm;
 		};
-		111D294324F2F6AE00C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294324F2F6AE00C8A7D1 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = RealmSwift;
 		};
-		111D294524F2F6B600C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294524F2F6B600C8A7D1 /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = Realm;
 		};
-		111D294724F2F6B600C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294724F2F6B600C8A7D1 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294024F2F6AE00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
 			productName = RealmSwift;
 		};
-		111D294A24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294A24F2F6CD00C8A7D1 /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Clibsodium;
 		};
-		111D294C24F2F6CD00C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294C24F2F6CD00C8A7D1 /* Sodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Sodium;
 		};
-		111D294E24F2F6D900C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D294E24F2F6D900C8A7D1 /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Clibsodium;
 		};
-		111D295024F2F6D900C8A7D1 /* SwiftPackageProductDependency */ = {
+		111D295024F2F6D900C8A7D1 /* Sodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 111D294924F2F6CC00C8A7D1 /* RemoteSwiftPackageReference */;
+			package = 111D294924F2F6CC00C8A7D1 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Sodium;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/HomeAssistant/Resources/HomeAssistant Beta-catalyst.entitlements
+++ b/HomeAssistant/Resources/HomeAssistant Beta-catalyst.entitlements
@@ -25,5 +25,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)$(BUNDLE_ID_PREFIX).HomeAssistant.beta</string>
 	</array>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>

--- a/HomeAssistant/Resources/HomeAssistant Development-catalyst.entitlements
+++ b/HomeAssistant/Resources/HomeAssistant Development-catalyst.entitlements
@@ -25,5 +25,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)$(BUNDLE_ID_PREFIX).HomeAssistant.dev</string>
 	</array>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>

--- a/HomeAssistant/Resources/HomeAssistant-catalyst.entitlements
+++ b/HomeAssistant/Resources/HomeAssistant-catalyst.entitlements
@@ -25,5 +25,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)$(BUNDLE_ID_PREFIX).HomeAssistant</string>
 	</array>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>

--- a/Shared/API/Webhook/Sensors/MacCameraSensor.swift
+++ b/Shared/API/Webhook/Sensors/MacCameraSensor.swift
@@ -1,0 +1,149 @@
+import Foundation
+import PromiseKit
+#if targetEnvironment(macCatalyst)
+import AVFoundation
+import CoreMediaIO
+#endif
+
+public class MacCameraSensor: SensorProvider {
+    public enum MacCameraError: Error, Equatable {
+        case noCameras
+    }
+
+    public let request: SensorProviderRequest
+    required public init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    #if targetEnvironment(macCatalyst)
+    public func sensors() -> Promise<[WebhookSensor]> {
+        firstly {
+            Promise<Void>.value(())
+        }.map(on: .global(qos: .userInitiated)) {
+            let cams = self.cameras
+            if cams.count == 0 {
+                throw MacCameraError.noCameras
+            }
+            return try cams.compactMap { try Self.sensor(camera: $0) }
+        }
+    }
+
+    private static func sensor(camera: Camera) throws -> WebhookSensor {
+        let sensor = WebhookSensor(
+            name: camera.name ?? "Unknown Camera",
+            uniqueID: "camera_\(camera.id)",
+            icon: camera.isOn ? .cameraIcon : .cameraOffIcon,
+            state: camera.isOn
+        )
+
+        sensor.Attributes = [
+            "Manufacturer": camera.manufacturer ?? "Unknown"
+        ]
+
+        return sensor
+    }
+
+    var cameras: [Camera] {
+        var innerArray: [Camera] = []
+        var opa = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMaster)
+        )
+
+        var dataSize: UInt32 = 0
+        var dataUsed: UInt32 = 0
+        var result = CMIOObjectGetPropertyDataSize(CMIOObjectID(kCMIOObjectSystemObject), &opa, 0, nil, &dataSize)
+        var devices: UnsafeMutableRawPointer?
+
+        repeat {
+            if devices != nil {
+                free(devices)
+                devices = nil
+            }
+
+            devices = malloc(Int(dataSize))
+            result = CMIOObjectGetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &opa, 0, nil, dataSize, &dataUsed,
+                                               devices)
+        } while result == OSStatus(kCMIOHardwareBadPropertySizeError)
+
+        if let devices = devices {
+            for offset in stride(from: 0, to: dataSize, by: MemoryLayout<CMIOObjectID>.size) {
+                let current = devices.advanced(by: Int(offset)).assumingMemoryBound(to: CMIOObjectID.self)
+                innerArray.append(Camera(id: current.pointee))
+            }
+        }
+
+        free(devices)
+
+        return innerArray
+    }
+
+    struct Camera {
+        var id: CMIOObjectID
+        var name: String? {
+            var address: CMIOObjectPropertyAddress = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIOObjectPropertyName),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMaster))
+
+            var name: CFString?
+            let propsize: UInt32 = UInt32(MemoryLayout<CFString?>.size)
+            var dataUsed: UInt32 = 0
+
+            let result: OSStatus = CMIOObjectGetPropertyData(self.id, &address, 0, nil, propsize, &dataUsed, &name)
+            if result != 0 {
+                return nil
+            }
+
+            return name as String?
+        }
+
+        var manufacturer: String? {
+            var address: CMIOObjectPropertyAddress = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIOObjectPropertyManufacturer),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMaster))
+
+            var manufName: CFString?
+            let propsize: UInt32 = UInt32(MemoryLayout<CFString?>.size)
+            var dataUsed: UInt32 = 0
+
+            let result: OSStatus = CMIOObjectGetPropertyData(self.id, &address, 0, nil, propsize, &dataUsed, &manufName)
+            if result != 0 {
+                return nil
+            }
+
+            return manufName as String?
+        }
+
+        var isOn: Bool {
+            var opa = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeWildcard),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementWildcard)
+            )
+
+            var isUsed = false
+
+            var dataSize: UInt32 = 0
+            var dataUsed: UInt32 = 0
+            var result = CMIOObjectGetPropertyDataSize(self.id, &opa, 0, nil, &dataSize)
+            if result == OSStatus(kCMIOHardwareNoError) {
+                if let data = malloc(Int(dataSize)) {
+                    result = CMIOObjectGetPropertyData(self.id, &opa, 0, nil, dataSize, &dataUsed, data)
+                    let on = data.assumingMemoryBound(to: UInt8.self)
+                    isUsed = on.pointee != 0
+                }
+            }
+
+            return isUsed
+        }
+    }
+
+    #else
+    public func sensors() -> Promise<[WebhookSensor]> {
+        return .init(error: MacCameraError.noCameras)
+    }
+    #endif
+}

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -73,6 +73,7 @@ public class Environment {
         $0.register(provider: ConnectivitySensor.self)
         $0.register(provider: GeocoderSensor.self)
         $0.register(provider: LastUpdateSensor.self)
+        $0.register(provider: MacCameraSensor.self)
     }
 
     public var tags: TagManager = EmptyTagManager()


### PR DESCRIPTION
Adds a sensor for every camera connected to a Mac. State is true if camera is in use. Only attribute is Manufacturer. Icon changes based on if camera is on or not.

[Cameo](https://github.com/lvsti/Cameo) shows the following data about cameras is provided by the system. If anything else looks interesting I can expose it as attributes:

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/18516/91372478-97887780-e7c8-11ea-918b-8cc5a5498bd8.png">

Next version of this should monitor for camera state changes and update sensors. Example implementations:

* [stackoverflow.com/questions/42681127/coremediaio-incorrectly-updated-properties-kcmiodevicepropertydeviceisrunningso?rq=1](https://stackoverflow.com/questions/42681127/coremediaio-incorrectly-updated-properties-kcmiodevicepropertydeviceisrunningso?rq=1)
* [wouterdebie/onair@`52f2ea0`/Sources/onair/Camera.swift](https://github.com/wouterdebie/onair/blob/52f2ea0b72793e1eee0f64478bc7c3a87c094a02/Sources/onair/Camera.swift)
* [jakobwesthoff/on-air-notifier@`de4a579`/on-air-notifier/CameraWatcher.swift](https://github.com/jakobwesthoff/on-air-notifier/blob/de4a5794c561be510b1a0537f229f03fbb6e6635/on-air-notifier/CameraWatcher.swift)
* [lvsti/Cameo@`79d0037`/CameoSDK/Property.swift](https://github.com/lvsti/Cameo/blob/79d0037e839807b08e590cd7f8027e1a163aa456/CameoSDK/Property.swift)

Fixes #944