### PR TITLE
Implement Graphic Bezel Circular Text

### DIFF
--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -579,13 +579,16 @@ public class WatchComplication: Object, ImmutableMappable {
             }
             return template
         case .GraphicBezelCircularText:
-            // TODO: need to implement CLKComplicationTemplateGraphicCircular
-            return nil
-//            let template = CLKComplicationTemplateGraphicBezelCircularText()
-//            if let textProvider = self.textDataProviders["Center"] {
-//                template.textProvider = textProvider
-//            }
-//            return template
+            let template = CLKComplicationTemplateGraphicBezelCircularText()
+            if let iconProvider = self.fullColorImageProvider {
+                template.circularTemplate = with(CLKComplicationTemplateGraphicCircularImage()) {
+                    $0.imageProvider = iconProvider
+                }
+            }
+            if let textProvider = self.textDataProviders["Center"] {
+                template.textProvider = textProvider
+            }
+            return template
         case .GraphicRectangularStandardBody:
             let template = CLKComplicationTemplateGraphicRectangularStandardBody()
             if let textProvider = self.textDataProviders["Header"] {

--- a/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
+++ b/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
@@ -1113,6 +1113,10 @@ public enum ComplicationTemplate: String {
                 40: CGSize(width: 22, height: 22),
                 44: CGSize(width: 24, height: 24)
             ],
+            "GraphicBezelCircularText": [
+                40: CGSize(width: 42, height: 42),
+                44: CGSize(width: 47, height: 47)
+            ],
             "GraphicRectangularLargeImage": [
                 40: CGSize(width: 300, height: 94),
                 44: CGSize(width: 342, height: 108)
@@ -1253,7 +1257,7 @@ public enum ComplicationTemplate: String {
              .GraphicCornerTextImage, .GraphicRectangularLargeImage, .GraphicRectangularStandardBody,
              .GraphicRectangularTextGauge, .ModularLargeColumns, .ModularLargeStandardBody, .ModularLargeTable,
              .ModularSmallRingImage, .ModularSmallSimpleImage, .ModularSmallStackImage, .UtilitarianLargeFlat,
-             .UtilitarianSmallFlat, .UtilitarianSmallRingImage, .UtilitarianSmallSquare:
+             .UtilitarianSmallFlat, .UtilitarianSmallRingImage, .UtilitarianSmallSquare, .GraphicBezelCircularText:
             return true
         default:
             return false


### PR DESCRIPTION
Requires an icon; adds the flag that we need the icon for the template and sets the image size.

Fixes #1166.

![iVBORw0KGgoAAAANSUhEUgAAAgAAAAN6CAYAAAD4tvHpAAAACXBIWXMAAAsTAAALEwEAmpwYAAFW-2](https://user-images.githubusercontent.com/74188/95287383-995b4700-081a-11eb-84bb-cc6792d9188e.png)
