### PR TITLE
Don't trigger location update on initial zone monitoring

### DIFF
--- a/HomeAssistant/Classes/ZoneManager/ZoneManagerCollector.swift
+++ b/HomeAssistant/Classes/ZoneManager/ZoneManagerCollector.swift
@@ -34,12 +34,6 @@ class ZoneManagerCollectorImpl: NSObject, ZoneManagerCollector {
         didStartMonitoringFor region: CLRegion
     ) {
         delegate?.collector(self, didLog: .didStartMonitoring(region))
-
-        if Current.isCatalyst {
-            Current.Log.info("not querying region state due to catalyst lacking persistent region monitoring")
-        } else {
-            manager.requestState(for: region)
-        }
     }
 
     func locationManager(

--- a/HomeAssistantTests/ZoneManager/ZoneManagerCollector.test.swift
+++ b/HomeAssistantTests/ZoneManager/ZoneManagerCollector.test.swift
@@ -64,35 +64,7 @@ class ZoneManagerCollectorTests: XCTestCase {
         }
     }
 
-    func testDidStartMonitoringLogsAndRequestsState() {
-        let wasCatalyst = Current.isCatalyst
-        Current.isCatalyst = false
-
-        let region = CLCircularRegion()
-        collector.locationManager(locationManager, didStartMonitoringFor: region)
-        XCTAssertEqual(delegate.states.count, 1)
-
-        guard let state = delegate.states.first else {
-            return
-        }
-
-        switch state {
-        case .didStartMonitoring(region):
-            // pass
-            break
-        default:
-            XCTFail("expected start, got \(state)")
-        }
-
-        XCTAssertEqual(locationManager.requestedRegions, [region])
-
-        Current.isCatalyst = wasCatalyst
-    }
-
-    func testDidStartMonitoringLogsButDoesntRequestsStateOnCatalyst() {
-        let wasCatalyst = Current.isCatalyst
-        Current.isCatalyst = true
-
+    func testDidStartMonitoringLogsButDoesntRequestState() {
         let region = CLCircularRegion()
         collector.locationManager(locationManager, didStartMonitoringFor: region)
         XCTAssertEqual(delegate.states.count, 1)
@@ -110,8 +82,6 @@ class ZoneManagerCollectorTests: XCTestCase {
         }
 
         XCTAssertEqual(locationManager.requestedRegions, [])
-
-        Current.isCatalyst = wasCatalyst
     }
 
     func testDidDetermineStateWithNoZoneInRealm() {


### PR DESCRIPTION
This avoids sending `ios.zone_{entered,exited}` on startup, and also stops resetting which monitored regions we are monitoring as a result of a location update, which may have been caused by resetting which monitored regions we are monitoring, etc., etc.

Since we do not locally need the in/out state of Zones, we can deal with their status being eventually correct instead of initially or whenever they change.

Fixes #1114.