### PR TITLE
Make camera sensors be binary_sensor

### DIFF
--- a/Shared/API/Webhook/Sensors/MacCameraSensor.swift
+++ b/Shared/API/Webhook/Sensors/MacCameraSensor.swift
@@ -83,6 +83,7 @@ public class MacCameraSensor: SensorProvider {
             state: camera.isOn
         )
 
+        sensor.Type = "binary_sensor"
         sensor.Attributes = [
             "Manufacturer": camera.manufacturer ?? "Unknown"
         ]


### PR DESCRIPTION
This changes from e.g. `sensor.debug_mac_facetime_hd_camera_built_in` with states like `True`/`False` with a `binary_sensor.debug_mac_facetime_hd_camera_built_in` with states like `on`/`off`.