### PR TITLE
Write android application record to NFC tags.

### DIFF
--- a/HomeAssistant/Views/Settings/NFC/iOSTagManager.swift
+++ b/HomeAssistant/Views/Settings/NFC/iOSTagManager.swift
@@ -44,7 +44,15 @@ class iOSTagManager: TagManager {
                 return .init(error: TagManagerError.notHomeAssistantTag)
             }
 
-            let message = NFCNDEFMessage(records: [ payload ])
+            // https://developer.android.com/guide/topics/connectivity/nfc/nfc.html#aar
+            let aarPayload = NFCNDEFPayload.init(
+                format: NFCTypeNameFormat.nfcExternal,
+                type: "android.com:pkg".data(using: String.Encoding.utf8)!,
+                identifier: Data(),
+                payload: "io.homeassistant.companion.android".data(using: String.Encoding.utf8)!
+            )
+
+            let message = NFCNDEFMessage(records: [ payload, aarPayload ])
             let writer = NFCWriter(message: message)
             var writerRetain: NFCWriter? = writer
 


### PR DESCRIPTION
Relates to https://github.com/home-assistant/android/issues/876
Relates to https://github.com/home-assistant/android/pull/969

This fixes an issue where on certain Android devices a dialog was showing up when scanning the NFC tags.

After this change, scanned NFC tags go directly into the home assistant android companion app.

I was not able to test this locally, but I should be able to tomorrow.
