### PR TITLE
Fix allowing a 404 error to be a 'successful' notification download

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -269,7 +269,7 @@ public class HomeAssistantAPI {
                 return (downloadPath, [.removePreviousFile, .createIntermediateDirectories])
             }
 
-            dataManager.download(finalURL, to: destination).responseData { downloadResponse in
+            dataManager.download(finalURL, to: destination).validate().responseData { downloadResponse in
                 switch downloadResponse.result {
                 case .success:
                     seal.fulfill(downloadResponse.destinationURL!)


### PR DESCRIPTION
This doesn't affect what happens -- saving 404 text to something.mp4 doesn't play -- but it does make the logs easier to see if something is going wrong.