### PR TITLE
Remove device_id from example tag triggers

### DIFF
--- a/HomeAssistant/Views/Settings/NFC/NFCTagViewController.swift
+++ b/HomeAssistant/Views/Settings/NFC/NFCTagViewController.swift
@@ -112,7 +112,6 @@ class NFCTagViewController: FormViewController {
                     return """
                     - platform: tag
                       tag_id: \(identifier)
-                      device_id: \(Current.settingsStore.integrationDeviceID)
                     """
                 }
             }, present: { [weak self] viewController in

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -641,7 +641,9 @@ public class HomeAssistantAPI {
     ) -> (eventType: String, eventData: [String: String]) {
         var eventData = [String: String]()
         eventData["tag_id"] = tagPath
-        eventData["device_id"] = Current.settingsStore.integrationDeviceID
+        if Current.serverVersion() < .tagWebhookAvailable {
+            eventData["device_id"] = Current.settingsStore.integrationDeviceID
+        }
         return (eventType: "tag_scanned", eventData: eventData)
     }
 


### PR DESCRIPTION
These values were incorrect (when we aren't firing the event) since the id used isn't the integration id we supply but a generated one we don't know about.

0.115 / 0.114

![Image 2](https://user-images.githubusercontent.com/74188/92999252-44a30580-f4d4-11ea-99b6-b82a5ed36575.png)
