### PR TITLE
Improve reliability of refreshing Watch Complications

### DIFF
--- a/Configuration/Entitlements/WatchApp.entitlements
+++ b/Configuration/Entitlements/WatchApp.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(BUNDLE_ID_PREFIX).homeassistant$(BUNDLE_ID_SUFFIX)</string>

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		1101568524D770B2009424C9 /* NFCReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D04E124D76CD3003CE877 /* NFCReader.swift */; };
 		1101568724D7712F009424C9 /* TagManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1101568624D7712F009424C9 /* TagManagerProtocol.swift */; };
 		1101568824D7712F009424C9 /* TagManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1101568624D7712F009424C9 /* TagManagerProtocol.swift */; };
+		1104FC9125322C1800B8BE34 /* Dictionary+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */; };
+		1104FC9225322C1800B8BE34 /* Dictionary+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */; };
 		1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82024A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F82324A25A41002590F2 /* SensorContainer.test.swift */; };
@@ -881,6 +883,7 @@
 		1100D51E2496F63400B1073C /* ThemeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColors.swift; sourceTree = "<group>"; };
 		1100D52024974D6700B1073C /* camera_notification.apns */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = camera_notification.apns; sourceTree = "<group>"; };
 		1101568624D7712F009424C9 /* TagManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagManagerProtocol.swift; sourceTree = "<group>"; };
+		1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Additions.swift"; sourceTree = "<group>"; };
 		1109B6BA25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Intents.strings; sourceTree = "<group>"; };
 		1109B6BB25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Onboarding.strings; sourceTree = "<group>"; };
 		1109B6BC25263EEF005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -2859,6 +2862,7 @@
 				11CB98C9249E62E700B05222 /* Version+HA.swift */,
 				11C4629024B14E6B00031902 /* XCGLogger+UNNotification.swift */,
 				11FA53F1251071D2008D9506 /* NSItemProvider+Additions.swift */,
+				1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4618,6 +4622,7 @@
 				11AF4D20249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,
 				B67CE8A622200F220034C1D0 /* HAAPI.swift in Sources */,
 				1141182724AF9A0500E6525C /* WebhookManager.swift in Sources */,
+				1104FC9225322C1800B8BE34 /* Dictionary+Additions.swift in Sources */,
 				118261F824F8D6B0000795C6 /* SensorProviderDependencies.swift in Sources */,
 				11C8E8AD24F36535003E7F89 /* DeviceWrapper.swift in Sources */,
 			);
@@ -4709,6 +4714,7 @@
 				113E73102518457C004006D8 /* LocalizedManager.swift in Sources */,
 				111D295624F30E2400C8A7D1 /* Updater.swift in Sources */,
 				B672334D225DE1490031D629 /* SubscribeEvents.swift in Sources */,
+				1104FC9125322C1800B8BE34 /* Dictionary+Additions.swift in Sources */,
 				113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */,
 				11C4627F24B04CB800031902 /* Promise+RetryNetworking.swift in Sources */,
 				D03D893920E0AF8E00D4F28D /* ClientEvent.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		1101568824D7712F009424C9 /* TagManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1101568624D7712F009424C9 /* TagManagerProtocol.swift */; };
 		1104FC9125322C1800B8BE34 /* Dictionary+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */; };
 		1104FC9225322C1800B8BE34 /* Dictionary+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */; };
+		1104FCA125323A9C00B8BE34 /* WebhookResponseUpdateComplications.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FCA025323A9C00B8BE34 /* WebhookResponseUpdateComplications.test.swift */; };
+		1104FCB025323C2B00B8BE34 /* FakeWebhookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FCAF25323C2B00B8BE34 /* FakeWebhookManager.swift */; };
 		1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82024A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F82324A25A41002590F2 /* SensorContainer.test.swift */; };
