### PR TITLE
Fix ring and single-color-tinted Watch Complications

### DIFF
--- a/Sources/App/Settings/WatchComplicationConfigurator.swift
+++ b/Sources/App/Settings/WatchComplicationConfigurator.swift
@@ -253,14 +253,35 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
             $0.tag = "ring_type"
             $0.title = L10n.Watch.Configurator.Rows.Ring.RingType.title
             $0.add(rule: RuleRequired())
-            $0.options = [L10n.Watch.Configurator.Rows.Ring.RingType.Options.open,
-                          L10n.Watch.Configurator.Rows.Ring.RingType.Options.closed]
+            $0.options = ["open", "closed"]
+
+            $0.displayValueFor = { value in
+                if value?.lowercased() == "open" {
+                    return L10n.Watch.Configurator.Rows.Ring.RingType.Options.open
+                } else {
+                    return L10n.Watch.Configurator.Rows.Ring.RingType.Options.closed
+                }
+            }
+
             $0.value = $0.options?.first
             if let dict = self.config.Data["ring"] as? [String: Any],
                 let value = dict[$0.tag!] as? String {
                 $0.value = value
             }
         }
+
+        <<< InlineColorPickerRow("ring_color") {
+                $0.title = L10n.Watch.Configurator.Rows.Ring.Color.title
+                $0.isCircular = true
+                $0.showsPaletteNames = true
+                $0.value = UIColor.green
+                if let dict = self.config.Data["ring"] as? [String: Any],
+                    let value = dict[$0.tag!] as? String {
+                    $0.value = UIColor(hex: value)
+                }
+            }.onChange { (picker) in
+                Current.Log.verbose("ring color: \(picker.value!.hexString(false))")
+            }
 
         +++ Section(header: L10n.Watch.Configurator.Sections.Icon.header,
                     footer: L10n.Watch.Configurator.Sections.Icon.footer) {

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -34,6 +34,8 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
                                  withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
         // Call the handler with the current timeline entry
 
+        Iconic.registerMaterialDesignIcons()
+
         Current.Log.verbose("Providing template for \(complication.family.description)")
 
         let matchedFamily = ComplicationGroupMember(family: complication.family)

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -128,10 +128,11 @@ public class WatchComplication: Object, ImmutableMappable {
     public var iconProvider: CLKImageProvider? {
         if let iconDict = self.Data["icon"] as? [String: String], let iconName = iconDict["icon"],
             let iconColor = iconDict["icon_color"], let iconSize = self.Template.imageSize {
+            let iconColor = UIColor(iconColor)
             let icon = MaterialDesignIcons(named: iconName)
-            let image = icon.image(ofSize: iconSize, color: .clear)
+            let image = icon.image(ofSize: iconSize, color: iconColor)
             let provider = CLKImageProvider(onePieceImage: image)
-            provider.tintColor = UIColor(iconColor)
+            provider.tintColor = iconColor
             return provider
         }
 
@@ -163,14 +164,22 @@ public class WatchComplication: Object, ImmutableMappable {
     }
 
     public var ringData: (Float, CLKComplicationRingStyle, UIColor) {
-        guard let ringDict = self.Data["ring"] as? [String: String], let ringValue = ringDict["ring"],
-            let floatVal = Float(ringValue), let ringColor = ringDict["ring_color"],
-            let ringStyle = ringDict["ring_style"] else {
-                Current.Log.warning("Unable to get ring data!")
-                return (0, .open, UIColor.black)
+        guard let ringDict = self.Data["ring"] as? [String: String],
+              let ringValue = ringDict["ring_value"],
+              let floatVal = Float(ringValue),
+              let ringColor = ringDict["ring_color"]
+        else {
+            Current.Log.warning("Unable to get ring data!")
+            return (0, .open, UIColor.black)
         }
 
-        let style = (ringStyle == "open" ? CLKComplicationRingStyle.open : CLKComplicationRingStyle.closed)
+        let style: CLKComplicationRingStyle
+
+        if ringDict["ring_type"]?.lowercased() == "open" {
+            style = .open
+        } else {
+            style = .closed
+        }
 
         return (floatVal, style, UIColor(ringColor))
     }

--- a/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
+++ b/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
@@ -992,136 +992,136 @@ public enum ComplicationTemplate: String {
     // https://gist.github.com/robbiet480/2a38d499323cb964d47b2f5d8004694a
     public var imageSize: CGSize? {
         // Template: Device Size: Image Size @1x
-        let imageSizes: [String: [Int: CGSize]] = [
-            "CircularSmallRingImage": [
+        let imageSizes: [Self: [Int: CGSize]] = [
+            .CircularSmallRingImage: [
                 38: CGSize(width: 40, height: 40),
                 40: CGSize(width: 44, height: 44),
                 42: CGSize(width: 44, height: 44),
                 44: CGSize(width: 48, height: 48)
             ],
-            "CircularSmallSimpleImage": [
+            .CircularSmallSimpleImage: [
                 38: CGSize(width: 32, height: 32),
                 40: CGSize(width: 36, height: 36),
                 42: CGSize(width: 36, height: 36),
                 44: CGSize(width: 40, height: 40)
             ],
-            "CircularSmallStackImage": [
+            .CircularSmallStackImage: [
                 38: CGSize(width: 32, height: 14),
                 40: CGSize(width: 34, height: 16),
                 42: CGSize(width: 34, height: 16),
                 44: CGSize(width: 38, height: 18)
             ],
-            "ModularSmallRingImage": [
+            .ModularSmallRingImage: [
                 38: CGSize(width: 36, height: 36),
                 40: CGSize(width: 38, height: 38),
                 42: CGSize(width: 38, height: 38),
                 44: CGSize(width: 42, height: 42)
             ],
-            "ModularSmallSimpleImage": [
+            .ModularSmallSimpleImage: [
                 38: CGSize(width: 52, height: 52),
                 40: CGSize(width: 58, height: 58),
                 42: CGSize(width: 58, height: 58),
                 44: CGSize(width: 64, height: 64)
             ],
-            "ModularSmallStackImage": [
+            .ModularSmallStackImage: [
                 38: CGSize(width: 52, height: 28),
                 40: CGSize(width: 58, height: 30),
                 42: CGSize(width: 58, height: 30),
                 44: CGSize(width: 64, height: 34)
             ],
-            "ModularLargeColumnsImage": [
+            .ModularLargeColumns: [
                 38: CGSize(width: 64, height: 22),
                 40: CGSize(width: 74, height: 24),
                 42: CGSize(width: 74, height: 24),
                 44: CGSize(width: 84, height: 28)
             ],
-            "ModularLargeStandardBody": [
+            .ModularLargeStandardBody: [
                 38: CGSize(width: 64, height: 22),
                 40: CGSize(width: 74, height: 24),
                 42: CGSize(width: 74, height: 24),
                 44: CGSize(width: 84, height: 28)
             ],
-            "ModularLargeTable": [
+            .ModularLargeTable: [
                 38: CGSize(width: 64, height: 22),
                 40: CGSize(width: 74, height: 24),
                 42: CGSize(width: 74, height: 24),
                 44: CGSize(width: 84, height: 28)
             ],
-            "UtilitarianSmallFlatImage": [
+            .UtilitarianSmallFlat: [
                 38: CGSize(width: 42, height: 18),
                 40: CGSize(width: 44, height: 20),
                 42: CGSize(width: 44, height: 20)
                 // 44: CGSize(width: 20, height: 20) -- 44mm is marked "N/A" in HIG
             ],
-            "UtilitarianSmallRingImage": [
+            .UtilitarianSmallRingImage: [
                 38: CGSize(width: 28, height: 28),
                 40: CGSize(width: 28, height: 28),
                 42: CGSize(width: 28, height: 28),
                 44: CGSize(width: 32, height: 32)
             ],
-            "UtilitarianSmallSquareImage": [
+            .UtilitarianSmallSquare: [
                 38: CGSize(width: 40, height: 40),
                 40: CGSize(width: 44, height: 44),
                 42: CGSize(width: 44, height: 44),
                 44: CGSize(width: 50, height: 50)
             ],
-            "UtilitarianLargeFlatImage": [
+            .UtilitarianLargeFlat: [
                 38: CGSize(width: 42, height: 18),
                 40: CGSize(width: 44, height: 20),
                 42: CGSize(width: 44, height: 20)
                 // 44: CGSize(width: 20, height: 20) -- 44mm is marked "N/A" in HIG
             ],
-            "ExtraLargeRingImage": [
+            .ExtraLargeRingImage: [
                 38: CGSize(width: 126, height: 126),
                 40: CGSize(width: 133, height: 133),
                 42: CGSize(width: 133, height: 133),
                 44: CGSize(width: 146, height: 146)
             ],
-            "ExtraLargeSimpleImage": [
+            .ExtraLargeSimpleImage: [
                 38: CGSize(width: 182, height: 182),
                 40: CGSize(width: 203, height: 203),
                 42: CGSize(width: 203, height: 203),
                 44: CGSize(width: 224, height: 224)
             ],
-            "ExtraLargeStackImage": [
+            .ExtraLargeStackImage: [
                 38: CGSize(width: 156, height: 84),
                 40: CGSize(width: 174, height: 90),
                 42: CGSize(width: 174, height: 90),
                 44: CGSize(width: 192, height: 102)
             ],
-            "GraphicCornerCircularImage": [
+            .GraphicCornerCircularImage: [
                 40: CGSize(width: 64, height: 64),
                 44: CGSize(width: 72, height: 72)
             ],
-            "GraphicCornerGaugeImage": [
+            .GraphicCornerGaugeImage: [
                 40: CGSize(width: 40, height: 40),
                 44: CGSize(width: 44, height: 44)
             ],
-            "GraphicCornerTextImage": [
+            .GraphicCornerTextImage: [
                 40: CGSize(width: 40, height: 40),
                 44: CGSize(width: 44, height: 44)
             ],
-            "GraphicCircularImage": [
+            .GraphicCircularImage: [
                 40: CGSize(width: 84, height: 84),
                 44: CGSize(width: 94, height: 94)
             ],
-            "GraphicCircularClosedGaugeImage": [
+            .GraphicCircularClosedGaugeImage: [
                 40: CGSize(width: 54, height: 54),
                 44: CGSize(width: 62, height: 62)
             ],
-            "GraphicCircularOpenGaugeImage": [
+            .GraphicCircularOpenGaugeImage: [
                 40: CGSize(width: 22, height: 22),
                 44: CGSize(width: 24, height: 24)
             ],
-            "GraphicRectangularLargeImage": [
+            .GraphicRectangularLargeImage: [
                 40: CGSize(width: 300, height: 94),
                 44: CGSize(width: 342, height: 108)
             ],
-            "GraphicRectangularStandardBody": [
+            .GraphicRectangularStandardBody: [
                 40: CGSize(width: 24, height: 24),
                 44: CGSize(width: 27, height: 27)
             ],
-            "GraphicRectangularTextGauge": [
+            .GraphicRectangularTextGauge: [
                 40: CGSize(width: 24, height: 24),
                 44: CGSize(width: 27, height: 27)
             ]
@@ -1129,7 +1129,7 @@ public enum ComplicationTemplate: String {
 
         let deviceSize = WKInterfaceDevice.currentResolution().rawValue
 
-        if let sizeDict = imageSizes[self.rawValue], let size = sizeDict[deviceSize] {
+        if let sizeDict = imageSizes[self], let size = sizeDict[deviceSize] {
             return size
         }
 


### PR DESCRIPTION
- Fixes, in general, any complication involving a Ring -- none of the values were being persisted in a way it could understand and color was missing entirely.
- Fixes Extra Large's "Simple Image", "Stack Image", "Ring Text" and "Ring Image". Fixes #1165.
- Fixes Utility's Small "Square" image (the size name was wrong), "Ring Image" (same as above), "Ring Text". Fixes #1164. 

![Image](https://user-images.githubusercontent.com/74188/95292561-89496480-0826-11eb-9301-1fdc4eb0b49f.png)
![Image](https://user-images.githubusercontent.com/74188/95292572-936b6300-0826-11eb-8a4c-e50403da190e.png)
