### PR TITLE
Support multiple Apple Watch complications

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		111D295624F30E2400C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
+		1130F532253A1E7400F371BE /* ComplicationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F531253A1E7400F371BE /* ComplicationListViewController.swift */; };
+		1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */; };
 		11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */; };
@@ -599,7 +601,7 @@
 		B6AAD7A81D827DD40090B220 /* Extensions-NotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6AAD7A11D827DD40090B220 /* Extensions-NotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B6B2E6A0216A940700D39A26 /* ActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B2E69F216A940700D39A26 /* ActionRow.swift */; };
 		B6B2E6A5216ACE4400D39A26 /* ActionConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B2E6A4216ACE4400D39A26 /* ActionConfigurator.swift */; };
-		B6B6B14A215B137C003DE2DD /* WatchComplicationConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B6B149215B137C003DE2DD /* WatchComplicationConfigurator.swift */; };
+		B6B6B14A215B137C003DE2DD /* ComplicationEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B6B149215B137C003DE2DD /* ComplicationEditViewController.swift */; };
 		B6B74CB6228397D100D58A68 /* WatchHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D6B1F2227A2EA009D8B90 /* WatchHelpers.swift */; };
 		B6B74CB82283983300D58A68 /* WatchComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B6B14E215B6866003DE2DD /* WatchComplication.swift */; };
 		B6B74CB92283983300D58A68 /* WatchComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B6B14E215B6866003DE2DD /* WatchComplication.swift */; };
@@ -915,6 +917,8 @@
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
+		1130F531253A1E7400F371BE /* ComplicationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationListViewController.swift; sourceTree = "<group>"; };
+		1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFamilySelectViewController.swift; sourceTree = "<group>"; };
 		11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.swift; sourceTree = "<group>"; };
 		11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.swift; sourceTree = "<group>"; };
 		113D04E124D76CD3003CE877 /* NFCReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReader.swift; sourceTree = "<group>"; };
@@ -1468,7 +1472,7 @@
 		B6B2E69F216A940700D39A26 /* ActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRow.swift; sourceTree = "<group>"; };
 		B6B2E6A1216AC21400D39A26 /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		B6B2E6A4216ACE4400D39A26 /* ActionConfigurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionConfigurator.swift; sourceTree = "<group>"; };
-		B6B6B149215B137C003DE2DD /* WatchComplicationConfigurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchComplicationConfigurator.swift; sourceTree = "<group>"; };
+		B6B6B149215B137C003DE2DD /* ComplicationEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComplicationEditViewController.swift; sourceTree = "<group>"; };
 		B6B6B14B215B1E86003DE2DD /* CLKComplication+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLKComplication+Strings.swift"; sourceTree = "<group>"; };
 		B6B6B14E215B6866003DE2DD /* WatchComplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchComplication.swift; sourceTree = "<group>"; };
 		B6C0911E2151F90300A326DC /* LocationHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationHistory.swift; sourceTree = "<group>"; };
@@ -1800,6 +1804,16 @@
 				B657A90A1CA646EB00121384 /* UI */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		1130F530253A1E6400F371BE /* AppleWatch */ = {
+			isa = PBXGroup;
+			children = (
+				1130F531253A1E7400F371BE /* ComplicationListViewController.swift */,
+				1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */,
+				B6B6B149215B137C003DE2DD /* ComplicationEditViewController.swift */,
+			);
+			path = AppleWatch;
 			sourceTree = "<group>";
 		};
 		1141182824AFA0F000E6525C /* Request&Response */ = {
@@ -2513,6 +2527,7 @@
 		B661FB6B226BCC8500E541DD /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				1130F530253A1E6400F371BE /* AppleWatch */,
 				11AD2E2B2528FDEB00FBC437 /* Observation */,
 				11AD2E1C2528FD6F00FBC437 /* Eureka */,
 				1161C01924D7633700A0E3C4 /* NFC */,
@@ -2520,7 +2535,6 @@
 				11AD2E392528FDF800FBC437 /* Connection */,
 				11AD2E542528FE1300FBC437 /* Notifications */,
 				B626AAF01D8F972800A0D225 /* SettingsDetailViewController.swift */,
-				B6B6B149215B137C003DE2DD /* WatchComplicationConfigurator.swift */,
 				B6B2E6A4216ACE4400D39A26 /* ActionConfigurator.swift */,
 				B661FB69226BBDA900E541DD /* SettingsViewController.swift */,
 				B641BC1D1E2097EF002CCBC1 /* AboutViewController.swift */,
@@ -4400,6 +4414,7 @@
 				B6617EED1CFE79AD004DEE6D /* NSURL+QueryDictionary.swift in Sources */,
 				B626AAF11D8F972800A0D225 /* SettingsDetailViewController.swift in Sources */,
 				11DE823024FAE66F00E636B8 /* UIWindow+Additions.swift in Sources */,
+				1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */,
 				B6022223226DBA3800E8DBFE /* OnboardingNavigationViewController.swift in Sources */,
 				11A71C6D24A4641600D9565F /* ZoneManagerEvent.swift in Sources */,
 				B616B29A227ED69300828165 /* InternetAddress.swift in Sources */,
@@ -4412,6 +4427,7 @@
 				11C4629424B189B100031902 /* NotificationRateLimitsAPI.swift in Sources */,
 				1161C01B24D7634300A0E3C4 /* NFCListViewController.swift in Sources */,
 				11A71C6B24A463FC00D9565F /* ZoneManagerState.swift in Sources */,
+				1130F532253A1E7400F371BE /* ComplicationListViewController.swift in Sources */,
 				B6B2E6A5216ACE4400D39A26 /* ActionConfigurator.swift in Sources */,
 				11B62DC024F2F06100E5CB55 /* UIApplication+OpenSettings.swift in Sources */,
 				115DA29324F464DC00C00BB1 /* MenuManager.swift in Sources */,
@@ -4421,7 +4437,7 @@
 				11948E8924DA5D50006F5657 /* InfoLabelRow.swift in Sources */,
 				11EFCDD824F5FCBE00314D85 /* SettingsSceneDelegate.swift in Sources */,
 				B68EDD09215F45EB00DD6B28 /* NotificationIdentifierEurekaRow.swift in Sources */,
-				B6B6B14A215B137C003DE2DD /* WatchComplicationConfigurator.swift in Sources */,
+				B6B6B14A215B137C003DE2DD /* ComplicationEditViewController.swift in Sources */,
 				B6DD5E6A24940F6F003A0154 /* OpenInFirefoxControllerSwift.swift in Sources */,
 				111858DF24CB83DF00B8CDDC /* Intents.intentdefinition in Sources */,
 				B64BB3A81E9C6551001E8B46 /* WebViewController.swift in Sources */,

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Complication).xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Complication).xcscheme
@@ -21,11 +21,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B657A8E51CA646EB00121384"
@@ -54,7 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
-      launchAutomaticallySubstyle = "32">
+      launchAutomaticallySubstyle = "32"
+      notificationPayloadFile = "Sources/Extensions/NotificationContent/Resources/TestNotifications/map_notification.apns">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Notification).xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp (Notification).xcscheme
@@ -21,11 +21,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B657A8E51CA646EB00121384"

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme
@@ -21,11 +21,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B657A8E51CA646EB00121384"
@@ -54,7 +54,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      notificationPayloadFile = "Sources/Extensions/NotificationContent/Resources/TestNotifications/map_notification.apns">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -901,3 +901,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.delete.message" = "Are you sure you want to delete this Complication? This cannot be undone.";
 "watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
 "watch.configurator.list.learn_more" = "Learn More";
