### PR TITLE
Fix 'Choose' and other Widget config text readability

### DIFF
--- a/Widgets/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Widgets/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.960",
+          "green" : "0.659",
+          "red" : "0.010"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0.960",
+          "green" : "0.659",
+          "red" : "0.010"
         }
       },
       "idiom" : "universal"

--- a/Widgets/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Widgets/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -2,13 +2,8 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
-        }
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
       },
       "idiom" : "universal"
     },
@@ -20,13 +15,8 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
-        }
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
       },
       "idiom" : "universal"
     }


### PR DESCRIPTION
Unexpectedly, these colors that I left at the default -- if white -- make the text hard to read. Any other color seems to set it to black. I don't understand, either. But it fixes it! And now we customize the 'add' button color.

![Image](https://user-images.githubusercontent.com/74188/93010134-e579db00-f53d-11ea-964d-05c39a201488.png)
![Image](https://user-images.githubusercontent.com/74188/93010139-eca0e900-f53d-11ea-99b3-ba23f2630775.png)
