### PR TITLE
Add cross-website tracking description to enable preference

### DIFF
--- a/Sources/App/Resources/Base.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/Base.lproj/InfoPlist.strings
@@ -9,3 +9,4 @@
 "NFCReaderUsageDescription" = "Reading and writing NFC tags allows you to trigger events.";
 "SEND_LOCATION_APP_SHORTCUT_TITLE" = "Send Location";
 "NSCameraUsageDescription" = "Take photos and send them to your Home Assistant server.";
+"NSCrossWebsiteTrackingUsageDescription" = "Optionally enable cross-website tracking if your configuration requires it.";

--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -670,5 +670,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Optionally enable cross-website tracking if your configuration requires it.</string>
 </dict>
 </plist>

--- a/Sources/App/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/en.lproj/InfoPlist.strings
@@ -9,3 +9,4 @@
 "NSLocalNetworkUsageDescription" = "Locate and communicate with your Home Assistant instance.";
 "NFCReaderUsageDescription" = "Reading and writing NFC tags allows you to trigger events.";
 "NSCameraUsageDescription" = "Take photos and send them to your Home Assistant server.";
+"NSCrossWebsiteTrackingUsageDescription" = "Optionally enable cross-website tracking if your configuration requires it.";


### PR DESCRIPTION
This is a preference (which can only be edited in the system Settings app) which can toggle on and off the intelligent tracking protection features of iOS 14. It doesn't appear that this string is used anywhere; it just shows a switch labeled "Allow Cross-Website Tracking."

![iVBORw0KGgoAAAANSUhEUgAABS0AAAo4CAYAAAC8JoK+AAABgmlDQ1BzUkdCIElFQzYxOTY2LTIu-2](https://user-images.githubusercontent.com/74188/95022006-466e6d80-0629-11eb-9e34-327d8117bc05.png)