+"watch.configurator.rows.display_name.title" = "Display Name";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -894,3 +894,10 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.rows.column_2_alignment.options.trailing" = "Trailing";
 "watch.configurator.preview_error.not_number" = "Expected a number but got %1$@: '%2$@'";
 "watch.configurator.preview_error.out_of_range" = "Expected a number between 0.0 and 1.0 but got %1$f";
+"watch.configurator.new.title" = "New Complication";
+"watch.configurator.new.multiple_complication_info" = "Adding another Complication for the same type as an existing one requires watchOS 7 or newer.";
+"watch.configurator.delete.button" = "Delete Complication";
+"watch.configurator.delete.title" = "Delete Complication?";
+"watch.configurator.delete.message" = "Are you sure you want to delete this Complication? This cannot be undone.";
+"watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
+"watch.configurator.list.learn_more" = "Learn More";

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -1,5 +1,5 @@
 //
-//  WatchComplicationConfigurator.swift
+//  ComplicationEditViewController.swift
 //  HomeAssistant
 //
 //  Created by Robert Trencheny on 9/25/18.
@@ -15,7 +15,7 @@ import ObjectMapper
 import ColorPickerRow
 
 // swiftlint:disable:next type_body_length
-class WatchComplicationConfigurator: FormViewController, TypedRowControllerType {
+class ComplicationEditViewController: FormViewController, TypedRowControllerType {
 
     var row: RowOf<ButtonRow>!
     /// A closure to be called when the controller disappears.
@@ -48,12 +48,17 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
         do {
             let realm = Current.realm()
             try realm.write {
-                self.config.Template = displayTemplate
-                self.config.Data = getValuesGroupedBySection()
+                if let name = (form.rowBy(tag: "name") as? TextRow)?.value, name.isEmpty == false {
+                    config.name = name
+                } else {
+                    config.name = nil
+                }
+                config.Template = displayTemplate
+                config.Data = getValuesGroupedBySection()
 
-                Current.Log.verbose("COMPLICATION \(self.config) \(self.config.Data)")
+                Current.Log.verbose("COMPLICATION \(config) \(config.Data)")
 
-                realm.add(self.config, update: .all)
+                realm.add(config, update: .all)
             }
         } catch {
             Current.Log.error(error)
@@ -62,6 +67,37 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
         HomeAssistantAPI.authenticatedAPI()?.updateComplications(passively: false).cauterize()
 
         onDismissCallback?(self)
+    }
+
+    @objc private func deleteComplication(_ sender: UIView) {
+        precondition(config.realm != nil)
+
+        let alert = UIAlertController(
+            title: L10n.Watch.Configurator.Delete.title,
+            message: L10n.Watch.Configurator.Delete.message,
+            preferredStyle: .actionSheet
+        )
+        with(alert.popoverPresentationController) {
+            $0?.sourceView = sender
+            $0?.sourceRect = sender.bounds
+        }
+        alert.addAction(UIAlertAction(
+                            title: L10n.Watch.Configurator.Delete.button, style: .destructive, handler: { [config] _ in
+            let realm = Current.realm()
+            do {
+                try realm.write {
+                    realm.delete(config)
+                }
+            } catch {
+                Current.Log.error(error)
+            }
+
+            HomeAssistantAPI.authenticatedAPI()?.updateComplications(passively: false).cauterize()
+
+            self.onDismissCallback?(self)
+        }))
+        alert.addAction(UIAlertAction(title: L10n.cancelLabel, style: .cancel, handler: nil))
+        present(alert, animated: true, completion: nil)
     }
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
@@ -103,6 +139,12 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
 
         +++ Section {
             $0.tag = "template"
+        }
+
+        <<< TextRow("name") {
+            $0.title = "Display Name"
+            $0.placeholder = self.config.Family.name
+            $0.value = self.config.name
         }
 
         <<< PushRow<ComplicationTemplate> {
@@ -372,8 +414,29 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
                 }
             }
 
-        reloadForm()
+        +++ Section { [config] section in
+            section.tag = "delete"
 
+            if config.realm == nil {
+                // don't need to show a delete button for an unpersisted complication
+                section.hidden = true
+            }
+        }
+        <<< ButtonRow {
+            $0.title = L10n.Watch.Configurator.Delete.button
+            $0.onCellSelection { [weak self] cell, _ in
+                self?.deleteComplication(cell)
+            }
+            $0.cellUpdate { cell, _ in
+                if #available(iOS 13, *) {
+                    cell.textLabel?.textColor = .systemRed
+                } else {
+                    cell.textLabel?.textColor = .red
+                }
+            }
+        }
+
+        reloadForm()
     }
 
     @objc
