### PR TITLE
Add "Configure…" to Actions menu

### DIFF
--- a/HomeAssistant/AppDelegate.swift
+++ b/HomeAssistant/AppDelegate.swift
@@ -175,6 +175,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         sceneManager.activateAnyScene(for: .settings)
     }
 
+    @available(iOS 13, *)
+    @objc internal func openActionsPreferences(_ command: UICommand) {
+        precondition(Current.sceneManager.supportsMultipleScenes)
+        let delegate: Guarantee<SettingsSceneDelegate> = sceneManager.scene(for: .init(activity: .settings))
+        delegate.done { $0.pushDetail(group: "actions", animated: true) }
+    }
+
     @objc internal func openHelp() {
         openURLInBrowser(
             URL(string: "https://companion.home-assistant.io")!,

--- a/HomeAssistant/Resources/en.lproj/Localizable.strings
+++ b/HomeAssistant/Resources/en.lproj/Localizable.strings
@@ -884,3 +884,5 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "open_label" = "Open";
 "sensors.active.setting.time_until_idle" = "Time Until Idle";
 "widgets.actions.description" = "Perform Home Assistant actions.";
+"menu.actions.title" = "Actions";
+"menu.actions.configure" = "Configure…";

--- a/HomeAssistant/Scenes/SettingsSceneDelegate.swift
+++ b/HomeAssistant/Scenes/SettingsSceneDelegate.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Shared
 
 @available(iOS 13, *)
 @objc class SettingsSceneDelegate: BasicSceneDelegate {
@@ -7,6 +8,19 @@ import UIKit
         .init(
             title: L10n.Settings.NavigationBar.title,
             rootViewController: UINavigationController(rootViewController: SettingsViewController())
+        )
+    }
+
+    func pushDetail(group: String, animated: Bool) {
+        guard let navigationController = window?.rootViewController as? UINavigationController else {
+            return
+        }
+
+        navigationController.pushViewController(
+            with(SettingsDetailViewController()) {
+                $0.detailGroup = group
+            },
+            animated: animated
         )
     }
 }

--- a/HomeAssistant/Utilities/MenuManager.swift
+++ b/HomeAssistant/Utilities/MenuManager.swift
@@ -6,6 +6,7 @@ import Shared
 @available(iOS 13, *)
 private extension UIMenu.Identifier {
     static var haActions: Self { .init(rawValue: "ha.actions") }
+    static var haActionsConfigure: Self { .init(rawValue: "ha.actions.configure") }
     static var haHelp: Self { .init(rawValue: "ha.help") }
     static var haWebViewActions: Self { .init(rawValue: "ha.webViewActions") }
     static var haFile: Self { .init(rawValue: "ha.file") }
@@ -145,10 +146,19 @@ class MenuManager {
                     action: #selector(AppDelegate.openMenuUrl(_:)),
                     propertyList: Self.propertyList(for: action.widgetLinkURL)
                 )
-            }
+            } + [
+                UIMenu(title: "", image: nil, identifier: .haActionsConfigure, options: [.displayInline], children: [
+                    UICommand(
+                        title: L10n.Menu.Actions.configure,
+                        image: nil,
+                        action: #selector(AppDelegate.openActionsPreferences),
+                        propertyList: nil
+                    )
+                ])
+            ]
 
         return UIMenu(
-            title: L10n.Widgets.Actions.title,
+            title: L10n.Menu.Actions.title,
             image: nil,
             identifier: .haActions,
             options: [],

--- a/Shared/Resources/Swiftgen/Strings.swift
+++ b/Shared/Resources/Swiftgen/Strings.swift
@@ -494,6 +494,12 @@ internal enum L10n {
   }
 
   internal enum Menu {
+    internal enum Actions {
+      /// Configure…
+      internal static let configure = L10n.tr("Localizable", "menu.actions.configure")
+      /// Actions
+      internal static let title = L10n.tr("Localizable", "menu.actions.title")
+    }
     internal enum Application {
       /// About %@
       internal static func about(_ p1: Any) -> String {


### PR DESCRIPTION
- Adds the menu item, which pushes the detail controller on the settings window (opening if necessary).
- Fixes the type handling of pending resolvers for scene activation. Since we may be calling in a superclass of the expected delegate type, we need to make the resolver conditionally cast to figure out if it's the same thing.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/74188/93686576-fa89c900-fa6b-11ea-8340-028ac5e873b6.png">

Fixes #940