### PR TITLE
Fix device name in events when overridden

### DIFF
--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -565,7 +565,7 @@ public class HomeAssistantAPI {
 
     private class var sharedEventDeviceInfo: [String: String] { [
         "sourceDevicePermanentID": Constants.PermanentID,
-        "sourceDeviceName": Current.device.deviceName(),
+        "sourceDeviceName": Current.settingsStore.overrideDeviceName ?? Current.device.deviceName(),
         "sourceDeviceID": Current.settingsStore.deviceID
     ] }
 


### PR DESCRIPTION
This value was not using the override. Fixes #967.