### PR TITLE
"Active" Sensor for Mac

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */; };
 		11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */; };
+		11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */; };
 		11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */; };
 		11C4627F24B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
 		11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
@@ -954,6 +955,7 @@
 		11B7FD732493225200E60ED9 /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
 		11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.test.swift; sourceTree = "<group>"; };
 		11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.test.swift; sourceTree = "<group>"; };
+		11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.test.swift; sourceTree = "<group>"; };
 		11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActions.swift; sourceTree = "<group>"; };
 		11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+RetryNetworking.swift"; sourceTree = "<group>"; };
 		11C4628124B053A800031902 /* WebhookResponseUpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateSensors.swift; sourceTree = "<group>"; };
@@ -1844,6 +1846,7 @@
 				119385A6249E9F930097F497 /* StorageSensor.test.swift */,
 				1109F82324A25A41002590F2 /* SensorContainer.test.swift */,
 				1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */,
+				11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -4586,6 +4589,7 @@
 				11AF4D2A249D88C5006C74C0 /* ActivitySensor.test.swift in Sources */,
 				11CD94B924B2D16F00BA801D /* WebhookResponseServiceCall.test.swift in Sources */,
 				11CD94B524B2C06700BA801D /* WebhookResponseUpdateSensors.test.swift in Sources */,
+				11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		111D295124F2F6D900C8A7D1 /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = 111D295024F2F6D900C8A7D1 /* Sodium */; };
 		111D295624F30E2400C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
+		11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
+		11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
+		11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */; };
+		11358AF024FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */; };
 		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */; };
@@ -843,6 +847,8 @@
 		1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.swift"; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
+		11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.swift; sourceTree = "<group>"; };
+		11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.swift; sourceTree = "<group>"; };
 		113D04E124D76CD3003CE877 /* NFCReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReader.swift; sourceTree = "<group>"; };
 		113D04E324D76CDB003CE877 /* NFCWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCWriter.swift; sourceTree = "<group>"; };
 		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
@@ -1817,6 +1823,7 @@
 				119385A3249E8E360097F497 /* StorageSensor.swift */,
 				1109F81E24A1C011002590F2 /* SensorProvider.swift */,
 				B613936824F728F8002B8C5D /* MacCameraSensor.swift */,
+				11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */,
 				118261F624F8D6B0000795C6 /* SensorProviderDependencies.swift */,
 				118261FF24F9C3D6000795C6 /* CoreMediaIO Helpers */,
 			);
@@ -2593,6 +2600,7 @@
 				1101568624D7712F009424C9 /* TagManagerProtocol.swift */,
 				11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */,
 				11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */,
+				11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -4349,6 +4357,7 @@
 				11C65CC1249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */,
 				111858DB24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */,
 				B6B74CBE228399AC00D58A68 /* Action.swift in Sources */,
+				11358AF024FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
 				B67CE8B922200F220034C1D0 /* Environment.swift in Sources */,
 				B6723342225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				B67CE8B122200F220034C1D0 /* CLError+DebugDescription.swift in Sources */,
@@ -4388,6 +4397,7 @@
 				11C4628C24B1230E00031902 /* WebhookResponseServiceCall.swift in Sources */,
 				B67CE8AA22200F220034C1D0 /* ConnectionInfo.swift in Sources */,
 				11EE9B4F24C6089800404AF8 /* RealmPersistable.swift in Sources */,
+				11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */,
 				B67CE8BC22200F220034C1D0 /* ClientEvent.swift in Sources */,
 				B67CE8BB22200F220034C1D0 /* UNNotificationContent+ClientEvent.swift in Sources */,
 				1148A45124E9AF9200345050 /* MDIMigration.swift in Sources */,
@@ -4485,6 +4495,7 @@
 				B6872E632226841400C475D1 /* MobileAppRegistrationRequest.swift in Sources */,
 				111858DA24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */,
 				D0EEF317214DD7A400D1D360 /* DiscoveryInfo.swift in Sources */,
+				11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
 				D03D893B20E0B2E300D4F28D /* Constants.swift in Sources */,
 				D03D893520E0AEF100D4F28D /* Realm+Initialization.swift in Sources */,
 				D0EEF2C9214D89A700D1D360 /* HAAPI+RequestHelpers.swift in Sources */,
@@ -4524,6 +4535,7 @@
 				11C4628B24B1230E00031902 /* WebhookResponseServiceCall.swift in Sources */,
 				D0EEF30A214DD64C00D1D360 /* UIImage+Icons.swift in Sources */,
 				D0EEF303214D8F0300D1D360 /* String+HA.swift in Sources */,
+				11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */,
 				11EE9B4E24C6089800404AF8 /* RealmPersistable.swift in Sources */,
 				B6723347225DC72A0031D629 /* AuthenticatedUser.swift in Sources */,
 				1148A45024E9AF9200345050 /* MDIMigration.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		11B7FD742493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD732493225200E60ED9 /* BackgroundTask.swift */; };
 		11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */; };