@@ -884,6 +886,8 @@
 		1100D52024974D6700B1073C /* camera_notification.apns */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = camera_notification.apns; sourceTree = "<group>"; };
 		1101568624D7712F009424C9 /* TagManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagManagerProtocol.swift; sourceTree = "<group>"; };
 		1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Additions.swift"; sourceTree = "<group>"; };
+		1104FCA025323A9C00B8BE34 /* WebhookResponseUpdateComplications.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateComplications.test.swift; sourceTree = "<group>"; };
+		1104FCAF25323C2B00B8BE34 /* FakeWebhookManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeWebhookManager.swift; sourceTree = "<group>"; };
 		1109B6BA25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Intents.strings; sourceTree = "<group>"; };
 		1109B6BB25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Onboarding.strings; sourceTree = "<group>"; };
 		1109B6BC25263EEF005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1893,6 +1897,8 @@
 				11CD94B824B2D16F00BA801D /* WebhookResponseServiceCall.test.swift */,
 				11CD94BA24B2D2C100BA801D /* WebhookResponseUnhandled.test.swift */,
 				11A3F08B24ECE88C0018D84F /* WebhookUpdateLocation.test.swift */,
+				1104FCA025323A9C00B8BE34 /* WebhookResponseUpdateComplications.test.swift */,
+				1104FCAF25323C2B00B8BE34 /* FakeWebhookManager.swift */,
 			);
 			path = Webhook;
 			sourceTree = "<group>";
@@ -4781,6 +4787,7 @@
 				1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */,
 				119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */,
 				11CD94B724B2CC7400BA801D /* WebhookResponseLocation.test.swift in Sources */,
+				1104FCB025323C2B00B8BE34 /* FakeWebhookManager.swift in Sources */,
 				11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */,
 				11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */,
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
@@ -4791,6 +4798,7 @@
 				114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */,
 				11CB98C6249DE15B00B05222 /* LastUpdateSensor.test.swift in Sources */,
 				D03D894D20E0BC2700D4F28D /* ClientEventTests.swift in Sources */,
+				1104FCA125323A9C00B8BE34 /* WebhookResponseUpdateComplications.test.swift in Sources */,
 				113D29E124946EE50014067C /* CLLocationManager+OneShotLocationTests.swift in Sources */,
 				11AF4D30249DCA88006C74C0 /* ConnectivitySensor.test.swift in Sources */,
 				11CB98C8249DE24100B05222 /* PedometerSensor.test.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		1171508124DFCEC50065E874 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1171508024DFCEC50065E874 /* WidgetActions.swift */; };
 		117318AB25199E1A0013E010 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AA25199E1A0013E010 /* AppKit.framework */; };
 		117318AD25199E220013E010 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AC25199E220013E010 /* Foundation.framework */; };
+		117675EF252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
+		117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
 		1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */; };
 		1179E42D24F9FAA100D4E307 /* SensorProviderDependencies.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */; };
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
@@ -931,6 +933,7 @@
 		1171508024DFCEC50065E874 /* WidgetActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActions.swift; sourceTree = "<group>"; };
 		117318AA25199E1A0013E010 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = DEVELOPER_DIR; };
 		117318AC25199E220013E010 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateComplications.swift; sourceTree = "<group>"; };
 		1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionURLViewController.swift; sourceTree = "<group>"; };
 		1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorProviderDependencies.test.swift; sourceTree = "<group>"; };
 		117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.swift"; sourceTree = "<group>"; };
@@ -1797,6 +1800,7 @@
 				11C4628724B109C000031902 /* WebhookResponseLocation.swift */,
 				11C4628A24B1230E00031902 /* WebhookResponseServiceCall.swift */,
 				11C4628D24B128EF00031902 /* WebhookResponseUnhandled.swift */,
+				117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */,
 				11C4629524B19FC700031902 /* URLSessionTask+WebhookPersisted.swift */,
 			);
 			path = "Request&Response";
@@ -4510,6 +4514,7 @@
 				B67CE8AB22200F220034C1D0 /* TokenInfo.swift in Sources */,
 				B67CE87722200F220034C1D0 /* Strings.swift in Sources */,
 				11C9E43C2505B04E00492A88 /* HACoreAudioObjectSystem.swift in Sources */,
+				117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */,
 				B67CE8AE22200F220034C1D0 /* TokenManager.swift in Sources */,
 				11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */,
 				B6723348225DC72A0031D629 /* AuthenticatedUser.swift in Sources */,
