### PR TITLE
Fix crash in connectivity sensor on iOS 14.0 (and not 14.1+)

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
@@ -178,7 +178,8 @@ public class ConnectivitySensor: SensorProvider {
         case CTRadioAccessTechnologyLTE:
             return "Long-Term Evolution (LTE)"
         default:
-            if #available(iOS 14, *) {
+            if #available(iOS 14.1, *) {
+                // although these are declared available in 14.0, they will crash on use before 14.1
                 switch radioTech {
                 case CTRadioAccessTechnologyNR:
                     return "5G"

--- a/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
+++ b/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
@@ -69,7 +69,8 @@ public enum NetworkType: Int, CaseIterable {
 
     #if !targetEnvironment(macCatalyst)
     init(_ radioTech: String) {
-        if #available(iOS 14, *), [CTRadioAccessTechnologyNR, CTRadioAccessTechnologyNRNSA].contains(radioTech) {
+        if #available(iOS 14.1, *), [CTRadioAccessTechnologyNR, CTRadioAccessTechnologyNRNSA].contains(radioTech) {
+            // although these are declared available in 14.0, they will crash on use before 14.1
             self = .wwan5g
             return
         }


### PR DESCRIPTION
The 5G connectivity defines are declared available in iOS 14.0+ but evaluate to nil or whatever on iOS 14.0.