### PR TITLE
Fix swapped labels in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request_iOS.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_iOS.md
@@ -2,7 +2,7 @@
 name: Feature request (iOS/iPadOS)
 about: Suggest an idea for the mobile app
 title: ''
-labels: feature-request, mac
+labels: feature-request, ios
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request_mac.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_mac.md
@@ -2,7 +2,7 @@
 name: Feature request (macOS)
 about: Suggest an idea for the macOS app
 title: ''
-labels: feature-request, ios
+labels: feature-request, mac
 assignees: ''
 
 ---


### PR DESCRIPTION
When opening a FR using the (awesome) new issue template, the mac/ios labels were accidentally mixed up, this fixes.