### PR TITLE
Fix a crash when lots of intent handlers are requested at once

### DIFF
--- a/Sources/Extensions/Intents/IntentHandler.swift
+++ b/Sources/Extensions/Intents/IntentHandler.swift
@@ -10,13 +10,15 @@ import Intents
 import Shared
 
 class IntentHandler: INExtension {
+    private let updateTokenQueue: DispatchQueue = .init(label: "update-token")
 
     override func handler(for intent: INIntent) -> Any {
-        // This is the default implementation.  If you want different objects to handle different intents,
-        // you can override this and return the handler you want for that particular intent.
-
-        if let tokenInfo = Current.settingsStore.tokenInfo {
-            Current.tokenManager = TokenManager(tokenInfo: tokenInfo)
+        // multiple intent handlers can be invoked at once. we want to make sure this is up-to-date, but
+        // it causes double-frees if it's mutating the non-atomic property in concurrently.
+        updateTokenQueue.sync {
+            if let tokenInfo = Current.settingsStore.tokenInfo {
+                Current.tokenManager = TokenManager(tokenInfo: tokenInfo)
+            }
         }
 
         let handler: Any = {


### PR DESCRIPTION
Reproducing this is pretty easy: add a Shortcut for e.g. call service and spam tap the placeholder while the intent is launching; it'll crash.