@@ -528,7 +591,7 @@ class WatchComplicationConfigurator: FormViewController, TypedRowControllerType 
         var textAreasDict: [String: [String: Any]] = [:]
 
         for row in self.form.allRows {
-            if row.section!.isHidden || row.section!.tag == "template" {
+            if row.section!.isHidden || row.section!.tag == "template" || row.section!.tag == "delete" {
                 continue
             }
 

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -142,7 +142,7 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
         }
 
         <<< TextRow("name") {
-            $0.title = "Display Name"
+            $0.title = L10n.Watch.Configurator.Rows.DisplayName.title
             $0.placeholder = self.config.Family.name
             $0.value = self.config.name
         }

--- a/Sources/App/Settings/AppleWatch/ComplicationFamilySelectViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationFamilySelectViewController.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Eureka
+import Shared
+
+class ComplicationFamilySelectViewController: FormViewController, RowControllerType {
+    let allowMultiple: Bool
+    let currentFamilies: Set<ComplicationGroupMember>
+
+    init(allowMultiple: Bool, currentFamilies: Set<ComplicationGroupMember>) {
+        self.allowMultiple = allowMultiple
+        self.currentFamilies = currentFamilies
+
+        if #available(iOS 13, *) {
+            super.init(style: .insetGrouped)
+        } else {
+            super.init(style: .grouped)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var onDismissCallback: ((UIViewController) -> Void)?
+
+    @objc private func cancel(_ sender: UIBarButtonItem) {
+        onDismissCallback?(self)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.Watch.Configurator.New.title
+
+        navigationItem.leftBarButtonItems = [
+            UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel(_:)))
+        ]
+
+        if !allowMultiple && !currentFamilies.isEmpty {
+            form +++ InfoLabelRow {
+                $0.title = L10n.Watch.Configurator.New.multipleComplicationInfo
+            }
+        }
+
+        form.append(contentsOf: ComplicationGroup.allCases.sorted().map { group in
+            let section = Section(header: group.name, footer: group.description)
+            section.append(contentsOf: group.members.sorted().map { family in
+                return ButtonRow {
+                    $0.title = family.shortName
+                    $0.cellStyle = .subtitle
+
+                    if !allowMultiple && currentFamilies.contains(family) {
+                        $0.disabled = true
+                    }
+
+                    $0.cellUpdate { cell, row in
+                        if #available(iOS 13, *) {
+                            cell.detailTextLabel?.textColor = row.isDisabled ? .tertiaryLabel : .secondaryLabel
+                            cell.textLabel?.textColor = row.isDisabled ? .secondaryLabel : .label
+                        } else {
+                            cell.detailTextLabel?.textColor = row.isDisabled ? .lightGray : .darkGray
+                            cell.textLabel?.textColor = row.isDisabled ? .darkGray : .black
+                        }
+                        cell.detailTextLabel?.numberOfLines = 0
+                        cell.detailTextLabel?.lineBreakMode = .byWordWrapping
+                        cell.detailTextLabel?.text = family.description
+
+                        if row.isDisabled {
+                            cell.accessibilityTraits.insert(.notEnabled)
+                        } else {
+                            cell.accessibilityTraits.remove(.notEnabled)
+                        }
+                    }
+
+                    let complication = WatchComplication()
+                    complication.Family = family
+
+                    $0.presentationMode = .show(controllerProvider: .callback {
+                        ComplicationEditViewController(config: complication)
+                    }, onDismiss: { [weak self] vc in
+                        guard let self = self else { return }
+
+                        if complication.realm == nil {
+                            // not saved
+                            self.navigationController?.popViewController(animated: true)
+                        } else {
+                            // saved
+                            self.onDismissCallback?(self)
+                        }
+                    })
+                }
+            })
+            return section
+        })
+    }
+}

