### PR TITLE
Handle background session completion before Extension/App Delegate

### DIFF
--- a/Tests/Shared/Webhook/WebhookManager.test.swift
+++ b/Tests/Shared/Webhook/WebhookManager.test.swift
@@ -60,6 +60,18 @@ class WebhookManagerTests: XCTestCase {
         XCTAssertNoThrow(try hang(didInvokePromise))
     }
 
+    func testBackgroundHandlingCallsCompletionHandlerWhenInvokedBefore() {
+        let (didInvokePromise, didInvokeSeal) = Promise<Void>.pending()
+
+        sendDidFinishEvents(for: manager.currentBackgroundSessionInfo)
+        
+        manager.handleBackground(for: manager.currentBackgroundSessionInfo.identifier, completionHandler: {
+            didInvokeSeal.fulfill(())
+        })
+
+        XCTAssertNoThrow(try hang(didInvokePromise))
+    }
+
     func testUnbalancedBackgroundHandlingDoesntCrash() {
         // not the best test: this will crash the test execution if it fails
         sendDidFinishEvents(for: manager.currentBackgroundSessionInfo)


### PR DESCRIPTION
(Likely; this is really hard to test) fixes a crash in the WatchApp when it's already in memory and the system wakes it to handle a background session completion event. What is happening is we're being killed after 25 seconds because we haven't completed the `WKURLSessionRefreshBackgroundTask`.

What I think is happening is that the background session processes and completes before the background task sets up the completion handlers, since the delegate method ends up jumping to the delegate dispatch queue of the background session.