### PR TITLE
Add "Placeholder" complication

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -903,3 +903,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.list.learn_more" = "Learn More";
 "watch.configurator.rows.display_name.title" = "Display Name";
 "watch.configurator.rows.is_public.title" = "Show When Locked";
+"watch.placeholder_complication_name" = "Placeholder";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2223,6 +2223,8 @@ public enum L10n {
   }
 
   public enum Watch {
+    /// Placeholder
+    public static var placeholderComplicationName: String { return L10n.tr("Localizable", "watch.placeholder_complication_name") }
     public enum Configurator {
       public enum Delete {
         /// Delete Complication


### PR DESCRIPTION
## Summary
Since we only offer complications for configured versions, we don't have a quick "launch the app" complication available without creating one, and you cannot create one that's just the HA logo.

Rather than adding a new template configuration for the app icon, this adds a complication to all places we support which show some variant of "Home Assistant", "HA" and the app icon without any kind of "this is an error!" state.

Fixes #1281. Fixes #525.

## Screenshots
![image](https://user-images.githubusercontent.com/74188/99714427-6e3f5680-2a5a-11eb-9a63-5418d30f74b3.png)
![image](https://user-images.githubusercontent.com/74188/99714546-90d16f80-2a5a-11eb-8640-916d7aec63eb.png)
