### PR TITLE
Allow hiding complications when watch is locked

### DIFF
--- a/Sources/App/Resources/en-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/en-GB.lproj/Localizable.strings
@@ -902,4 +902,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
 "watch.configurator.list.learn_more" = "Learn More";
 "watch.configurator.rows.display_name.title" = "Display Name";
-"watch.configurator.rows.is_private.title" = "Hide When Locked";
+"watch.configurator.rows.is_public.title" = "Show When Locked";

--- a/Sources/App/Resources/en-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/en-GB.lproj/Localizable.strings
@@ -902,3 +902,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
 "watch.configurator.list.learn_more" = "Learn More";
 "watch.configurator.rows.display_name.title" = "Display Name";
+"watch.configurator.rows.is_private.title" = "Hide When Locked";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -902,4 +902,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
 "watch.configurator.list.learn_more" = "Learn More";
 "watch.configurator.rows.display_name.title" = "Display Name";
-"watch.configurator.rows.is_private.title" = "Hide When Locked";
+"watch.configurator.rows.is_public.title" = "Show When Locked";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -902,3 +902,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.list.description" = "Configure a new Complication using the Add button. Once saved, you can choose it on your Apple Watch or in the Watch app.";
 "watch.configurator.list.learn_more" = "Learn More";
 "watch.configurator.rows.display_name.title" = "Display Name";
+"watch.configurator.rows.is_private.title" = "Hide When Locked";

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -147,6 +147,11 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
             $0.value = self.config.name
         }
 
+        <<< SwitchRow {
+            $0.title = L10n.Watch.Configurator.Rows.IsPrivate.title
+            $0.value = self.config.IsPrivate
+        }
+
         <<< PushRow<ComplicationTemplate> {
             $0.tag = "template"
             $0.title = L10n.Watch.Configurator.Rows.Template.title

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -147,11 +147,6 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
             $0.value = self.config.name
         }
 
-        <<< SwitchRow {
-            $0.title = L10n.Watch.Configurator.Rows.IsPrivate.title
-            $0.value = self.config.IsPrivate
-        }
-
         <<< PushRow<ComplicationTemplate> {
             $0.tag = "template"
             $0.title = L10n.Watch.Configurator.Rows.Template.title
@@ -187,6 +182,11 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
             cell.detailTextLabel?.text = row.value?.style
         }.cellSetup { cell, row in
             cell.detailTextLabel?.text = row.value?.style
+        }
+
+        <<< SwitchRow("IsPrivate") {
+            $0.title = L10n.Watch.Configurator.Rows.IsPrivate.title
+            $0.value = self.config.IsPrivate
         }
 
         self.form.append(contentsOf: textSections)

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -53,6 +53,11 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
                 } else {
                     config.name = nil
                 }
+                if let IsPrivate = (form.rowBy(tag: "IsPrivate") as? SwitchRow)?.value {
+                    config.IsPrivate = IsPrivate
+                } else {
+                    config.IsPrivate = false
+                }
                 config.Template = displayTemplate
                 config.Data = getValuesGroupedBySection()
 

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -53,10 +53,10 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
                 } else {
                     config.name = nil
                 }
-                if let IsPrivate = (form.rowBy(tag: "IsPrivate") as? SwitchRow)?.value {
-                    config.IsPrivate = IsPrivate
+                if let IsPublic = (form.rowBy(tag: "IsPublic") as? SwitchRow)?.value {
+                    config.IsPublic = IsPublic
                 } else {
-                    config.IsPrivate = false
+                    config.IsPublic = true
                 }
                 config.Template = displayTemplate
                 config.Data = getValuesGroupedBySection()
@@ -189,9 +189,9 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
             cell.detailTextLabel?.text = row.value?.style
         }
 
-        <<< SwitchRow("IsPrivate") {
-            $0.title = L10n.Watch.Configurator.Rows.IsPrivate.title
-            $0.value = self.config.IsPrivate
+        <<< SwitchRow("IsPublic") {
+            $0.title = L10n.Watch.Configurator.Rows.IsPublic.title
+            $0.value = self.config.IsPublic
         }
 
         self.form.append(contentsOf: textSections)

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -33,23 +33,14 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         }
 
         return model
-    } 
+    }
 
     private func template(for complication: CLKComplication) -> CLKComplicationTemplate? {
         Iconic.registerMaterialDesignIcons()
 
         let model: WatchComplication?
 
-        if #available(watchOS 7, *), complication.identifier != CLKDefaultComplicationIdentifier {
-            // existing complications that were configured pre-7 have no identifier set
-            // so we can only access the value if it's a valid one. otherwise, fall back to old matching behavior.
-            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: complication.identifier)
-        } else {
-            // we migrate pre-existing complications, and when still using watchOS 6 create new ones,
-            // with the family as the identifier, so we can rely on this code path for older OS and older complications
-            let matchedFamily = ComplicationGroupMember(family: complication.family)
-            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: matchedFamily.rawValue)
-        }
+        model = getComplicationModel(for: complication)
 
         return model?.CLKComplicationTemplate(family: complication.family)
     }

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -55,7 +55,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
             model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: matchedFamily.rawValue)
         }
 
