### PR TITLE
Fix sensor detail view of Objective-C booleans

### DIFF
--- a/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
@@ -110,7 +110,13 @@ class SensorDetailViewController: FormViewController {
     class func row(attribute: String, value: Any) -> BaseRow {
         return LabelRow { row in
             row.title = attribute
-            row.value = String(describing: value)
+
+            if let value = value as? NSNumber, value === kCFBooleanTrue || value === kCFBooleanFalse {
+                // boolean from objective-c is represented by NSNumber, which would normally be `0` or `1` here
+                row.value = String(describing: value.boolValue)
+            } else {
+                row.value = String(describing: value)
+            }
         }
     }
 }


### PR DESCRIPTION
Booleans encoded as NSNumbers from Objective-C when evaluated by `String(describing:)` end up showing their integer value, rather than boolean value. Since they're constants, we can directly compare -- otherwise we'd have no way of knowing it was `@YES` or `@NO`.

Fixes #1006.

![ss](https://user-images.githubusercontent.com/74188/93025787-d6367400-f5b5-11ea-8b3c-d02b3085bc48.png)
