### PR TITLE
End Watch Complication refresh task on network start, not network end

### DIFF
--- a/Sources/App/Settings/WatchComplicationConfigurator.swift
+++ b/Sources/App/Settings/WatchComplicationConfigurator.swift
@@ -59,7 +59,7 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
             Current.Log.error(error)
         }
 
-        HomeAssistantAPI.authenticatedAPI()?.updateComplications().cauterize()
+        HomeAssistantAPI.authenticatedAPI()?.updateComplications(passively: false).cauterize()
 
         onDismissCallback?(self)
     }

--- a/Sources/Extensions/Watch/ExtensionDelegate.swift
+++ b/Sources/Extensions/Watch/ExtensionDelegate.swift
@@ -94,7 +94,6 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
                 watchConnectivityTask = connectivityTask
             case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
                 // Be sure to complete the URL session task once you’re done.
-                Current.Log.verbose("Should rejoin URLSession! \(urlSessionTask.sessionIdentifier)")
                 Current.webhooks.handleBackground(for: urlSessionTask.sessionIdentifier) {
                     Current.backgroundRefreshScheduler.schedule().done {
                         urlSessionTask.setTaskCompletedWithSnapshot(false)
@@ -226,7 +225,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         firstly {
             HomeAssistantAPI.authenticatedAPIPromise
         }.then {
-            $0.updateComplications()
+            $0.updateComplications(passively: true)
         }.recover { _ in
             ()
         }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -203,7 +203,7 @@ public class HomeAssistantAPI {
                 self.GetConfig().asVoid(),
                 Current.modelManager.fetch(),
                 self.UpdateSensors(trigger: reason.updateSensorTrigger).asVoid(),
-                self.updateComplications().asVoid()
+                self.updateComplications(passively: false).asVoid()
             ]).asVoid()
         }.get { _ in
             NotificationCenter.default.post(name: Self.didConnectNotification,

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -76,7 +76,7 @@ extension HomeAssistantAPI {
         return nil
     }
 
-    public func updateComplications() -> Promise<Void> {
+    public func updateComplications(passively: Bool) -> Promise<Void> {
         let complications = Set(Current.realm().objects(WatchComplication.self))
 
         guard let request = WebhookResponseUpdateComplications.request(for: complications) else {
@@ -84,9 +84,10 @@ extension HomeAssistantAPI {
             return .value(())
         }
 
-        return Current.webhooks.send(
-            identifier: .updateComplications,
-            request: request
-        )
+        if passively {
+            return Current.webhooks.sendPassive(identifier: .updateComplications, request: request)
+        } else {
+            return Current.webhooks.send(identifier: .updateComplications, request: request)
+        }
     }
 }


### PR DESCRIPTION
Running the latest Watch Extension on my device, I'm seeing a lot of kills like:

> Termination Reason: CAROUSEL, Background App Refresh watchdog transgression. Exhausted wall time allowance of 15.00 seconds.

From the [documentation on `WKApplicationRefreshBackgroundTask`](https://developer.apple.com/documentation/watchkit/wkapplicationrefreshbackgroundtask#), the suggestion is to kick off a background URLSession request and immediately end the app refresh task, allowing the background session code paths to complete the execution. Given we're being killed so often, I'm guessing that part'll work just fine.

Fixes #1191.