### PR TITLE
Assign a different bundle identifier for Shared.framework on watchOS

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -21,8 +21,6 @@
 		110E694224E7710E004AA96D /* WidgetActionsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694124E7710E004AA96D /* WidgetActionsContainerView.swift */; };
 		110E694424E77125004AA96D /* WidgetActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694324E77125004AA96D /* WidgetActionsProvider.swift */; };
 		110E694624E771AB004AA96D /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694524E771AB004AA96D /* Color+Hex.swift */; };
-		110EC9FD251708D5009C9A1B /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
-		110EC9FE251708D5009C9A1B /* Shared-iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		110FB44C2499C1A3000865B4 /* CameraStreamHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44B2499C1A3000865B4 /* CameraStreamHandler.swift */; };
 		110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44D2499C1CF000865B4 /* CameraStreamHLSViewController.swift */; };
 		110FB4502499CE34000865B4 /* CameraStreamMJPEGViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */; };
@@ -87,8 +85,10 @@
 		1171508124DFCEC50065E874 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171508024DFCEC50065E874 /* WidgetActions.swift */; };
 		117318AB25199E1A0013E010 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AA25199E1A0013E010 /* AppKit.framework */; };
 		117318AD25199E220013E010 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AC25199E220013E010 /* Foundation.framework */; };
-		1175148F251EBAE700132030 /* Shared-watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; };
-		11751490251EBAE700132030 /* Shared-watchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		117514EC251EBD0C00132030 /* Shared-watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; };
+		117514ED251EBD0C00132030 /* Shared-watchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		11751558251EBDAF00132030 /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
+		11751559251EBDAF00132030 /* Shared-iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */; };
 		1179E42D24F9FAA100D4E307 /* SensorProviderDependencies.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */; };
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
@@ -719,12 +719,26 @@
 			remoteGlobalIDString = D03D891620E0A85200D4F28D;
 			remoteInfo = "Shared-iOS";
 		};
-		11751491251EBAE700132030 /* PBXContainerItemProxy */ = {
+		117514EE251EBD0C00132030 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = B67CE82322200D420034C1D0;
 			remoteInfo = "Shared-watchOS";
+		};
+		11751548251EBD5B00132030 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D03D891620E0A85200D4F28D;
+			remoteInfo = "Shared-iOS";
+		};
+		1175155A251EBDAF00132030 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D03D891620E0A85200D4F28D;
+			remoteInfo = "Shared-iOS";
 		};
 		119A172624D74DA800D1B66D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -782,13 +796,6 @@
 			remoteGlobalIDString = B6CC5D812159D10D00833E5D;
 			remoteInfo = WatchApp;
 		};
-		D03D892A20E0A85300D4F28D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D03D891620E0A85200D4F28D;
-			remoteInfo = Shared;
-		};
 		D03D894820E0BC1800D4F28D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
