### PR TITLE
Fix a couple Mac onboarding issues

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		11DC6BAB24E23780002D9FDA /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		11DE822E24FAC51100E636B8 /* IncomingURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DE822D24FAC51000E636B8 /* IncomingURLHandler.swift */; };
 		11DE823024FAE66F00E636B8 /* UIWindow+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DE822F24FAE66F00E636B8 /* UIWindow+Additions.swift */; };
+		11E1639A250B1B760076D612 /* OnboardingStateObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E16399250B1B760076D612 /* OnboardingStateObservation.swift */; };
+		11E1639B250B1B760076D612 /* OnboardingStateObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E16399250B1B760076D612 /* OnboardingStateObservation.swift */; };
 		11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */; };
 		11EE9B4624C4E01500404AF8 /* SharedPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4524C4E01500404AF8 /* SharedPlist.swift */; };
@@ -985,6 +987,7 @@
 		11D826F024E39F2D005B8A86 /* CoreNFC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreNFC.framework; path = System/Library/Frameworks/CoreNFC.framework; sourceTree = SDKROOT; };
 		11DE822D24FAC51000E636B8 /* IncomingURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingURLHandler.swift; sourceTree = "<group>"; };
 		11DE822F24FAE66F00E636B8 /* UIWindow+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Additions.swift"; sourceTree = "<group>"; };
+		11E16399250B1B760076D612 /* OnboardingStateObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStateObservation.swift; sourceTree = "<group>"; };
 		11E5CF8024BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+BackgroundTask.swift"; sourceTree = "<group>"; };
 		11E981E824E10DDC0095962B /* WidgetsExtension Development.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WidgetsExtension Development.entitlements"; sourceTree = "<group>"; };
 		11E981E924E10DDC0095962B /* WidgetsExtension Beta.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WidgetsExtension Beta.entitlements"; sourceTree = "<group>"; };
@@ -2614,6 +2617,7 @@
 				11C8E8AB24F36535003E7F89 /* DeviceWrapper.swift */,
 				11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */,
 				11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */,
+				11E16399250B1B760076D612 /* OnboardingStateObservation.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -4389,6 +4393,7 @@
 				1182620524F9C453000795C6 /* HACoreMediaObjectSystem.swift in Sources */,
 				B67CE8B722200F220034C1D0 /* UIImage+Icons.swift in Sources */,
 				B67CE8A222200F220034C1D0 /* Services.swift in Sources */,
+				11E1639B250B1B760076D612 /* OnboardingStateObservation.swift in Sources */,
 				B6221F6522266F9F00502A30 /* WebhookRequest.swift in Sources */,
 				11F3847C24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */,
 				11A48D7E24CA7E4E0021BDD9 /* NotificationCategory.swift in Sources */,
@@ -4529,6 +4534,7 @@
 				1182620424F9C453000795C6 /* HACoreMediaObjectSystem.swift in Sources */,
 				D0EEF2FF214D8D4C00D1D360 /* CLError+DebugDescription.swift in Sources */,
 				B62CD2A5225B099D008DF3C5 /* WebhookSensor.swift in Sources */,
+				11E1639A250B1B760076D612 /* OnboardingStateObservation.swift in Sources */,
 				11C4628224B053A800031902 /* WebhookResponseUpdateSensors.swift in Sources */,
 				11F3847B24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */,
 				B6B74CB82283983300D58A68 /* WatchComplication.swift in Sources */,

