### PR TITLE
Fix handling of cameras without unique ID

### DIFF
--- a/Shared/API/Webhook/Sensors/CoreMediaIO Helpers/HACoreMediaObjectCamera.swift
+++ b/Shared/API/Webhook/Sensors/CoreMediaIO Helpers/HACoreMediaObjectCamera.swift
@@ -4,11 +4,12 @@ import Foundation
 import CoreMediaIO
 
 class HACoreMediaObjectCamera: HACoreMediaObject {
-    var deviceUID: String {
+    var deviceUID: String? {
         if let string = value(for: .deviceUID) {
             return string.takeRetainedValue() as String
         } else {
-            return "\(id)"
+            // UID can actually come back as nil occasionally
+            return nil
         }
     }
 


### PR DESCRIPTION
When a camera doesn't have a unique ID (which appears to be transient), ignore it until another sensor pass. We still observe for changes, so it should update if it turns on and gains a unique ID.

Fixes #971.