### PR TITLE
Persist sensor values and only send updates for those changed

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		114E9B4E24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */; };
 		114E9B4F24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */; };
 		114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */; };
+		1155DD00250EC01A003405C0 /* PersistedSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1155DCFF250EC01A003405C0 /* PersistedSensor.swift */; };
+		1155DD01250EC01A003405C0 /* PersistedSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1155DCFF250EC01A003405C0 /* PersistedSensor.swift */; };
 		115DA29324F464DC00C00BB1 /* MenuManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115DA28C24F4646500C00BB1 /* MenuManager.swift */; };
 		1161C01B24D7634300A0E3C4 /* NFCListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161C01A24D7634300A0E3C4 /* NFCListViewController.swift */; };
 		1171506B24DFCDE60065E874 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1171506A24DFCDE60065E874 /* WidgetKit.framework */; };
@@ -870,6 +872,7 @@
 		1148A44F24E9AF9200345050 /* MDIMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDIMigration.swift; sourceTree = "<group>"; };
 		114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "INImage+MaterialDesignIcons.swift"; sourceTree = "<group>"; };
 		114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.test.swift"; sourceTree = "<group>"; };
+		1155DCFF250EC01A003405C0 /* PersistedSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedSensor.swift; sourceTree = "<group>"; };
 		115DA28C24F4646500C00BB1 /* MenuManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuManager.swift; sourceTree = "<group>"; };
 		1161C01624D75BD500A0E3C4 /* iOSTagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTagManager.swift; sourceTree = "<group>"; };
 		1161C01A24D7634300A0E3C4 /* NFCListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCListViewController.swift; sourceTree = "<group>"; };
@@ -1733,6 +1736,15 @@
 			path = "Request&Response";
 			sourceTree = "<group>";
 		};
+		1155DCFE250EC007003405C0 /* Container */ = {
+			isa = PBXGroup;
+			children = (
+				B6D3B4EB225B26300082BB4F /* SensorContainer.swift */,
+				1155DCFF250EC01A003405C0 /* PersistedSensor.swift */,
+			);
+			path = Container;
+			sourceTree = "<group>";
+		};
 		1161C01924D7633700A0E3C4 /* NFC */ = {
 			isa = PBXGroup;
 			children = (
@@ -1831,7 +1843,7 @@
 		11AF4D0F249C7DD8006C74C0 /* Sensors */ = {
 			isa = PBXGroup;
 			children = (
-				B6D3B4EB225B26300082BB4F /* SensorContainer.swift */,
+				1155DCFE250EC007003405C0 /* Container */,
 				11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */,
 				11AF4D1B249C8AA0006C74C0 /* BatterySensor.swift */,
 				11AF4D1E249C8AF0006C74C0 /* ConnectivitySensor.swift */,
@@ -4432,6 +4444,7 @@
 				1101568824D7712F009424C9 /* TagManagerProtocol.swift in Sources */,
 				111858D724CB620600B8CDDC /* Intents.intentdefinition in Sources */,
 				B67CE89D22200F220034C1D0 /* Config.swift in Sources */,
+				1155DD01250EC01A003405C0 /* PersistedSensor.swift in Sources */,
 				11F3B85824C4279700642676 /* Entity.swift in Sources */,
 				11F855D924DF6C7A0018013E /* MaterialDesignIcons.swift in Sources */,
 				11EE9B5524C62EB300404AF8 /* RealmScene.swift in Sources */,
@@ -4574,6 +4587,7 @@
 				1101568724D7712F009424C9 /* TagManagerProtocol.swift in Sources */,
 				1141182624AF9A0500E6525C /* WebhookManager.swift in Sources */,
 				111858D624CB620500B8CDDC /* Intents.intentdefinition in Sources */,
+				1155DD00250EC01A003405C0 /* PersistedSensor.swift in Sources */,
 				D0EEF316214DD7A400D1D360 /* Config.swift in Sources */,
 				11F855D824DF6C7A0018013E /* MaterialDesignIcons.swift in Sources */,
 				11F3B85724C4279700642676 /* Entity.swift in Sources */,

--- a/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
@@ -51,8 +51,10 @@ class SensorDetailViewController: FormViewController {
 
         form +++ baseSection
 
-        if sensor.Settings.isEmpty == false {
-            form.append(Self.settingsSection(from: sensor.Settings))
+        let settings = Current.sensors.settings(for: sensor)
+
+        if settings.isEmpty == false {
+            form.append(Self.settingsSection(from: settings))
         }
 
         if let attributes = sensor.attributeDescriptions {
@@ -65,7 +67,7 @@ class SensorDetailViewController: FormViewController {
         }
     }
 
-    class func settingsSection(from settings: [WebhookSensorSetting]) -> Section {
+    class func settingsSection(from settings: [SensorProviderSetting]) -> Section {
         let section = Section(
             header: L10n.SettingsSensors.Settings.header,
             footer: L10n.SettingsSensors.Settings.footer

--- a/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorDetailViewController.swift
@@ -55,7 +55,7 @@ class SensorDetailViewController: FormViewController {
             form.append(Self.settingsSection(from: sensor.Settings))
         }
 
-        if let attributes = sensor.Attributes {
+        if let attributes = sensor.attributeDescriptions {
             let attributesSection = Section(header: L10n.SettingsSensors.Detail.attributes, footer: nil)
             let attributeRows = attributes
                 .sorted(by: { lhs, rhs in lhs.0 < rhs.0 })
@@ -107,16 +107,10 @@ class SensorDetailViewController: FormViewController {
         return section
     }
 
-    class func row(attribute: String, value: Any) -> BaseRow {
+    class func row(attribute: String, value: String) -> BaseRow {
         return LabelRow { row in
             row.title = attribute
-
-            if let value = value as? NSNumber, value === kCFBooleanTrue || value === kCFBooleanFalse {
-                // boolean from objective-c is represented by NSNumber, which would normally be `0` or `1` here
-                row.value = String(describing: value.boolValue)
-            } else {
-                row.value = String(describing: value)
-            }
+            row.value = value
         }
     }
 }

--- a/Shared/API/Models/WebhookSensor.swift
+++ b/Shared/API/Models/WebhookSensor.swift
@@ -9,23 +9,6 @@
 import Foundation
 import ObjectMapper
 
-public struct WebhookSensorSetting {
-    public enum SettingType {
-        case `switch`(getter: () -> Bool, setter: (Bool) -> Void)
-        case stepper(
-                getter: () -> Double,
-                setter: (Double) -> Void,
-                minimum: Double = 0,
-                maximum: Double = 100,
-                step: Double = 1,
-                displayValueFor: ((Double?) -> String?)?
-             )
-    }
-
-    public let type: SettingType
-    public let title: String
-}
-
 public class WebhookSensor: Mappable, Equatable {
     public var Attributes: [String: Any]?
     public var DeviceClass: DeviceClass?
@@ -35,8 +18,6 @@ public class WebhookSensor: Mappable, Equatable {
     public var `Type`: String = "sensor"
     public var UniqueID: String?
     public var UnitOfMeasurement: String?
-
-    public var Settings: [WebhookSensorSetting] = []
 
     init() {}
 

--- a/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -24,6 +24,38 @@ final class ActiveSensor: SensorProvider {
         self.request = request
     }
 
+    static func settings(for sensor: WebhookSensor) -> [SensorProviderSetting]? {
+        if sensor.UniqueID == "active" {
+            let activeState = Current.activeState
+
+            let durationFormatter = with(DateComponentsFormatter()) {
+                $0.allowedUnits = [.minute]
+                $0.allowsFractionalUnits = false
+                $0.formattingContext = .standalone
+                $0.unitsStyle = .short
+            }
+
+            return [
+                .init(
+                    type: .stepper(
+                        getter: { activeState.minimumIdleTime.converted(to: .minutes).value },
+                        setter: { activeState.minimumIdleTime = .init(value: $0, unit: .minutes) },
+                        minimum: 1,
+                        maximum: .greatestFiniteMagnitude,
+                        step: 1.0,
+                        displayValueFor: { value in
+                            let valueMeasurement = Measurement<UnitDuration>(value: value ?? 0, unit: .minutes)
+                            return durationFormatter.string(from: valueMeasurement.converted(to: .seconds).value)
+                        }
+                    ),
+                    title: L10n.Sensors.Active.Setting.timeUntilIdle
+                )
+            ]
+        } else {
+            return nil
+        }
+    }
+
     func sensors() -> Promise<[WebhookSensor]> {
         let activeState = Current.activeState
 
@@ -41,30 +73,6 @@ final class ActiveSensor: SensorProvider {
         )
         sensor.Type = "binary_sensor"
         sensor.Attributes = activeState.states.attributes
-
-        let durationFormatter = with(DateComponentsFormatter()) {
-            $0.allowedUnits = [.minute]
-            $0.allowsFractionalUnits = false
-            $0.formattingContext = .standalone
-            $0.unitsStyle = .short
-        }
-
-        sensor.Settings = [
-            .init(
-                type: .stepper(
-                    getter: { activeState.minimumIdleTime.converted(to: .minutes).value },
-                    setter: { activeState.minimumIdleTime = .init(value: $0, unit: .minutes) },
-                    minimum: 1,
-                    maximum: .greatestFiniteMagnitude,
-                    step: 1.0,
-                    displayValueFor: { value in
-                        let valueMeasurement = Measurement<UnitDuration>(value: value ?? 0, unit: .minutes)
-                        return durationFormatter.string(from: valueMeasurement.converted(to: .seconds).value)
-                    }
-                ),
-                title: L10n.Sensors.Active.Setting.timeUntilIdle
-            )
-        ]
 
         // Set up our observer
         let _: ActiveSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)

--- a/Shared/API/Webhook/Sensors/ActivitySensor.swift
+++ b/Shared/API/Webhook/Sensors/ActivitySensor.swift
@@ -19,7 +19,7 @@ public class ActivitySensor: SensorProvider {
             Self.latestMotionActivity()
         }.map { activity in
             with(WebhookSensor(name: "Activity", uniqueID: "activity")) {
-                $0.State = activity.activityTypes.first
+                $0.State = activity.activityTypes.first ?? "Unknown"
                 $0.Attributes = [
                     "Confidence": activity.confidence.description,
                     "Types": activity.activityTypes

--- a/Shared/API/Webhook/Sensors/Container/PersistedSensor.swift
+++ b/Shared/API/Webhook/Sensors/Container/PersistedSensor.swift
@@ -1,0 +1,54 @@
+import RealmSwift
+import ObjectMapper
+
+class PersistedSensor: Object {
+    @objc dynamic var uniqueID: String
+    @objc dynamic var updated: Date
+    @objc private dynamic var sensorData: Data
+    var sensor: WebhookSensor {
+        get {
+            let object = (try? JSONSerialization.jsonObject(with: sensorData, options: [])) ?? [:]
+            return Mapper<WebhookSensor>().map(JSONObject: object) ?? WebhookSensor()
+        }
+        set {
+            assert(newValue.UniqueID == uniqueID)
+            sensorData = Self.data(for: newValue)
+            updated = Current.date()
+        }
+    }
+
+    override class func primaryKey() -> String? {
+        #keyPath(uniqueID)
+    }
+
+    private static func data(for sensor: WebhookSensor) -> Data {
+        let mapper = Mapper<WebhookSensor>(
+            context: WebhookSensorContext(update: false),
+            shouldIncludeNilValues: true
+        )
+        return (try? JSONSerialization.data(
+            withJSONObject: mapper.toJSON(sensor),
+            options: [.sortedKeys]
+        )) ?? Data()
+    }
+
+    init?(sensor: WebhookSensor) {
+        if let uniqueID = sensor.UniqueID {
+            self.uniqueID = uniqueID
+        } else {
+            return nil
+        }
+
+        self.sensorData = Self.data(for: sensor)
+        self.updated = Current.date()
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init() {
+        // this gets invoked by the realm runtime only
+        self.uniqueID = ""
+        self.sensorData = Data()
+        self.updated = Current.date()
+    }
+}

--- a/Shared/API/Webhook/Sensors/Container/SensorContainer.swift
+++ b/Shared/API/Webhook/Sensors/Container/SensorContainer.swift
@@ -50,6 +50,10 @@ public class SensorContainer {
         observers.remove(observer)
     }
 
+    public func settings(for sensor: WebhookSensor) -> [SensorProviderSetting] {
+        providers.flatMap { $0.settings(for: sensor) ?? [] }
+    }
+
     private var lastUpdate: SensorObserverUpdate? {
         didSet {
             guard let lastUpdate = lastUpdate else { return }

--- a/Shared/API/Webhook/Sensors/GeocoderSensor.swift
+++ b/Shared/API/Webhook/Sensors/GeocoderSensor.swift
@@ -23,6 +23,20 @@ public class GeocoderSensor: SensorProvider {
         self.request = request
     }
 
+    public static func settings(for sensor: WebhookSensor) -> [SensorProviderSetting]? {
+        if sensor.UniqueID == "geocoded_location" {
+            return [
+                .init(type: .switch(getter: {
+                    Current.settingsStore.prefs.bool(forKey: UserDefaultsKeys.geocodeUseZone.rawValue)
+                }, setter: {
+                    Current.settingsStore.prefs.set($0, forKey: UserDefaultsKeys.geocodeUseZone.rawValue)
+                }), title: UserDefaultsKeys.geocodeUseZone.title)
+            ]
+        } else {
+            return []
+        }
+    }
+
     public func sensors() -> Promise<[WebhookSensor]> {
         return firstly { () -> Promise<[CLPlacemark]> in
             guard let location = request.location else {
@@ -37,13 +51,6 @@ public class GeocoderSensor: SensorProvider {
             let sensor = with(WebhookSensor(name: "Geocoded Location", uniqueID: "geocoded_location")) {
                 $0.State = "Unknown"
                 $0.Icon = "mdi:\(MaterialDesignIcons.mapIcon.name)"
-                $0.Settings = [
-                    .init(type: .switch(getter: {
-                        Current.settingsStore.prefs.bool(forKey: UserDefaultsKeys.geocodeUseZone.rawValue)
-                    }, setter: {
-                        Current.settingsStore.prefs.set($0, forKey: UserDefaultsKeys.geocodeUseZone.rawValue)
-                    }), title: UserDefaultsKeys.geocodeUseZone.title)
-                ]
             }
 
             guard !placemarks.isEmpty else {

--- a/Shared/API/Webhook/Sensors/SensorProvider.swift
+++ b/Shared/API/Webhook/Sensors/SensorProvider.swift
@@ -6,6 +6,13 @@ public struct SensorProviderRequest {
     public enum Reason {
         case registration
         case trigger(String)
+
+        var shouldAllowPersistedFilter: Bool {
+            switch self {
+            case .registration: return false
+            case .trigger: return true
+            }
+        }
     }
     public var reason: Reason
     public var dependencies: SensorProviderDependencies

--- a/Shared/API/Webhook/Sensors/SensorProvider.swift
+++ b/Shared/API/Webhook/Sensors/SensorProvider.swift
@@ -34,7 +34,31 @@ public struct SensorProviderRequest {
     }
 }
 
+public struct SensorProviderSetting {
+    public enum SettingType {
+        case `switch`(getter: () -> Bool, setter: (Bool) -> Void)
+        case stepper(
+                getter: () -> Double,
+                setter: (Double) -> Void,
+                minimum: Double = 0,
+                maximum: Double = 100,
+                step: Double = 1,
+                displayValueFor: ((Double?) -> String?)?
+             )
+    }
+
+    public let type: SettingType
+    public let title: String
+}
+
 public protocol SensorProvider: AnyObject {
+    static func settings(for sensor: WebhookSensor) -> [SensorProviderSetting]?
     init(request: SensorProviderRequest)
     func sensors() -> Promise<[WebhookSensor]>
+}
+
+extension SensorProvider {
+    public static func settings(for sensor: WebhookSensor) -> [SensorProviderSetting]? {
+        nil
+    }
 }


### PR DESCRIPTION
- Adds a disk cache for the last time we updated a sensor and uses it to decide if we should update a sensor.
- Shows all sensors, even those we didn't recently update. For example, the geocoded location sensor will now display the last value we sent up for it.
- Move sensor settings out of the model objects (since they are serializing/deserializing before display) and into a SensorProvider static method.
- Does a lot of value display massaging to handle serial/deserial-izing turning things from e.g. `Array` into `NSArray`-bridge variants, which have significantly different descriptions from `String(describing:)`

TODO:
- [ ] Do all of our sensors always exist? e.g. is there a case a persisted sensor would be invalid and should be deleted? How do we make this migration cleaner?
- [ ] Should this just be an in-memory cache rather than on-disk?
- [ ] Tests