### PR TITLE
Immediately update Watch upon Complication saving

### DIFF
--- a/Sources/App/Settings/WatchComplicationConfigurator.swift
+++ b/Sources/App/Settings/WatchComplicationConfigurator.swift
@@ -59,6 +59,8 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
             Current.Log.error(error)
         }
 
+        _ = HomeAssistantAPI.SyncWatchContext()
+
         onDismissCallback?(self)
     }
 


### PR DESCRIPTION
Found during debugging that this configuration wasn't being pushed to the Watch fast enough; I'd often need to forcibly call this to get the configuration updated.