-        if model?.IsPrivate == true {
+        if model?.IsPublic == false {
             handler(.hideOnLockScreen)
         } else {
             handler(.showOnLockScreen)

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -16,7 +16,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
     // https://github.com/LoopKit/Loop/issues/816
     // https://crunchybagel.com/detecting-which-complication-was-tapped/
 
-    private func complication(for complication: CLKComplication) -> WatchComplication? {
+    private func getComplicationModel(for complication: CLKComplication) -> WatchComplication? {
         // Helper function to get a complication using the correct ID depending on watchOS version
 
         let model: WatchComplication?
@@ -63,7 +63,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
 
         let model: WatchComplication?
 
-        model = complication()
+        model = getComplicationModel(for: complication)
 
         if model?.IsPublic == false {
             handler(.hideOnLockScreen)

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -16,7 +16,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
     // https://github.com/LoopKit/Loop/issues/816
     // https://crunchybagel.com/detecting-which-complication-was-tapped/
 
-    private func getComplicationModel(for complication: CLKComplication) -> WatchComplication? {
+    private func complicationModel(for complication: CLKComplication) -> WatchComplication? {
         // Helper function to get a complication using the correct ID depending on watchOS version
 
         let model: WatchComplication?
@@ -40,7 +40,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
 
         let model: WatchComplication?
 
-        model = getComplicationModel(for: complication)
+        model = complicationModel(for: complication)
 
         return model?.CLKComplicationTemplate(family: complication.family)
     }
@@ -54,7 +54,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
 
         let model: WatchComplication?
 
-        model = getComplicationModel(for: complication)
+        model = complicationModel(for: complication)
 
         if model?.IsPublic == false {
             handler(.hideOnLockScreen)

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -41,7 +41,21 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         for complication: CLKComplication,
         withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void
     ) {
-        if template.IsPrivate {
+
+        let model: WatchComplication?
+
+        if #available(watchOS 7, *), complication.identifier != CLKDefaultComplicationIdentifier {
+            // existing complications that were configured pre-7 have no identifier set
+            // so we can only access the value if it's a valid one. otherwise, fall back to old matching behavior.
+            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: complication.identifier)
+        } else {
+            // we migrate pre-existing complications, and when still using watchOS 6 create new ones,
+            // with the family as the identifier, so we can rely on this code path for older OS and older complications
+            let matchedFamily = ComplicationGroupMember(family: complication.family)
+            model = Current.realm().object(ofType: WatchComplication.self, forPrimaryKey: matchedFamily.rawValue)
+        }
+
+        if model?.IsPrivate == true {
             handler(.hideOnLockScreen)
         } else {
             handler(.showOnLockScreen)

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -41,7 +41,11 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         for complication: CLKComplication,
         withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void
     ) {
-        handler(.showOnLockScreen)
+        if template.IsPrivate {
+            handler(.hideOnLockScreen)
+        } else {
+            handler(.showOnLockScreen)
+        }
     }
 
     // MARK: - Timeline Population

--- a/Sources/Extensions/Watch/ComplicationController.swift
+++ b/Sources/Extensions/Watch/ComplicationController.swift
@@ -38,9 +38,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
     private func template(for complication: CLKComplication) -> CLKComplicationTemplate? {
         Iconic.registerMaterialDesignIcons()
 
-        let model: WatchComplication?
-
-        model = complicationModel(for: complication)
+        let model = complicationModel(for: complication)
 
         return model?.CLKComplicationTemplate(family: complication.family)
     }
@@ -52,9 +50,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void
     ) {
 
-        let model: WatchComplication?
-
-        model = complicationModel(for: complication)
+        let model = complicationModel(for: complication)
 
         if model?.IsPublic == false {
             handler(.hideOnLockScreen)

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -75,6 +75,8 @@ public class WatchComplication: Object, ImmutableMappable {
         name ?? Template.style
     }
 
+    @objc dynamic public var IsPrivate: Bool = false
+
     override public static func primaryKey() -> String? {
         return "identifier"
     }
@@ -96,6 +98,7 @@ public class WatchComplication: Object, ImmutableMappable {
         self.Family = try map.value("Family")
         self.identifier = try map.value("identifier")
         self.name = try map.value("name")
+        self.IsPrivate = try map.value("IsPrivate")
     }
 
     public func mapping(map: Map) {
@@ -105,6 +108,7 @@ public class WatchComplication: Object, ImmutableMappable {
         Family >>> map["Family"]
         identifier >>> map["identifier"]
         name >>> map["name"]
+        IsPrivate >>> map["IsPrivate"]
     }
 
     enum RenderedValueType: Hashable {

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -75,7 +75,7 @@ public class WatchComplication: Object, ImmutableMappable {
         name ?? Template.style
     }
 
-    @objc dynamic public var IsPrivate: Bool = false
+    @objc dynamic public var IsPublic: Bool = true
 
     override public static func primaryKey() -> String? {
         return "identifier"
@@ -98,7 +98,7 @@ public class WatchComplication: Object, ImmutableMappable {
         self.Family = try map.value("Family")
         self.identifier = try map.value("identifier")
         self.name = try map.value("name")
-        self.IsPrivate = try map.value("IsPrivate")
+        self.IsPublic = try map.value("IsPublic")
     }
 
     public func mapping(map: Map) {
@@ -108,7 +108,7 @@ public class WatchComplication: Object, ImmutableMappable {
         Family >>> map["Family"]
         identifier >>> map["identifier"]
         name >>> map["name"]
-        IsPrivate >>> map["IsPrivate"]
+        IsPublic >>> map["IsPublic"]
     }
 
     enum RenderedValueType: Hashable {

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -75,6 +75,8 @@ extension Realm {
         // 10 - 2020-07-31 v2020.5 (added isServerControlled to Action)
         // 11 - 2020-08-12 v2020.5.2 (cleaning up duplicate NotificationCategory identifiers)
         // 12 - 2020-08-16 v2020.6 (mdi upgrade/migration to 5.x)
+        // 13 - 2020-10-17 v2020.7 (allow multiple complications)
+        // 14 - 2020-10-29 v2020.8 (complication privacy)
         let config = Realm.Configuration(
             fileURL: storeURL,
             schemaVersion: 13,
@@ -143,6 +145,12 @@ extension Realm {
                         // since future objects are created with a UUID-based identifier, this won't be an issue
                         // we also need to reference them by family for complications configured prior to watchOS 7
                         newObject!["identifier"] = newObject!["rawFamily"]
+                    }
+                }
+
+                if oldVersion < 14 {
+                    migration.enumerateObjects(ofType: WatchComplication.className()) { _, newObject in
+                         newObject!["IsPrivate"] = false
                     }
                 }
             },

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -79,7 +79,7 @@ extension Realm {
         // 14 - 2020-10-29 v2020.8 (complication privacy)
         let config = Realm.Configuration(
             fileURL: storeURL,
-            schemaVersion: 13,
+            schemaVersion: 14,
             migrationBlock: { migration, oldVersion in
                 Current.Log.info("migrating from \(oldVersion)")
                 if oldVersion < 9 {

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -150,7 +150,7 @@ extension Realm {
 
                 if oldVersion < 14 {
                     migration.enumerateObjects(ofType: WatchComplication.className()) { _, newObject in
-                         newObject!["IsPrivate"] = false
+                         newObject?["IsPrivate"] = false
                     }
                 }
             },

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -150,7 +150,7 @@ extension Realm {
 
                 if oldVersion < 14 {
                     migration.enumerateObjects(ofType: WatchComplication.className()) { _, newObject in
-                         newObject?["IsPrivate"] = false
+                         newObject?["IsPublic"] = true
                     }
                 }
             },

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2315,9 +2315,9 @@ public enum L10n {
             public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.icon.color.title") }
           }
         }
-        public enum IsPrivate {
-          /// Hide When Locked
-          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.is_private.title") }
+        public enum IsPublic {
+          /// Show When Locked
+          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.is_public.title") }
         }
         public enum Ring {
           /// Ring

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2273,6 +2273,10 @@ public enum L10n {
           /// Display Name
           public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.display_name.title") }
         }
+        public enum IsPrivate {
+          /// Display Name
+          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.is_private.title") }
+        }
         public enum FractionalValue {
           /// Fractional value
           public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.fractional_value.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2273,10 +2273,6 @@ public enum L10n {
           /// Display Name
           public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.display_name.title") }
         }
-        public enum IsPrivate {
-          /// Display Name
-          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.is_private.title") }
-        }
         public enum FractionalValue {
           /// Fractional value
           public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.fractional_value.title") }
@@ -2318,6 +2314,10 @@ public enum L10n {
             /// Color
             public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.icon.color.title") }
           }
+        }
+        public enum IsPrivate {
+          /// Hide When Locked
+          public static var title: String { return L10n.tr("Localizable", "watch.configurator.rows.is_private.title") }
         }
         public enum Ring {
           /// Ring


### PR DESCRIPTION
Given that we essentially let users add anything from Home Assistant that can be represented as text as a complication I thought it would be a good idea to let people choose whether or not to display a complication when the watch is locked.

Tested on my watch and seems to be working 😯although I haven't tested the Realm migration yet. Apologies in advance, this is my first time trying something of this complexity (for me, appreciate it's actually pretty simple) 