### PR TITLE
Add BatterySensor Update Signaler

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		11EFCDDA24F5FE0600314D85 /* SceneActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDD924F5FE0600314D85 /* SceneActivity.swift */; };
 		11EFCDDC24F6065F00314D85 /* AboutSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */; };
 		11EFCDE024F60E5900314D85 /* BasicSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */; };
+		11F3847B24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */; };
+		11F3847C24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */; };
 		11F3B85724C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
 		11F3B85824C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
 		11F3B85924C4279700642676 /* Zone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85624C4279700642676 /* Zone.swift */; };
@@ -984,6 +986,7 @@
 		11EFCDD924F5FE0600314D85 /* SceneActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneActivity.swift; sourceTree = "<group>"; };
 		11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSceneDelegate.swift; sourceTree = "<group>"; };
 		11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicSceneDelegate.swift; sourceTree = "<group>"; };
+		11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWrapperBatteryObserver.swift; sourceTree = "<group>"; };
 		11F3B85524C4279700642676 /* Entity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		11F3B85624C4279700642676 /* Zone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone.swift; sourceTree = "<group>"; };
 		11F3B85B24C4295200642676 /* EurekaLocationRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EurekaLocationRow.swift; sourceTree = "<group>"; };
@@ -2589,6 +2592,7 @@
 				D03D893A20E0B2E300D4F28D /* Constants.swift */,
 				1101568624D7712F009424C9 /* TagManagerProtocol.swift */,
 				11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */,
+				11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -4361,6 +4365,7 @@
 				B67CE8B722200F220034C1D0 /* UIImage+Icons.swift in Sources */,
 				B67CE8A222200F220034C1D0 /* Services.swift in Sources */,
 				B6221F6522266F9F00502A30 /* WebhookRequest.swift in Sources */,
+				11F3847C24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */,
 				11A48D7E24CA7E4E0021BDD9 /* NotificationCategory.swift in Sources */,
 				11F855DD24DF6C7A0018013E /* IconImageView.swift in Sources */,
 				B67CE87922200F220034C1D0 /* RealmZone.swift in Sources */,
@@ -4496,6 +4501,7 @@
 				D0EEF2FF214D8D4C00D1D360 /* CLError+DebugDescription.swift in Sources */,
 				B62CD2A5225B099D008DF3C5 /* WebhookSensor.swift in Sources */,
 				11C4628224B053A800031902 /* WebhookResponseUpdateSensors.swift in Sources */,
+				11F3847B24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */,
 				B6B74CB82283983300D58A68 /* WatchComplication.swift in Sources */,
 				11F855DC24DF6C7A0018013E /* IconImageView.swift in Sources */,
 				11A48D7D24CA7E4E0021BDD9 /* NotificationCategory.swift in Sources */,

