### PR TITLE
Fix crash when signed out and issuing intent

### DIFF
--- a/Sources/Extensions/Intents/CallService.swift
+++ b/Sources/Extensions/Intents/CallService.swift
@@ -66,16 +66,6 @@ class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
         }
     }
 
-    func confirm(intent: CallServiceIntent, completion: @escaping (CallServiceIntentResponse) -> Void) {
-        HomeAssistantAPI.authenticatedAPIPromise.catch { (error) in
-            Current.Log.error("Can't get a authenticated API \(error)")
-            completion(CallServiceIntentResponse(code: .failureConnectivity, userActivity: nil))
-            return
-        }
-
-        completion(CallServiceIntentResponse(code: .ready, userActivity: nil))
-    }
-
     // swiftlint:disable:next function_body_length
     func handle(intent: CallServiceIntent, completion: @escaping (CallServiceIntentResponse) -> Void) {
         guard let api = HomeAssistantAPI.authenticatedAPI() else {

--- a/Sources/Extensions/Intents/GetCameraImage.swift
+++ b/Sources/Extensions/Intents/GetCameraImage.swift
@@ -53,16 +53,6 @@ class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
         }
     }
 
-    func confirm(intent: GetCameraImageIntent, completion: @escaping (GetCameraImageIntentResponse) -> Void) {
-        HomeAssistantAPI.authenticatedAPIPromise.catch { (error) in
-            Current.Log.error("Can't get a authenticated API \(error)")
-            completion(GetCameraImageIntentResponse(code: .failureConnectivity, userActivity: nil))
-            return
-        }
-
-        completion(GetCameraImageIntentResponse(code: .ready, userActivity: nil))
-    }
-
     func handle(intent: GetCameraImageIntent, completion: @escaping (GetCameraImageIntentResponse) -> Void) {
         guard let api = HomeAssistantAPI.authenticatedAPI() else {
             completion(GetCameraImageIntentResponse(code: .failureConnectivity, userActivity: nil))

--- a/Sources/Extensions/Intents/RenderTemplate.swift
+++ b/Sources/Extensions/Intents/RenderTemplate.swift
@@ -23,16 +23,6 @@ class RenderTemplateIntentHandler: NSObject, RenderTemplateIntentHandling {
         }
     }
 
-    func confirm(intent: RenderTemplateIntent, completion: @escaping (RenderTemplateIntentResponse) -> Void) {
-        HomeAssistantAPI.authenticatedAPIPromise.catch { (error) in
-            Current.Log.error("Can't get a authenticated API \(error)")
-            completion(RenderTemplateIntentResponse(code: .failureConnectivity, userActivity: nil))
-            return
-        }
-
-        completion(RenderTemplateIntentResponse(code: .ready, userActivity: nil))
-    }
-
     func handle(intent: RenderTemplateIntent, completion: @escaping (RenderTemplateIntentResponse) -> Void) {
         guard let api = HomeAssistantAPI.authenticatedAPI() else {
             completion(RenderTemplateIntentResponse(code: .failureConnectivity, userActivity: nil))

--- a/Sources/Extensions/Intents/SendLocation.swift
+++ b/Sources/Extensions/Intents/SendLocation.swift
@@ -24,24 +24,6 @@ class SendLocationIntentHandler: NSObject, SendLocationIntentHandling {
         }
     }
 
-    func confirm(intent: SendLocationIntent, completion: @escaping (SendLocationIntentResponse) -> Void) {
-
-        HomeAssistantAPI.authenticatedAPIPromise.catch { (error) in
-            Current.Log.error("Can't get a authenticated API \(error)")
-            completion(SendLocationIntentResponse(code: .failureConnectivity, userActivity: nil))
-            return
-        }
-
-        guard intent.location != nil else {
-            let resp = SendLocationIntentResponse(code: .failure, userActivity: nil)
-            resp.error = "Location is not set"
-            completion(resp)
-            return
-        }
-
-        completion(SendLocationIntentResponse(code: .ready, userActivity: nil))
-    }
-
     func handle(intent: SendLocationIntent, completion: @escaping (SendLocationIntentResponse) -> Void) {
         Current.Log.verbose("Handling send location")
 


### PR DESCRIPTION
These confirm blocks were firing an error case and then success case. They aren't needed necessary any more since we do the validation when resolving.

Fixes #1250.