### PR TITLE
Avoid thread-blocking ProcessInfo background tasks in app

### DIFF
--- a/HomeAssistant/Classes/LifecycleManager.swift
+++ b/HomeAssistant/Classes/LifecycleManager.swift
@@ -110,7 +110,7 @@ class LifecycleManager {
         firstly {
             HomeAssistantAPI.authenticatedAPIPromise
         }.then { api in
-            return UIApplication.shared.backgroundTask(withName: "connect-api") { _ in
+            return Current.backgroundTask(withName: "connect-api") { _ in
                 api.Connect(reason: reason)
             }
         }.done {

--- a/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManager.swift
@@ -67,7 +67,7 @@ class ZoneManager {
 
         // although technically the processor also does this, it does it after some async processing.
         // let's be very confident that we're not going to miss out on an update due to being suspended
-        UIApplication.shared.backgroundTask(withName: "zone-manager-perform-event") { _ in
+        Current.backgroundTask(withName: "zone-manager-perform-event") { _ in
             processor.perform(event: event)
         }.get { [weak self] _ in
             // a location change means we should consider changing our monitored regions

--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerProcessor.swift
@@ -35,7 +35,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
                 self.delegate?.processor(self, didLog: .didIgnore(event, error))
             }
         }.then {
-            UIApplication.shared.backgroundTask(withName: event.backgroundTaskDescription) { remaining in
+            Current.backgroundTask(withName: event.backgroundTaskDescription) { remaining in
                 let trigger = event.asTrigger()
                 return firstly { () -> Promise<CLLocation?> in
                     if event.shouldOneShotLocation {

--- a/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
+++ b/HomeAssistant/Utilities/UIApplication+BackgroundTask.swift
@@ -3,7 +3,16 @@ import UIKit
 import PromiseKit
 import Shared
 
-extension UIApplication {
+class ApplicationBackgroundTaskRunner: HomeAssistantBackgroundTaskRunner {
+    public func callAsFunction<PromiseValue>(
+        withName name: String,
+        wrapping: (TimeInterval?) -> Promise<PromiseValue>
+    ) -> Promise<PromiseValue> {
+        UIApplication.shared.backgroundTask(withName: name, wrapping: wrapping)
+    }
+}
+
+private extension UIApplication {
     func backgroundTask<PromiseValue>(
         withName name: String,
         wrapping: (TimeInterval?) -> Promise<PromiseValue>

--- a/HomeAssistant/Views/IncomingURLHandler.swift
+++ b/HomeAssistant/Views/IncomingURLHandler.swift
@@ -69,7 +69,7 @@ class IncomingURLHandler {
         return firstly {
             HomeAssistantAPI.authenticatedAPIPromise
         }.then { api in
-            UIApplication.shared.backgroundTask(withName: "shortcut-item") { remaining -> Promise<Void> in
+            Current.backgroundTask(withName: "shortcut-item") { remaining -> Promise<Void> in
                 if shortcutItem.type == "sendLocation" {
                     return api.GetAndSendLocation(trigger: .AppShortcut, maximumBackgroundTime: remaining)
                 } else {

--- a/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
+++ b/HomeAssistant/Views/Settings/Sensors/SensorListViewController.swift
@@ -69,7 +69,7 @@ class SensorListViewController: FormViewController, SensorObserver {
         firstly {
             HomeAssistantAPI.authenticatedAPIPromise
         }.then { api -> Promise<Void> in
-            return UIApplication.shared.backgroundTask(withName: "manual-location-update-settings") { _ in
+            return Current.backgroundTask(withName: "manual-location-update-settings") { _ in
                 if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState) {
                     return api.GetAndSendLocation(trigger: .Manual).asVoid()
                 } else {

--- a/HomeAssistant/Views/WebViewController.swift
+++ b/HomeAssistant/Views/WebViewController.swift
@@ -525,7 +525,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             }
 
             if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState) {
-                return UIApplication.shared.backgroundTask(withName: "manual-location-update") { remaining in
+                return Current.backgroundTask(withName: "manual-location-update") { remaining in
                     return api.GetAndSendLocation(trigger: .Manual, maximumBackgroundTime: remaining)
                         .recover { error -> Promise<Void> in
                             if error is CLError {

--- a/Shared/API/HAAPI.swift
+++ b/Shared/API/HAAPI.swift
@@ -781,7 +781,7 @@ extension HomeAssistantAPI.APIError: LocalizedError {
 
 extension HomeAssistantAPI: SensorObserver {
     public func sensorContainerDidSignalForUpdate(_ container: SensorContainer) {
-        ProcessInfo.processInfo.backgroundTask(withName: "signaled-update-sensors") { _ in
+        Current.backgroundTask(withName: "signaled-update-sensors") { _ in
             UpdateSensors(trigger: .Signaled)
         }.cauterize()
     }

--- a/Shared/API/Webhook/Request&Response/WebhookManager.swift
+++ b/Shared/API/Webhook/Request&Response/WebhookManager.swift
@@ -176,7 +176,7 @@ public class WebhookManager: NSObject {
     }
 
     public func sendEphemeral<ResponseType>(request: WebhookRequest) -> Promise<ResponseType> {
-        ProcessInfo.processInfo.backgroundTask(withName: "webhook-send-ephemeral") { [self, dataQueue] _ in
+        Current.backgroundTask(withName: "webhook-send-ephemeral") { [self, dataQueue] _ in
             attemptNetworking {
                 firstly {
                     Self.urlRequest(for: request)
@@ -266,7 +266,7 @@ public class WebhookManager: NSObject {
         // wrap this in a background task, but don't let the expiration cause the resolve chain to be aborted
         // this is important because we may be woken up later and asked to continue the same request, even if timed out
         // since, you know, background execution and whatnot
-        ProcessInfo.processInfo.backgroundTask(withName: "webhook-send") { _ in promise }.cauterize()
+        Current.backgroundTask(withName: "webhook-send") { _ in promise }.cauterize()
 
         firstly {
             Self.urlRequest(for: request)

--- a/Shared/Common/Structs/Environment.swift
+++ b/Shared/Common/Structs/Environment.swift
@@ -115,6 +115,7 @@ public class Environment {
 
     public var logEvent: ((String, [String: Any]) -> Void)?
     public var logError: ((NSError) -> Void)?
+    public var backgroundTask: HomeAssistantBackgroundTaskRunner = ProcessInfoBackgroundTaskRunner()
 
     public var setUserProperty: ((String?, String) -> Void)?
 

--- a/Shared/Networking/BackgroundTask.swift
+++ b/Shared/Networking/BackgroundTask.swift
@@ -8,6 +8,13 @@ public enum BackgroundTaskError: Error {
     case outOfTime
 }
 
+public protocol HomeAssistantBackgroundTaskRunner {
+    func callAsFunction<PromiseValue>(
+        withName name: String,
+        wrapping: (TimeInterval?) -> Promise<PromiseValue>
+    ) -> Promise<PromiseValue>
+}
+
 // enum for namespacing
 public enum HomeAssistantBackgroundTask {
     public static func execute<ReturnType, IdentifierType>(

--- a/Shared/Networking/ProcessInfo+BackgroundTask.swift
+++ b/Shared/Networking/ProcessInfo+BackgroundTask.swift
@@ -1,7 +1,16 @@
 import Foundation
 import PromiseKit
 
-extension ProcessInfo {
+public class ProcessInfoBackgroundTaskRunner: HomeAssistantBackgroundTaskRunner {
+    public func callAsFunction<PromiseValue>(
+        withName name: String,
+        wrapping: (TimeInterval?) -> Promise<PromiseValue>
+    ) -> Promise<PromiseValue> {
+        ProcessInfo.processInfo.backgroundTask(withName: name, wrapping: wrapping)
+    }
+}
+
+private extension ProcessInfo {
     func backgroundTask<PromiseValue>(
         withName name: String,
         wrapping: (TimeInterval?) -> Promise<PromiseValue>


### PR DESCRIPTION
Since we're running in the app, we have access to the UIApplication background task assertions, which are a lot cleaner than the ProcessInfo variety since that API doesn't require blocking the execution of a thread while we do work elsewhere.