### PR TITLE
Fix synced actions failing via Widget/Actions menu

### DIFF
--- a/Shared/API/Models/Action.swift
+++ b/Shared/API/Models/Action.swift
@@ -212,7 +212,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         var components = URLComponents()
         components.scheme = "homeassistant"
         components.host = "perform_action"
-        components.path = "/" + ID.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
+        components.path = "/" + ID
         components.queryItems = [
             .init(name: "source", value: HomeAssistantAPI.ActionSource.Widget.rawValue)
         ]


### PR DESCRIPTION
Apple _specifically_ says:
> Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).

Whoops.