### PR TITLE
Fix series 3 crash by disabling dead code stripping on watchOS

### DIFF
--- a/Configuration/HomeAssistant.xcconfig
+++ b/Configuration/HomeAssistant.xcconfig
@@ -10,6 +10,9 @@ SWIFT_INSTALL_OBJC_HEADER=NO
 // watchOS simulator incompatibility with xcode 12 betas and our dependencies
 EXCLUDED_ARCHS[sdk=watchsimulator*] = x86_64 arm64
 
+// works around a realm crash on series 1-3 watches, see https://github.com/home-assistant/iOS/issues/1058
+DEAD_CODE_STRIPPING[sdk=watchos*] = NO
+
 // Create this file to override configuration. It's ignored by git
 #include? "HomeAssistant.overrides.xcconfig"
 


### PR DESCRIPTION
Fixes #1058. Probably.