### PR TITLE
Update the Watch when connectivity changes

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -452,6 +452,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupWatchCommunicator() {
+        _ = NotificationCenter.default.addObserver(
+            forName: SettingsStore.connectionInfoDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            _ = HomeAssistantAPI.SyncWatchContext()
+        }
+
         Communicator.shared.activationStateChangedObservers.add { state in
             Current.Log.verbose("Activation state changed: \(state)")
             _ = HomeAssistantAPI.SyncWatchContext()


### PR DESCRIPTION
For example, going from external to internal or vice-versa should update the context flag `isOnInternalNetwork`. We're likely still going to have cases where the Watch is not correct on which connection type to use, but hopefully location services causes the app to inform it most of the time.