### PR TITLE
Fix crash when deleting some Complications

### DIFF
--- a/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
@@ -82,8 +82,9 @@ class ComplicationListViewController: FormViewController {
                     ButtonRow {
                         $0.cellStyle = .value1
                         $0.title = complication.Family.shortName
-                        $0.cellUpdate { cell, _ in
-                            cell.detailTextLabel?.text = complication.displayName
+                        $0.value = complication.displayName
+                        $0.cellUpdate { cell, row in
+                            cell.detailTextLabel?.text = row.value
                         }
                         $0.presentationMode = .show(controllerProvider: .callback {
                             return ComplicationEditViewController(config: complication)


### PR DESCRIPTION
Accessing the .displayName can occur during the deletion from e.g. UIView events causing a cell to update. We reload the cell on update, anyway, so all we really need to do is set the value initially.