### PR TITLE
Fix battery sensor inconsistent unique ID (again)

### DIFF
--- a/Shared/Common/Structs/DeviceBattery.swift
+++ b/Shared/Common/Structs/DeviceBattery.swift
@@ -87,8 +87,12 @@ public struct DeviceBattery {
         } else {
             self.name = name
         }
-        if let id = info[kIOPSPowerSourceIDKey] as? Int {
-            self.uniqueID = String(describing: id)
+        if let serialNumber = info[kIOPSHardwareSerialNumberKey] as? String {
+            self.uniqueID = serialNumber
+        } else if let name = name {
+            self.uniqueID = name
+        } else if let type = info[kIOPSTypeKey] as? String {
+            self.uniqueID = type
         } else {
             self.uniqueID = nil
         }


### PR DESCRIPTION
Unfortunately I need to change the unique ID backing the Mac battery sensors again, which will mean duplicate entities for beta users.

At the time of writing this, my MacBook Pro entry in my HA instance has 4 batteries, which is of course incorrect. It looks like we cannot trust the ID for the power source like we trust e.g. the ID for the camera/microphone. They're of course different APIs but IOKit doesn't seem to make any guarantees.

This moves us to use, in the following order of preference:

1. Serial number (recommended to exist)
2. Name (required to exist)
3. Type (required)

Stringly-typed dictionary APIs are the worst! My hunch is we'll never drop down to type since name should win, but we'll see how often we are without a serial number as well.

Fixes #1030.