### PR TITLE
Fix crash caused by background connection status change

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -114,7 +114,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         ] {
             NotificationCenter.default.addObserver(
                 self,
-                selector: #selector(loadActiveURLIfNeeded),
+                selector: #selector(connectionInfoDidChange),
                 name: name,
                 object: nil
             )
@@ -489,6 +489,12 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         alertController.popoverPresentationController?.sourceView = self.webView
         present(alertController, animated: true, completion: nil)
+    }
+
+    @objc private func connectionInfoDidChange() {
+        DispatchQueue.main.async { [self] in
+            loadActiveURLIfNeeded()
+        }
     }
 
     @objc private func loadActiveURLIfNeeded() {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -18,7 +18,9 @@ public class SettingsStore {
     let keychain = Constants.Keychain
     let prefs = UserDefaults(suiteName: Constants.AppGroupID)!
 
+    /// This will only be posted on the main thread
     public static let webViewRelatedSettingDidChange: Notification.Name = .init("webViewRelatedSettingDidChange")
+    /// This may be posted on any thread
     public static let connectionInfoDidChange: Notification.Name = .init("connectionInfoDidChange")
 
     public var tokenInfo: TokenInfo? {
@@ -268,6 +270,7 @@ public class SettingsStore {
             }
         }
         set {
+            precondition(Thread.isMainThread)
             prefs.set(newValue.zoom, forKey: "page_zoom")
             NotificationCenter.default.post(name: Self.webViewRelatedSettingDidChange, object: nil)
         }


### PR DESCRIPTION
Fixes #1201. WebKit (unsurprisingly) really does not like being told to execute JavaScript off the main thread.