### PR TITLE
Scale up WebView zoom to counteract Catalyst 77% scaling

### DIFF
--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -225,11 +225,12 @@ public class SettingsStore {
         }
 
         public var viewScaleValue: String {
-            return String(format: "%.02f", CGFloat(zoom) / 100.0)
-        }
-
-        public var viewScaleMultiple: CGFloat {
-            return CGFloat(zoom) / 100.0
+            if Current.isCatalyst {
+                // Catalyst apps are sized down to 77% of normal, so invert it to get normal
+                return String(format: "%.02f", CGFloat(zoom) / 100.0 * 1.0/0.77)
+            } else {
+                return String(format: "%.02f", CGFloat(zoom) / 100.0)
+            }
         }
 
         public static let `default`: PageZoom = .init(100)


### PR DESCRIPTION
Catalyst [renders content at 77%](https://developer.apple.com/design/human-interface-guidelines/ios/overview/mac-catalyst/) to adjust for iPad sizing being appropriate on a Mac. However, it's inappropriate to downscale our webview -- this just makes the content unnecessarily small compared to the default 100%.

This resets so e.g.:

100% -> 130%
150% -> 195%

Fixes #994.