@@ -4696,6 +4701,7 @@
 				B6872E632226841400C475D1 /* MobileAppRegistrationRequest.swift in Sources */,
 				111858DA24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */,
 				D0EEF317214DD7A400D1D360 /* DiscoveryInfo.swift in Sources */,
+				117675EF252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */,
 				11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
 				D03D893B20E0B2E300D4F28D /* Constants.swift in Sources */,
 				D03D893520E0AEF100D4F28D /* Realm+Initialization.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -341,7 +341,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 updatePromise = api.UpdateSensors(trigger: .BackgroundFetch).asVoid()
             }
 
-            return when(fulfilled: [updatePromise, api.updateComplications().asVoid()]).asVoid()
+            return when(fulfilled: [updatePromise, api.updateComplications()]).asVoid()
         }.done {
             completionHandler(.newData)
         }.catch { error in
@@ -744,7 +744,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupFirebase() {
-        #if targetEnvironment(simulator)
+        #if targetEnvironment(simulator) || DEBUG
         if FirebaseOptions.defaultOptions() == nil {
             Current.Log.error("*** Firebase options unavailable ***")
         } else {

--- a/Sources/App/Settings/WatchComplicationConfigurator.swift
+++ b/Sources/App/Settings/WatchComplicationConfigurator.swift
@@ -59,7 +59,7 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
             Current.Log.error(error)
         }
 
-        _ = HomeAssistantAPI.SyncWatchContext()
+        HomeAssistantAPI.authenticatedAPI()?.updateComplications().cauterize()
 
         onDismissCallback?(self)
     }
@@ -490,11 +490,6 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
                     }
 
                     textAreasDict[sectionTag]![rowTag] = rowValue
-
-                    if rowTag == "text", let value = rowValue as? String {
-                        textAreasDict[sectionTag]!["textNeedsRender"] = (value.contains("{{") || value.contains("}}"))
-                    }
-
                 } else {
                     if groupedVals[sectionTag] == nil {
                         groupedVals[sectionTag] = [String: Any]()

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -525,8 +525,8 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }.then { api -> Promise<Void> in
             func updateWithoutLocation() -> Promise<Void> {
                 return when(fulfilled: [
-                    api.UpdateSensors(trigger: .Manual).asVoid(),
-                    api.updateComplications().asVoid()
+                    api.UpdateSensors(trigger: .Manual),
+                    api.updateComplications()
                 ])
             }
 

--- a/Sources/Extensions/Watch/ExtensionDelegate.swift
+++ b/Sources/Extensions/Watch/ExtensionDelegate.swift
@@ -16,10 +16,6 @@ import Shared
 import PromiseKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
-    // MARK: - Properties -
-
-    var urlIdentifier: String?
-
     // MARK: Fileprivate
 
     fileprivate var watchConnectivityTask: WKWatchConnectivityRefreshBackgroundTask? {
@@ -94,7 +90,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
                 watchConnectivityTask = connectivityTask
             case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
                 // Be sure to complete the URL session task once you’re done.
-                Current.Log.verbose("Should rejoin URLSession! \(String(describing: urlIdentifier))")
+                Current.Log.verbose("Should rejoin URLSession! \(urlSessionTask.sessionIdentifier)")
                 Current.webhooks.handleBackground(for: urlSessionTask.sessionIdentifier) {
                     urlSessionTask.setTaskCompletedWithSnapshot(false)
                 }

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -129,18 +129,16 @@ public class WatchComplication: Object, ImmutableMappable {
         }
     }
 
-    func rendered() -> [RenderedValueType: String] {
+    func renderedValues() -> [RenderedValueType: String] {
         return (Data["rendered"] as? [String: String] ?? [:])
             .compactMapKeys(RenderedValueType.init(stringValue:))
     }
 
-    func updateRawRendered(for key: String, value: String) {
-        var existing = Data["rendered"] as? [String: String] ?? [:]
-        existing[key] = value
-        Data["rendered"] = existing
+    func updateRawRendered(from response: [String: String]) {
+        Data["rendered"] = response
     }
 
-    func preRendered() -> [String: String] {
+    func rawRendered() -> [String: String] {
         var renders = [RenderedValueType: String]()
 
         if let textAreas = Data["textAreas"] as? [String: [String: Any]], textAreas.isEmpty == false {

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -68,14 +68,12 @@ public class WatchComplication: Object, ImmutableMappable {
     @objc fileprivate dynamic var complicationData: Data?
     @objc dynamic public var CreatedAt = Date()
 
-    @objc dynamic public var RenderedData: [String: Any] = [String: Any]()
-
     override public static func primaryKey() -> String? {
         return "rawFamily"
     }
 
     override public static func ignoredProperties() -> [String] {
-        return ["RenderedData", "Family", "Template"]
+        return ["Family", "Template"]
     }
 
     public required init() {
@@ -98,14 +96,98 @@ public class WatchComplication: Object, ImmutableMappable {
         Family    >>> map["Family"]
     }
 
+    enum RenderedValueType: Hashable {
+        case textArea(String)
+        case gauge
+        case ring
+
+        init?(stringValue: String) {
+            let values = stringValue.components(separatedBy: ",")
+
+            guard values.count >= 1 else {
+                return nil
+            }
+
+            switch values[0] {
+            case "textArea" where values.count >= 2:
+                self = .textArea(values[1])
+            case "gauge":
+                self = .gauge
+            case "ring":
+                self = .ring
+            default:
+                return nil
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .textArea(let value): return "textArea,\(value)"
+            case .gauge: return "gauge"
+            case .ring: return "ring"
+            }
+        }
+    }
+
+    func rendered() -> [RenderedValueType: String] {
+        return (Data["rendered"] as? [String: String])?
+            .reduce(into: [RenderedValueType: String]()) {
+                if let key = RenderedValueType(stringValue: $1.key) {
+                    $0[key] = $1.value
+                }
+            } ?? [:]
+    }
+
+    func updateRawRendered(for key: String, value: String) {
+        var existing = Data["rendered"] as? [String: String] ?? [:]
+        existing[key] = value
+        Data["rendered"] = existing
+    }
+
+    func preRendered() -> [String: String] {
+        var renders = [RenderedValueType: String]()
+
+        if let textAreas = Data["textAreas"] as? [String: [String: Any]], textAreas.isEmpty == false {
+            renders.merge(
+                textAreas.compactMapValues { $0["text"] as? String }
+                    .filter { $1.containsJinjaTemplate }
+                    .reduce(into: [RenderedValueType: String]()) {
+                        $0[.textArea($1.key)] = $1.value
+                    },
+                uniquingKeysWith: { a, _ in a }
+            )
+        }
+
+        if let gaugeDict = Data["gauge"] as? [String: String],
+           let gauge = gaugeDict["gauge"], gauge.containsJinjaTemplate {
+            renders[.gauge] = gauge
+        }
+
+        if let ringDict = self.Data["ring"] as? [String: String],
+           let ringValue = ringDict["ring_value"], ringValue.containsJinjaTemplate {
+            renders[.ring] = ringValue
+        }
+
+        return renders.reduce(into: [String: String]()) {
+            $0[$1.key.stringValue] = $1.value
+        }
+    }
+
     #if os(watchOS)
+
+    private static func percentileNumber(from string: String) -> Float? {
+        // a bit more forgiving than Float(_:)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.number(from: string)?.floatValue
+    }
 
     public var textDataProviders: [String: CLKTextProvider] {
         var providers: [String: CLKTextProvider] = [String: CLKTextProvider]()
 
         if let textAreas = self.Data["textAreas"] as? [String: [String: Any]] {
             for (key, textArea) in textAreas {
-                guard let text = textArea["text"] as? String else {
+                guard let text = rendered()[.textArea(key)] ?? textArea["text"] as? String else {
                     Current.Log.warning("TextArea \(key) doesn't have any text!")
                     continue
                 }
@@ -113,12 +195,9 @@ public class WatchComplication: Object, ImmutableMappable {
                     Current.Log.warning("TextArea \(key) doesn't have a text color!")
                     continue
                 }
-                var provider = CLKSimpleTextProvider(text: text)
-                if let renderedText = textArea["renderedText"] as? String {
-                    provider = CLKSimpleTextProvider(text: renderedText)
+                providers[key] = with(CLKSimpleTextProvider(text: text)) {
+                    $0.tintColor = UIColor(color)
                 }
-                provider.tintColor = UIColor(color)
-                providers[key] = provider
             }
         }
 
@@ -151,10 +230,11 @@ public class WatchComplication: Object, ImmutableMappable {
     }
 
     public var gaugeProvider: CLKSimpleGaugeProvider? {
-        if let gaugeDict = self.Data["gauge"] as? [String: String], let gaugeValue = gaugeDict["gauge"],
-            let floatVal = Float(gaugeValue), let gaugeColor = gaugeDict["gauge_color"],
-            let gaugeStyle = gaugeDict["gauge_style"] {
-
+        if let gaugeDict = self.Data["gauge"] as? [String: String],
+           let gaugeValue = rendered()[.gauge] ?? gaugeDict["gauge"],
+           let floatVal = Self.percentileNumber(from: gaugeValue),
+           let gaugeColor = gaugeDict["gauge_color"],
+           let gaugeStyle = gaugeDict["gauge_style"] {
             let style = (gaugeStyle == "fill" ? CLKGaugeProviderStyle.fill : CLKGaugeProviderStyle.ring)
 
             return CLKSimpleGaugeProvider(style: style, gaugeColor: UIColor(gaugeColor), fillFraction: floatVal)
@@ -165,8 +245,8 @@ public class WatchComplication: Object, ImmutableMappable {
 
     public var ringData: (Float, CLKComplicationRingStyle, UIColor) {
         guard let ringDict = self.Data["ring"] as? [String: String],
-              let ringValue = ringDict["ring_value"],
-              let floatVal = Float(ringValue),
+              let ringValue = rendered()[.ring] ?? ringDict["ring_value"],
+              let floatVal = Self.percentileNumber(from: ringValue),
               let ringColor = ringDict["ring_color"]
         else {
             Current.Log.warning("Unable to get ring data!")

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -174,8 +174,9 @@ public class WatchComplication: Object, ImmutableMappable {
         var providers: [String: CLKTextProvider] = [String: CLKTextProvider]()
 
         if let textAreas = self.Data["textAreas"] as? [String: [String: Any]] {
+            let rendered = renderedValues()
             for (key, textArea) in textAreas {
-                guard let text = rendered()[.textArea(key)] ?? textArea["text"] as? String else {
+                guard let text = rendered[.textArea(key)] ?? textArea["text"] as? String else {
                     Current.Log.warning("TextArea \(key) doesn't have any text!")
                     continue
                 }
@@ -219,7 +220,7 @@ public class WatchComplication: Object, ImmutableMappable {
 
     public var gaugeProvider: CLKSimpleGaugeProvider? {
         if let gaugeDict = self.Data["gauge"] as? [String: String],
-           let gaugeValue = rendered()[.gauge] ?? gaugeDict["gauge"],
+           let gaugeValue = renderedValues()[.gauge] ?? gaugeDict["gauge"],
            let floatVal = Self.percentileNumber(from: gaugeValue),
            let gaugeColor = gaugeDict["gauge_color"],
            let gaugeStyle = gaugeDict["gauge_style"] {
@@ -233,7 +234,7 @@ public class WatchComplication: Object, ImmutableMappable {
 
     public var ringData: (Float, CLKComplicationRingStyle, UIColor) {
         guard let ringDict = self.Data["ring"] as? [String: String],
-              let ringValue = rendered()[.ring] ?? ringDict["ring_value"],
+              let ringValue = renderedValues()[.ring] ?? ringDict["ring_value"],
               let floatVal = Self.percentileNumber(from: ringValue),
               let ringColor = ringDict["ring_color"]
         else {

--- a/Sources/Shared/API/Webhook/Request&Response/WebhookResponseUpdateComplications.swift
+++ b/Sources/Shared/API/Webhook/Request&Response/WebhookResponseUpdateComplications.swift
@@ -25,9 +25,8 @@ struct WebhookResponseUpdateComplications: WebhookResponseHandler {
 
             payload.merge(
                 complication.preRendered()
-                    .reduce(into: [String: [String: String]]()) {
-                        $0[keyPrefix + $1.key] = ["template": $1.value]
-                    },
+                    .mapKeys { keyPrefix + $0 }
+                    .mapValues { ["template": $0] },
                 uniquingKeysWith: { a, _ in a }
             )
         }

--- a/Sources/Shared/API/Webhook/Request&Response/WebhookResponseUpdateComplications.swift
+++ b/Sources/Shared/API/Webhook/Request&Response/WebhookResponseUpdateComplications.swift
@@ -1,0 +1,69 @@
+import Foundation
+import UserNotifications
+import PromiseKit
+import RealmSwift
+
+extension WebhookResponseIdentifier {
+    static var updateComplications: Self { .init(rawValue: "updateComplications") }
+}
+
+struct WebhookResponseUpdateComplications: WebhookResponseHandler {
+    let api: HomeAssistantAPI
+    init(api: HomeAssistantAPI) {
+        self.api = api
+    }
+
+    static func shouldReplace(request current: WebhookRequest, with proposed: WebhookRequest) -> Bool {
+        return true
+    }
+
+    func handle(
+        request: Promise<WebhookRequest>,
+        result: Promise<Any>
+    ) -> Guarantee<WebhookResponseHandlerResult> {
+        return firstly {
+            result
+        }.compactMap {
+            return $0 as? [String: String]
+        }.then { jsonDict -> Promise<Void> in
+            Current.Log.verbose("JSON Dict1 \(jsonDict)")
+
+            for (templateKey, renderedText) in jsonDict {
+                let components = templateKey.components(separatedBy: "|")
+                let rawTemplate = components[0]
+                let textAreaKey = components[1]
+                let pred = NSPredicate(format: "rawTemplate == %@", rawTemplate)
+                let realm = Realm.live()
+                guard let complication = realm.objects(WatchComplication.self).filter(pred).first else {
+                    Current.Log.error("Couldn't get complication from DB for \(rawTemplate)")
+                    continue
+                }
+
+                guard var storedAreas = complication.Data["textAreas"] as? [String: [String: Any]] else {
+                    Current.Log.error("Couldn't cast stored areas")
+                    continue
+                }
+
+                storedAreas[textAreaKey]!["renderedText"] = renderedText
+
+                // swiftlint:disable:next force_try
+                try! realm.write {
+                    complication.Data["textAreas"] = storedAreas
+                }
+
+                Current.Log.verbose("complication \(complication.Data)")
+            }
+
+            if let syncError = HomeAssistantAPI.SyncWatchContext() {
+                return .init(error: syncError)
+            }
+
+            return .value(())
+        }.map { _ in
+            WebhookResponseHandlerResult.default
+        }.recover { error -> Guarantee<WebhookResponseHandlerResult> in
+            Current.Log.error("got error: \(error)")
+            return Guarantee.value(WebhookResponseHandlerResult.default)
+        }
+    }
+}

--- a/Sources/Shared/Common/Extensions/Dictionary+Additions.swift
+++ b/Sources/Shared/Common/Extensions/Dictionary+Additions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Dictionary {
+    public func mapKeys<T>(_ transform: (Key) throws -> T) rethrows -> [T: Value] {
+        try reduce(into: [T: Value]()) { result, element in
+            result[try transform(element.key)] = element.value
+        }
+    }
+
+    public func compactMapKeys<T>(_ transform: (Key) throws -> T?) rethrows -> [T: Value] {
+        try reduce(into: [T: Value]()) { result, element in
+            if let newKey = try transform(element.key) {
+                result[newKey] = element.value
+            }
+        }
+    }
+}

--- a/Sources/Shared/Common/Extensions/String+HA.swift
+++ b/Sources/Shared/Common/Extensions/String+HA.swift
@@ -15,6 +15,10 @@ extension String {
         return unicodeScalars.map { $0.value }.reduce(5381) { ($0 << 5) &+ $0 &+ Int($1) }
     }
 
+    var containsJinjaTemplate: Bool {
+        return contains("{{") || contains("{%") || contains("{#")
+    }
+
     func dictionary() -> [String: Any]? {
         if let data = self.data(using: .utf8) {
             do {

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -67,6 +67,7 @@ public class Environment {
         $0.register(responseHandler: WebhookResponseUpdateSensors.self, for: .updateSensors)
         $0.register(responseHandler: WebhookResponseLocation.self, for: .location)
         $0.register(responseHandler: WebhookResponseServiceCall.self, for: .serviceCall)
+        $0.register(responseHandler: WebhookResponseUpdateComplications.self, for: .updateComplications)
     }
 
     public var sensors = with(SensorContainer()) {

--- a/Tests/Shared/Webhook/FakeWebhookManager.swift
+++ b/Tests/Shared/Webhook/FakeWebhookManager.swift
@@ -1,0 +1,13 @@
+import Foundation
+import PromiseKit
+@testable import Shared
+
+class FakeWebhookManager: WebhookManager {
+    var sendRequestHandler: ((WebhookResponseIdentifier, WebhookRequest, Resolver<Void>) -> Void)?
+
+    override func send(identifier: WebhookResponseIdentifier = .unhandled, request: WebhookRequest) -> Promise<Void> {
+        let (promise, seal) = Promise<Void>.pending()
+        sendRequestHandler?(identifier, request, seal)
+        return promise
+    }
+}

--- a/Tests/Shared/Webhook/WebhookResponseUpdateComplications.test.swift
+++ b/Tests/Shared/Webhook/WebhookResponseUpdateComplications.test.swift
@@ -1,0 +1,158 @@
+import Foundation
+@testable import Shared
+import PromiseKit
+import XCTest
+import RealmSwift
+
+class WebhookResponseUpdateComplicationsTests: XCTestCase {
+    private var api: FakeHomeAssistantAPI!
+    private var webhookManager: FakeWebhookManager!
+    private var realm: Realm!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let executionIdentifier = UUID().uuidString
+
+        realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
+        Current.realm = { self.realm }
+
+        api = FakeHomeAssistantAPI(
+            tokenInfo: .init(
+                accessToken: "atoken",
+                refreshToken: "refreshtoken",
+                expiration: Date()
+            )
+        )
+        webhookManager = FakeWebhookManager()
+        Current.webhooks = webhookManager
+
+        FakeWatchComplication.rawRenderedUpdates = [:]
+    }
+
+    func testNoComplicationGivesNoRequest() {
+        XCTAssertNil(WebhookResponseUpdateComplications.request(for: .init()))
+    }
+
+    func testComplicationsWithoutPreRendered() {
+        let complications = Set([
+            FakeWatchComplication(),
+            FakeWatchComplication(),
+            FakeWatchComplication(),
+        ])
+
+        XCTAssertNil(WebhookResponseUpdateComplications.request(for: complications))
+    }
+
+    func testComplicationsWithPreRendered() {
+        let complications = [
+            with(FakeWatchComplication()) {
+                $0.Template = .ExtraLargeColumnsText
+                $0.resultRawRendered = [
+                    "fwc1k1": "fwc1v1",
+                    "fwc1k2": "fwc1v2"
+                ]
+            },
+            with(FakeWatchComplication()) {
+                $0.Template = .CircularSmallRingText
+                $0.resultRawRendered = [:]
+            },
+            with(FakeWatchComplication()) {
+                $0.Template = .GraphicBezelCircularText
+                $0.resultRawRendered = [
+                    "fwc3k1": "fwc3v1"
+                ]
+            },
+        ]
+
+        let request = WebhookResponseUpdateComplications.request(for: Set(complications))
+        XCTAssertEqual(request?.type, "render_template")
+
+        let expected: [String: [String: String]] = [
+            complications[0].Template.rawValue + "|fwc1k1": [
+                "template": "fwc1v1"
+            ],
+            complications[0].Template.rawValue + "|fwc1k2": [
+                "template": "fwc1v2"
+            ],
+            complications[2].Template.rawValue + "|fwc3k1": [
+                "template": "fwc3v1"
+            ]
+        ]
+
+        XCTAssertEqual(request?.data as? [String: [String: String]], expected)
+    }
+
+    func testResponseUpdatesComplication() throws {
+        let complications = [
+            with(FakeWatchComplication()) {
+                $0.Template = .ExtraLargeColumnsText
+                $0.Family = .extraLarge
+                $0.resultRawRendered = [
+                    "fwc1k1": "fwc1v1",
+                    "fwc1k2": "fwc1v2"
+                ]
+            },
+            with(FakeWatchComplication()) {
+                $0.Template = .CircularSmallRingText
+                $0.Family = .circularSmall
+                $0.resultRawRendered = [:]
+            },
+            with(FakeWatchComplication()) {
+                $0.Template = .GraphicBezelCircularText
+                $0.Family = .graphicBezel
+                $0.resultRawRendered = [
+                    "fwc3k1": "fwc3v1"
+                ]
+            },
+        ]
+        try realm.write {
+            realm.add(complications)
+        }
+
+        var handler = WebhookResponseUpdateComplications(api: api)
+        handler.watchComplicationClass = FakeWatchComplication.self
+
+        let request = WebhookResponseUpdateComplications.request(for: Set(complications))!
+        let result: [String: String] = [
+            complications[0].Template.rawValue + "|fwc1k1": "rendered_fwc1v1",
+            complications[0].Template.rawValue + "|fwc1k2": "rendered_fwc1v2",
+            complications[2].Template.rawValue + "|fwc3k1": "rendered_fwc3v1",
+        ]
+
+        let expectation = self.expectation(description: "result")
+        handler.handle(request: .value(request), result: .value(result)).done { handlerResult in
+            XCTAssertNil(handlerResult.notification)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+
+        XCTAssertEqual(FakeWatchComplication.rawRenderedUpdates, [
+            complications[0].Template.rawValue: [
+                "fwc1k1": "rendered_fwc1v1",
+                "fwc1k2": "rendered_fwc1v2"
+            ],
+            complications[2].Template.rawValue: [
+                "fwc3k1": "rendered_fwc3v1"
+            ]
+        ])
+    }
+}
+
+private class FakeHomeAssistantAPI: HomeAssistantAPI {
+
+}
+
+class FakeWatchComplication: WatchComplication {
+    var resultRawRendered: [String: String] = [:]
+
+    override func rawRendered() -> [String : String] {
+        resultRawRendered
+    }
+
+    static var rawRenderedUpdates: [String: [String: String]] = [:]
+
+    override func updateRawRendered(from response: [String : String]) {
+        Self.rawRenderedUpdates[Template.rawValue] = response
+    }
+}

--- a/Tests/Shared/Webhook/WebhookResponseUpdateSensors.test.swift
+++ b/Tests/Shared/Webhook/WebhookResponseUpdateSensors.test.swift
@@ -127,13 +127,3 @@ class WebhookResponseUpdateSensorsTests: XCTestCase {
 private class FakeHomeAssistantAPI: HomeAssistantAPI {
 
 }
-
-private class FakeWebhookManager: WebhookManager {
-    var sendRequestHandler: ((WebhookResponseIdentifier, WebhookRequest, Resolver<Void>) -> Void)?
-
-    override func send(identifier: WebhookResponseIdentifier = .unhandled, request: WebhookRequest) -> Promise<Void> {
-        let (promise, seal) = Promise<Void>.pending()
-        sendRequestHandler?(identifier, request, seal)
-        return promise
-    }
-}


### PR DESCRIPTION
One of our top crashes (on all platforms) is crashing when completing the background refresh operation of the Watch Extension's update cycle. I believe this is because the task is being called more than once; presumably because we're mixing multiple types of tasks in one pointer -- communication updates and complication updates, and they stomp on each other.

Another issue here is that we're not using Background Sessions to do the complication updates, when we want to -- when I refactored Webhooks out of the HomeAssistantAPI code path, I neglected to update this Webhook call to handle background updating; it now does.

- Updates complication text rendering to go through the background session supporting Webhook update mechanism.
- Adds support for ring and gauge template rendering. Fixes #1127.