### PR TITLE
config/get: make async, hide config from sidebar on Mac

### DIFF
--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -732,14 +732,18 @@ extension WebViewController: WKScriptMessageHandler {
 
         switch incomingMessage.MessageType {
         case "config/get":
-            response = .value(WebSocketMessage(
-                id: incomingMessage.ID!,
-                type: "result",
-                result: [
-                    "hasSettingsScreen": true,
-                    "canWriteTag": Current.tags.isNFCAvailable
-                ]
-            ))
+            response = Guarantee { seal in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    seal(WebSocketMessage(
+                        id: incomingMessage.ID!,
+                        type: "result",
+                        result: [
+                            "hasSettingsScreen": !Current.isCatalyst,
+                            "canWriteTag": Current.tags.isNFCAvailable
+                        ]
+                    ))
+                }
+            }
         case "config_screen/show":
             self.showSettingsViewController()
         case "haptic":


### PR DESCRIPTION
- Reading whether NFC is supported requires a few XPC calls, which slow down startup. Moves the overall reading off the main thread so the webview can continue to load.
- Reports false for `hasSettingsScreen` so the app's settings do not show up in the sidebar on Mac. App Menu > Preferences is the entry point for Mac.