@@ -806,24 +813,24 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		110EC9FF251708D5009C9A1B /* Embed Frameworks */ = {
+		117514F0251EBD0C00132030 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				110EC9FE251708D5009C9A1B /* Shared-iOS.framework in Embed Frameworks */,
+				117514ED251EBD0C00132030 /* Shared-watchOS.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		11751493251EBAE700132030 /* Embed Frameworks */ = {
+		1175155C251EBDAF00132030 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				11751490251EBAE700132030 /* Shared-watchOS.framework in Embed Frameworks */,
+				11751559251EBDAF00132030 /* Shared-iOS.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1673,11 +1680,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				1148A44E24E8B59100345050 /* WidgetKit.framework in Frameworks */,
-				110EC9FD251708D5009C9A1B /* Shared-iOS.framework in Frameworks */,
 				11D826F124E39F2E005B8A86 /* CoreNFC.framework in Frameworks */,
 				D0C88460211ED11A00CCB501 /* SafariServices.framework in Frameworks */,
 				B6393F881CB2561100503916 /* MapKit.framework in Frameworks */,
 				7A06D3D7A5B4746FE6F5BFA6 /* Pods_HomeAssistant.framework in Frameworks */,
+				11751558251EBDAF00132030 /* Shared-iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1741,7 +1748,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A878F53E975DE79AC797AD45 /* Pods_WatchAppExtension.framework in Frameworks */,
-				1175148F251EBAE700132030 /* Shared-watchOS.framework in Frameworks */,
+				117514EC251EBD0C00132030 /* Shared-watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3130,13 +3137,12 @@
 				B6CC5DA62159D10F00833E5D /* Embed Watch Content */,
 				9C08D123229F187E001B4F73 /* Enable Critical Alerts */,
 				8A763BD9E9F25F0704269545 /* [CP] Embed Pods Frameworks */,
-				110EC9FF251708D5009C9A1B /* Embed Frameworks */,
 				11F3820F2518795700494258 /* Unembed Lokalise for Catalyst */,
+				1175155C251EBDAF00132030 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D03D892B20E0A85300D4F28D /* PBXTargetDependency */,
 				B6AAD7A71D827DD40090B220 /* PBXTargetDependency */,
 				B627CB141D83C87B0057173E /* PBXTargetDependency */,
 				B6CC5D9D2159D10F00833E5D /* PBXTargetDependency */,
@@ -3145,6 +3151,7 @@
 				1171507524DFCDEE0065E874 /* PBXTargetDependency */,
 				1155DD0F250F4101003405C0 /* PBXTargetDependency */,
 				1167405F25198FDD00F51626 /* PBXTargetDependency */,
+				1175155B251EBDAF00132030 /* PBXTargetDependency */,
 			);
 			name = HomeAssistant;
 			productName = HomeAssistant;
@@ -3238,6 +3245,11 @@
 			buildRules = (
 			);
 			dependencies = (
+				11751549251EBD5B00132030 /* PBXTargetDependency */,
+				117514FA251EBD2100132030 /* PBXTargetDependency */,
+				117514FC251EBD2100132030 /* PBXTargetDependency */,
+				117514F6251EBD1A00132030 /* PBXTargetDependency */,
+				117514F8251EBD1A00132030 /* PBXTargetDependency */,
 			);
 			name = "Shared-watchOS";
 			packageProductDependencies = (
@@ -3295,12 +3307,12 @@
 				B6CC5D8B2159D10E00833E5D /* Frameworks */,
 				B6CC5D8C2159D10E00833E5D /* Resources */,
 				F3E3FC23B4E5B348B92D05F4 /* [CP] Embed Pods Frameworks */,
-				11751493251EBAE700132030 /* Embed Frameworks */,
+				117514F0251EBD0C00132030 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				11751492251EBAE700132030 /* PBXTargetDependency */,
+				117514EF251EBD0C00132030 /* PBXTargetDependency */,
 			);
 			name = WatchAppExtension;
 			productName = "WatchApp Extension";
@@ -3473,9 +3485,7 @@
 					};
 					B67CE82322200D420034C1D0 = {
 						CreatedOnToolsVersion = 10.1;
-						DevelopmentTeam = QMQYCKL255;
 						LastSwiftMigration = 1020;
-						ProvisioningStyle = Automatic;
 					};
 					B6AAD7A01D827DD40090B220 = {
 						CreatedOnToolsVersion = 8.0;
@@ -4882,10 +4892,36 @@
 			target = D03D891620E0A85200D4F28D /* Shared-iOS */;
 			targetProxy = 1171507D24DFCE0D0065E874 /* PBXContainerItemProxy */;
 		};
-		11751492251EBAE700132030 /* PBXTargetDependency */ = {
+		117514EF251EBD0C00132030 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B67CE82322200D420034C1D0 /* Shared-watchOS */;
-			targetProxy = 11751491251EBAE700132030 /* PBXContainerItemProxy */;
+			targetProxy = 117514EE251EBD0C00132030 /* PBXContainerItemProxy */;
+		};
+		117514F6251EBD1A00132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 117514F5251EBD1A00132030 /* Clibsodium */;
+		};
+		117514F8251EBD1A00132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 117514F7251EBD1A00132030 /* Sodium */;
+		};
+		117514FA251EBD2100132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 117514F9251EBD2100132030 /* Realm */;
+		};
+		117514FC251EBD2100132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 117514FB251EBD2100132030 /* RealmSwift */;
+		};
+		11751549251EBD5B00132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D03D891620E0A85200D4F28D /* Shared-iOS */;
+			targetProxy = 11751548251EBD5B00132030 /* PBXContainerItemProxy */;
+		};
+		1175155B251EBDAF00132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D03D891620E0A85200D4F28D /* Shared-iOS */;
+			targetProxy = 1175155A251EBDAF00132030 /* PBXContainerItemProxy */;
 		};
 		119A172724D74DA800D1B66D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4929,11 +4965,6 @@
 			platformFilter = ios;
 			target = B6CC5D812159D10D00833E5D /* WatchApp */;
 			targetProxy = B6CC5D9C2159D10F00833E5D /* PBXContainerItemProxy */;
