### PR TITLE
Resolve minor debug logging and try! crashes

### DIFF
--- a/Sources/App/ZoneManager/ZoneManagerEvent.swift
+++ b/Sources/App/ZoneManager/ZoneManagerEvent.swift
@@ -49,7 +49,11 @@ struct ZoneManagerEvent: Equatable, CustomStringConvertible {
         attributes.append(String(describing: eventType))
 
         if let zone = associatedZone {
-            attributes.append(zone.ID)
+            if zone.isInvalidated {
+                attributes.append("zone deleted")
+            } else {
+                attributes.append(zone.ID)
+            }
         }
 
         return "ZoneManagerEvent(\(attributes.joined(separator: ", ")))"

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -529,10 +529,9 @@ public class HomeAssistantAPI {
             } else {
                 throw HomeAssistantAPI.APIError.updateNotPossible
             }
-        }.map { payload -> [String: Any] in
+        }.get { payload in
             let realm = Current.realm()
-            // swiftlint:disable:next force_try
-            try! realm.write {
+            try realm.write {
                 var jsonPayload = "{\"missing\": \"payload\"}"
                 if let p = payload.toJSONString(prettyPrint: false) {
                     jsonPayload = p
@@ -541,7 +540,7 @@ public class HomeAssistantAPI {
                 realm.add(LocationHistoryEntry(updateType: updateType, location: payload.cllocation,
                                                zone: zone, payload: jsonPayload))
             }
-
+        }.map { payload -> [String: Any] in
             let payloadDict: [String: Any] = Mapper<WebhookUpdateLocation>().toJSON(payload)
             Current.Log.info("Location update payload: \(payloadDict)")
             return payloadDict

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -180,21 +180,23 @@ public class Environment {
         // Create a logger object with no destinations
         let log = XCGLogger(identifier: "advancedLogger", includeDefaultDestinations: false)
 
-        // Create a destination for the system console log (via NSLog)
-        let systemDestination = AppleSystemLogDestination(identifier: "advancedLogger.systemDestination")
+        #if DEBUG
+        log.dateFormatter = with(DateFormatter()) {
+            $0.dateFormat = "HH:mm:ss.SSS"
+            $0.locale = Locale.current
+        }
 
-        // Optionally set some configuration options
-        systemDestination.outputLevel = .verbose
-        systemDestination.showLogIdentifier = false
-        systemDestination.showFunctionName = true
-        systemDestination.showThreadName = true
-        systemDestination.showLevel = true
-        systemDestination.showFileName = true
-        systemDestination.showLineNumber = true
-        systemDestination.showDate = true
-
-        // Add the destination to the logger
-        log.add(destination: systemDestination)
+        log.add(destination: with(ConsoleDestination()) {
+            $0.outputLevel = .verbose
+            $0.showLogIdentifier = false
+            $0.showFunctionName = true
+            $0.showThreadName = true
+            $0.showLevel = true
+            $0.showFileName = true
+            $0.showLineNumber = true
+            $0.showDate = true
+        })
+        #endif
 
         let logPath = Constants.LogsDirectory.appendingPathComponent("log.txt", isDirectory: false)
 

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -200,8 +200,7 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
 
         if let clErr = error as? CLError {
             let realm = Current.realm()
-            // swiftlint:disable:next force_try
-            try! realm.write {
+            try? realm.write {
                 let locErr = LocationError(err: clErr)
                 realm.add(locErr)
             }


### PR DESCRIPTION
- NSLog is dangerous in production; it crashes randomly on iOS 13. It also truncates the logs to a certain length, unlike print(), so swap to that one.
- This also changes a few try! into not-force-unwrapping, one or two of which have fired into the crash reporter.
- Avoids logging about deleted zones while they are being deleted. Likely related to the infinite-loop zone (#1136) but definitely happens quite a bit right now.