--- a/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Eureka
+import Shared
+import RealmSwift
+import Communicator
+import Version
+
+class ComplicationListViewController: FormViewController {
+    init() {
+        if #available(iOS 13, *) {
+            super.init(style: .insetGrouped)
+        } else {
+            super.init(style: .grouped)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func add(_ sender: UIBarButtonItem) {
+        let editListViewController = ComplicationFamilySelectViewController(
+            allowMultiple: supportsMultipleComplications,
+            currentFamilies: Set(Current.realm().objects(WatchComplication.self).map(\.Family))
+        )
+        editListViewController.onDismissCallback = { $0.dismiss(animated: true, completion: nil) }
+        let navigationController = UINavigationController(rootViewController: editListViewController)
+        present(navigationController, animated: true, completion: nil)
+    }
+
+    private var supportsMultipleComplications: Bool {
+        guard let string = Communicator.shared.mostRecentlyReceievedContext.content["watchVersion"] as? String else {
+            return false
+        }
+        do {
+            let version = try Version(string)
+            return version >= Version(major: 7)
+        } catch {
+            Current.Log.error("failed to parse \(string), saying we're not 7+")
+            return false
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.SettingsDetails.Watch.title
+
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(title: L10n.addButtonLabel, style: .plain, target: self, action: #selector(add(_:)))
+        ]
+
+        form +++ InfoLabelRow {
+            $0.title = L10n.Watch.Configurator.List.description
+            $0.displayType = .primary
+        }
+        <<< ButtonRow {
+            $0.title = L10n.Watch.Configurator.List.learnMore
+            $0.cellUpdate { cell, _ in
+                cell.textLabel?.textAlignment = .natural
+            }
+            $0.onCellSelection { [weak self] _, _ in
+                openURLInBrowser(URL(string: "https://companion.home-assistant.io/app/ios/apple-watch")!, self)
+            }
+        }
+
+        let allComplications = Current.realm()
+            .objects(WatchComplication.self)
+
+        for group in ComplicationGroup.allCases.sorted() {
+            let familyItems = allComplications
+                .filter("rawFamily in %@", group.members.map(\.rawValue))
+                .sorted(byKeyPath: "rawFamily")
+
+            form +++ RealmSection(
+                header: group.name,
+                footer: group.description,
+                collection: AnyRealmCollection(familyItems),
+                emptyRows: [],
+                getter: { (complication: WatchComplication) -> ButtonRow in
+                    ButtonRow {
+                        $0.cellStyle = .value1
+                        $0.title = complication.Family.shortName
+                        $0.cellUpdate { cell, _ in
+                            cell.detailTextLabel?.text = complication.displayName
+                        }
+                        $0.presentationMode = .show(controllerProvider: .callback {
+                            return ComplicationEditViewController(config: complication)
+                        }, onDismiss: { vc in
+                            _ = vc.navigationController?.popViewController(animated: true)
+                        })
+                    }
+                }, didUpdate: { section, collection in
+                    let shouldBeHidden = collection.isEmpty
+                    if shouldBeHidden != section.isHidden {
+                        section.hidden = .init(booleanLiteral: shouldBeHidden)
+                        section.evaluateHidden()
+                    }
+                }
+            )
+        }
+    }
+}

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -241,61 +241,6 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     +++ Section(header: "", footer: L10n.SettingsDetails.Location.Zones.footer)
             }
 
-        case "watch":
-            self.title = L10n.SettingsDetails.Watch.title
-
-            let infoBarButtonItem = Constants.helpBarButtonItem
-
-            infoBarButtonItem.action = #selector(watchHelp)
-            infoBarButtonItem.target = self
-
-            self.navigationItem.rightBarButtonItem = infoBarButtonItem
-
-            let existingComplications = self.realm.objects(WatchComplication.self)
-
-            for group in ComplicationGroup.allCases {
-                let members = group.members
-                var header = group.name
-                if members.count == 1 {
-                    header = ""
-                }
-                self.form +++ Section(header: header, footer: group.description)
-
-                for member in members {
-                    let config: WatchComplication
-
-                    if let persistedConfig = existingComplications.filter(
-                        NSPredicate(format: "rawFamily == %@", member.rawValue)
-                    ).first {
-                        config = persistedConfig
-                    } else {
-                        config = WatchComplication()
-                        config.Family = member
-                    }
-
-                    self.form.last!
-                        <<< ButtonRow {
-                            $0.cellStyle = .subtitle
-                            $0.title = member.shortName
-                            $0.presentationMode = .show(controllerProvider: .callback {
-                                return WatchComplicationConfigurator(config: config)
-                            }, onDismiss: { vc in
-                                _ = vc.navigationController?.popViewController(animated: true)
-                            })
-                        }.cellUpdate({ (cell, _) in
-                            if #available(iOS 13, *) {
-                                cell.detailTextLabel?.textColor = .secondaryLabel
-                            } else {
-                                cell.detailTextLabel?.textColor = .darkGray
-                            }
-                            cell.detailTextLabel?.text = member.description
-                            cell.detailTextLabel?.numberOfLines = 0
-                            cell.detailTextLabel?.lineBreakMode = .byWordWrapping
-                        })
-                }
-
-            }
-
         case "actions":
             self.title = L10n.SettingsDetails.Actions.title
             let actions = realm.objects(Action.self)