-		};
-		D03D892B20E0A85300D4F28D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D03D891620E0A85200D4F28D /* Shared-iOS */;
-			targetProxy = D03D892A20E0A85300D4F28D /* PBXContainerItemProxy */;
 		};
 		D03D894920E0BC1800D4F28D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -6220,7 +6251,7 @@
 				DYLIB_CURRENT_VERSION = 2;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Shared-watchOS/Info.plist";
+				INFOPLIST_FILE = Shared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6260,7 +6291,7 @@
 				DYLIB_CURRENT_VERSION = 2;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Shared-watchOS/Info.plist";
+				INFOPLIST_FILE = Shared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6298,7 +6329,7 @@
 				DYLIB_CURRENT_VERSION = 2;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Shared-watchOS/Info.plist";
+				INFOPLIST_FILE = Shared/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6828,6 +6859,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 118F872F251806BD001E1AD7 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Clibsodium;
+		};
+		117514F5251EBD1A00132030 /* Clibsodium */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118F872F251806BD001E1AD7 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			productName = Clibsodium;
+		};
+		117514F7251EBD1A00132030 /* Sodium */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 118F872F251806BD001E1AD7 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			productName = Sodium;
+		};
+		117514F9251EBD2100132030 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = Realm;
+		};
+		117514FB251EBD2100132030 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 111D294024F2F6AE00C8A7D1 /* XCRemoteSwiftPackageReference "realm-cocoa" */;
+			productName = RealmSwift;
 		};
 		118F8732251806BD001E1AD7 /* Sodium */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -6230,7 +6230,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
 				PRODUCT_NAME = Shared;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -6268,7 +6268,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
 				PRODUCT_NAME = Shared;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -6305,7 +6305,7 @@
 				MTL_FAST_MATH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
 				PRODUCT_NAME = Shared;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -21,8 +21,8 @@
 		110E694224E7710E004AA96D /* WidgetActionsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694124E7710E004AA96D /* WidgetActionsContainerView.swift */; };
 		110E694424E77125004AA96D /* WidgetActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694324E77125004AA96D /* WidgetActionsProvider.swift */; };
 		110E694624E771AB004AA96D /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694524E771AB004AA96D /* Color+Hex.swift */; };
-		110EC9FD251708D5009C9A1B /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
-		110EC9FE251708D5009C9A1B /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		110EC9FD251708D5009C9A1B /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
+		110EC9FE251708D5009C9A1B /* Shared-iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		110FB44C2499C1A3000865B4 /* CameraStreamHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44B2499C1A3000865B4 /* CameraStreamHandler.swift */; };
 		110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44D2499C1CF000865B4 /* CameraStreamHLSViewController.swift */; };
 		110FB4502499CE34000865B4 /* CameraStreamMJPEGViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */; };
@@ -70,7 +70,7 @@
 		114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */; };
 		1155DD09250F4100003405C0 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1155DD08250F4100003405C0 /* ShareViewController.swift */; };
 		1155DD10250F4101003405C0 /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 1155DD06250F4100003405C0 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		1155DD1E250F446F003405C0 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		1155DD1E250F446F003405C0 /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		1158D6282511DA68008C0C9F /* ManualPodLicenses.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1158D6272511DA67008C0C9F /* ManualPodLicenses.plist */; };
 		115DA29324F464DC00C00BB1 /* MenuManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115DA28C24F4646500C00BB1 /* MenuManager.swift */; };
 		1161C01B24D7634300A0E3C4 /* NFCListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161C01A24D7634300A0E3C4 /* NFCListViewController.swift */; };