+		11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */; };
 		11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */; };
 		11C4627F24B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
 		11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
@@ -952,6 +953,7 @@
 		11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenSettings.swift"; sourceTree = "<group>"; };
 		11B7FD732493225200E60ED9 /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
 		11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.test.swift; sourceTree = "<group>"; };
+		11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.test.swift; sourceTree = "<group>"; };
 		11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActions.swift; sourceTree = "<group>"; };
 		11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+RetryNetworking.swift"; sourceTree = "<group>"; };
 		11C4628124B053A800031902 /* WebhookResponseUpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateSensors.swift; sourceTree = "<group>"; };
@@ -2663,6 +2665,7 @@
 				11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */,
 				11883CC624C131EE0036A6C6 /* RealmZone.test.swift */,
 				11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */,
+				11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */,
 			);
 			path = SharedTests;
 			sourceTree = "<group>";
@@ -4563,6 +4566,7 @@
 				1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */,
 				119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */,
 				11CD94B724B2CC7400BA801D /* WebhookResponseLocation.test.swift in Sources */,
+				11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */,
 				11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */,
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -882,3 +882,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "menu.view.reload_page" = "Reload Page";
 "menu.file.update_sensors" = "Update Sensors";
 "open_label" = "Open";
+"sensors.active.setting.time_until_idle" = "Time Until Idle";

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -752,7 +752,9 @@ extension HomeAssistantAPI.APIError: LocalizedError {
 
 extension HomeAssistantAPI: SensorObserver {
     public func sensorContainerDidSignalForUpdate(_ container: SensorContainer) {
-        UpdateSensors(trigger: .Signaled).cauterize()
+        ProcessInfo.processInfo.backgroundTask(withName: "signaled-update-sensors") { _ in
+            UpdateSensors(trigger: .Signaled)
+        }.cauterize()
     }
 
     public func sensorContainer(_ container: SensorContainer, didUpdate update: SensorObserverUpdate) {

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -12,6 +12,14 @@ import ObjectMapper
 public struct WebhookSensorSetting {
     public enum SettingType {
         case `switch`(getter: () -> Bool, setter: (Bool) -> Void)
+        case stepper(
+                getter: () -> Double,
+                setter: (Double) -> Void,
+                minimum: Double = 0,
+                maximum: Double = 100,
+                step: Double = 1,
+                displayValueFor: ((Double?) -> String?)?
+             )
     }
 
     public let type: SettingType

--- a/Shared/API/Webhook/Request&Response/WebhookManager.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookManager.swift
@@ -401,7 +401,7 @@ public class WebhookManager: NSObject {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
             let jsonObject = Mapper<WebhookRequest>(context: WebhookRequestContext.server).toJSON(request)
-            let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
+            let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.sortedKeys])
 
             // httpBody is ignored by URLSession but is made available in tests
             urlRequest.httpBody = data

--- a/Shared/API/Webhook/Request&Response/WebhookRequest.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookRequest.swift
@@ -62,7 +62,7 @@ public struct WebhookRequest: ImmutableMappable {
 
         let sodium = Sodium()
 
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: data, options: []) else {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: data, options: [.sortedKeys]) else {
             Current.Log.error("Unable to convert JSON dictionary to data!")
             return nil
         }

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -40,7 +40,9 @@ final class ActiveSensor: SensorProvider {
         sensor.Attributes = [
             "Screensaver": activeState.isScreensavering,
             "Locked": activeState.isLocked,
-            "Sleep": activeState.isSleeping
+            "Screen Off": activeState.isScreenOff,
+            "Fast User Switched": activeState.isFastUserSwitched,
+            "Sleeping": activeState.isSleeping
         ]
 
         // Set up our observer

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -1,0 +1,51 @@
+import Foundation
+import PromiseKit
+
+final class ActiveSensorUpdateSignaler: SensorProviderUpdateSignaler, ActiveStateObserver {
+    let signal: () -> Void
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+
+        Current.activeState.register(observer: self)
+    }
+
+    func activeStateDidChange(for manager: ActiveStateManager) {
+        signal()
+    }
+}
+
+final class ActiveSensor: SensorProvider {
+    public enum ActiveError: Error, Equatable {
+        case noActiveState
+    }
+
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        guard Current.activeState.canTrackActiveStatus else {
+            return .init(error: ActiveError.noActiveState)
+        }
+
+        let activeState = Current.activeState
+
+        let sensor = WebhookSensor(
+            name: "active",
+            uniqueID: "active",
+            icon: .radioactiveIcon,
+            state: activeState.isActive
+        )
+        sensor.Attributes = [
+            "Screensaver": activeState.isScreensavering,
+            "Locked": activeState.isLocked,
+            "Sleep": activeState.isSleeping
+        ]
+
+        // Set up our observer
+        let _: ActiveSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+
+        return .value([sensor])
+    }
+}

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -37,17 +37,10 @@ final class ActiveSensor: SensorProvider {
             name: "Active",
             uniqueID: "active",
             icon: isActive ? "mdi:monitor" : "mdi:monitor-off",
-            state: activeState.isActive
+            state: isActive
         )
         sensor.Type = "binary_sensor"
-        sensor.Attributes = [
-            "Idle": activeState.isIdle,
-            "Screensaver": activeState.isScreensavering,
-            "Locked": activeState.isLocked,
-            "Screen Off": activeState.isScreenOff,
-            "Fast User Switched": activeState.isFastUserSwitched,
-            "Sleeping": activeState.isSleeping
-        ]
+        sensor.Attributes = activeState.states.attributes
 
         let durationFormatter = with(DateComponentsFormatter()) {
             $0.allowedUnits = [.minute]

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -59,8 +59,8 @@ final class ActiveSensor: SensorProvider {
         sensor.Settings = [
             .init(
                 type: .stepper(
-                    getter: { activeState.idleTime.converted(to: .minutes).value },
-                    setter: { activeState.idleTime = .init(value: $0, unit: .minutes) },
+                    getter: { activeState.minimumIdleTime.converted(to: .minutes).value },
+                    setter: { activeState.minimumIdleTime = .init(value: $0, unit: .minutes) },
                     minimum: 1,
                     maximum: .greatestFiniteMagnitude,
                     step: 1.0,

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -25,24 +25,52 @@ final class ActiveSensor: SensorProvider {
     }
 
     func sensors() -> Promise<[WebhookSensor]> {
-        guard Current.activeState.canTrackActiveStatus else {
+        let activeState = Current.activeState
+
+        guard activeState.canTrackActiveStatus else {
             return .init(error: ActiveError.noActiveState)
         }
 
-        let activeState = Current.activeState
+        let isActive = activeState.isActive
 
         let sensor = WebhookSensor(
-            name: "active",
+            name: "Active",
             uniqueID: "active",
-            icon: .radioactiveIcon,
+            icon: isActive ? "mdi:monitor" : "mdi:monitor-off",
             state: activeState.isActive
         )
+        sensor.Type = "binary_sensor"
         sensor.Attributes = [
+            "Idle": activeState.isIdle,
             "Screensaver": activeState.isScreensavering,
             "Locked": activeState.isLocked,
             "Screen Off": activeState.isScreenOff,
             "Fast User Switched": activeState.isFastUserSwitched,
             "Sleeping": activeState.isSleeping
+        ]
+
+        let durationFormatter = with(DateComponentsFormatter()) {
+            $0.allowedUnits = [.minute]
+            $0.allowsFractionalUnits = false
+            $0.formattingContext = .standalone
+            $0.unitsStyle = .short
+        }
+
+        sensor.Settings = [
+            .init(
+                type: .stepper(
+                    getter: { activeState.idleTime.converted(to: .minutes).value },
+                    setter: { activeState.idleTime = .init(value: $0, unit: .minutes) },
+                    minimum: 1,
+                    maximum: .greatestFiniteMagnitude,
+                    step: 1.0,
+                    displayValueFor: { value in
+                        let valueMeasurement = Measurement<UnitDuration>(value: value ?? 0, unit: .minutes)
+                        return durationFormatter.string(from: valueMeasurement.converted(to: .seconds).value)
+                    }
+                ),
+                title: L10n.Sensors.Active.Setting.timeUntilIdle
+            )
         ]
 
         // Set up our observer

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public protocol ActiveStateObserver: AnyObject {
+    func activeStateDidChange(for manager: ActiveStateManager)
+}
+
+public class ActiveStateManager {
+    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
+
+    var canTrackActiveStatus: Bool {
+        #if targetEnvironment(macCatalyst)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    var isActive: Bool {
+        precondition(canTrackActiveStatus)
+        return !isScreensavering && !isLocked && !isSleeping
+    }
+
+    private(set) var isScreensavering = false
+    private(set) var isLocked = false
+    private(set) var isSleeping = false
+
+    init() {
+        setup()
+    }
+
+    public func register(observer: ActiveStateObserver) {
+        observers.add(observer)
+    }
+
+    public func unregister(observer: ActiveStateObserver) {
+        observers.remove(observer)
+    }
+
+    private func setup() {
+        #if targetEnvironment(macCatalyst)
+        if let type = NSClassFromString("NSDistributedNotificationCenter") as? NotificationCenter.Type,
+           case let notificationCenter = type.default {
+            for name in UpdateType.allCases.compactMap(\.distributedNotificationName) {
+                notificationCenter.addObserver(
+                    self,
+                    selector: #selector(distributedNotificationDidPost(_:)),
+                    name: name,
+                    object: nil
+                )
+            }
+        }
+        #endif
+    }
+
+    @objc private func distributedNotificationDidPost(_ note: Notification) {
+        Current.Log.verbose(note)
+
+        if let type = UpdateType(distributedNotificationName: note.name) {
+            handle(updateType: type)
+        } else {
+            Current.Log.error("unknown notification: \(note)")
+        }
+    }
+
+    private func handle(updateType: UpdateType) {
+        let affectedKeyPath: ReferenceWritableKeyPath<ActiveStateManager, Bool> = {
+            switch updateType {
+            case .screensaverStart, .screensaverEnd:
+                return \.isScreensavering
+            case .lockStart, .lockEnd:
+                return \.isLocked
+            case .sleepStart, .sleepEnd:
+                return \.isSleeping
+            }
+        }()
+
+        let currentValue = self[keyPath: affectedKeyPath]
+        let newValue = updateType.isStart
+
+        guard currentValue != newValue else {
+            Current.Log.info("ignoring \(updateType) from \(currentValue) to \(newValue)")
+            return
+        }
+
+        Current.Log.info("from \(updateType) setting its state to \(newValue)")
+        self[keyPath: affectedKeyPath] = newValue
+
+        observers
+            .allObjects
+            .compactMap { $0 as? ActiveStateObserver }
+            .forEach { $0.activeStateDidChange(for: self) }
+    }
+}
+
+private enum UpdateType: CaseIterable {
+    case screensaverStart
+    case screensaverEnd
+    case lockStart
+    case lockEnd
+    case sleepStart
+    case sleepEnd
+
+    init?(distributedNotificationName name: Notification.Name) {
+        if let found = Self.allCases.first(where: { $0.distributedNotificationName == name }) {
+            self = found
+        } else {
+            return nil
+        }
+    }
+
+    var distributedNotificationName: Notification.Name? {
+        switch self {
+        case .screensaverStart: return .init(rawValue: "com.apple.screensaver.didstart")
+        case .screensaverEnd: return .init(rawValue: "com.apple.screensaver.didstop")
+        case .lockStart: return .init(rawValue: "com.apple.screenIsLocked")
+        case .lockEnd: return .init(rawValue: "com.apple.screenIsUnlocked")
+        case .sleepStart: return nil
+        case .sleepEnd: return nil
+        }
+    }
+
+    var isStart: Bool {
+        switch self {
+        case .screensaverStart: return true
+        case .screensaverEnd: return false
+        case .lockStart: return true
+        case .lockEnd: return false
+        case .sleepStart: return true
+        case .sleepEnd: return false
+        }
+    }
+}

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -23,6 +23,26 @@ public class ActiveStateManager {
     public private(set) var isSleeping = false
     public private(set) var isScreenOff = false
     public private(set) var isFastUserSwitched = false
+    public private(set) var isIdle = false
+
+    public var idleTime: Measurement<UnitDuration> {
+        get {
+            if Current.settingsStore.prefs.object(forKey: UserDefaultsKeys.minimumIdleTime.rawValue) == nil {
+                return .init(value: 5.0, unit: .minutes)
+            } else {
+                return .init(
+                    value: Current.settingsStore.prefs.double(forKey: UserDefaultsKeys.minimumIdleTime.rawValue),
+                    unit: .seconds
+                )
+            }
+        }
+        set {
+            Current.settingsStore.prefs.set(
+                newValue.converted(to: .seconds).value,
+                forKey: UserDefaultsKeys.minimumIdleTime.rawValue
+            )
+        }
+    }
 
     init() {
         setup()
@@ -36,6 +56,10 @@ public class ActiveStateManager {
 
     public func unregister(observer: ActiveStateObserver) {
         observers.remove(observer)
+    }
+
+    private enum UserDefaultsKeys: String {
+        case minimumIdleTime = "active_minimum_idle_time"
     }
 
     private func setup() {

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -25,7 +25,7 @@ public class ActiveStateManager {
     public private(set) var isFastUserSwitched = false
     public private(set) var isIdle = false
 
-    public var idleTime: Measurement<UnitDuration> {
+    public var minimumIdleTime: Measurement<UnitDuration> {
         get {
             if Current.settingsStore.prefs.object(forKey: UserDefaultsKeys.minimumIdleTime.rawValue) == nil {
                 return .init(value: 5.0, unit: .minutes)

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -5,9 +5,7 @@ public protocol ActiveStateObserver: AnyObject {
 }
 
 public class ActiveStateManager {
-    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
-
-    var canTrackActiveStatus: Bool {
+    public var canTrackActiveStatus: Bool {
         #if targetEnvironment(macCatalyst)
         return true
         #else
@@ -15,20 +13,22 @@ public class ActiveStateManager {
         #endif
     }
 
-    var isActive: Bool {
+    public var isActive: Bool {
         precondition(canTrackActiveStatus)
         return !isScreensavering && !isLocked && !isSleeping && !isScreenOff && !isFastUserSwitched
     }
 
-    private(set) var isScreensavering = false
-    private(set) var isLocked = false
-    private(set) var isSleeping = false
-    private(set) var isScreenOff = false
-    private(set) var isFastUserSwitched = false
+    public private(set) var isScreensavering = false
+    public private(set) var isLocked = false
+    public private(set) var isSleeping = false
+    public private(set) var isScreenOff = false
+    public private(set) var isFastUserSwitched = false
 
     init() {
         setup()
     }
+
+    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
 
     public func register(observer: ActiveStateObserver) {
         observers.add(observer)

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -17,12 +17,14 @@ public class ActiveStateManager {
 
     var isActive: Bool {
         precondition(canTrackActiveStatus)
-        return !isScreensavering && !isLocked && !isSleeping
+        return !isScreensavering && !isLocked && !isSleeping && !isScreenOff && !isFastUserSwitched
     }
 
     private(set) var isScreensavering = false
     private(set) var isLocked = false
     private(set) var isSleeping = false
+    private(set) var isScreenOff = false
+    private(set) var isFastUserSwitched = false
 
     init() {
         setup()
@@ -37,25 +39,58 @@ public class ActiveStateManager {
     }
 
     private func setup() {
-        #if targetEnvironment(macCatalyst)
-        if let type = NSClassFromString("NSDistributedNotificationCenter") as? NotificationCenter.Type,
-           case let notificationCenter = type.default {
-            for name in UpdateType.allCases.compactMap(\.distributedNotificationName) {
-                notificationCenter.addObserver(
+        let distributedNotificationCenter: NotificationCenter? = {
+            #if targetEnvironment(macCatalyst)
+            if let type = NSClassFromString("NSDistributedNotificationCenter") as? NotificationCenter.Type {
+                return type.default
+            } else {
+                Current.Log.error("couldn't find distributed notification center")
+                return nil
+            }
+            #else
+            return nil
+            #endif
+        }()
+        let workspaceNotificationCenter: NotificationCenter? = {
+            #if targetEnvironment(macCatalyst)
+            let center = NSClassFromString("NSWorkspace")?
+                .value(forKeyPath: "sharedWorkspace.notificationCenter") as? NotificationCenter
+
+            if let center = center {
+                return center
+            } else {
+                Current.Log.error("couldn't find workspace notification center")
+                return nil
+            }
+            #else
+            return nil
+            #endif
+        }()
+
+        for name in UpdateType.allCases {
+            switch name.notification {
+            case .distributed(let name):
+                distributedNotificationCenter?.addObserver(
                     self,
-                    selector: #selector(distributedNotificationDidPost(_:)),
+                    selector: #selector(notificationDidPost(_:)),
+                    name: name,
+                    object: nil
+                )
+            case .workspace(let name):
+                workspaceNotificationCenter?.addObserver(
+                    self,
+                    selector: #selector(notificationDidPost(_:)),
                     name: name,
                     object: nil
                 )
             }
         }
-        #endif
     }
 
-    @objc private func distributedNotificationDidPost(_ note: Notification) {
+    @objc private func notificationDidPost(_ note: Notification) {
         Current.Log.verbose(note)
 
-        if let type = UpdateType(distributedNotificationName: note.name) {
+        if let type = UpdateType(notificationName: note.name) {
             handle(updateType: type)
         } else {
             Current.Log.error("unknown notification: \(note)")
@@ -71,6 +106,10 @@ public class ActiveStateManager {
                 return \.isLocked
             case .sleepStart, .sleepEnd:
                 return \.isSleeping
+            case .screenOffStart, .screenOffEnd:
+                return \.isScreenOff
+            case .fastUserSwitchStart, .fastUserSwitchEnd:
+                return \.isFastUserSwitched
             }
         }()
 
@@ -82,13 +121,18 @@ public class ActiveStateManager {
             return
         }
 
+        let wasActive = isActive
+
         Current.Log.info("from \(updateType) setting its state to \(newValue)")
         self[keyPath: affectedKeyPath] = newValue
 
-        observers
-            .allObjects
-            .compactMap { $0 as? ActiveStateObserver }
-            .forEach { $0.activeStateDidChange(for: self) }
+        if wasActive != isActive {
+            Current.Log.info("notifying about change of active from \(wasActive) to \(isActive)")
+            observers
+                .allObjects
+                .compactMap { $0 as? ActiveStateObserver }
+                .forEach { $0.activeStateDidChange(for: self) }
+        }
     }
 }
 
@@ -99,23 +143,45 @@ private enum UpdateType: CaseIterable {
     case lockEnd
     case sleepStart
     case sleepEnd
+    case screenOffStart
+    case screenOffEnd
+    case fastUserSwitchStart
+    case fastUserSwitchEnd
 
-    init?(distributedNotificationName name: Notification.Name) {
-        if let found = Self.allCases.first(where: { $0.distributedNotificationName == name }) {
+    init?(notificationName name: Notification.Name) {
+        let found = Self.allCases.first(where: {
+            switch $0.notification {
+            case .distributed(let caseName), .workspace(let caseName):
+                return caseName == name
+            }
+        })
+
+        if let found = found {
             self = found
         } else {
             return nil
         }
     }
 
-    var distributedNotificationName: Notification.Name? {
+    enum UpdateNotification {
+        case distributed(Notification.Name)
+        case workspace(Notification.Name)
+    }
+
+    var notification: UpdateNotification {
         switch self {
-        case .screensaverStart: return .init(rawValue: "com.apple.screensaver.didstart")
-        case .screensaverEnd: return .init(rawValue: "com.apple.screensaver.didstop")
-        case .lockStart: return .init(rawValue: "com.apple.screenIsLocked")
-        case .lockEnd: return .init(rawValue: "com.apple.screenIsUnlocked")
-        case .sleepStart: return nil
-        case .sleepEnd: return nil
+        // these distributed ones do not have constants we can access
+        case .screensaverStart: return .distributed(.init(rawValue: "com.apple.screensaver.didstart"))
+        case .screensaverEnd: return .distributed(.init(rawValue: "com.apple.screensaver.didstop"))
+        case .lockStart: return .distributed(.init(rawValue: "com.apple.screenIsLocked"))
+        case .lockEnd: return .distributed(.init(rawValue: "com.apple.screenIsUnlocked"))
+        // these workspace ones do have constants, but they are in AppKit which we do not currently have access to
+        case .sleepStart: return .workspace(.init("NSWorkspaceWillSleepNotification"))
+        case .sleepEnd: return .workspace(.init("NSWorkspaceDidWakeNotification"))
+        case .screenOffStart: return .workspace(.init("NSWorkspaceScreensDidSleepNotification"))
+        case .screenOffEnd: return .workspace(.init("NSWorkspaceScreensDidWakeNotification"))
+        case .fastUserSwitchStart: return .workspace(.init("NSWorkspaceSessionDidResignActiveNotification"))
+        case .fastUserSwitchEnd: return .workspace(.init("NSWorkspaceSessionDidBecomeActiveNotification"))
         }
     }
 
@@ -127,6 +193,10 @@ private enum UpdateType: CaseIterable {
         case .lockEnd: return false
         case .sleepStart: return true
         case .sleepEnd: return false
+        case .screenOffStart: return true
+        case .screenOffEnd: return false
+        case .fastUserSwitchStart: return true
+        case .fastUserSwitchEnd: return false
         }
     }
 }

--- a/Shared/Common/Structs/ActiveStateManager.swift
+++ b/Shared/Common/Structs/ActiveStateManager.swift
@@ -67,6 +67,7 @@ public class ActiveStateManager {
 
     internal var idleTimer: Timer? {
         willSet {
+            Current.Log.info(newValue == nil ? "removing timer" : "starting timer")
             idleTimer?.invalidate()
         }
     }

--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -222,4 +222,24 @@ public class DeviceWrapper {
             return Self.unameMachine()
         }
     }
+
+    public lazy var idleTime: () -> Measurement<UnitDuration>? = {
+        #if targetEnvironment(macCatalyst)
+        let seconds = CGEventSource.secondsSinceLastEventType(
+            .combinedSessionState,
+            eventType: {
+                /*
+                 Apple's docs say:
+                 > The event type to access. To get the elapsed time since the previous input event—keyboard, mouse, or
+                 > tablet—specify kCGAnyInputEventType.
+                 But kCGAnyInputEventType isn't available in Swift. In Objective-C it's defined as `((CGEventType)(~0))`
+                 */
+                return CGEventType(rawValue: ~0)!
+            }()
+        )
+        return .init(value: seconds, unit: .seconds)
+        #else
+        return nil
+        #endif
+    }
 }

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -74,11 +74,14 @@ public class Environment {
         $0.register(provider: GeocoderSensor.self)
         $0.register(provider: LastUpdateSensor.self)
         $0.register(provider: MacCameraSensor.self)
+        $0.register(provider: ActiveSensor.self)
     }
 
     public var tags: TagManager = EmptyTagManager()
 
     public var updater: Updater = Updater()
+
+    public var activeState: ActiveStateManager = ActiveStateManager()
 
     public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
 

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -81,7 +81,7 @@ public class Environment {
 
     public var updater: Updater = Updater()
 
-    public var activeState: ActiveStateManager = ActiveStateManager()
+    public lazy var activeState: ActiveStateManager = { ActiveStateManager() }()
 
     public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
 

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -910,6 +910,12 @@ internal enum L10n {
     internal static let notAvailableState = L10n.tr("Localizable", "sensors.not_available_state")
     /// Unknown
     internal static let unknownState = L10n.tr("Localizable", "sensors.unknown_state")
+    internal enum Active {
+      internal enum Setting {
+        /// Time Until Idle
+        internal static let timeUntilIdle = L10n.tr("Localizable", "sensors.active.setting.time_until_idle")
+      }
+    }
     internal enum Activity {
       /// Activity
       internal static let name = L10n.tr("Localizable", "sensors.activity.name")

--- a/SharedTests/ActiveStateManager.test.swift
+++ b/SharedTests/ActiveStateManager.test.swift
@@ -1,0 +1,206 @@
+import Foundation
+@testable import Shared
+import XCTest
+
+class ActiveStateManagerTests: XCTestCase {
+    var manager: ActiveStateManager!
+    var observer: MockActiveStateObserver!
+    var notificationCenter: NotificationCenter!
+
+    override func setUp() {
+        // pretend like we're in catalyst for these tests
+        Current.isCatalyst = true
+
+        notificationCenter = NotificationCenter.default
+        observer = MockActiveStateObserver()
+        manager = ActiveStateManager()
+
+        manager.register(observer: observer)
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        Current.isCatalyst = false
+
+        super.tearDown()
+    }
+
+    func testInitialStateIsActive() {
+        XCTAssertTrue(manager.canTrackActiveStatus)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isFastUserSwitched)
+        XCTAssertFalse(manager.states.isIdle)
+        XCTAssertFalse(manager.states.isLocked)
+        XCTAssertFalse(manager.states.isScreensavering)
+        XCTAssertFalse(manager.states.isSleeping)
+        XCTAssertFalse(manager.states.isScreenOff)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testObserverRemoval() {
+        manager.unregister(observer: observer)
+
+        notificationCenter.post(name: .init(rawValue: "com.apple.screensaver.didstart"), object: nil)
+        XCTAssertFalse(observer.didUpdate)
+
+        manager.register(observer: observer)
+        notificationCenter.post(name: .init(rawValue: "com.apple.screensaver.didstop"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+    }
+
+    func testScreensaver() {
+        notificationCenter.post(name: .init(rawValue: "com.apple.screensaver.didstart"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isScreensavering)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "com.apple.screensaver.didstop"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isScreensavering)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testLock() {
+        notificationCenter.post(name: .init(rawValue: "com.apple.screenIsLocked"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isLocked)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "com.apple.screenIsUnlocked"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isLocked)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testSleep() {
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceWillSleepNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isSleeping)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceDidWakeNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isSleeping)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testScreenOff() {
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceScreensDidSleepNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isScreenOff)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceScreensDidWakeNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isScreenOff)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testFUS() {
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceSessionDidResignActiveNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isFastUserSwitched)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceSessionDidBecomeActiveNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isFastUserSwitched)
+        XCTAssertEqual(manager.idleTimer?.isValid, true)
+    }
+
+    func testIdleTimeWithoutAnythingElse() {
+        Current.device.idleTime = { .init(value: 99, unit: .seconds) }
+        manager.minimumIdleTime = .init(value: 100, unit: .seconds)
+        XCTAssertNotNil(manager.idleTimer)
+        manager.idleTimer?.fire()
+
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isIdle)
+
+        Current.device.idleTime = { .init(value: 100, unit: .seconds) }
+        manager.idleTimer?.fire()
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isIdle)
+        XCTAssertNotNil(manager.idleTimer)
+        observer.reset()
+
+        Current.device.idleTime = { .init(value: 300, unit: .seconds) }
+        manager.idleTimer?.fire()
+        XCTAssertFalse(observer.didUpdate, "already posted for this idle period")
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isIdle)
+        XCTAssertNotNil(manager.idleTimer)
+        observer.reset()
+
+        Current.device.idleTime = { .init(value: 10, unit: .seconds) }
+        manager.idleTimer?.fire()
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isIdle)
+        XCTAssertNotNil(manager.idleTimer)
+        observer.reset()
+    }
+
+    func testIdleTimeThenAnotherEvent() {
+        Current.device.idleTime = { .init(value: 100, unit: .seconds) }
+        manager.minimumIdleTime = .init(value: 100, unit: .seconds)
+        XCTAssertNotNil(manager.idleTimer)
+        manager.idleTimer?.fire()
+
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isIdle)
+        XCTAssertTrue(observer.didUpdate)
+
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceSessionDidResignActiveNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isFastUserSwitched)
+        XCTAssertNil(manager.idleTimer)
+        observer.reset()
+
+        notificationCenter.post(name: .init(rawValue: "NSWorkspaceSessionDidBecomeActiveNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertFalse(manager.states.isFastUserSwitched)
+        XCTAssertTrue(manager.states.isIdle)
+        XCTAssertNotNil(manager.idleTimer)
+        observer.reset()
+
+        Current.device.idleTime = { .init(value: 99, unit: .seconds) }
+        manager.idleTimer?.fire()
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertTrue(manager.isActive)
+        XCTAssertFalse(manager.states.isIdle)
+        XCTAssertNotNil(manager.idleTimer)
+        observer.reset()
+    }
+}
+
+class MockActiveStateObserver: ActiveStateObserver {
+    var didUpdate = false
+
+    func reset() {
+        didUpdate = false
+    }
+
+    func activeStateDidChange(for manager: ActiveStateManager) {
+        didUpdate = true
+    }
+}

--- a/SharedTests/Sensors/ActiveSensor.test.swift
+++ b/SharedTests/Sensors/ActiveSensor.test.swift
@@ -1,0 +1,100 @@
+@testable import Shared
+import XCTest
+import PromiseKit
+
+class ActiveSensorTests: XCTestCase {
+    private var request: SensorProviderRequest = .init(
+        reason: .trigger("unit-test"),
+        dependencies: .init(),
+        location: nil
+    )
+
+    private var activeState: FakeActiveStateManager!
+
+    override func setUp() {
+        super.setUp()
+
+        activeState = FakeActiveStateManager()
+        Current.activeState = activeState
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        Current.activeState = ActiveStateManager()
+    }
+
+    func testNotAvailable() {
+        activeState.overrideCanTrackActiveStatus = false
+
+        let promise = ActiveSensor(request: request).sensors()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? ActiveSensor.ActiveError, .noActiveState)
+        }
+    }
+
+    func testIsActive() throws {
+        activeState.overrideCanTrackActiveStatus = true
+        activeState.overrideIsActive = true
+
+        let promise = ActiveSensor(request: request).sensors()
+        let sensors = try hang(promise)
+        XCTAssertEqual(sensors.count, 1)
+
+        XCTAssertEqual(sensors[0].Name, "Active")
+        XCTAssertEqual(sensors[0].UniqueID, "active")
+        XCTAssertEqual(sensors[0].Icon, "mdi:monitor")
+        XCTAssertEqual(sensors[0].Type, "binary_sensor")
+        XCTAssertEqual(sensors[0].State as? Bool, true)
+    }
+
+    func testNotActive() throws {
+        activeState.overrideCanTrackActiveStatus = true
+        activeState.overrideIsActive = false
+
+        let promise = ActiveSensor(request: request).sensors()
+        let sensors = try hang(promise)
+        XCTAssertEqual(sensors.count, 1)
+
+        XCTAssertEqual(sensors[0].Name, "Active")
+        XCTAssertEqual(sensors[0].UniqueID, "active")
+        XCTAssertEqual(sensors[0].Icon, "mdi:monitor-off")
+        XCTAssertEqual(sensors[0].Type, "binary_sensor")
+        XCTAssertEqual(sensors[0].State as? Bool, false)
+    }
+
+    func testSignalerCreated() throws {
+        activeState.overrideCanTrackActiveStatus = true
+        activeState.overrideIsActive = false
+
+        let dependencies = SensorProviderDependencies()
+        let provider = ActiveSensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: dependencies,
+            location: nil
+        ))
+        let promise = provider.sensors()
+        _ = try hang(promise)
+
+        let signaler: ActiveSensorUpdateSignaler? = dependencies.existingSignaler(for: provider)
+        XCTAssertNotNil(signaler)
+    }
+
+    func testSignaler() {
+        var didSignal = false
+        let signaler = ActiveSensorUpdateSignaler(signal: {
+            didSignal = true
+        })
+
+        signaler.activeStateDidChange(for: activeState)
+        XCTAssertTrue(didSignal)
+    }
+}
+
+private class FakeActiveStateManager: ActiveStateManager {
+    var overrideCanTrackActiveStatus = false
+    override var canTrackActiveStatus: Bool { overrideCanTrackActiveStatus }
+
+    var overrideIsActive = false
+    override var isActive: Bool { overrideIsActive }
+}


### PR DESCRIPTION
This binary sensor reports `on` when the machine is active, `off` otherwise. Active state tracks: 

- Idle time, defaulting to 5 minutes. If no keyboard, mouse, or tablet (wat) input is detected in that period, we consider this idle. This is exposed as a Sensor setting (in Preferences > Sensors > Active).
- Screensaver starting and ending.
- Sleeping starting and ending.
- Screen turning off and on (also called sleeping in some places in Apple-land).
- Lock Screen, which is both the Apple > Lock Screen and the Fast User Switching mechanism.
- Fast user switching. This is the Menu Bar "switch to X user" and can also end up triggering Lock Screen too.

If none of these are happening, we consider the machine active.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/74188/91780244-d1cc8d00-ebab-11ea-8b8c-1867f7cefab6.png">