--- a/Sources/App/Settings/SettingsViewController.swift
+++ b/Sources/App/Settings/SettingsViewController.swift
@@ -140,11 +140,9 @@ class SettingsViewController: FormViewController {
             $0.hidden = .isCatalyst
             $0.title = L10n.Settings.DetailsSection.WatchRow.title
             $0.presentationMode = .show(controllerProvider: ControllerProvider.callback {
-                let view = SettingsDetailViewController()
-                view.detailGroup = "watch"
-                return view
+                return ComplicationListViewController()
             }, onDismiss: { _ in
-                
+
             })
         }
 

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -24,6 +24,8 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
             // so we can only access the value if it's a valid one. otherwise, fall back to old matching behavior.
             model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: complication.identifier)
         } else {
+            // we migrate pre-existing complications, and when still using watchOS 6 create new ones,
+            // with the family as the identifier, so we can rely on this code path for older OS and older complications
             let matchedFamily = ComplicationGroupMember(family: complication.family)
             model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: matchedFamily.rawValue)
         }

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -16,70 +16,74 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
     // https://github.com/LoopKit/Loop/issues/816
     // https://crunchybagel.com/detecting-which-complication-was-tapped/
 
-    // MARK: - Timeline Configuration
+    private func template(for complication: CLKComplication) -> CLKComplicationTemplate? {
+        let model: WatchComplication?
 
-    func getSupportedTimeTravelDirections(for complication: CLKComplication, withHandler
-        handler: @escaping (CLKComplicationTimeTravelDirections) -> Void) {
-        handler([])
+        if #available(watchOS 7, *), complication.identifier != CLKDefaultComplicationIdentifier {
+            // existing complications that were configured pre-7 have no identifier set
+            // so we can only access the value if it's a valid one. otherwise, fall back to old matching behavior.
+            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: complication.identifier)
+        } else {
+            let matchedFamily = ComplicationGroupMember(family: complication.family)
+            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: matchedFamily.rawValue)
+        }
+
+        return model?.CLKComplicationTemplate(family: complication.family)
     }
 
