### PR TITLE
Add Mac SSID/BSSID sensors

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		119385A5249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A6249E9F930097F497 /* StorageSensor.test.swift */; };
 		11948E8924DA5D50006F5657 /* InfoLabelRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11948E8824DA5D50006F5657 /* InfoLabelRow.swift */; };
+		1194B3ED2519B48600AA01C3 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1194B3EC2519B48500AA01C3 /* Info.plist */; };
+		1194B4162519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */; };
 		11993D2424E78A3700627944 /* WidgetActionsActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11993D2324E78A3700627944 /* WidgetActionsActionView.swift */; };
 		119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C9B1E24A448A600308A54 /* ZoneManager.swift */; };
@@ -919,7 +921,6 @@
 		1161C01A24D7634300A0E3C4 /* NFCListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCListViewController.swift; sourceTree = "<group>"; };
 		1166363289B5E05B7BAB7204 /* Pods_Shared_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shared_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1167402225198F9A00F51626 /* MacBridge.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacBridge.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		1167402425198F9A00F51626 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		116740722519907400F51626 /* MacBridgeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeProtocol.swift; sourceTree = "<group>"; };
 		1167408D251990D500F51626 /* MacBridgeImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeImpl.swift; sourceTree = "<group>"; };
 		1171506924DFCDE60065E874 /* WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -973,6 +974,8 @@
 		119385A3249E8E360097F497 /* StorageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.swift; sourceTree = "<group>"; };
 		119385A6249E9F930097F497 /* StorageSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.test.swift; sourceTree = "<group>"; };
 		11948E8824DA5D50006F5657 /* InfoLabelRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabelRow.swift; sourceTree = "<group>"; };
+		1194B3EC2519B48500AA01C3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeWiFiConnectivityImpl.swift; sourceTree = "<group>"; };
 		11993D2324E78A3700627944 /* WidgetActionsActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsActionView.swift; sourceTree = "<group>"; };
 		119C9B1E24A448A600308A54 /* ZoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManager.swift; sourceTree = "<group>"; };
 		119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+BackgroundTask.swift"; sourceTree = "<group>"; };
@@ -1847,8 +1850,9 @@
 		1167402325198F9A00F51626 /* MacBridge */ = {
 			isa = PBXGroup;
 			children = (
-				1167402425198F9A00F51626 /* Info.plist */,
+				1194B3EB2519B48500AA01C3 /* Resources */,
 				1167408D251990D500F51626 /* MacBridgeImpl.swift */,
+				1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */,
 			);
 			path = MacBridge;
 			sourceTree = "<group>";
@@ -1904,6 +1908,14 @@
 				11A3F08B24ECE88C0018D84F /* WebhookUpdateLocation.test.swift */,
 			);
 			path = Webhook;
+			sourceTree = "<group>";
+		};
+		1194B3EB2519B48500AA01C3 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1194B3EC2519B48500AA01C3 /* Info.plist */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		11A71C6924A463EE00D9565F /* ZoneManager */ = {
@@ -3594,6 +3606,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1194B3ED2519B48600AA01C3 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4363,6 +4376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1167409B251991AB00F51626 /* MacBridgeProtocol.swift in Sources */,
+				1194B4162519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift in Sources */,
 				1167408E251990D500F51626 /* MacBridgeImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -126,7 +126,6 @@
 		119385A5249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
 		119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A6249E9F930097F497 /* StorageSensor.test.swift */; };
 		11948E8924DA5D50006F5657 /* InfoLabelRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11948E8824DA5D50006F5657 /* InfoLabelRow.swift */; };
-		1194B3ED2519B48600AA01C3 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1194B3EC2519B48500AA01C3 /* Info.plist */; };
 		1194B4162519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */; };
 		11993D2424E78A3700627944 /* WidgetActionsActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11993D2324E78A3700627944 /* WidgetActionsActionView.swift */; };
 		119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -3606,7 +3605,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1194B3ED2519B48600AA01C3 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
@@ -101,8 +101,9 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
             }
 
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
-                // need to write crazy indirection to get access to wifi ssid information via CoreWLAN
-                row.hidden = .isCatalyst
+                row.hidden = .function([],  { _ in
+                    ConnectionInfo.hasWiFi == false
+                })
 
                 row.cellStyle = .value1
                 row.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
@@ -113,6 +114,8 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                     row.updateCell()
                     navigationController?.popViewController(animated: true)
                 })
+
+                row.evaluateHidden()
             }
 
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in

