### PR TITLE
Allow widget text size to be larger when given more space

### DIFF
--- a/Widgets/Actions/WidgetActionsActionView.swift
+++ b/Widgets/Actions/WidgetActionsActionView.swift
@@ -4,10 +4,26 @@ import WidgetKit
 
 struct WidgetActionsActionView: View {
     let action: Action
+    let sizeStyle: SizeStyle
     @SwiftUI.Environment(\.widgetFamily) var family: WidgetFamily
 
-    init(action: Action) {
+    enum SizeStyle {
+        case single
+        case multiple(expanded: Bool)
+
+        var font: Font {
+            switch self {
+            case .single:
+                return .subheadline
+            case .multiple(expanded: let expanded):
+                return expanded ? .subheadline : .footnote
+            }
+        }
+    }
+
+    init(action: Action, sizeStyle: SizeStyle) {
         self.action = action
+        self.sizeStyle = sizeStyle
         MaterialDesignIcons.register()
     }
 
@@ -21,7 +37,7 @@ struct WidgetActionsActionView: View {
                     .foregroundColor(.init(hex: action.IconColor))
                 Spacer()
                 Text(verbatim: action.Text)
-                    .font(family == .systemSmall ? .subheadline : .footnote)
+                    .font(sizeStyle.font)
                     .fontWeight(.bold)
                     .multilineTextAlignment(.leading)
                     .foregroundColor(.init(hex: action.TextColor))
@@ -36,13 +52,13 @@ struct WidgetActionsActionView_Previews: PreviewProvider {
     static func shortAction() -> some View {
         WidgetActionsActionView(action: with(Action()) {
             $0.Text = "Short Name"
-        })
+        }, sizeStyle: .single)
     }
 
     static func longAction() -> some View {
         WidgetActionsActionView(action: with(Action()) {
             $0.Text = "Very Long Name Which Exceeds One Line"
-        })
+        }, sizeStyle: .single)
     }
 
     static var previews: some View {

--- a/Widgets/Actions/WidgetActionsContainerView.swift
+++ b/Widgets/Actions/WidgetActionsContainerView.swift
@@ -23,23 +23,23 @@ struct WidgetActionsContainerView: View {
     }
 
     func singleView(for action: Action) -> some View {
-        WidgetActionsActionView(action: action)
+        WidgetActionsActionView(action: action, sizeStyle: .single)
             .widgetURL(action.widgetLinkURL)
     }
 
     @ViewBuilder
     func multiView(for actions: [Action]) -> some View {
-        let columns = columnify(
-            count: Self.columnCount(family: family, actionCount: actions.count),
-            actions: actions
-        )
+        let columnCount = Self.columnCount(family: family, actionCount: actions.count)
+        let rows = Array(columnify(count: columnCount, actions: actions))
+        let maximumRowCount = Self.maximumCount(family: family) / columnCount
+        let sizeStyle: WidgetActionsActionView.SizeStyle = .multiple(expanded: rows.count < maximumRowCount)
 
         VStack(alignment: .leading, spacing: 1) {
-            ForEach(Array(columns), id: \.self) { column in
+            ForEach(rows, id: \.self) { column in
                 HStack(spacing: 1) {
                     ForEach(column, id: \.ID) { action in
                         Link(destination: action.widgetLinkURL) {
-                            WidgetActionsActionView(action: action)
+                            WidgetActionsActionView(action: action, sizeStyle: sizeStyle)
                         }
                     }
                 }
@@ -57,7 +57,7 @@ struct WidgetActionsContainerView: View {
         }
     }
 
-    private static func columnCount(family: WidgetFamily, actionCount: Int) -> Int {
+    static func columnCount(family: WidgetFamily, actionCount: Int) -> Int {
         switch family {
         case .systemSmall: return 1
         case .systemMedium: return 2
@@ -69,6 +69,15 @@ struct WidgetActionsContainerView: View {
                 return 2
             }
         @unknown default: return 2
+        }
+    }
+
+    static func maximumCount(family: WidgetFamily) -> Int {
+        switch family {
+        case .systemSmall: return 1
+        case .systemMedium: return 4
+        case .systemLarge: return 8
+        @unknown default: return 8
         }
     }
 }

--- a/Widgets/Actions/WidgetActionsProvider.swift
+++ b/Widgets/Actions/WidgetActionsProvider.swift
@@ -10,17 +10,9 @@ struct WidgetActionsProvider: IntentTimelineProvider {
     typealias Intent = WidgetActionsIntent
     typealias Entry = WidgetActionsEntry
 
-    private static func actionCount(for family: WidgetFamily) -> Int {
-        switch family {
-        case .systemSmall: return 1
-        case .systemMedium: return 4
-        case .systemLarge: return 8
-        @unknown default: return 8
-        }
-    }
-
     func placeholder(in context: Context) -> WidgetActionsEntry {
-        let actions = stride(from: 0, to: Self.actionCount(for: context.family), by: 1).map { _ in
+        let count = WidgetActionsContainerView.maximumCount(family: context.family)
+        let actions = stride(from: 0, to: count, by: 1).map { _ in
             with(Action()) {
                 $0.Text = "Redacted Text"
                 $0.IconName = MaterialDesignIcons.bedEmptyIcon.name
@@ -32,7 +24,7 @@ struct WidgetActionsProvider: IntentTimelineProvider {
 
     private static func defaultActions(in context: Context) -> [Action] {
         let allActions = Current.realm().objects(Action.self).sorted(byKeyPath: #keyPath(Action.Position))
-        let maxCount = Self.actionCount(for: context.family)
+        let maxCount = WidgetActionsContainerView.maximumCount(family: context.family)
 
         switch allActions.count {
         case 0: return []


### PR DESCRIPTION
If we're given more space than we think is the minimum for a particular widget size, bump up the font. Fixes #1005. Applies to both iOS and Mac.

![Image](https://user-images.githubusercontent.com/74188/93010129-d5fa9200-f53d-11ea-9f03-43860b6ae046.png)
