### PR TITLE
Fix notification settings showing 'errors' instead of 'attempts'

### DIFF
--- a/HomeAssistant/Views/Settings/NotificationRateLimitsAPI.swift
+++ b/HomeAssistant/Views/Settings/NotificationRateLimitsAPI.swift
@@ -59,7 +59,7 @@ extension RateLimitResponse.RateLimits {
             $0.title = { () -> String in
                 switch keyPath {
                 case \.attempts:
-                    return L10n.SettingsDetails.Notifications.RateLimits.errors
+                    return L10n.SettingsDetails.Notifications.RateLimits.attempts
                 case \.successful:
                     return L10n.SettingsDetails.Notifications.RateLimits.delivered
                 case \.errors:


### PR DESCRIPTION
I would have assumed I had noticed this earlier but it looks like it has been this way since I moved it off Firestore in July.
