### PR TITLE
Force 'macOS' as the OS name wherever we ask the system, fixing User-Agent

### DIFF
--- a/Shared/Common/Structs/DeviceWrapper.swift
+++ b/Shared/Common/Structs/DeviceWrapper.swift
@@ -83,7 +83,10 @@ public class DeviceWrapper {
     }
 
     public lazy var systemName: () -> String = {
-        #if os(iOS)
+        #if targetEnvironment(macCatalyst)
+        // UIDevice returns 'iOS' on Mac, so we hard-code it
+        return "macOS"
+        #elseif os(iOS)
         // iOS
         return UIDevice.current.systemName
         #elseif os(watchOS)


### PR DESCRIPTION
Fixes #1038, e.g.: the user agent will be like `Home Assistant/2020.7 (io.robbie.HomeAssistant; build:1; macOS 11.0.0)`.