@@ -83,10 +83,12 @@
 		1171507024DFCDE60065E874 /* Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171506F24DFCDE60065E874 /* Widgets.swift */; };
 		1171507224DFCDEE0065E874 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1171507124DFCDEE0065E874 /* Assets.xcassets */; };
 		1171507624DFCDEE0065E874 /* WidgetsExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 1171506924DFCDE60065E874 /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		1171507B24DFCE0D0065E874 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		1171507B24DFCE0D0065E874 /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		1171508124DFCEC50065E874 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171508024DFCEC50065E874 /* WidgetActions.swift */; };
 		117318AB25199E1A0013E010 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AA25199E1A0013E010 /* AppKit.framework */; };
 		117318AD25199E220013E010 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AC25199E220013E010 /* Foundation.framework */; };
+		1175148F251EBAE700132030 /* Shared-watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; };
+		11751490251EBAE700132030 /* Shared-watchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */; };
 		1179E42D24F9FAA100D4E307 /* SensorProviderDependencies.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */; };
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
@@ -543,8 +545,6 @@
 		B675ECC7221BDF4500C65D31 /* BackgroundRefreshScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B675ECC6221BDF4500C65D31 /* BackgroundRefreshScheduler.swift */; };
 		B678DB371EA9999C0045312F /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B678DB351EA9999C0045312F /* MainInterface.storyboard */; };
 		B67CE82822200D420034C1D0 /* Shared_watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B67CE82622200D420034C1D0 /* Shared_watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B67CE82B22200D420034C1D0 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared.framework */; };
-		B67CE82C22200D420034C1D0 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B67CE82422200D420034C1D0 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B67CE87622200F220034C1D0 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF326214DF31D00D1D360 /* Notifications.swift */; };
 		B67CE87722200F220034C1D0 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF31F214DE3B300D1D360 /* Strings.swift */; };
 		B67CE87922200F220034C1D0 /* RealmZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EE36A120CF593E001494E3 /* RealmZone.swift */; };
@@ -605,9 +605,9 @@
 		B6B74CBC228398DD00D58A68 /* WKInterfaceDevice+Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69769832162430300FFFAD6 /* WKInterfaceDevice+Size.swift */; };
 		B6B74CBD228399AB00D58A68 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B2E6A1216AC21400D39A26 /* Action.swift */; };
 		B6B74CBE228399AC00D58A68 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B2E6A1216AC21400D39A26 /* Action.swift */; };
-		B6BDBBC72177FFB10044E0B9 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		B6BDBBC72177FFB10044E0B9 /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		B6C091232151F90300A326DC /* LocationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C0911E2151F90300A326DC /* LocationHistory.swift */; };
-		B6C09153215206BB00A326DC /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		B6C09153215206BB00A326DC /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		B6CC5D862159D10D00833E5D /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6CC5D842159D10D00833E5D /* Interface.storyboard */; };
 		B6CC5D882159D10E00833E5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B6CC5D872159D10E00833E5D /* Assets.xcassets */; };
 		B6CC5D942159D10E00833E5D /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CC5D932159D10E00833E5D /* InterfaceController.swift */; };
@@ -631,17 +631,17 @@
 		B6E2D4B82270406B00446DFA /* Beta LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4BA2270406B00446DFA /* Beta LaunchScreen.storyboard */; };
 		B6E2D4BB2270407500446DFA /* Debug LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4BD2270407500446DFA /* Debug LaunchScreen.storyboard */; };
 		B6E2D4D52270706300446DFA /* ha-loading.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4D42270706200446DFA /* ha-loading.json */; };