-    func getPrivacyBehavior(for complication: CLKComplication,
-                            withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void) {
+    // MARK: - Timeline Configuration
+
+    func getPrivacyBehavior(
+        for complication: CLKComplication,
+        withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void
+    ) {
         handler(.showOnLockScreen)
     }
 
     // MARK: - Timeline Population
 
-    func getCurrentTimelineEntry(for complication: CLKComplication,
-                                 withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
-        // Call the handler with the current timeline entry
-
+    func getCurrentTimelineEntry(
+        for complication: CLKComplication,
+        withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void
+    ) {
         Iconic.registerMaterialDesignIcons()
 
-        Current.Log.verbose("Providing template for \(complication.family.description)")
-
-        let matchedFamily = ComplicationGroupMember(family: complication.family)
-
-        guard let date = Date().encodedForComplication(family: complication.family) else {
-            Current.Log.warning("Unable to generate complication family specific date, returning family specific error")
-            handler(CLKComplicationTimelineEntry(date: Date(), complicationTemplate: matchedFamily.errorTemplate!))
-            return
+        Current.Log.verbose {
+            if #available(watchOS 7, *) {
+                return "Providing template for \(complication.identifier) family \(complication.family.description)"
+            } else {
+                return "Providing template for \(complication.family.description)"
+            }
         }
 
-        let fallback = CLKComplicationTimelineEntry(date: date, complicationTemplate: matchedFamily.errorTemplate!)
+        let template: CLKComplicationTemplate
 
-        let pred = NSPredicate(format: "rawFamily == %@", matchedFamily.rawValue)
-        guard let config = Realm.live().objects(WatchComplication.self).filter(pred).first else {
-            // swiftlint:disable:next line_length
-            Current.Log.warning("No configured complication found for \(matchedFamily.rawValue), returning family specific error")
-            handler(fallback)
-            return
+        if let fromComplication = self.template(for: complication) {
+            template = fromComplication
+        } else {
+            Current.Log.error("failed to get template, providing error")
+            template = ComplicationGroupMember(family: complication.family).errorTemplate
         }
 
-        Current.Log.verbose("complicationObjects \(config)")
-
-        guard let template = config.CLKComplicationTemplate(family: complication.family) else {
-            // swiftlint:disable:next line_length
-            Current.Log.warning("Unable to generate template for \(matchedFamily.rawValue), returning family specific error")
-            handler(fallback)
-            return
-        }
-
-        Current.Log.verbose("Generated template for \(complication.family.rawValue), \(template)")
-
-        handler(CLKComplicationTimelineEntry(date: date, complicationTemplate: template))
+        let date = Date().encodedForComplication(family: complication.family) ?? Date()
+        handler(.init(date: date, complicationTemplate: template))
     }
 
     // MARK: - Placeholder Templates
 
-    func getLocalizableSampleTemplate(for complication: CLKComplication,
-                                      withHandler handler: @escaping (CLKComplicationTemplate?) -> Void) {
-        // This method will be called once per supported complication, and the results will be cached
-
-        // Current.Log.verbose("Get sample template!", ComplicationGroupMember(family: complication.family))
-        handler(ComplicationGroupMember(family: complication.family).errorTemplate)
+    func getLocalizableSampleTemplate(
+        for complication: CLKComplication,
+        withHandler handler: @escaping (CLKComplicationTemplate?) -> Void
+    ) {
+        handler(template(for: complication))
     }
 
+    // MARK: - Complication Descriptors
+
+    @available(watchOS 7.0, *)
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        handler(Current.realm().objects(WatchComplication.self).map(\.complicationDescriptor))
+    }
 }
 
 extension CLKComplicationFamily {

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -17,7 +17,7 @@ import ClockKit
 
 // swiftlint:disable:next type_body_length
 public class WatchComplication: Object, ImmutableMappable {
-    @objc dynamic var identifier: String = UUID().uuidString
+    @objc public dynamic var identifier: String = UUID().uuidString
 
     @objc private dynamic var rawFamily: String = ""
     public var Family: ComplicationGroupMember {

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -17,6 +17,8 @@ import ClockKit
 
 // swiftlint:disable:next type_body_length
 public class WatchComplication: Object, ImmutableMappable {
+    @objc dynamic var identifier: String = UUID().uuidString
+
     @objc private dynamic var rawFamily: String = ""
     public var Family: ComplicationGroupMember {
         get {
@@ -68,8 +70,13 @@ public class WatchComplication: Object, ImmutableMappable {
     @objc fileprivate dynamic var complicationData: Data?
     @objc dynamic public var CreatedAt = Date()
 
+    @objc dynamic public var name: String?
+    public var displayName: String {
+        name ?? Template.style
+    }
+
     override public static func primaryKey() -> String? {
-        return "rawFamily"
+        return "identifier"
     }
 
     override public static func ignoredProperties() -> [String] {
@@ -84,16 +91,20 @@ public class WatchComplication: Object, ImmutableMappable {
         // this is used for watch<->app syncing
         self.CreatedAt = try map.value("CreatedAt", using: DateTransform())
         super.init()
-        self.Template  = try map.value("Template")
-        self.Data      = try map.value("Data")
-        self.Family    = try map.value("Family")
+        self.Template = try map.value("Template")
+        self.Data = try map.value("Data")
+        self.Family = try map.value("Family")
+        self.identifier = try map.value("identifier")
+        self.name = try map.value("name")
     }
 
     public func mapping(map: Map) {
-        Template  >>> map["Template"]
-        Data      >>> map["Data"]
+        Template >>> map["Template"]
+        Data >>> map["Data"]
         CreatedAt >>> (map["CreatedAt"], DateTransform())
-        Family    >>> map["Family"]
+        Family >>> map["Family"]
+        identifier >>> map["identifier"]
+        name >>> map["name"]
     }
 
     enum RenderedValueType: Hashable {
@@ -181,6 +192,17 @@ public class WatchComplication: Object, ImmutableMappable {
     }
 
     #if os(watchOS)
+
+    @available(watchOS 7.0, *)
+    public var complicationDescriptor: CLKComplicationDescriptor {
+        CLKComplicationDescriptor(
+            identifier: identifier,
+            displayName: displayName,
+            supportedFamilies: [
+                Family.family
+            ]
+        )
+    }
 
     public var textDataProviders: [String: CLKTextProvider] {
         var providers: [String: CLKTextProvider] = [String: CLKTextProvider]()

--- a/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
+++ b/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
@@ -14,12 +14,16 @@ import ClockKit
 #endif
 
 // swiftlint:disable cyclomatic_complexity type_body_length file_length
-public enum ComplicationGroup: String {
+public enum ComplicationGroup: String, Comparable {
     case circularSmall
     case extraLarge
     case graphic
     case modular
     case utilitarian
+
+    public static func < (lhs: ComplicationGroup, rhs: ComplicationGroup) -> Bool {
+        lhs.name < rhs.name
+    }
 
     public var name: String {
         switch self {
@@ -71,7 +75,7 @@ public enum ComplicationGroup: String {
 
 extension ComplicationGroup: CaseIterable {}
 
-public enum ComplicationGroupMember: String {
+public enum ComplicationGroupMember: String, Comparable {
     case circularSmall
     case extraLarge
     case graphicBezel
@@ -83,6 +87,10 @@ public enum ComplicationGroupMember: String {
     case utilitarianLarge
     case utilitarianSmall
     case utilitarianSmallFlat
+
+    public static func < (lhs: ComplicationGroupMember, rhs: ComplicationGroupMember) -> Bool {
+        lhs.name < rhs.name
+    }
 
     public init(name: String) {
         switch name {
@@ -332,9 +340,7 @@ public enum ComplicationGroupMember: String {
     }
 
     #if os(watchOS)
-    public var errorTemplate: CLKComplicationTemplate? {
-        MaterialDesignIcons.register()
-
+    public var errorTemplate: CLKComplicationTemplate {
         let logoImage = UIImage(named: "RoundLogo")!
         let templateImage = UIImage(named: "TemplateLogo")!
         let hassColor = UIColor(red: 0.25, green: 0.74, blue: 0.96, alpha: 1.0)

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -77,7 +77,7 @@ extension Realm {
         // 12 - 2020-08-16 v2020.6 (mdi upgrade/migration to 5.x)
         let config = Realm.Configuration(
             fileURL: storeURL,
-            schemaVersion: 12,
+            schemaVersion: 13,
             migrationBlock: { migration, oldVersion in
                 Current.Log.info("migrating from \(oldVersion)")
                 if oldVersion < 9 {
@@ -133,6 +133,16 @@ extension Realm {
                                 newObject?[dataKey] = newData
                             }
                         }
+                    }
+                }
+
+                if oldVersion < 13 {
+                    migration.enumerateObjects(ofType: WatchComplication.className()) { _, newObject in
+                        // initially creating these with their old family name
+                        // this is so we migrate them to have identical names on both watch and phone, independently
+                        // since future objects are created with a UUID-based identifier, this won't be an issue
+                        // we also need to reference them by family for complications configured prior to watchOS 7
+                        newObject!["identifier"] = newObject!["rawFamily"]
                     }
                 }
             },

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2269,6 +2269,10 @@ public enum L10n {
             public static var trailing: String { return L10n.tr("Localizable", "watch.configurator.rows.column_2_alignment.options.trailing") }
           }
         }
+        public enum DisplayName {
+          /// Display Name
+          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.display_name.title") }
+        }
         public enum FractionalValue {
           /// Fractional value
           public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.fractional_value.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2224,6 +2224,26 @@ public enum L10n {
 
   public enum Watch {
     public enum Configurator {
+      public enum Delete {
+        /// Delete Complication
+        public static var button: String { return L10n.tr("Localizable", "watch.configurator.delete.button") }
+        /// Are you sure you want to delete this Complication? This cannot be undone.
+        public static var message: String { return L10n.tr("Localizable", "watch.configurator.delete.message") }
+        /// Delete Complication?
+        public static var title: String { return L10n.tr("Localizable", "watch.configurator.delete.title") }
+      }
+      public enum List {
+        /// Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.
+        public static var description: String { return L10n.tr("Localizable", "watch.configurator.list.description") }
+        /// Learn More
+        public static var learnMore: String { return L10n.tr("Localizable", "watch.configurator.list.learn_more") }
+      }
+      public enum New {
+        /// Adding another Complication for the same type as an existing one requires watchOS 7 or newer.
+        public static var multipleComplicationInfo: String { return L10n.tr("Localizable", "watch.configurator.new.multiple_complication_info") }
+        /// New Complication
+        public static var title: String { return L10n.tr("Localizable", "watch.configurator.new.title") }
+      }
       public enum PreviewError {
         /// Expected a number but got %1$@: '%2$@'
         public static func notNumber(_ p1: Any, _ p2: Any) -> String {

--- a/Tests/Shared/Webhook/WebhookResponseUpdateComplications.test.swift
+++ b/Tests/Shared/Webhook/WebhookResponseUpdateComplications.test.swift
@@ -47,6 +47,7 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
     func testComplicationsWithPreRendered() {
         let complications = [
             with(FakeWatchComplication()) {
+                $0.identifier = "c1"
                 $0.Template = .ExtraLargeColumnsText
                 $0.resultRawRendered = [
                     "fwc1k1": "fwc1v1",
@@ -54,10 +55,12 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
                 ]
             },
             with(FakeWatchComplication()) {
+                $0.identifier = "c2"
                 $0.Template = .CircularSmallRingText
                 $0.resultRawRendered = [:]
             },
             with(FakeWatchComplication()) {
+                $0.identifier = "c3"
                 $0.Template = .GraphicBezelCircularText
                 $0.resultRawRendered = [
                     "fwc3k1": "fwc3v1"
@@ -69,13 +72,13 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
         XCTAssertEqual(request?.type, "render_template")
 
         let expected: [String: [String: String]] = [
-            complications[0].Template.rawValue + "|fwc1k1": [
+            "c1|fwc1k1": [
                 "template": "fwc1v1"
             ],
-            complications[0].Template.rawValue + "|fwc1k2": [
+            "c1|fwc1k2": [
                 "template": "fwc1v2"
             ],
-            complications[2].Template.rawValue + "|fwc3k1": [
+            "c3|fwc3k1": [
                 "template": "fwc3v1"
             ]
         ]
@@ -86,6 +89,7 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
     func testResponseUpdatesComplication() throws {
         let complications = [
             with(FakeWatchComplication()) {
+                $0.identifier = "c1"
                 $0.Template = .ExtraLargeColumnsText
                 $0.Family = .extraLarge
                 $0.resultRawRendered = [
@@ -94,11 +98,13 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
                 ]
             },
             with(FakeWatchComplication()) {
+                $0.identifier = "c2"
                 $0.Template = .CircularSmallRingText
                 $0.Family = .circularSmall
                 $0.resultRawRendered = [:]
             },
             with(FakeWatchComplication()) {
+                $0.identifier = "c3"
                 $0.Template = .GraphicBezelCircularText
                 $0.Family = .graphicBezel
                 $0.resultRawRendered = [
@@ -115,9 +121,9 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
 
         let request = WebhookResponseUpdateComplications.request(for: Set(complications))!
         let result: [String: Any] = [
-            complications[0].Template.rawValue + "|fwc1k1": "rendered_fwc1v1",
-            complications[0].Template.rawValue + "|fwc1k2": "rendered_fwc1v2",
-            complications[2].Template.rawValue + "|fwc3k1": 3,
+            "c1|fwc1k1": "rendered_fwc1v1",
+            "c1|fwc1k2": "rendered_fwc1v2",
+            "c3|fwc3k1": 3,
         ]
 
         let expectation = self.expectation(description: "result")
@@ -127,8 +133,8 @@ class WebhookResponseUpdateComplicationsTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 10)
 
-        let complication0Updates = FakeWatchComplication.rawRenderedUpdates[complications[0].Template.rawValue]
-        let complication2Updates = FakeWatchComplication.rawRenderedUpdates[complications[2].Template.rawValue]
+        let complication0Updates = FakeWatchComplication.rawRenderedUpdates["c1"]
+        let complication2Updates = FakeWatchComplication.rawRenderedUpdates["c3"]
 
         XCTAssertEqual(
             complication0Updates?["fwc1k1"] as? String,
@@ -161,6 +167,6 @@ class FakeWatchComplication: WatchComplication {
     static var rawRenderedUpdates: [String: [String: Any]] = [:]
 
     override func updateRawRendered(from response: [String : Any]) {
-        Self.rawRenderedUpdates[Template.rawValue] = response
+        Self.rawRenderedUpdates[identifier] = response
     }
 }


### PR DESCRIPTION
This allows for configuring more than 1 e.g. Modular Small at a time. This requires watchOS 7; for releases before watchOS 7 we do not allow a secondary template to be created. This could be improved by allowing swapping between one of the multiple for watchOS 6 and earlier, but I didn't implement this.

- Adds a "Display Name" to Complications. This is optional and falls back to the template type. This is primarily to differentiate complications; the underlying unique ID is just a UUID.
- Enable previews of complications, which is used when selecting them. This is a stripped-down version of the items in the template, usually just an icon provider or one of the text providers. This is largely easier now since we're now requesting templates for all complications, even those not actively visible.

This also changes the flow when setting up initially. Instead of a list of families to choose from at the start, the user must tap the 'Add' button and pick one from there.

Fixes #839.

![Image](https://user-images.githubusercontent.com/74188/96321122-28115600-0fc9-11eb-8db9-81b40ac61d1d.png)
![Image](https://user-images.githubusercontent.com/74188/96320783-357a1080-0fc8-11eb-9c70-e40f610ab969.png)
