### PR TITLE
Add "Update Sensors" intent

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		111D294824F2F6B600C8A7D1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 111D294724F2F6B600C8A7D1 /* RealmSwift */; };
 		111D295624F30E2400C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
+		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
 		11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */; };
@@ -905,6 +906,7 @@
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
+		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
 		11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.swift; sourceTree = "<group>"; };
 		11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.swift; sourceTree = "<group>"; };
 		113D04E124D76CD3003CE877 /* NFCReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReader.swift; sourceTree = "<group>"; };
@@ -2469,6 +2471,7 @@
 				B62817EF221D269B000BA86A /* RenderTemplate.swift */,
 				111858D324CB5B8900B8CDDC /* PerformAction.swift */,
 				11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */,
+				112B705A2526B1C500FEAA76 /* UpdateSensors.swift */,
 			);
 			path = Intents;
 			sourceTree = "<group>";
@@ -4563,6 +4566,7 @@
 				11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */,
 				B66C58B12150891B004AB261 /* CallService.swift in Sources */,
 				11DC6BAB24E23780002D9FDA /* Intents.intentdefinition in Sources */,
+				112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */,
 				111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HomeAssistant/Resources/Base.lproj/Intents.intentdefinition
+++ b/HomeAssistant/Resources/Base.lproj/Intents.intentdefinition
@@ -9,11 +9,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>sI7YSe</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>19G2021</string>
+	<string>20A5384c</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>12A8179i</string>
+	<string>12B5025f</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>12.0</string>
+	<string>12.2</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -1243,6 +1243,74 @@
 			<string>Custom</string>
 			<key>INIntentVerb</key>
 			<string>Open</string>
+		</dict>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>share</string>
+			<key>INIntentConfigurable</key>
+			<true/>
+			<key>INIntentDescription</key>
+			<string>Send a sensor update to Home Assistant</string>
+			<key>INIntentDescriptionID</key>
+			<string>vAIAF2</string>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentManagedParameterCombinations</key>
+			<dict>
+				<key></key>
+				<dict>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Update Sensors</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>pjQR7t</string>
+					<key>INIntentParameterCombinationUpdatesLinked</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>INIntentName</key>
+			<string>UpdateSensors</string>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeConciseFormatString</key>
+						<string>Sensors updated.</string>
+						<key>INIntentResponseCodeConciseFormatStringID</key>
+						<string>fnz838</string>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>Done!</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>MwEpGz</string>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeConciseFormatString</key>
+						<string>Failed to update sensors.</string>
+						<key>INIntentResponseCodeConciseFormatStringID</key>
+						<string>lGqSSG</string>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>Unsuccessful!</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>r6LXFe</string>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Update Sensors</string>
+			<key>INIntentTitleID</key>
+			<string>h1xQ53</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>Send</string>
 		</dict>
 	</array>
 	<key>INTypes</key>

--- a/HomeAssistant/Resources/Info.plist
+++ b/HomeAssistant/Resources/Info.plist
@@ -620,6 +620,7 @@
 		<string>PerformActionIntent</string>
 		<string>RenderTemplateIntent</string>
 		<string>SendLocationIntent</string>
+		<string>UpdateSensorsIntent</string>
 		<string>WidgetActionsIntent</string>
 	</array>
 	<key>UIApplicationShortcutItems</key>

--- a/Intents/Info.plist
+++ b/Intents/Info.plist
@@ -41,6 +41,7 @@
 				<string>PerformActionIntent</string>
 				<string>RenderTemplateIntent</string>
 				<string>SendLocationIntent</string>
+				<string>UpdateSensorsIntent</string>
 				<string>WidgetActionsIntent</string>
 			</array>
 		</dict>

--- a/Intents/IntentHandler.swift
+++ b/Intents/IntentHandler.swift
@@ -38,6 +38,9 @@ class IntentHandler: INExtension {
             if intent is PerformActionIntent {
                 return PerformActionIntentHandler()
             }
+            if intent is UpdateSensorsIntent {
+                return UpdateSensorsIntentHandler()
+            }
             if #available(iOS 14, *), intent is WidgetActionsIntent {
                 return WidgetActionsIntentHandler()
             }

--- a/Intents/UpdateSensors.swift
+++ b/Intents/UpdateSensors.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Shared
+import PromiseKit
+
+class UpdateSensorsIntentHandler: NSObject, UpdateSensorsIntentHandling {
+    func handle(intent: UpdateSensorsIntent, completion: @escaping (UpdateSensorsIntentResponse) -> Void) {
+        Current.Log.info("starting")
+
+        firstly {
+            HomeAssistantAPI.authenticatedAPIPromise
+        }.then {
+            $0.UpdateSensors(trigger: .Siri)
+        }.done {
+            Current.Log.info("finished successfully")
+            completion(.init(code: .success, userActivity: nil))
+        }.catch { error in
+            Current.Log.error("failed: \(error)")
+            completion(.init(code: .failure, userActivity: nil))
+        }
+    }
+}


### PR DESCRIPTION
This is functionally nearly identical to the "Send Location" intent, but doesn't require providing a location to the shortcut to execute, nor does it need to do a network request to geocode, so it should be a lot faster at providing updates.

This is useful for e.g. "When Low Power Mode is turned on or off" or "When (phone) is connected or disconnected from power" automations in Shortcuts.app.

I submitted Intents.strings to Lokalise externally so it should come down in the next download into English as well.