### PR TITLE
Handle hass: prefix in icon names

### DIFF
--- a/Sources/Shared/Common/Extensions/UIImage+Icons.swift
+++ b/Sources/Shared/Common/Extensions/UIImage+Icons.swift
@@ -48,7 +48,7 @@ public extension MaterialDesignIcons {
 internal extension String {
     var normalizingIconString: String {
         return self
-            .replacingOccurrences(of: "mdi:", with: "")
+            .replacingOccurrences(of: "mdi:|hass:", with: "", options: .regularExpression)
             .replacingOccurrences(of: ":", with: "_")
             .replacingOccurrences(of: "-", with: "_")
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
So turns out there is a subset of the MDI icons available with the `hass:` prefix which is totally undocumented. It was introduced back in home-assistant/frontend#1214 to avoid loading the entire MDI set and I don't think was intended for user use but they do work perfectly in the frontend if used. I think this is now handled differently in the frontend but these icons remain.

This PR simply uses a little regex to check for `hass:` in addition to `mdi:`.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Could of course add as an additional `replacingOccurrences` after the first one but this to me seems neater, could perhaps tidy the other two to match.

Was reported on Discord [here](https://discordapp.com/channels/330944238910963714/551871772484698112/774005750011920384)