### PR TITLE
Enable server-defined actions for 0.115

### DIFF
--- a/Shared/Common/Structs/Constants.swift
+++ b/Shared/Common/Structs/Constants.swift
@@ -131,5 +131,5 @@ public extension Version {
     static var pedometerIconsAvailable: Version = .init(minor: 105)
     static var tagWebhookAvailable: Version = .init(minor: 114, prerelease: "b5")
     static var tagPlatformTrigger: Version = .init(minor: 115, prerelease: "any0")
-    static var actionSyncing: Version = .init(minor: 200)
+    static var actionSyncing: Version = .init(minor: 115, prerelease: "any0")
 }


### PR DESCRIPTION
Per home-assistant/core#38572 we can define actions in YAML. Actions are provided as view due to HA limitations in getting one integration (`ios` here) to access webhooks registered to another (`mobile_app`).

Tested locally in the following cases:
- `ios:` loaded in `configuration.yaml` with `actions` key.
- `ios:` loaded in `configuration.yaml` without `actions` key.
- `ios:` not loaded.

Push categories are also loaded fine.

Fixes #494 