### PR TITLE
Handle 0…n batteries on Mac

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		110FB4532499DC28000865B4 /* NotificationErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */; };
 		1110836824AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */; };
 		1110836924AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */; };
+		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
+		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformAction.swift */; };
 		111858D624CB620500B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		111858D724CB620600B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
@@ -853,6 +855,7 @@
 		110FB4512499DB3A000865B4 /* map_notification.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = map_notification.apns; sourceTree = "<group>"; };
 		110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationErrorViewController.swift; sourceTree = "<group>"; };
 		1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.swift"; sourceTree = "<group>"; };
+		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.swift; sourceTree = "<group>"; };
@@ -2618,6 +2621,7 @@
 				11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */,
 				11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */,
 				11E16399250B1B760076D612 /* OnboardingStateObservation.swift */,
+				1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -4340,6 +4344,7 @@
 				B67CE87A22200F220034C1D0 /* LocationTrigger.swift in Sources */,
 				B672333F225DB68B0031D629 /* WebSocketMessage.swift in Sources */,
 				11AF4D1A249C8253006C74C0 /* PedometerSensor.swift in Sources */,
+				1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */,
 				11F855DB24DF6C7A0018013E /* IconDrawable.swift in Sources */,
 				11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */,
 				B6A258462232485300ADD202 /* Alamofire+EncryptedResponses.swift in Sources */,
@@ -4481,6 +4486,7 @@
 				D0DD2CEE213BCA8900C3D9F7 /* URL+Extensions.swift in Sources */,
 				B6872E6022267EE800C475D1 /* HAAPI.swift in Sources */,
 				B62817F2221D6CF4000BA86A /* Reachability+NetworkType.swift in Sources */,
+				1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */,
 				11F855DA24DF6C7A0018013E /* IconDrawable.swift in Sources */,
 				D0EEF335214EB77100D1D360 /* CLLocation+Extensions.swift in Sources */,
 				11AF4D1F249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -63,9 +63,9 @@ public class WebhookSensor: Mappable {
         self.init(name: name, uniqueID: uniqueID, icon: "mdi:\(icon.name)", state: state, unit: unit)
     }
 
