### PR TITLE
Fix a couple crashes on Mac

### DIFF
--- a/HomeAssistant/Views/Settings/NFC/iOSTagManager.swift
+++ b/HomeAssistant/Views/Settings/NFC/iOSTagManager.swift
@@ -8,7 +8,12 @@ class iOSTagManager: TagManager {
     var isNFCAvailable: Bool {
         if #available(iOS 13, *) {
             // We need both iOS 13 and NFC
-            return NFCNDEFReaderSession.readingAvailable
+            if Current.isCatalyst {
+                // NFC doesn't work on Catalyst but _does_ crash occasionally asking
+                return false
+            } else {
+                return NFCNDEFReaderSession.readingAvailable
+            }
         } else {
             return false
         }

--- a/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
+++ b/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
@@ -36,9 +36,8 @@ class HACoreBlahObject {
             return nil
         }
 
-        let dataCount = Int(countBytes) / MemoryLayout<ElementType>.size
         let data = UnsafeMutableRawPointer.allocate(
-            byteCount: dataCount,
+            byteCount: Int(countBytes),
             alignment: MemoryLayout<ElementType>.alignment
         )
         defer {
@@ -48,8 +47,9 @@ class HACoreBlahObject {
         let getResult = property.getPropertyData(objectID: id, dataSize: countBytes, output: data)
 
         if getResult == OSStatus(0) {
-            let buffer = data.bindMemory(to: ElementType.self, capacity: dataCount)
-            return Array(UnsafeBufferPointer<ElementType>(start: buffer, count: dataCount))
+            let elementCount = Int(countBytes) / MemoryLayout<ElementType>.size
+            let buffer = data.bindMemory(to: ElementType.self, capacity: elementCount)
+            return Array(UnsafeBufferPointer<ElementType>(start: buffer, count: elementCount))
         } else {
             return nil
         }


### PR DESCRIPTION
- Fix under-allocation crash in Core{Media, Audio} reading. This was, for example, allocating 1 byte for a 4-byte integer when reading arrays. Often times this worked, but would not work long-term.
- Fix occasional crash checking for NFC support. It's never supported, so avoid the call on Catalyst. Fixes #989.