### PR TITLE
Improve some connection settings behaviors

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -147,8 +147,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func setupTokens() {
         if Current.appConfiguration == .FastlaneSnapshot { setupFastlaneSnapshotConfiguration() }
 
-        if let tokenInfo = Current.settingsStore.tokenInfo, let connectionInfo = Current.settingsStore.connectionInfo {
-            Current.tokenManager = TokenManager(connectionInfo: connectionInfo, tokenInfo: tokenInfo)
+        if let tokenInfo = Current.settingsStore.tokenInfo {
+            Current.tokenManager = TokenManager(tokenInfo: tokenInfo)
         }
     }
 
@@ -611,7 +611,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let tokenInfo = TokenInfo(accessToken: token, refreshToken: "", expiration: Date.distantFuture)
 
-        let api = HomeAssistantAPI(connectionInfo: connectionInfo, tokenInfo: tokenInfo)
+        let api = HomeAssistantAPI(tokenInfo: tokenInfo)
 
         Current.settingsStore.tokenInfo = tokenInfo
         Current.settingsStore.connectionInfo = connectionInfo

--- a/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
+++ b/HomeAssistant/Views/Onboarding/ConnectInstanceViewController.swift
@@ -148,6 +148,10 @@ class ConnectInstanceViewController: UIViewController {
             let cloudState: AnimationState = cloudAvailable ? .success : .failed
             self.setAnimationStatus(self.cloudStatus, state: cloudState)
 
+            if cloudAvailable {
+                Current.settingsStore.connectionInfo?.useCloud = true
+            }
+
             let encryptState: AnimationState = regResponse.WebhookSecret != nil ? .success : .failed
             self.setAnimationStatus(self.encrypted, state: encryptState)
 

--- a/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManager.test.swift
@@ -31,15 +31,6 @@ class ZoneManagerTests: XCTestCase {
 
         realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
         api = FakeHassAPI(
-            connectionInfo: ConnectionInfo(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ),
             tokenInfo: TokenInfo(
                 accessToken: "token",
                 refreshToken: "token",

--- a/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerProcessor.test.swift
@@ -48,15 +48,6 @@ class ZoneManagerProcessorTests: XCTestCase {
         }
 
         api = FakeHassAPI(
-            connectionInfo: ConnectionInfo(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ),
             tokenInfo: TokenInfo(
                 accessToken: "token",
                 refreshToken: "token",

--- a/Intents/IntentHandler.swift
+++ b/Intents/IntentHandler.swift
@@ -15,10 +15,8 @@ class IntentHandler: INExtension {
         // This is the default implementation.  If you want different objects to handle different intents,
         // you can override this and return the handler you want for that particular intent.
 
-        if let tokenInfo = Current.settingsStore.tokenInfo,
-            let connectionInfo = Current.settingsStore.connectionInfo {
-
-            Current.tokenManager = TokenManager(connectionInfo: connectionInfo, tokenInfo: tokenInfo)
+        if let tokenInfo = Current.settingsStore.tokenInfo {
+            Current.tokenManager = TokenManager(tokenInfo: tokenInfo)
         }
 
         let handler: Any = {

--- a/NotificationContentExtension/CameraStreamHLSViewController.swift
+++ b/NotificationContentExtension/CameraStreamHLSViewController.swift
@@ -6,6 +6,7 @@ import AVKit
 
 class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
     let api: HomeAssistantAPI
+    let connectionInfo: ConnectionInfo
     let response: StreamCameraResponse
     let playerViewController: AVPlayerViewController
     let promise: Promise<Void>
@@ -33,6 +34,7 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
         }
 
         self.api = api
+        self.connectionInfo = try api.connectionInfo()
         self.response = response
         self.playerViewController = AVPlayerViewController()
         (self.promise, self.seal) = Promise<Void>.pending()
@@ -96,7 +98,7 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
             fatalError("we checked for a non-nil path on init, this should not be possible")
         }
 
-        let url = api.connectionInfo.activeURL.appendingPathComponent(path)
+        let url = connectionInfo.activeURL.appendingPathComponent(path)
         let videoPlayer = AVPlayer(url: url)
         playerViewController.player = videoPlayer
         videoPlayer.isMuted = true

--- a/NotificationContentExtension/CameraStreamMJPEGViewController.swift
+++ b/NotificationContentExtension/CameraStreamMJPEGViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 
 class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
     let api: HomeAssistantAPI
+    let connectionInfo: ConnectionInfo
     let response: StreamCameraResponse
     let imageView: UIImageView
     let streamer: MJPEGStreamer
@@ -51,6 +52,7 @@ class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
         }
 
         self.api = api
+        self.connectionInfo = try api.connectionInfo()
         self.response = response
         self.streamer = streamer
         self.imageView = UIImageView()
@@ -111,7 +113,7 @@ class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
             fatalError("we checked for a non-nil path on init, this should not be possible")
         }
 
-        let url = api.connectionInfo.activeURL.appendingPathComponent(path)
+        let url = connectionInfo.activeURL.appendingPathComponent(path)
 
         // assume 16:9
         lastSize = CGSize(width: 16, height: 9)

--- a/Shared/API/HAAPI+RequestHelpers.swift
+++ b/Shared/API/HAAPI+RequestHelpers.swift
@@ -29,7 +29,7 @@ extension HomeAssistantAPI {
                  parameters: Parameters? = nil, encoding: ParameterEncoding = URLEncoding.default,
                  headers: HTTPHeaders? = nil) -> Promise<String> {
         return Promise { seal in
-            let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding,
                                 headers: headers)
                 .validate()
@@ -46,7 +46,7 @@ extension HomeAssistantAPI {
                                   encoding: ParameterEncoding = URLEncoding.default,
                                   headers: HTTPHeaders? = nil) -> Promise<T> {
         return Promise { seal in
-            let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
                 .validate()
                 .responseObject { (response: DataResponse<T>) in
@@ -62,7 +62,7 @@ extension HomeAssistantAPI {
                                   encoding: ParameterEncoding = URLEncoding.default,
                                   headers: HTTPHeaders? = nil) -> Promise<[T]> {
         return Promise { seal in
-            let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
                 .validate()
                 .responseArray { (response: DataResponse<[T]>) in
@@ -78,7 +78,7 @@ extension HomeAssistantAPI {
                                        encoding: ParameterEncoding = URLEncoding.default,
                                        headers: HTTPHeaders? = nil) -> Promise<[T]> {
         return Promise { seal in
-           let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
                 .validate()
                 .responseArray { (response: DataResponse<[T]>) in
@@ -94,7 +94,7 @@ extension HomeAssistantAPI {
                                        encoding: ParameterEncoding = URLEncoding.default,
                                        headers: HTTPHeaders? = nil) -> Promise<T> {
         return Promise { seal in
-            let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
                 .validate()
                 .responseObject { (response: DataResponse<T>) in
@@ -110,7 +110,7 @@ extension HomeAssistantAPI {
                                                 encoding: ParameterEncoding = URLEncoding.default,
                                                 headers: HTTPHeaders? = nil) -> Promise<T> {
         return Promise { seal in
-            let url = self.connectionInfo.activeAPIURL.appendingPathComponent(path)
+            let url = try connectionInfo().activeAPIURL.appendingPathComponent(path)
             _ = manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
                 .validate()
                 .responseObject { (response: DataResponse<T>) in

--- a/Shared/API/Webhook/Request&Response/WebhookManager.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookManager.swift
@@ -384,7 +384,7 @@ public class WebhookManager: NSObject {
         baseURL: URL? = nil
     ) -> Promise<(URLRequest, Data)> {
         return Promise { seal in
-            guard let api = Current.api() else {
+            guard let connectionInfo = Current.settingsStore.connectionInfo else {
                 seal.reject(WebhookManagerError.noApi)
                 return
             }
@@ -392,9 +392,9 @@ public class WebhookManager: NSObject {
             let webhookURL: URL
 
             if let baseURL = baseURL {
-                webhookURL = baseURL.appendingPathComponent(api.connectionInfo.webhookPath, isDirectory: false)
+                webhookURL = baseURL.appendingPathComponent(connectionInfo.webhookPath, isDirectory: false)
             } else {
-                webhookURL = api.connectionInfo.webhookURL
+                webhookURL = connectionInfo.webhookURL
             }
 
             var urlRequest = try URLRequest(url: webhookURL, method: .post)

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -114,7 +114,6 @@ public class Environment {
 
     public func updateWith(authenticatedAPI: HomeAssistantAPI) {
         self.tokenManager = authenticatedAPI.tokenManager
-        self.settingsStore.connectionInfo = authenticatedAPI.connectionInfo
     }
 
     // Use of 'appConfiguration' is preferred, but sometimes Beta builds are done as releases.

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -51,6 +51,10 @@ public class SettingsStore {
                 return cachedConnectionInfo
             }
 
+            if NSClassFromString("XCTest") != nil {
+                return nil
+            }
+
             guard let connectionData = ((try? keychain.getData("connectionInfo")) as Data??),
                 let unwrappedData = connectionData else {
                     return nil
@@ -65,6 +69,10 @@ public class SettingsStore {
         }
         set {
             cachedConnectionInfo = newValue
+
+            if NSClassFromString("XCTest") != nil {
+                return
+            }
 
             guard let info = newValue else {
                 keychain["connectionInfo"] = nil

--- a/SharedTests/ModelManager.test.swift
+++ b/SharedTests/ModelManager.test.swift
@@ -18,15 +18,7 @@ class ModelManagerTests: XCTestCase {
         testQueue = DispatchQueue(label: #file)
         manager = ModelManager()
         api = FakeHomeAssistantAPI(
-            connectionInfo: .init(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ), tokenInfo: .init(
+            tokenInfo: .init(
                 accessToken: "atoken",
                 refreshToken: "refreshtoken",
                 expiration: Date()

--- a/SharedTests/Webhook/WebhookResponseLocation.test.swift
+++ b/SharedTests/Webhook/WebhookResponseLocation.test.swift
@@ -13,15 +13,7 @@ class WebhookResponseLocationTests: XCTestCase {
         super.setUp()
 
         api = HomeAssistantAPI(
-            connectionInfo: .init(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ), tokenInfo: .init(
+            tokenInfo: .init(
                 accessToken: "atoken",
                 refreshToken: "refreshtoken",
                 expiration: Date()

--- a/SharedTests/Webhook/WebhookResponseServiceCall.test.swift
+++ b/SharedTests/Webhook/WebhookResponseServiceCall.test.swift
@@ -14,15 +14,7 @@ class WebhookResponseServiceCallTests: XCTestCase {
         super.setUp()
 
         api = HomeAssistantAPI(
-            connectionInfo: .init(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ), tokenInfo: .init(
+            tokenInfo: .init(
                 accessToken: "atoken",
                 refreshToken: "refreshtoken",
                 expiration: Date()

--- a/SharedTests/Webhook/WebhookResponseUnhandled.test.swift
+++ b/SharedTests/Webhook/WebhookResponseUnhandled.test.swift
@@ -14,15 +14,7 @@ class WebhookResponseUnhandledTests: XCTestCase {
         super.setUp()
 
         api = HomeAssistantAPI(
-            connectionInfo: .init(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ), tokenInfo: .init(
+            tokenInfo: .init(
                 accessToken: "atoken",
                 refreshToken: "refreshtoken",
                 expiration: Date()

--- a/SharedTests/Webhook/WebhookResponseUpdateSensors.test.swift
+++ b/SharedTests/Webhook/WebhookResponseUpdateSensors.test.swift
@@ -13,15 +13,7 @@ class WebhookResponseUpdateSensorsTests: XCTestCase {
         super.setUp()
 
         api = FakeHomeAssistantAPI(
-            connectionInfo: .init(
-                externalURL: nil,
-                internalURL: nil,
-                cloudhookURL: nil,
-                remoteUIURL: nil,
-                webhookID: "id",
-                webhookSecret: nil,
-                internalSSIDs: nil
-            ), tokenInfo: .init(
+            tokenInfo: .init(
                 accessToken: "atoken",
                 refreshToken: "refreshtoken",
                 expiration: Date()

--- a/TodayWidget/TodayViewController.swift
+++ b/TodayWidget/TodayViewController.swift
@@ -59,9 +59,8 @@ class TodayViewController: UICollectionViewController, UICollectionViewDelegateF
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if let tokenInfo = Current.settingsStore.tokenInfo,
-            let connectionInfo = Current.settingsStore.connectionInfo {
-            Current.tokenManager = TokenManager(connectionInfo: connectionInfo, tokenInfo: tokenInfo)
+        if let tokenInfo = Current.settingsStore.tokenInfo {
+            Current.tokenManager = TokenManager(tokenInfo: tokenInfo)
         }
     }
 

--- a/WatchAppExtension/CameraNotificationController.swift
+++ b/WatchAppExtension/CameraNotificationController.swift
@@ -76,8 +76,13 @@ class CameraNotificationController: WKUserNotificationInterfaceController {
             return
         }
 
+        guard let connectionInfo = try? api.connectionInfo() else {
+            Current.Log.error("no connection info available")
+            return
+        }
+
         self.streamer = streamer
-        let apiURL = api.connectionInfo.activeAPIURL
+        let apiURL = connectionInfo.activeAPIURL
         let queryUrl = apiURL.appendingPathComponent("camera_proxy_stream/\(entityId)", isDirectory: false)
 
         streamer.streamImages(fromURL: queryUrl) { (image, error) in


### PR DESCRIPTION
- Potentially fix persisting connection info changes. There are a few situations where we appear to have multiple copies in memory of ConnectionInfo and they fight each other. This removes all caches of this value except for via the SettingsStore getter. Refs #932. 
- Enables cloud by default. Fixes #745.