-    convenience init(name: String, uniqueID: String, icon: MaterialDesignIcons, deviceClass: DeviceClass,
+    convenience init(name: String, uniqueID: String, icon: String, deviceClass: DeviceClass,
                      state: Any, unit: String? = nil) {
-        self.init(name: name, uniqueID: uniqueID, state: state, unit: unit)
+        self.init(name: name, uniqueID: uniqueID, icon: icon, state: state, unit: unit)
         self.DeviceClass = deviceClass
     }
 

--- a/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Shared/API/Models/WebhookUpdateLocation.swift
@@ -39,7 +39,7 @@ public class WebhookUpdateLocation: Mappable {
         self.init()
 
         self.Trigger = trigger
-        self.Battery = Current.device.batteryLevel()
+        self.Battery = Current.device.batteries().first?.level ?? -1
 
         let useLocation: Bool
 

--- a/Shared/Common/Structs/DeviceBattery.swift
+++ b/Shared/Common/Structs/DeviceBattery.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+#if canImport(IOKit)
+import IOKit.ps
+#endif
+
+#if os(iOS)
+import UIKit
+#elseif os(watchOS)
+import WatchKit
+#endif
+
+public struct DeviceBattery {
+    public enum State: CustomStringConvertible {
+        case charging
+        case unplugged
+        case full
+
+        public var description: String {
+            switch self {
+            case .charging: return "Charging"
+            case .unplugged: return "Not Charging"
+            case .full: return "Full"
+            }
+        }
+
+        #if targetEnvironment(macCatalyst)
+        init(verboseInfo: [String: Any]) {
+            let isCharged = verboseInfo[kIOPSIsChargedKey] as? Bool ?? false
+            let isCharging = verboseInfo[kIOPSIsChargingKey] as? Bool ?? false
+
+            switch (isCharged, isCharging) {
+            case (true, _):
+                self = .full
+            case (false, true):
+                self = .charging
+            case (false, false):
+                self = .unplugged
+            }
+        }
+        #endif
+
+        #if os(iOS)
+        init(state: UIDevice.BatteryState) {
+            switch state {
+            case .charging: self = .charging
+            case .full: self = .full
+            case .unplugged: self = .unplugged
+            case .unknown: self = .full
+            @unknown default: self = .full
+            }
+        }
+        #endif
+
+        #if os(watchOS)
+        init(state: WKInterfaceDeviceBatteryState) {
+            switch state {
+            case .charging: self = .charging
+            case .full: self = .full
+            case .unplugged: self = .unplugged
+            case .unknown: self = .full
+            @unknown default: self = .full
+            }
+        }
+        #endif
+    }
+
+    public var name: String?
+    public var uniqueID: String?
+    public var level: Int
+    public var state: State
+    public var attributes: [String: Any]
+
+    init(level: Int, state: State, attributes: [String: Any]) {
+        self.level = level
+        self.state = state
+        self.attributes = attributes
+    }
+
+    #if canImport(IOKit)
+    init(powerSourceDescription info: [String: Any]) {
+        /// keys: https://developer.apple.com/documentation/iokit/iopskeys_h/defines
+        let name = info[kIOPSNameKey] as? String
+        if name == "InternalBattery-0" {
+            // minor readability improvement
+            self.name = "Internal Battery"
+        } else {
+            self.name = name
+        }
+        if let id = info[kIOPSPowerSourceIDKey] as? Int {
+            self.uniqueID = String(describing: id)
+        } else {
+            self.uniqueID = nil
+        }
+        self.level = info[kIOPSCurrentCapacityKey] as? Int ?? -1
+        self.state = .init(verboseInfo: info)
+        self.attributes = info
+    }
+    #endif
+
+    #if os(iOS)
+    init(device: UIDevice) {
+        let isMonitoringEnabled = device.isBatteryMonitoringEnabled
+        device.isBatteryMonitoringEnabled = true
+        defer { device.isBatteryMonitoringEnabled = isMonitoringEnabled }
+
+        self.name = nil
+        self.attributes = [:]
+
+        #if targetEnvironment(simulator)
+        self.level = 100
+        #else
+        self.level = Int(round(device.batteryLevel * 100))
+        #endif
+
+        self.state = .init(state: device.batteryState)
+    }
+    #endif
+
+    #if os(watchOS)
+    init(device: WKInterfaceDevice) {
+        let isMonitoringEnabled = device.isBatteryMonitoringEnabled
+        device.isBatteryMonitoringEnabled = true
+        defer { device.isBatteryMonitoringEnabled = isMonitoringEnabled }
+
+        self.name = nil
+        self.attributes = [:]
+
+        #if targetEnvironment(simulator)
+        self.level = 100
+        #else
+        self.level = Int(round(device.batteryLevel * 100))
+        #endif
+
+        self.state = .init(state: device.batteryState)
+    }
+    #endif
+}

--- a/SharedTests/Webhook/WebhookUpdateLocation.test.swift
+++ b/SharedTests/Webhook/WebhookUpdateLocation.test.swift
@@ -12,7 +12,7 @@ class WebhookUpdateLocationTests: XCTestCase {
     }
 
     func testBeaconEnterNotPassive() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         guard let model = WebhookUpdateLocation(
             trigger: .BeaconRegionEnter,
@@ -69,7 +69,7 @@ class WebhookUpdateLocationTests: XCTestCase {
     }
 
     func testBeaconExitNotPassive() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         guard let model = WebhookUpdateLocation(
             trigger: .BeaconRegionExit,
@@ -99,7 +99,7 @@ class WebhookUpdateLocationTests: XCTestCase {
     }
 
     func testBeaconEnterHome() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         guard let model = WebhookUpdateLocation(
             trigger: .BeaconRegionEnter,
@@ -128,7 +128,7 @@ class WebhookUpdateLocationTests: XCTestCase {
     }
 
     func testBeaconExitHome() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         guard let model = WebhookUpdateLocation(
             trigger: .BeaconRegionExit,
@@ -158,7 +158,7 @@ class WebhookUpdateLocationTests: XCTestCase {
     }
 
     func testBeaconExitPassive() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         guard let model = WebhookUpdateLocation(
             trigger: .BeaconRegionExit,
@@ -190,7 +190,7 @@ class WebhookUpdateLocationTests: XCTestCase {
 
     @available(iOS 13.4, *)
     func testGPSEnter() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         let now = Date()
 
@@ -232,7 +232,7 @@ class WebhookUpdateLocationTests: XCTestCase {
 
     @available(iOS 13.4, *)
     func testGPSExit() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         let now = Date()
 
@@ -275,7 +275,7 @@ class WebhookUpdateLocationTests: XCTestCase {
 
     @available(iOS 13.4, *)
     func testGPSEnterHome() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         let now = Date()
 
@@ -317,7 +317,7 @@ class WebhookUpdateLocationTests: XCTestCase {
 
     @available(iOS 13.4, *)
     func testGPSExitHome() {
-        Current.device.batteryLevel = { 44 }
+        Current.device.batteries = { [ DeviceBattery(level: 44, state: .charging, attributes: [:]) ] }
 
         let now = Date()
 


### PR DESCRIPTION
- Handles 0 batteries where we expect to not send any sensor. Fixes #992.
- Handles more than 1 battery, for example having a UPS hooked up over USB.

I don't have any non-battery Macs that I can test on, nor do I have a UPS to test with, so the actual real-world testing of this will unfortunately have to be by users.

Breaking change for current Mac users: the internal battery is gaining a new Unique ID, so devices with or without a battery are going to need to manually disable the old battery entries.