### PR TITLE
Aggressively watch for connection changes in WebView

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -141,10 +141,8 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
     }
 
     @objc func ActiveURLTypeChanged(_ notification: Notification) {
-        guard let userInfo = notification.userInfo as? [String: ConnectionInfo.URLType],
-            let newType = userInfo["newType"],
-            let pathRow = self.form.rowBy(tag: "connectionPath") as? LabelRow else { return }
-        pathRow.value = newType.description
+        guard let pathRow = self.form.rowBy(tag: "connectionPath") as? LabelRow else { return }
+        pathRow.value = Current.settingsStore.connectionInfo?.activeURLType.description
         pathRow.updateCell()
     }
 }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -108,10 +108,17 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         self.becomeFirstResponder()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(WebViewController.loadActiveURLIfNeeded),
-                                               name: HomeAssistantAPI.didConnectNotification,
-                                               object: nil)
+        for name: Notification.Name in [
+            SettingsStore.connectionInfoDidChange,
+            HomeAssistantAPI.didConnectNotification
+        ] {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(loadActiveURLIfNeeded),
+                name: name,
+                object: nil
+            )
+        }
 
         let statusBarView = UIView()
         statusBarView.tag = 111

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -19,6 +19,7 @@ import Communicator
 public class ConnectionInfo: Codable {
     public private(set) var externalURL: URL? {
         didSet {
+            guard externalURL != oldValue else { return }
             Current.settingsStore.connectionInfo = self
             guard self.externalURL != nil else { return }
             Current.setUserProperty?("externalURL", "RemoteConnectionMethod")
@@ -26,11 +27,13 @@ public class ConnectionInfo: Codable {
     }
     public private(set) var internalURL: URL? {
         didSet {
+            guard internalURL != oldValue else { return }
             Current.settingsStore.connectionInfo = self
         }
     }
     public private(set) var remoteUIURL: URL? {
         didSet {
+            guard remoteUIURL != oldValue else { return }
             Current.settingsStore.connectionInfo = self
             guard self.remoteUIURL != nil else { return }
             Current.setUserProperty?("remoteUI", "RemoteConnectionMethod")
@@ -38,26 +41,32 @@ public class ConnectionInfo: Codable {
     }
     public var webhookID: String {
         didSet {
+            guard webhookID != oldValue else { return }
             Current.settingsStore.connectionInfo = self
         }
     }
     public var webhookSecret: String? {
         didSet {
+            guard webhookSecret != oldValue else { return }
             Current.settingsStore.connectionInfo = self
         }
     }
     public var cloudhookURL: URL? {
         didSet {
+            guard cloudhookURL != oldValue else { return }
             Current.settingsStore.connectionInfo = self
         }
     }
     public var internalSSIDs: [String]? {
         didSet {
+            guard internalSSIDs != oldValue else { return }
             Current.settingsStore.connectionInfo = self
         }
     }
     public var useCloud: Bool = false {
         didSet {
+            guard useCloud != oldValue else { return }
+
             Current.settingsStore.connectionInfo = self
             if self.useCloud {
                 if self.internalURL != nil && self.isOnInternalNetwork {

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -77,8 +77,7 @@ public class ConnectionInfo: Codable {
 
     public var activeURLType: URLType = .external {
         didSet {
-            guard oldValue != self.activeURLType else { print("No change", oldValue, self.activeURLType); return }
-            Current.settingsStore.connectionInfo = self
+            guard oldValue != self.activeURLType else { return }
             var oldURL: String = "Unknown URL"
             switch oldValue {
             case .internal:
@@ -89,9 +88,7 @@ public class ConnectionInfo: Codable {
                 oldURL = self.externalURL?.absoluteString ?? oldURL
             }
             Current.Log.verbose("Updated URL from \(oldValue) (\(oldURL)) to \(activeURLType) \(self.activeURL)")
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "connectioninfo.activeurltype_changed"),
-                                            object: nil,
-                                            userInfo: ["oldType": oldValue, "newType": activeURLType])
+            Current.settingsStore.connectionInfo = self
         }
     }
 

--- a/Sources/Shared/Common/Extensions/URL+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/URL+Extensions.swift
@@ -11,6 +11,10 @@ import Foundation
 extension URL {
     /// Return true if receiver's host and scheme is equal to `otherURL`
     public func baseIsEqual(to otherURL: URL) -> Bool {
-        return self.host == otherURL.host && self.scheme == otherURL.scheme
+        return host == otherURL.host
+        && port == otherURL.port
+        && scheme == otherURL.scheme
+        && user == otherURL.user
+        && password == otherURL.password
     }
 }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -19,6 +19,7 @@ public class SettingsStore {
     let prefs = UserDefaults(suiteName: Constants.AppGroupID)!
 
     public static let webViewRelatedSettingDidChange: Notification.Name = .init("webViewRelatedSettingDidChange")
+    public static let connectionInfoDidChange: Notification.Name = .init("connectionInfoDidChange")
 
     public var tokenInfo: TokenInfo? {
         get {
@@ -85,6 +86,12 @@ public class SettingsStore {
             } catch {
                 assertionFailure("Error while saving token info: \(error)")
             }
+
+            NotificationCenter.default.post(
+                name: Self.connectionInfoDidChange,
+                object: nil,
+                userInfo: nil
+            )
         }
     }
 


### PR DESCRIPTION
This moves the 'connection did change' notification from "we moved from internal to external" to "connection info changed in any way." For example, updating the connection settings will cause the WebView to immediately update, rather than requiring a pull-to-refresh.

- We now update the WebView URL and Settings "Connected Via" much more aggressively/reliably. Fixes #339.
- Comparing the 'should we reload?' for the URL now takes into account things like port being different.

This also avoids persisting/notifying ConnectionInfo changes when the values aren't changing. For example, every time we update our registration if it's just staying the same don't bother.