-		B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		B6E42613215C4333007FEB7E /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		C346BC5570250C2987D7A44B /* Pods-HomeAssistantTests-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B9D9755DDCFA473A79F125A3 /* Pods-HomeAssistantTests-metadata.plist */; };
 		D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D014EEA82128E192008EA6F5 /* ConnectionInfo.swift */; };
 		D03D892920E0A85300D4F28D /* Shared.h in Headers */ = {isa = PBXBuildFile; fileRef = D03D891920E0A85300D4F28D /* Shared.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D03D893420E0A8FE00D4F28D /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		D03D893420E0A8FE00D4F28D /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		D03D893520E0AEF100D4F28D /* Realm+Initialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A6367420DBE93400E5C49B /* Realm+Initialization.swift */; };
 		D03D893620E0AEFA00D4F28D /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00302BD20D4BEDB004C2CA9 /* Environment.swift */; };
 		D03D893820E0AF8A00D4F28D /* ClientEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF79CD20D85C3A0034574D /* ClientEventStore.swift */; };
 		D03D893920E0AF8E00D4F28D /* ClientEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF79CB20D778B50034574D /* ClientEvent.swift */; };
 		D03D893B20E0B2E300D4F28D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03D893A20E0B2E300D4F28D /* Constants.swift */; };
-		D03D894720E0BC1800D4F28D /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
+		D03D894720E0BC1800D4F28D /* Shared-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared-iOS.framework */; };
 		D03D894D20E0BC2700D4F28D /* ClientEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A6367120DB7D1100E5C49B /* ClientEventTests.swift */; };
 		D05A4D32216DD206009FD1EB /* MJPEGStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05A4D31216DD206009FD1EB /* MJPEGStreamer.swift */; };
 		D06C751020D87FAF00E9DB7F /* ClientEventCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06C750F20D87FAF00E9DB7F /* ClientEventCell.swift */; };
@@ -719,6 +719,13 @@
 			remoteGlobalIDString = D03D891620E0A85200D4F28D;
 			remoteInfo = "Shared-iOS";
 		};
+		11751491251EBAE700132030 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B67CE82322200D420034C1D0;
+			remoteInfo = "Shared-watchOS";
+		};
 		119A172624D74DA800D1B66D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
@@ -760,13 +767,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = B66F9F21216B1E61000CAA0F;
 			remoteInfo = TodayWidget;
-		};
-		B67CE82922200D420034C1D0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B657A8DE1CA646EB00121384 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B67CE82322200D420034C1D0;
-			remoteInfo = "Shared-watchOS";
 		};
 		B6AAD7A61D827DD40090B220 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -812,7 +812,18 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				110EC9FE251708D5009C9A1B /* Shared.framework in Embed Frameworks */,
+				110EC9FE251708D5009C9A1B /* Shared-iOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		11751493251EBAE700132030 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				11751490251EBAE700132030 /* Shared-watchOS.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -826,17 +837,6 @@
 				119A172524D74DA800D1B66D /* WatchAppExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B61DA2A7221E8D8F00AADEDD /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				B67CE82C22200D420034C1D0 /* Shared.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B6AAD7AC1D827DD40090B220 /* Embed App Extensions */ = {
@@ -1462,7 +1462,7 @@
 		B67CE817221FB13C0034C1D0 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B67CE819221FB1480034C1D0 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B67CE81A221FB1480034C1D0 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
-		B67CE82422200D420034C1D0 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B67CE82422200D420034C1D0 /* Shared-watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Shared-watchOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B67CE82622200D420034C1D0 /* Shared_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Shared_watchOS.h; sourceTree = "<group>"; };
 		B67CE82722200D420034C1D0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B67CE8CF2220EF1D0034C1D0 /* ObjectMapper+RealmList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObjectMapper+RealmList.swift"; sourceTree = "<group>"; };
@@ -1575,7 +1575,7 @@
 		CCD706884B80054E107B89D5 /* Pods-HomeAssistantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HomeAssistantTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-HomeAssistantTests/Pods-HomeAssistantTests.release.xcconfig"; sourceTree = "<group>"; };
 		D00302BD20D4BEDB004C2CA9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		D014EEA82128E192008EA6F5 /* ConnectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionInfo.swift; sourceTree = "<group>"; };
-		D03D891720E0A85200D4F28D /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D03D891720E0A85200D4F28D /* Shared-iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "Shared-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D03D891920E0A85300D4F28D /* Shared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Shared.h; sourceTree = "<group>"; };
 		D03D891A20E0A85300D4F28D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D03D893A20E0B2E300D4F28D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -1625,7 +1625,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1155DD1E250F446F003405C0 /* Shared.framework in Frameworks */,
+				1155DD1E250F446F003405C0 /* Shared-iOS.framework in Frameworks */,
 				FE2C6998B2744CB302699C16 /* Pods_ShareExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1644,7 +1644,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1171506D24DFCDE60065E874 /* SwiftUI.framework in Frameworks */,
-				1171507B24DFCE0D0065E874 /* Shared.framework in Frameworks */,
+				1171507B24DFCE0D0065E874 /* Shared-iOS.framework in Frameworks */,
 				1171506B24DFCDE60065E874 /* WidgetKit.framework in Frameworks */,
 				6C4FFEB9F3881ECFD4FDDBA8 /* Pods_WidgetsExtension.framework in Frameworks */,
 			);
