### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@
 ## Summary
 <!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 
+## Screenshots
+<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
 ## Link to pull request in Documentation repository
 <!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
 Documentation: home-assistant/companion.home-assistant#

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
+
+## Summary
+<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
+
+## Link to pull request in Documentation repository
+<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
+Documentation: home-assistant/companion.home-assistant#
+
+## Any other notes
+<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 
 ## Screenshots
 <!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
+
 ## Link to pull request in Documentation repository
 <!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
 Documentation: home-assistant/companion.home-assistant#


### PR DESCRIPTION
In the discussion coming from companion.home-assistant#376, it was noted we need to make sure docs are ready prior to merging/releasing changes. This PR tries to support that by adding a PR template with a reminder to do this. Hopefully we can then leverage the bot to apply labels on both repo.

@dshokouhi tagging you for your reference. Comments/changes welcome of course :)