--- a/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
+++ b/HomeAssistant/Views/Settings/ConnectionSettingsViewController.swift
@@ -101,7 +101,7 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
             }
 
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
-                row.hidden = .function([],  { _ in
+                row.hidden = .function([], { _ in
                     ConnectionInfo.hasWiFi == false
                 })
 

--- a/Intents/PerformAction.swift
+++ b/Intents/PerformAction.swift
@@ -32,7 +32,7 @@ class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
         @escaping (IntentActionResolutionResult) -> Void
     ) {
         if let result = intent.action?.asActionWithUpdated() {
-            Current.Log.info("using action \(result.updated.identifier)")
+            Current.Log.info("using action \(String(describing: result.updated.identifier))")
             completion(.success(with: result.updated))
         } else {
             Current.Log.info("asking for value")

--- a/MacBridge/MacBridgeImpl.swift
+++ b/MacBridge/MacBridgeImpl.swift
@@ -1,8 +1,13 @@
 import Foundation
 import AppKit
+import CoreWLAN
 
 @objc(HAMacBridgeImpl) final class MacBridgeImpl: NSObject, MacBridge {
+    let wifiClient: CWWiFiClient
+
     override init() {
+        self.wifiClient = CWWiFiClient.shared()
+
         super.init()
     }
 
@@ -12,5 +17,13 @@ import AppKit
 
     var workspaceNotificationCenter: NotificationCenter {
         NSWorkspace.shared.notificationCenter
+    }
+
+    var wifiConnectivity: MacBridgeWiFiConnectivity? {
+        if let interface = wifiClient.interfaces()?.first {
+            return MacBridgeWiFiConnectivityImpl(ssid: interface.ssid(), bssid: interface.bssid())
+        } else {
+            return nil
+        }
     }
 }

--- a/MacBridge/MacBridgeWiFiConnectivityImpl.swift
+++ b/MacBridge/MacBridgeWiFiConnectivityImpl.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@objc class MacBridgeWiFiConnectivityImpl: NSObject, MacBridgeWiFiConnectivity {
+    let ssid: String?
+    let bssid: String?
+
+    init(ssid: String?, bssid: String?) {
+        self.ssid = ssid
+        self.bssid = bssid
+    }
+}

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -268,6 +268,7 @@ public class Environment {
 
     /// Wrapper around CoreTelephony, Reachability
     public struct Connectivity {
+        public var hasWiFi: () -> Bool = { ConnectionInfo.hasWiFi }
         public var currentWiFiSSID: () -> String? = { ConnectionInfo.CurrentWiFiSSID }
         public var currentWiFiBSSID: () -> String? = { ConnectionInfo.CurrentWiFiBSSID }
         #if os(iOS) && !targetEnvironment(macCatalyst)

--- a/Shared/Common/Structs/MacBridgeProtocol.swift
+++ b/Shared/Common/Structs/MacBridgeProtocol.swift
@@ -6,4 +6,11 @@ import Foundation
 
     var distributedNotificationCenter: NotificationCenter { get }
     var workspaceNotificationCenter: NotificationCenter { get }
+
+    var wifiConnectivity: MacBridgeWiFiConnectivity? { get }
+}
+
+@objc(MacBridgeWiFiConnectivity) public protocol MacBridgeWiFiConnectivity: NSObjectProtocol {
+    var ssid: String? { get }
+    var bssid: String? { get }
 }

--- a/Shared/Networking/ConnectionInfo.swift
+++ b/Shared/Networking/ConnectionInfo.swift
@@ -344,10 +344,18 @@ public class ConnectionInfo: Codable {
         #endif
     }
 
+    public static var hasWiFi: Bool {
+        #if targetEnvironment(macCatalyst)
+        return Current.macBridge.wifiConnectivity != nil
+        #else
+        return true
+        #endif
+    }
+
     /// Returns the current SSID if it exists and the platform supports it.
     public static var CurrentWiFiSSID: String? {
         #if targetEnvironment(macCatalyst)
-        return nil
+        return Current.macBridge.wifiConnectivity?.ssid
         #elseif os(iOS)
         guard let interfaces = CNCopySupportedInterfaces() as? [String] else { return nil }
         for interface in interfaces {
@@ -363,7 +371,7 @@ public class ConnectionInfo: Codable {
     /// Returns the current BSSID if it exists and the platform supports it.
     public static var CurrentWiFiBSSID: String? {
         #if targetEnvironment(macCatalyst)
-        return nil
+        return Current.macBridge.wifiConnectivity?.bssid
         #elseif os(iOS)
         guard let interfaces = CNCopySupportedInterfaces() as? [String] else { return nil }
         for interface in interfaces {

--- a/SharedTests/Sensors/ConnectivitySensor.test.swift
+++ b/SharedTests/Sensors/ConnectivitySensor.test.swift
@@ -12,8 +12,10 @@ class ConnectivitySensorTests: XCTestCase {
         networkType: NetworkType,
         cellularNetworkType: NetworkType?,
         cellular: [String?: CTCarrier]? = nil,
-        radioTech: [String?: String]? = nil
+        radioTech: [String?: String]? = nil,
+        hasWiFi: Bool = true
     ) throws -> (ssid: WebhookSensor?, bssid: WebhookSensor?, connection: WebhookSensor?, sims: [WebhookSensor]) {
+        Current.connectivity.hasWiFi = { hasWiFi }
         Current.connectivity.currentWiFiSSID = { ssid }
         Current.connectivity.currentWiFiBSSID = { bssid }
         Current.connectivity.simpleNetworkType = { networkType }
@@ -36,6 +38,19 @@ class ConnectivitySensorTests: XCTestCase {
                 $0.UniqueID?.contains("sim") == true || $0.UniqueID?.contains("cellular") == true
             }.sorted(by: { lhs, rhs in (lhs.UniqueID ?? "") < (rhs.UniqueID ?? "") })
         )
+    }
+
+    func testNoWifiAtAll() throws {
+        let s = try setUp(
+            ssid: nil,
+            bssid: nil,
+            networkType: .noConnection,
+            cellularNetworkType: nil,
+            hasWiFi: false
+        )
+
+        XCTAssertNil(s.ssid)
+        XCTAssertNil(s.bssid)
     }
 
     func testNoWifiNoCellular() throws {


### PR DESCRIPTION
Uses the new MacBridge to talk to macOS-only CoreWLAN, which can give us the WiFi information about the Mac.

- Adds back in the SSID/BSSID sensors, mirroring how iOS creates them. If there are no WiFi devices, this doesn't add any sensors.
- Restores the Internal URL when WiFi is available.

This is intentionally (currently) ignoring the fact that there may be more than one WiFi interface, because I did not want to refactor the connection things throughout the app yet.

This does not include the connectivity type sensors, because they do not provide useful information as of yet -- if we can say e.g. which ethernet devices are connected, that might be more useful.

This framework _does_ support live-updating us if there are any changes, so an update signaler for this may be good. Or it may conflict with other things we do on reachability changes, we'll see.

Fixes #941.