--- a/HomeAssistant/Authentication/AuthenticationController.swift
+++ b/HomeAssistant/Authentication/AuthenticationController.swift
@@ -38,16 +38,22 @@ class AuthenticationController: NSObject, SFSafariViewControllerDelegate {
         return Promise { (resolver: Resolver<String>) in
             self.promiseResolver = resolver
 
-            var redirectURI = "homeassistant://auth-callback"
-
-            var clientID = "https://home-assistant.io/iOS"
+            let redirectURI: String
+            let scheme: String
+            let clientID: String
 
             if Current.appConfiguration == .Debug {
                 clientID = "https://home-assistant.io/iOS/dev-auth"
                 redirectURI = "homeassistant-dev://auth-callback"
+                scheme = "homeassistant-dev"
             } else if Current.appConfiguration == .Beta {
                 clientID = "https://home-assistant.io/iOS/beta-auth"
                 redirectURI = "homeassistant-beta://auth-callback"
+                scheme = "homeassistant-beta"
+            } else {
+                clientID = "https://home-assistant.io/iOS"
+                redirectURI = "homeassistant://auth-callback"
+                scheme = "homeassistant"
             }
 
             var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
@@ -74,7 +80,7 @@ class AuthenticationController: NSObject, SFSafariViewControllerDelegate {
 
                 if #available(iOS 12.0, *) {
                     self.authStyle = "ASWebAuthenticationSession"
-                    let webAuthSession = ASWebAuthenticationSession(url: authURL, callbackURLScheme: redirectURI,
+                    let webAuthSession = ASWebAuthenticationSession(url: authURL, callbackURLScheme: scheme,
                                                                     completionHandler: newStyleAuthCallback)
 
                     if #available(iOS 13.0, *) {

--- a/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
+++ b/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
@@ -60,7 +60,8 @@ class ConnectInstanceViewController: UIViewController {
             self.overallProgress.loopMode = .playOnce
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
-                Current.onboardingComplete?()
+                Current.onboardingObservation.complete()
+
                 if let navVC = self.navigationController as? OnboardingNavigationViewController {
                     Current.Log.verbose("Dismissing from permissions")
                     navVC.dismiss()

--- a/HomeAssistant/Views/SettingsViewController.swift
+++ b/HomeAssistant/Views/SettingsViewController.swift
@@ -479,7 +479,7 @@ class SettingsViewController: FormViewController {
             prefs.removePersistentDomain(forName: bundleId)
             prefs.synchronize()
 
-            Current.signInRequiredCallback?(.logout)
+            Current.onboardingObservation.needed(.logout)
         }
     }
 

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -678,7 +678,7 @@ extension WebViewController: WKScriptMessageHandler {
                 Current.Log.verbose("Running revoke external auth callback \(script)")
 
                 self.webView.evaluateJavaScript(script, completionHandler: { (_, error) in
-                    Current.signInRequiredCallback?(.logout)
+                    Current.onboardingObservation.needed(.logout)
 
                     if let error = error {
                         Current.Log.error("Failed calling sign out callback: \(error)")

--- a/Shared/Authentication/TokenManager.swift
+++ b/Shared/Authentication/TokenManager.swift
@@ -164,7 +164,7 @@ public class TokenManager: RequestAdapter, RequestRetrier {
                 completion(false, 0)
 
                 DispatchQueue.main.async {
-                    Current.signInRequiredCallback?(.error)
+                    Current.onboardingObservation.needed(.error)
                 }
             } else {
                 completion(false, 0)
@@ -286,7 +286,7 @@ public class TokenManager: RequestAdapter, RequestRetrier {
 
                         self.tokenInfo = nil
                         Current.settingsStore.tokenInfo = nil
-                        Current.signInRequiredCallback?(.error)
+                        Current.onboardingObservation.needed(.error)
                     }
                 case .fulfilled:
                     Current.Log.info("refresh token got success")

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -85,25 +85,7 @@ public class Environment {
 
     public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
 
-    #if os(iOS)
-    public var authenticationControllerPresenter: ((UIViewController) -> Void)?
-    #endif
-
-    public enum SignInRequiredType {
-        case logout
-        case error
-
-        public var shouldShowError: Bool {
-            switch self {
-            case .logout: return false
-            case .error:  return true
-            }
-        }
-    }
-
-    public var signInRequiredCallback: ((SignInRequiredType) -> Void)?
-
-    public var onboardingComplete: (() -> Void)?
+    public var onboardingObservation = OnboardingStateObservation()
 
     public var isPerformingSingleShotLocationQuery = false
 

--- a/Shared/Common/Structs/OnboardingStateObservation.swift
+++ b/Shared/Common/Structs/OnboardingStateObservation.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public enum NeededType {
+    case logout
+    case error
+
+    public var shouldShowError: Bool {
+        switch self {
+        case .logout: return false
+        case .error:  return true
+        }
+    }
+}
+
+public enum OnboardingState {
+    case complete
+    case needed(NeededType)
+}
+
+public protocol OnboardingStateObserver: AnyObject {
+    func onboardingStateDidChange(to state: OnboardingState)
+}
+
+public class OnboardingStateObservation {
+    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
+
+    public func register(observer: OnboardingStateObserver) {
+        observers.add(observer)
+    }
+
+    public func unregister(observer: OnboardingStateObserver) {
+        observers.remove(observer)
+    }
+
+    private func notify(for state: OnboardingState) {
+        observers
+            .allObjects
+            .compactMap { $0 as? OnboardingStateObserver }
+            .forEach { $0.onboardingStateDidChange(to: state) }
+    }
+
+    public func complete() {
+        notify(for: .complete)
+    }
+
+    public func needed(_ type: NeededType) {
+        notify(for: .needed(type))
+    }
+}


### PR DESCRIPTION
- Handle multiple WebViewWindowController instances for onboarding, so if more than 1 (File > New) window is open during onboarding or when onboarding is needed, the state updates. Fixes #993.
- Fix Safari handling on Mac for onboarding. The scheme provided needs to be just the scheme and not the full callback URL. Although the latter works on iOS, the former is required for Mac. This resolves it prompting to open the app during login, and the Safari window not being closed.