### PR TITLE
Fix slightly-blurry scale issues with WebView

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */; };
 		113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */; };
+		113FB1132515A065000AC680 /* ScaleFactorMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113FB1122515A065000AC680 /* ScaleFactorMutator.swift */; };
 		1141182624AF9A0500E6525C /* WebhookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141182524AF9A0500E6525C /* WebhookManager.swift */; };
 		1141182724AF9A0500E6525C /* WebhookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141182524AF9A0500E6525C /* WebhookManager.swift */; };
 		1141182A24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141182924AFA10900E6525C /* WebhookResponseHandler.swift */; };
@@ -866,6 +867,7 @@
 		113D04E324D76CDB003CE877 /* NFCWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCWriter.swift; sourceTree = "<group>"; };
 		113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocation.swift"; sourceTree = "<group>"; };
 		113D29E024946EE50014067C /* CLLocationManager+OneShotLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+OneShotLocationTests.swift"; sourceTree = "<group>"; };
+		113FB1122515A065000AC680 /* ScaleFactorMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleFactorMutator.swift; sourceTree = "<group>"; };
 		1141182524AF9A0500E6525C /* WebhookManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookManager.swift; sourceTree = "<group>"; };
 		1141182924AFA10900E6525C /* WebhookResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseHandler.swift; sourceTree = "<group>"; };
 		11482AD52505CB6E00C48C58 /* HACoreAudioObjectDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HACoreAudioObjectDevice.swift; sourceTree = "<group>"; };
@@ -2446,6 +2448,7 @@
 				11EFCDD224F5F39100314D85 /* WebViewWindowController.swift */,
 				11DE822D24FAC51000E636B8 /* IncomingURLHandler.swift */,
 				11DE822F24FAE66F00E636B8 /* UIWindow+Additions.swift */,
+				113FB1122515A065000AC680 /* ScaleFactorMutator.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -4265,6 +4268,7 @@
 				B605C891226E9DAC00EF46DD /* Permissions.swift in Sources */,
 				B616B29B227ED69500828165 /* DNSResolver.swift in Sources */,
 				B65B15052273188300635D5C /* Assets.swift in Sources */,
+				113FB1132515A065000AC680 /* ScaleFactorMutator.swift in Sources */,
 				B661FB7C226C199200E541DD /* PermissionsViewController.swift in Sources */,
 				B605C893226EC25800EF46DD /* AuthenticationViewController.swift in Sources */,
 				11B62DBE24F2EDD800E5CB55 /* EurekaCondition+Additions.swift in Sources */,

--- a/HomeAssistant/Scenes/WebViewSceneDelegate.swift
+++ b/HomeAssistant/Scenes/WebViewSceneDelegate.swift
@@ -15,6 +15,8 @@ final class WebViewSceneDelegate: NSObject, UIWindowSceneDelegate {
     ) {
         guard let scene = scene as? UIWindowScene else { return }
 
+        ScaleFactorMutator.record(sceneIdentifier: session.persistentIdentifier)
+
         let window = UIWindow(haScene: scene)
         let windowController = WebViewWindowController(
             window: window,

--- a/HomeAssistant/Views/ScaleFactorMutator.swift
+++ b/HomeAssistant/Views/ScaleFactorMutator.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Shared
+
+class ScaleFactorMutator {
+    fileprivate static var sceneIdentifiers = Set<String>()
+    public static func record(sceneIdentifier: String) {
+        swizzleIfNeeded()
+        sceneIdentifiers.insert(sceneIdentifier)
+    }
+
+    static private var hasSwizzled = false
+    static private func swizzleIfNeeded() {
+        guard !hasSwizzled else { return }
+        defer { hasSwizzled = true }
+
+        #if targetEnvironment(macCatalyst)
+        func exchange(for klassString: String, original: Selector, with replacement: Selector) {
+            guard
+                let klass = objc_getClass(klassString) as? AnyClass,
+                let originalMethod = class_getInstanceMethod(klass, original),
+                let replacementMethod = class_getInstanceMethod(klass, replacement)
+            else {
+                Current.Log.error("couldn't get \(klassString) method \(original) and \(replacement)")
+                return
+            }
+
+            method_exchangeImplementations(originalMethod, replacementMethod)
+        }
+
+        exchange(
+            for: "UINSSceneView",
+            original: Selector(("setScaleFactor:")),
+            with: #selector(NSObject.setHa_scaleFactor(_:))
+        )
+        exchange(
+            for: "UINSSceneView",
+            original: Selector(("setSceneIdentifier:")),
+            with: #selector(NSObject.setHa_sceneIdentifier(_:))
+        )
+        #endif
+    }
+}
+
+#if targetEnvironment(macCatalyst)
+fileprivate extension NSObject {
+    var sceneIdentifier: String? {
+        if responds(to: Selector(("sceneIdentifier"))) {
+            return value(forKey: "sceneIdentifier") as? String
+        } else {
+            return nil
+        }
+    }
+
+    @objc func setHa_scaleFactor(_ scaleFactor: CGFloat) {
+        if let identifier = sceneIdentifier, ScaleFactorMutator.sceneIdentifiers.contains(identifier) {
+            setHa_scaleFactor(1.0)
+        } else {
+            setHa_scaleFactor(scaleFactor)
+        }
+    }
+
+    @objc func setHa_sceneIdentifier(_ identifier: String) {
+        setHa_sceneIdentifier(identifier)
+
+        if ScaleFactorMutator.sceneIdentifiers.contains(identifier) {
+            // this calls the UIKit/AppKit version
+            setHa_scaleFactor(1.0)
+        }
+    }
+}
+#endif

--- a/Shared/Settings/SettingsStore.swift
+++ b/Shared/Settings/SettingsStore.swift
@@ -237,12 +237,7 @@ public class SettingsStore {
         }
 
         public var viewScaleValue: String {
-            if Current.isCatalyst {
-                // Catalyst apps are sized down to 77% of normal, so invert it to get normal
-                return String(format: "%.02f", CGFloat(zoom) / 100.0 * 1.0/0.77)
-            } else {
-                return String(format: "%.02f", CGFloat(zoom) / 100.0)
-            }
+            return String(format: "%.02f", CGFloat(zoom) / 100.0)
         }
 
         public static let `default`: PageZoom = .init(100)


### PR DESCRIPTION
When the NSView's scaleFactor is 0.77 and we set the WebView to be 1.30 to offset it, we end up slightly scaling the text since it's not a perfect multiplication.

This eliminates the scale factor entirely when the scene is for the WebView, but leaves other scenes (e.g. settings, about) alone since we do want the automatic scaling in them.

Fixes #1041.