### PR TITLE
Add device info to lifecycle events

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -39,8 +39,14 @@ class LifecycleManager {
         )
     }
 
+    private class var sharedEventDeviceInfo: [String: String] { [
+        "sourceDevicePermanentID": Constants.PermanentID,
+        "sourceDeviceName": Current.settingsStore.overrideDeviceName ?? Current.device.deviceName(),
+        "sourceDeviceID": Current.settingsStore.deviceID
+    ] }
+
     func didFinishLaunching() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.finished_launching", eventData: [:])
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.finished_launching", eventData: sharedEventDeviceInfo)
 
         #if !targetEnvironment(macCatalyst)
         Lokalise.shared.checkForUpdates { (updated, error) in
@@ -56,7 +62,7 @@ class LifecycleManager {
     }
 
     @objc private func didEnterBackground() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.entered_background", eventData: [:])
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.entered_background", eventData: sharedEventDeviceInfo)
         invalidatePeriodicUpdateTimer()
     }
 
@@ -76,7 +82,7 @@ class LifecycleManager {
     }
 
     @objc private func didBecomeActive() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.became_active", eventData: [:])
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.became_active", eventData: sharedEventDeviceInfo)
     }
 
     private func invalidatePeriodicUpdateTimer() {

--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -39,14 +39,11 @@ class LifecycleManager {
         )
     }
 
-    private class var sharedEventDeviceInfo: [String: String] { [
-        "sourceDevicePermanentID": Constants.PermanentID,
-        "sourceDeviceName": Current.settingsStore.overrideDeviceName ?? Current.device.deviceName(),
-        "sourceDeviceID": Current.settingsStore.deviceID
-    ] }
-
     func didFinishLaunching() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.finished_launching", eventData: sharedEventDeviceInfo)
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(
+            eventType: "ios.finished_launching",
+            eventData: HomeAssistantAPI.sharedEventDeviceInfo
+        )
 
         #if !targetEnvironment(macCatalyst)
         Lokalise.shared.checkForUpdates { (updated, error) in
@@ -62,7 +59,10 @@ class LifecycleManager {
     }
 
     @objc private func didEnterBackground() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.entered_background", eventData: sharedEventDeviceInfo)
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(
+            eventType: "ios.entered_background",
+            eventData: HomeAssistantAPI.sharedEventDeviceInfo
+        )
         invalidatePeriodicUpdateTimer()
     }
 
@@ -82,7 +82,10 @@ class LifecycleManager {
     }
 
     @objc private func didBecomeActive() {
-        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(eventType: "ios.became_active", eventData: sharedEventDeviceInfo)
+        _ = HomeAssistantAPI.authenticatedAPI()?.CreateEvent(
+            eventType: "ios.became_active",
+            eventData: HomeAssistantAPI.sharedEventDeviceInfo
+        )
     }
 
     private func invalidatePeriodicUpdateTimer() {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -602,7 +602,7 @@ public class HomeAssistantAPI {
         }
     }
 
-    private class var sharedEventDeviceInfo: [String: String] { [
+    public class var sharedEventDeviceInfo: [String: String] { [
         "sourceDevicePermanentID": Constants.PermanentID,
         "sourceDeviceName": Current.settingsStore.overrideDeviceName ?? Current.device.deviceName(),
         "sourceDeviceID": Current.settingsStore.deviceID


### PR DESCRIPTION
We provide three lifecycle events communicated back to HA, `ios.finsihed_launching`, `ios_entered_background` and `ios.became_active`. One of the most obvious use cases, IMHO, of `ios.became_active` is to reset/clear the app badge. However, we currently provide any clear data in the event payload about the source (e.g. device name) of the event. This PR provides the same basic device info that we include in the action events. For sake of a single source, the definition of dictionary in `HomeAssistantAPI` is changed to public rather than duplicating elsewhere. Tested against current dev