### PR TITLE
Fix not-fully-defined Shortcut execution by asking for values

### DIFF
--- a/Intents/CallService.swift
+++ b/Intents/CallService.swift
@@ -13,23 +13,23 @@ import Intents
 
 class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
     func resolveService(for intent: CallServiceIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
-        guard let serviceName = intent.service else {
-            completion(.confirmationRequired(with: intent.service))
-            return
+        if let serviceName = intent.service, serviceName.isEmpty == false {
+            Current.Log.info("using given \(serviceName)")
+            completion(.success(with: serviceName))
+        } else {
+            Current.Log.info("loading values due to no service")
+            completion(.needsValue())
         }
-
-        completion(.success(with: serviceName))
-        return
     }
 
     func resolvePayload(for intent: CallServiceIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
-        guard let servicePayload = intent.payload else {
-            completion(.confirmationRequired(with: intent.payload))
-            return
+        if let servicePayload = intent.payload, servicePayload.isEmpty == false {
+            Current.Log.info("using provided \(servicePayload)")
+            completion(.success(with: servicePayload))
+        } else {
+            Current.Log.info("requesting a value")
+            completion(.needsValue())
         }
-
-        completion(.success(with: servicePayload))
-        return
     }
 
     func provideServiceOptions(for intent: CallServiceIntent, with completion: @escaping ([String]?, Error?) -> Void) {

--- a/Intents/FireEvent.swift
+++ b/Intents/FireEvent.swift
@@ -13,19 +13,23 @@ import Intents
 
 class FireEventIntentHandler: NSObject, FireEventIntentHandling {
     func resolveEventName(for intent: FireEventIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
-        if let eventName = intent.eventName {
+        if let eventName = intent.eventName, eventName.isEmpty == false {
+            Current.Log.info("using provided \(eventName)")
             completion(.success(with: eventName))
-            return
+        } else {
+            Current.Log.info("requesting a value")
+            completion(.needsValue())
         }
-        completion(.confirmationRequired(with: intent.eventName))
     }
 
     func resolveEventData(for intent: FireEventIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
-        if let eventData = intent.eventData {
+        if let eventData = intent.eventData, eventData.isEmpty == false {
+            Current.Log.info("using provided data \(eventData)")
             completion(.success(with: eventData))
-            return
+        } else {
+            Current.Log.info("using empty dictionary")
+            completion(.notRequired())
         }
-        completion(.confirmationRequired(with: intent.eventData))
     }
 
     func confirm(intent: FireEventIntent, completion: @escaping (FireEventIntentResponse) -> Void) {

--- a/Intents/GetCameraImage.swift
+++ b/Intents/GetCameraImage.swift
@@ -15,17 +15,13 @@ import Intents
 class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
     func resolveCameraID(for intent: GetCameraImageIntent,
                          with completion: @escaping (INStringResolutionResult) -> Void) {
-        guard let cameraID = intent.cameraID else {
-            completion(.confirmationRequired(with: intent.cameraID))
-            return
+        if let cameraID = intent.cameraID, cameraID.hasPrefix("camera.") {
+            Current.Log.info("using given \(cameraID)")
+            completion(.success(with: cameraID))
+        } else {
+            Current.Log.info("loading values due to no camera id")
+            completion(.needsValue())
         }
-
-        if !cameraID.hasPrefix("camera.") {
-            completion(.confirmationRequired(with: intent.cameraID))
-            return
-        }
-
-        completion(.success(with: cameraID))
     }
 
     func provideCameraIDOptions(for intent: GetCameraImageIntent,

--- a/Intents/PerformAction.swift
+++ b/Intents/PerformAction.swift
@@ -32,8 +32,10 @@ class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
         @escaping (IntentActionResolutionResult) -> Void
     ) {
         if let result = intent.action?.asActionWithUpdated() {
+            Current.Log.info("using action \(result.updated.identifier)")
             completion(.success(with: result.updated))
         } else {
+            Current.Log.info("asking for value")
             completion(.needsValue())
         }
     }

--- a/Intents/RenderTemplate.swift
+++ b/Intents/RenderTemplate.swift
@@ -14,11 +14,13 @@ import Intents
 class RenderTemplateIntentHandler: NSObject, RenderTemplateIntentHandling {
     func resolveTemplate(for intent: RenderTemplateIntent,
                          with completion: @escaping (INStringResolutionResult) -> Void) {
-        if let templateStr = intent.template {
+        if let templateStr = intent.template, templateStr.isEmpty == false {
+            Current.Log.info("using provided '\(templateStr)'")
             completion(.success(with: templateStr))
-            return
+        } else {
+            Current.Log.info("requesting a value")
+            completion(.needsValue())
         }
-        completion(.confirmationRequired(with: intent.template))
     }
 
     func confirm(intent: RenderTemplateIntent, completion: @escaping (RenderTemplateIntentResponse) -> Void) {

--- a/Intents/SendLocation.swift
+++ b/Intents/SendLocation.swift
@@ -16,10 +16,12 @@ class SendLocationIntentHandler: NSObject, SendLocationIntentHandling {
     func resolveLocation(for intent: SendLocationIntent,
                          with completion: @escaping (INPlacemarkResolutionResult) -> Void) {
         if let loc = intent.location {
+            Current.Log.info("using provided \(loc)")
             completion(.success(with: loc))
-            return
+        } else {
+            Current.Log.info("requesting a value")
+            completion(.needsValue())
         }
-        completion(.confirmationRequired(with: intent.location))
     }
 
     func confirm(intent: SendLocationIntent, completion: @escaping (SendLocationIntentResponse) -> Void) {


### PR DESCRIPTION
When we use `.confirmationRequired(…)` for the result of a parameter resolve, the system drops it and silently stops executing the shortcut (without erroring or success). This is a change in behavior from iOS 13.

Working around this improves the user experience anyway - if a value is required, for example, telling the system this allows it to prompt the user for a value rather than erroring.

Fixes #1031.