### PR TITLE
Fix re-registering integration unnecessarily for some http errors

### DIFF
--- a/SharedTests/Webhook/Promise+WebhookJson.test.swift
+++ b/SharedTests/Webhook/Promise+WebhookJson.test.swift
@@ -74,7 +74,19 @@ class PromiseWebhookJsonTests: XCTestCase {
         let promise = Promise<Data>.value(String("abcdefg").data(using: .utf8)!)
         let json = promise.webhookJson(statusCode: 404)
         XCTAssertThrowsError(try hang(json)) { error in
-            if case HomeAssistantAPI.APIError.mobileAppComponentNotLoaded = error {
+            if case WebhookError.unacceptableStatusCode(404) = error {
+                // pass
+            } else {
+                XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    func testUnencryptedStatus504() {
+        let promise = Promise<Data>.value(String("abcdefg").data(using: .utf8)!)
+        let json = promise.webhookJson(statusCode: 504)
+        XCTAssertThrowsError(try hang(json)) { error in
+            if case WebhookError.unacceptableStatusCode(504) = error {
                 // pass
             } else {
                 XCTFail("unexpected error \(error)")
@@ -86,7 +98,7 @@ class PromiseWebhookJsonTests: XCTestCase {
         let promise = Promise<Data>.value(String("abcdefg").data(using: .utf8)!)
         let json = promise.webhookJson(statusCode: 410)
         XCTAssertThrowsError(try hang(json)) { error in
-            if case HomeAssistantAPI.APIError.webhookGone = error {
+            if case WebhookError.unacceptableStatusCode(410) = error {
                 // pass
             } else {
                 XCTFail("unexpected error \(error)")

--- a/SharedTests/Webhook/WebhookManager.test.swift
+++ b/SharedTests/Webhook/WebhookManager.test.swift
@@ -217,7 +217,7 @@ class WebhookManagerTests: XCTestCase {
 
         let promise: Promise<String> = manager.sendEphemeral(request: expectedRequest)
         XCTAssertThrowsError(try hang(promise)) { error in
-            switch error as? WebhookManagerError {
+            switch error as? WebhookError {
             case .unexpectedType:
                 break
             default:
@@ -271,7 +271,7 @@ class WebhookManagerTests: XCTestCase {
 
         let promise: Promise<ExampleMappable> = manager.sendEphemeral(request: expectedRequest)
         XCTAssertThrowsError(try hang(promise)) { error in
-            switch error as? WebhookManagerError {
+            switch error as? WebhookError {
             case .unmappableValue:
                 break
             default:
@@ -312,7 +312,7 @@ class WebhookManagerTests: XCTestCase {
 
         let promise: Promise<[ExampleMappable]> = manager.sendEphemeral(request: expectedRequest)
         XCTAssertThrowsError(try hang(promise)) { error in
-            switch error as? WebhookManagerError {
+            switch error as? WebhookError {
             case .unmappableValue:
                 break
             default:
@@ -358,7 +358,7 @@ class WebhookManagerTests: XCTestCase {
     func testSendingUnregisteredIdentifierErrors() {
         let promise1 = manager.send(identifier: .init(rawValue: "unregistered"), request: .init(type: "test", data: ()))
         XCTAssertThrowsError(try hang(promise1)) { error in
-            switch error as? WebhookManagerError {
+            switch error as? WebhookError {
             case .unregisteredIdentifier:
                 break
             default:


### PR DESCRIPTION
There's 2 ways that we're told that an integration/webhook has gone away:

1. Cloud will give a 404 error for the webhook response (easy!)
2. HA will give a 200 with an empty/unparseable body for the webhook response (hard!)

Rather than trying to build the inverse set of these errors, add logic to explicitly capture them. Hopefully.

Fixes #1085.