@@ -1661,7 +1661,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */,
+				B6E42613215C4333007FEB7E /* Shared-iOS.framework in Frameworks */,
 				B627CB0B1D83C87B0057173E /* UserNotificationsUI.framework in Frameworks */,
 				B627CB091D83C87B0057173E /* UserNotifications.framework in Frameworks */,
 				B28248018AD4202CBDAA9179 /* Pods_NotificationContentExtension.framework in Frameworks */,
@@ -1673,7 +1673,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1148A44E24E8B59100345050 /* WidgetKit.framework in Frameworks */,
-				110EC9FD251708D5009C9A1B /* Shared.framework in Frameworks */,
+				110EC9FD251708D5009C9A1B /* Shared-iOS.framework in Frameworks */,
 				11D826F124E39F2E005B8A86 /* CoreNFC.framework in Frameworks */,
 				D0C88460211ED11A00CCB501 /* SafariServices.framework in Frameworks */,
 				B6393F881CB2561100503916 /* MapKit.framework in Frameworks */,
@@ -1700,7 +1700,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6C09153215206BB00A326DC /* Shared.framework in Frameworks */,
+				B6C09153215206BB00A326DC /* Shared-iOS.framework in Frameworks */,
 				6DFADFAFF2B1E4A5C7A00D10 /* Pods_SiriIntents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1709,7 +1709,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6BDBBC72177FFB10044E0B9 /* Shared.framework in Frameworks */,
+				B6BDBBC72177FFB10044E0B9 /* Shared-iOS.framework in Frameworks */,
 				B66F9F24216B1E61000CAA0F /* NotificationCenter.framework in Frameworks */,
 				9E0BAD90B73333854D6D31E1 /* Pods_TodayWidget.framework in Frameworks */,
 			);
@@ -1731,7 +1731,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D03D893420E0A8FE00D4F28D /* Shared.framework in Frameworks */,
+				D03D893420E0A8FE00D4F28D /* Shared-iOS.framework in Frameworks */,
 				E1FA731332EB8E4C346F56FA /* Pods_APNSAttachmentService.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1740,8 +1740,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B67CE82B22200D420034C1D0 /* Shared.framework in Frameworks */,
 				A878F53E975DE79AC797AD45 /* Pods_WatchAppExtension.framework in Frameworks */,
+				1175148F251EBAE700132030 /* Shared-watchOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1764,7 +1764,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D03D894720E0BC1800D4F28D /* Shared.framework in Frameworks */,
+				D03D894720E0BC1800D4F28D /* Shared-iOS.framework in Frameworks */,
 				9C6DA9943461C9F73DE026E5 /* Pods_Shared_iOS_SharedTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2336,13 +2336,13 @@
 				B657A9071CA646EB00121384 /* HomeAssistantUITests.xctest */,
 				B6AAD7A11D827DD40090B220 /* APNSAttachmentService.appex */,
 				B627CB071D83C87B0057173E /* NotificationContentExtension.appex */,
-				D03D891720E0A85200D4F28D /* Shared.framework */,
+				D03D891720E0A85200D4F28D /* Shared-iOS.framework */,
 				D03D894220E0BC1800D4F28D /* SharedTests.xctest */,
 				B66C58A5215086F0004AB261 /* SiriIntents.appex */,
 				B6CC5D822159D10D00833E5D /* WatchApp.app */,
 				B6CC5D8E2159D10E00833E5D /* WatchAppExtension.appex */,
 				B66F9F22216B1E61000CAA0F /* TodayWidget.appex */,