--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -78,10 +78,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        if NSClassFromString("XCTest") != nil {
-            return true
-        }
-
         setDefaults()
         Current.isBackgroundRequestsImmediate = {
             if Current.isCatalyst {

--- a/Shared/API/Webhook/Sensors/SensorProviderDependencies.swift
+++ b/Shared/API/Webhook/Sensors/SensorProviderDependencies.swift
@@ -8,13 +8,22 @@ public class SensorProviderDependencies {
     internal var updateSignalHandler: (SensorProvider.Type) -> Void = { _ in }
     private var updateSignalers: [String: [SensorProviderUpdateSignaler]] = [:]
 
+    private func key(for sensorProvider: SensorProvider) -> String {
+        String(describing: type(of: sensorProvider))
+    }
+
+    internal func existingSignaler<SignalerType: SensorProviderUpdateSignaler>(
+        for sensorProvider: SensorProvider
+    ) -> SignalerType? {
+        let key = self.key(for: sensorProvider)
+        return updateSignalers[key]?.compactMap({ $0 as? SignalerType }).first
+    }
+
     public func updateSignaler<SignalerType: SensorProviderUpdateSignaler>(
         for sensorProvider: SensorProvider
     ) -> SignalerType {
-        let key = String(describing: type(of: sensorProvider))
-
-        if let existingValue = updateSignalers[key]?.compactMap({ $0 as? SignalerType }).first {
-            return existingValue
+        if let existing: SignalerType = existingSignaler(for: sensorProvider) {
+            return existing
         }
 
         let sensorType = type(of: sensorProvider)
@@ -22,7 +31,7 @@ public class SensorProviderDependencies {
             self?.updateSignalHandler(sensorType)
         })
 
-        updateSignalers[key, default: []] += [created]
+        updateSignalers[key(for: sensorProvider), default: []] += [created]
         return created
     }
 }

--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if targetEnvironment(macCatalyst)
+#if canImport(IOKit)
 import IOKit.ps
 #endif
 #if os(iOS)
@@ -11,8 +11,10 @@ import WatchKit
 
 /// Wrapper around UIDevice/WKInterfaceDevice
 public class DeviceWrapper {
+    public lazy var batteryNotificationCenter = DeviceWrapperBatteryNotificationCenter()
+
     public lazy var verboseBatteryInfo: () -> [String: Any] = {
-        #if targetEnvironment(macCatalyst)
+        #if canImport(IOKit)
         /// keys: https://developer.apple.com/documentation/iokit/iopskeys_h/defines
         let blob = IOPSCopyPowerSourcesInfo().takeRetainedValue()
         let powerSources = IOPSCopyPowerSourcesList(blob).takeRetainedValue() as [CFTypeRef]

--- a/Shared/Common/Structs/DeviceWrapperBatteryObserver.swift
+++ b/Shared/Common/Structs/DeviceWrapperBatteryObserver.swift
@@ -1,0 +1,107 @@
+import Foundation
+#if canImport(IOKit)
+import IOKit.ps
+#endif
+#if os(iOS)
+import UIKit
+#endif
+#if os(watchOS)
+import WatchKit
+#endif
+
+public protocol DeviceWrapperBatteryNotificationObserver: AnyObject {
+    // We only observe state, because observing level is effectively the same as our periodic updating.
+    func deviceBatteryStateDidChange(_ center: DeviceWrapperBatteryNotificationCenter)
+}
+
+public class DeviceWrapperBatteryNotificationCenter {
+    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
+
+    public init() {
+        #if canImport(IOKit)
+        // We only observe state, because observing level is effectively
+        // observing every 60 seconds, which is covered by periodic.
+        addIOKitObserver(for: kIOPSNotifyPowerSource as CFString)
+        #endif
+
+        #if os(iOS)
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        addObserver(for: UIDevice.batteryStateDidChangeNotification)
+        #endif
+
+        #if os(watchOS)
+        // doesn't appear there are any notifications available for watchOS
+        // so we do not turn on monitoring, either
+        #endif
+    }
+
+    deinit {
+        #if canImport(IOKit)
+        CFNotificationCenterRemoveObserver(
+            /* center */ CFNotificationCenterGetDarwinNotifyCenter(),
+            /* observer */ Unmanaged.passUnretained(self).toOpaque(),
+            /* notification name */ nil /* to remove all */,
+            /* ignored for darwin; object */ nil
+        )
+        #endif
+
+        #if os(iOS)
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        #endif
+    }
+
+    public func register(observer: DeviceWrapperBatteryNotificationObserver) {
+        observers.add(observer)
+    }
+
+    public func unregister(observer: DeviceWrapperBatteryNotificationObserver) {
+        observers.remove(observer)
+    }
+
+    private func notify() {
+        observers
+            .allObjects
+            .compactMap { $0 as? DeviceWrapperBatteryNotificationObserver }
+            .forEach { $0.deviceBatteryStateDidChange(self) }
+    }
+
+    private func addObserver(for notification: Notification.Name) {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationDidFire(_:)),
+            name: notification,
+            object: nil
+        )
+    }
+
+    @objc private func notificationDidFire(_ note: Notification) {
+        Current.Log.info("battery updated from \(note.name)")
+        notify()
+    }
+
+    #if canImport(IOKit)
+    private func addIOKitObserver(for notificationName: CFString) {
+        let callback: CFNotificationCallback = { center, observer, name, /* ignored */ _, /* ignored */ _ in
+            // this block is a C block, which cannot weakly capture self, so we do the dance
+            guard let observer = observer else {
+                Current.Log.error("unexpected nil observer for battery sensor")
+                return
+            }
+
+            let this = Unmanaged<DeviceWrapperBatteryNotificationCenter>.fromOpaque(observer).takeUnretainedValue()
+            let loggableName = name?.rawValue as String? ?? "(unknown)"
+            Current.Log.info("battery updated from \(loggableName)")
+            this.notify()
+        }
+
+        CFNotificationCenterAddObserver(
+            /* center */ CFNotificationCenterGetDarwinNotifyCenter(),
+            /* observer */ Unmanaged.passUnretained(self).toOpaque(),
+            /* callback */ callback,
+            /* notification name */ notificationName,
+            /* ignored for drawin; object */ nil,
+            /* ignored for darwin; suspension behavior */ .coalesce
+        )
+    }
+    #endif
+}


### PR DESCRIPTION
Adds an Update Signaler for battery state (but not level) changes. Level is effectively a timer for updating (on Mac it's every 60 seconds), which is effectively the same as our periodic timer -- it doesn't signal any kind of state changes, just that time has elapsed. This will, for example, update sensors immediately upon charge starting or ending (while the app is running, of course). This works on macOS and iOS but not on watchOS.