-				B67CE82422200D420034C1D0 /* Shared.framework */,
+				B67CE82422200D420034C1D0 /* Shared-watchOS.framework */,
 				1171506924DFCDE60065E874 /* WidgetsExtension.appex */,
 				1155DD06250F4100003405C0 /* ShareExtension.appex */,
 				1167402225198F9A00F51626 /* MacBridge.bundle */,
@@ -3247,7 +3247,7 @@
 				1147C6D425181208002BEB20 /* Clibsodium */,
 			);
 			productName = "Shared-watchOS";
-			productReference = B67CE82422200D420034C1D0 /* Shared.framework */;
+			productReference = B67CE82422200D420034C1D0 /* Shared-watchOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		B6AAD7A01D827DD40090B220 /* APNSAttachmentService */ = {
@@ -3295,12 +3295,12 @@
 				B6CC5D8B2159D10E00833E5D /* Frameworks */,
 				B6CC5D8C2159D10E00833E5D /* Resources */,
 				F3E3FC23B4E5B348B92D05F4 /* [CP] Embed Pods Frameworks */,
-				B61DA2A7221E8D8F00AADEDD /* Embed Frameworks */,
+				11751493251EBAE700132030 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				B67CE82A22200D420034C1D0 /* PBXTargetDependency */,
+				11751492251EBAE700132030 /* PBXTargetDependency */,
 			);
 			name = WatchAppExtension;
 			productName = "WatchApp Extension";
@@ -3329,7 +3329,7 @@
 				1147C6D225181200002BEB20 /* Clibsodium */,
 			);
 			productName = Shared;
-			productReference = D03D891720E0A85200D4F28D /* Shared.framework */;
+			productReference = D03D891720E0A85200D4F28D /* Shared-iOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		D03D894120E0BC1800D4F28D /* SharedTests */ = {
@@ -4882,6 +4882,11 @@
 			target = D03D891620E0A85200D4F28D /* Shared-iOS */;
 			targetProxy = 1171507D24DFCE0D0065E874 /* PBXContainerItemProxy */;
 		};
+		11751492251EBAE700132030 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B67CE82322200D420034C1D0 /* Shared-watchOS */;
+			targetProxy = 11751491251EBAE700132030 /* PBXContainerItemProxy */;
+		};
 		119A172724D74DA800D1B66D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B6CC5D8D2159D10E00833E5D /* WatchAppExtension */;
@@ -4913,11 +4918,6 @@
 			platformFilter = ios;
 			target = B66F9F21216B1E61000CAA0F /* TodayWidget */;
 			targetProxy = B66F9F2C216B1E61000CAA0F /* PBXContainerItemProxy */;
-		};
-		B67CE82A22200D420034C1D0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B67CE82322200D420034C1D0 /* Shared-watchOS */;
-			targetProxy = B67CE82922200D420034C1D0 /* PBXContainerItemProxy */;
 		};
 		B6AAD7A71D827DD40090B220 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5609,7 +5609,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-iOS";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6231,7 +6232,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-watchOS";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -6269,7 +6271,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-watchOS";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -6306,7 +6309,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared-watchOS";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-watchOS";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -6515,7 +6519,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-iOS";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
@@ -6552,7 +6557,8 @@
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				OTHER_SWIFT_FLAGS = "$(inherited) -DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID_PREFIX}.HomeAssistant.Shared";
-				PRODUCT_NAME = Shared;
+				PRODUCT_MODULE_NAME = Shared;
+				PRODUCT_NAME = "Shared-iOS";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
When the bundle identifier of an iOS and watchOS framework match, the Swift Package Manager integration in Xcode has difficulties separating them out, so it ends up erroring in strange ways. In our case, this looks like `error: no such module 'Clibsodium'` failures at build time for one of them.

We don't need the bundle identifier to match -- in fact, it doesn't matter either way, since we don't need to code sign it, and we never reference it directly