### PR TITLE
Update notification attachment handling, add error images

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -258,6 +258,19 @@
 		11EFCDDA24F5FE0600314D85 /* SceneActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDD924F5FE0600314D85 /* SceneActivity.swift */; };
 		11EFCDDC24F6065F00314D85 /* AboutSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */; };
 		11EFCDE024F60E5900314D85 /* BasicSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */; };
+		11F2F1EC2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
+		11F2F1ED2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
+		11F2F2092586FB0C00F61F7C /* NotificationAttachmentManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */; };
+		11F2F24125871CAF00F61F7C /* NotificationAttachmentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F22525871C3100F61F7C /* NotificationAttachmentParser.swift */; };
+		11F2F24225871CB000F61F7C /* NotificationAttachmentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F22525871C3100F61F7C /* NotificationAttachmentParser.swift */; };
+		11F2F25E25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F25D25871D6000F61F7C /* NotificationAttachmentParserCamera.swift */; };
+		11F2F25F25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F25D25871D6000F61F7C /* NotificationAttachmentParserCamera.swift */; };
+		11F2F26E25871D8200F61F7C /* NotificationAttachmentParserURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F26D25871D8200F61F7C /* NotificationAttachmentParserURL.swift */; };
+		11F2F26F25871D8200F61F7C /* NotificationAttachmentParserURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F26D25871D8200F61F7C /* NotificationAttachmentParserURL.swift */; };
+		11F2F27E258725D300F61F7C /* NotificationAttachmentErrorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F27D258725D300F61F7C /* NotificationAttachmentErrorImage.swift */; };
+		11F2F27F258725D300F61F7C /* NotificationAttachmentErrorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F27D258725D300F61F7C /* NotificationAttachmentErrorImage.swift */; };
+		11F2F2A92587288200F61F7C /* NotificationAttachmentParserCamera.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F2A82587288200F61F7C /* NotificationAttachmentParserCamera.test.swift */; };
+		11F2F2B8258728B200F61F7C /* NotificationAttachmentParserURL.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F2B7258728B200F61F7C /* NotificationAttachmentParserURL.test.swift */; };
 		11F3847B24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */; };
 		11F3847C24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */; };
 		11F3B85724C4279700642676 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3B85524C4279700642676 /* Entity.swift */; };
@@ -1077,6 +1090,14 @@
 		11EFCDD924F5FE0600314D85 /* SceneActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneActivity.swift; sourceTree = "<group>"; };
 		11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSceneDelegate.swift; sourceTree = "<group>"; };
 		11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicSceneDelegate.swift; sourceTree = "<group>"; };
+		11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentManager.swift; sourceTree = "<group>"; };
+		11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentManager.test.swift; sourceTree = "<group>"; };
+		11F2F22525871C3100F61F7C /* NotificationAttachmentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParser.swift; sourceTree = "<group>"; };
+		11F2F25D25871D6000F61F7C /* NotificationAttachmentParserCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParserCamera.swift; sourceTree = "<group>"; };
+		11F2F26D25871D8200F61F7C /* NotificationAttachmentParserURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParserURL.swift; sourceTree = "<group>"; };
+		11F2F27D258725D300F61F7C /* NotificationAttachmentErrorImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentErrorImage.swift; sourceTree = "<group>"; };
+		11F2F2A82587288200F61F7C /* NotificationAttachmentParserCamera.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParserCamera.test.swift; sourceTree = "<group>"; };
+		11F2F2B7258728B200F61F7C /* NotificationAttachmentParserURL.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParserURL.test.swift; sourceTree = "<group>"; };
 		11F3847A24FB27FB00CB0D74 /* DeviceWrapperBatteryObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWrapperBatteryObserver.swift; sourceTree = "<group>"; };
 		11F3B85524C4279700642676 /* Entity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		11F3B85624C4279700642676 /* Zone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone.swift; sourceTree = "<group>"; };
@@ -2158,6 +2179,28 @@
 			path = Scenes;
 			sourceTree = "<group>";
 		};
+		11F2F21725871C1700F61F7C /* NotificationAttachments */ = {
+			isa = PBXGroup;
+			children = (
+				11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */,
+				11F2F22525871C3100F61F7C /* NotificationAttachmentParser.swift */,
+				11F2F25D25871D6000F61F7C /* NotificationAttachmentParserCamera.swift */,
+				11F2F26D25871D8200F61F7C /* NotificationAttachmentParserURL.swift */,
+				11F2F27D258725D300F61F7C /* NotificationAttachmentErrorImage.swift */,
+			);
+			path = NotificationAttachments;
+			sourceTree = "<group>";
+		};
+		11F2F28D2587285300F61F7C /* NotificationAttachment */ = {
+			isa = PBXGroup;
+			children = (
+				11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */,
+				11F2F2A82587288200F61F7C /* NotificationAttachmentParserCamera.test.swift */,
+				11F2F2B7258728B200F61F7C /* NotificationAttachmentParserURL.test.swift */,
+			);
+			path = NotificationAttachment;
+			sourceTree = "<group>";
+		};
 		11F3D74F2495433800C05BBA /* Sensors */ = {
 			isa = PBXGroup;
 			children = (
@@ -2870,6 +2913,7 @@
 				11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */,
 				11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */,
 				1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */,
+				11F2F28D2587285300F61F7C /* NotificationAttachment */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2989,6 +3033,7 @@
 			isa = PBXGroup;
 			children = (
 				D0EEF326214DF31D00D1D360 /* Notifications.swift */,
+				11F2F21725871C1700F61F7C /* NotificationAttachments */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -4541,6 +4586,7 @@
 				B67CE8AB22200F220034C1D0 /* TokenInfo.swift in Sources */,
 				B67CE87722200F220034C1D0 /* Strings.swift in Sources */,
 				11C9E43C2505B04E00492A88 /* HACoreAudioObjectSystem.swift in Sources */,
+				11F2F1ED2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */,
 				117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */,
 				B67CE8AE22200F220034C1D0 /* TokenManager.swift in Sources */,
 				11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */,
@@ -4551,6 +4597,7 @@
 				11AF4D1A249C8253006C74C0 /* PedometerSensor.swift in Sources */,
 				1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */,
 				11F855DB24DF6C7A0018013E /* IconDrawable.swift in Sources */,
+				11F2F25F25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */,
 				11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */,
 				B6A258462232485300ADD202 /* Alamofire+EncryptedResponses.swift in Sources */,
 				11AF4D23249C924B006C74C0 /* GeocoderSensor.swift in Sources */,
@@ -4618,7 +4665,9 @@
 				B672334E225DE1490031D629 /* SubscribeEvents.swift in Sources */,
 				11C4628F24B128EF00031902 /* WebhookResponseUnhandled.swift in Sources */,
 				B6723345225DBACF0031D629 /* AuthRequestMessage.swift in Sources */,
+				11F2F26F25871D8200F61F7C /* NotificationAttachmentParserURL.swift in Sources */,
 				11F3B85A24C4279700642676 /* Zone.swift in Sources */,
+				11F2F24225871CB000F61F7C /* NotificationAttachmentParser.swift in Sources */,
 				B67CE8AC22200F220034C1D0 /* AuthenticationRoutes.swift in Sources */,
 				119EC3C824D5119300617D51 /* MobileAppConfig.swift in Sources */,
 				B67CE89E22200F220034C1D0 /* DiscoveryInfo.swift in Sources */,
@@ -4647,6 +4696,7 @@
 				11F855D924DF6C7A0018013E /* MaterialDesignIcons.swift in Sources */,
 				11EE9B5524C62EB300404AF8 /* RealmScene.swift in Sources */,
 				11AF4D20249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,
+				11F2F27F258725D300F61F7C /* NotificationAttachmentErrorImage.swift in Sources */,
 				B67CE8A622200F220034C1D0 /* HAAPI.swift in Sources */,
 				1141182724AF9A0500E6525C /* WebhookManager.swift in Sources */,
 				1104FC9225322C1800B8BE34 /* Dictionary+Additions.swift in Sources */,
@@ -4720,6 +4770,7 @@
 				D0EEF305214DD0D400D1D360 /* UIColor+HA.swift in Sources */,
 				B613936924F728F8002B8C5D /* InputDeviceSensor.swift in Sources */,
 				11C4629624B19FC700031902 /* URLSessionTask+WebhookPersisted.swift in Sources */,
+				11F2F25E25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */,
 				11AF4D1C249C8AA0006C74C0 /* BatterySensor.swift in Sources */,
 				D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */,
 				11AF4D14249C7E09006C74C0 /* ActivitySensor.swift in Sources */,
@@ -4782,9 +4833,11 @@
 				D0EEF303214D8F0300D1D360 /* String+HA.swift in Sources */,
 				11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */,
 				11EE9B4E24C6089800404AF8 /* RealmPersistable.swift in Sources */,
+				11F2F27E258725D300F61F7C /* NotificationAttachmentErrorImage.swift in Sources */,
 				B6723347225DC72A0031D629 /* AuthenticatedUser.swift in Sources */,
 				1148A45024E9AF9200345050 /* MDIMigration.swift in Sources */,
 				116740732519907400F51626 /* MacBridgeProtocol.swift in Sources */,
+				11F2F24125871CAF00F61F7C /* NotificationAttachmentParser.swift in Sources */,
 				114E9B4E24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */,
 				118261FD24F9B81A000795C6 /* HACoreBlahProperty.swift in Sources */,
 				1101568724D7712F009424C9 /* TagManagerProtocol.swift in Sources */,
@@ -4792,10 +4845,12 @@
 				119A7E0F2529769A00D7000D /* UIImageView+UIActivityIndicator.swift in Sources */,
 				111858D624CB620500B8CDDC /* Intents.intentdefinition in Sources */,
 				D0EEF316214DD7A400D1D360 /* Config.swift in Sources */,
+				11F2F1EC2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */,
 				11F855D824DF6C7A0018013E /* MaterialDesignIcons.swift in Sources */,
 				11F3B85724C4279700642676 /* Entity.swift in Sources */,
 				11521BBC25400284009C5C72 /* CrashReporter.swift in Sources */,
 				11EE9B5424C62EB300404AF8 /* RealmScene.swift in Sources */,
+				11F2F26E25871D8200F61F7C /* NotificationAttachmentParserURL.swift in Sources */,
 				D0EEF322214DE56B00D1D360 /* LocationTrigger.swift in Sources */,
 				D0B25BD62133128800678C2C /* UNNotificationContent+ClientEvent.swift in Sources */,
 				118261F724F8D6B0000795C6 /* SensorProviderDependencies.swift in Sources */,
@@ -4815,6 +4870,7 @@
 				11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */,
 				11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */,
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
+				11F2F2B8258728B200F61F7C /* NotificationAttachmentParserURL.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
 				11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */,
 				11CB98CD249E637300B05222 /* Version+HA.test.swift in Sources */,
@@ -4831,9 +4887,11 @@
 				1179E42D24F9FAA100D4E307 /* SensorProviderDependencies.test.swift in Sources */,
 				11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */,
 				11AF4D2A249D88C5006C74C0 /* ActivitySensor.test.swift in Sources */,
+				11F2F2092586FB0C00F61F7C /* NotificationAttachmentManager.test.swift in Sources */,
 				11CD94B924B2D16F00BA801D /* WebhookResponseServiceCall.test.swift in Sources */,
 				11CD94B524B2C06700BA801D /* WebhookResponseUpdateSensors.test.swift in Sources */,
 				11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */,
+				11F2F2A92587288200F61F7C /* NotificationAttachmentParserCamera.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				1104FD07253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-iOS.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Shared-iOS.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D03D891620E0A85200D4F28D"
+               BuildableName = "Shared.framework"
+               BlueprintName = "Shared-iOS"
+               ReferencedContainer = "container:HomeAssistant.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D03D894120E0BC1800D4F28D"
+               BuildableName = "Tests-Shared.xctest"
+               BlueprintName = "Tests-Shared"
+               ReferencedContainer = "container:HomeAssistant.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D03D891620E0A85200D4F28D"
+            BuildableName = "Shared.framework"
+            BlueprintName = "Shared-iOS"
+            ReferencedContainer = "container:HomeAssistant.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D03D894120E0BC1800D4F28D"
+               BuildableName = "Tests-Shared.xctest"
+               BlueprintName = "Tests-Shared"
+               ReferencedContainer = "container:HomeAssistant.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D03D891620E0A85200D4F28D"
+            BuildableName = "Shared.framework"
+            BlueprintName = "Shared-iOS"
+            ReferencedContainer = "container:HomeAssistant.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -904,3 +904,8 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "watch.configurator.rows.display_name.title" = "Display Name";
 "watch.configurator.rows.is_public.title" = "Show When Locked";
 "watch.placeholder_complication_name" = "Placeholder";
+"notification_service.failed_to_load" = "Failed to load attachment";
+"notification_service.parser.url.no_url" = "No URL was provided.";
+"notification_service.parser.url.invalid_url" = "The given URL was invalid.";
+"notification_service.parser.camera.no_entity" = "No entity_id was provided.";
+"notification_service.parser.camera.invalid_entity" = "entity_id provided was invalid.";

--- a/Sources/Extensions/NotificationService/NotificationService.swift
+++ b/Sources/Extensions/NotificationService/NotificationService.swift
@@ -1,143 +1,23 @@
-//
-//  NotificationService.swift
-//  APNSAttachmentService
-//
-//  Created by Robbie Trencheny on 9/8/16.
-//  Copyright © 2016 Robbie Trencheny. All rights reserved.
-//
-
 import UserNotifications
-import MobileCoreServices
 import Shared
-import Alamofire
 import PromiseKit
 
 final class NotificationService: UNNotificationServiceExtension {
-    private var contentHandler: ((UNNotificationContent) -> Void)?
-    private var bestAttemptContent: UNMutableNotificationContent?
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        Current.Log.info("didReceive \(request), user info \(request.content.userInfo)")
 
-    // swiftlint:disable cyclomatic_complexity function_body_length
-    override func didReceive(_ request: UNNotificationRequest,
-                             withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        Current.Log.verbose("APNSAttachmentService started!")
-        Current.Log.verbose("Received userInfo \(request.content.userInfo)")
-
-        // FIXME: Memory leak caused by ClientEvent/Realm.
-        /* let event = ClientEvent(text: request.content.clientEventTitle, type: .notification,
-                                payload: request.content.userInfo as? [String: Any])
-        Current.clientEventStore.addEvent(event) */
-
-        Current.Log.debug("Added client event")
-
-        self.contentHandler = contentHandler
-        bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-
-        Current.Log.debug("Set bestAttemptContent")
-
-        func failEarly(_ reason: String) {
-            Current.Log.error("Failing early because \(reason)!")
+        guard let api = Current.api() else {
+            Current.Log.error("no available api, not attaching")
             contentHandler(request.content)
+            return
         }
 
-        guard let content = (request.content.mutableCopy() as? UNMutableNotificationContent) else {
-            return failEarly("Unable to get mutable copy of notification content")
-        }
-
-        // if there's no attachment, we want to still allow the camera category to be automatic
-        var incomingAttachment = content.userInfo["attachment"] as? [String: Any] ?? [:]
-
-        var needsAuth = false
-
-        if content.categoryIdentifier.lowercased().hasPrefix("camera") && incomingAttachment["url"] == nil {
-            Current.Log.debug("Camera cat prefix")
-            guard let entityId = content.userInfo["entity_id"] as? String else {
-                return failEarly("Category identifier was prefixed camera but no entity_id was set")
-            }
-
-            incomingAttachment["url"] = "/api/camera_proxy/\(entityId)"
-            if incomingAttachment["content-type"] == nil {
-                incomingAttachment["content-type"] = "jpeg"
-            }
-
-            needsAuth = true
-            Current.Log.debug("Camera so requiring auth")
-        } else {
-            Current.Log.debug("Not a camera notification")
-            // Check if we still have an empty dictionary
-            if incomingAttachment.isEmpty {
-                // Attachment wasn't there/not a string:any, and this isn't a camera category, so we should fail
-                return failEarly("Content dictionary was not empty")
-            }
-        }
-
-        guard let attachmentString = incomingAttachment["url"] as? String else {
-            return failEarly("url string did not exist in dictionary")
-        }
-
-        if attachmentString.hasPrefix("/") { // URL is something like /api or /www so lets prepend base URL
-            Current.Log.debug("Appears to be local URL, requiring auth")
-            needsAuth = true
-        }
-
-        guard let attachmentURL = URL(string: attachmentString) else {
-            return failEarly("Could not convert string to URL")
-        }
-
-        var attachmentOptions: [String: Any] = [:]
-        if let attachmentContentType = incomingAttachment["content-type"] as? String {
-            attachmentOptions[UNNotificationAttachmentOptionsTypeHintKey] =
-                self.contentTypeForString(attachmentContentType)
-        }
-
-        if let attachmentHideThumbnail = incomingAttachment["hide-thumbnail"] as? Bool {
-            attachmentOptions[UNNotificationAttachmentOptionsThumbnailHiddenKey] = attachmentHideThumbnail
-        }
-
-        Current.Log.debug("Set attachment options to \(attachmentOptions)s")
-
-        Current.Log.verbose("Going to get URL at \(attachmentURL)")
-
-        firstly {
-            return HomeAssistantAPI.authenticatedAPIPromise
-        }.then { api in
-            return api.DownloadDataAt(url: attachmentURL, needsAuth: needsAuth)
-        }.done { fileURL in
-            do {
-                let attachment = try UNNotificationAttachment(identifier: attachmentURL.lastPathComponent, url: fileURL,
-                                                              options: attachmentOptions)
-                content.attachments.append(attachment)
-            } catch let error {
-                return failEarly("Unable to build UNNotificationAttachment: \(error)")
-            }
-
-            Current.Log.debug("Successfully created and appended attachment \(content.attachments)")
-
-            // Attempt to fill in the summary argument with the thread or category ID if it doesn't exist in payload.
-            if content.summaryArgument == "" {
-                if content.threadIdentifier != "" {
-                    content.summaryArgument = content.threadIdentifier
-                } else if content.categoryIdentifier != "" {
-                    content.summaryArgument = content.categoryIdentifier
-                }
-            }
-
-            Current.Log.debug("About to return")
-
-            guard let copiedContent = content.copy() as? UNNotificationContent else {
-                return failEarly("Unable to copy contents")
-            }
-
-            Current.Log.debug("Returning \(copiedContent)")
-
-            contentHandler(copiedContent)
-        }.catch { error in
-            var reason = "Error when getting attachment data! \(error)"
-            if let error = error as? AFError {
-                reason = "Alamofire error while getting attachment data: \(error)"
-            }
-
-            return failEarly(reason)
-        }
+        NotificationAttachmentManager()
+            .content(from: request.content, api: api)
+            .done { contentHandler($0) }
     }
 
     override func serviceExtensionTimeWillExpire() {
@@ -145,40 +25,5 @@ final class NotificationService: UNNotificationServiceExtension {
         // Use this as an opportunity to deliver your "best attempt" at modified content,
         // otherwise the original push payload will be used.
         Current.Log.warning("serviceExtensionTimeWillExpire")
-        if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
-            contentHandler(bestAttemptContent)
-        }
-    }
-
-    private func contentTypeForString(_ contentTypeString: String) -> CFString {
-        let contentType: CFString
-        switch contentTypeString.lowercased() {
-        case "aiff":
-            contentType = kUTTypeAudioInterchangeFileFormat
-        case "avi":
-            contentType = kUTTypeAVIMovie
-        case "gif":
-            contentType = kUTTypeGIF
-        case "jpeg", "jpg":
-            contentType = kUTTypeJPEG
-        case "mp3":
-            contentType = kUTTypeMP3
-        case "mpeg":
-            contentType = kUTTypeMPEG
-        case "mpeg2":
-            contentType = kUTTypeMPEG2Video
-        case "mpeg4":
-            contentType = kUTTypeMPEG4
-        case "mpeg4audio":
-            contentType = kUTTypeMPEG4Audio
-        case "png":
-            contentType = kUTTypePNG
-        case "waveformaudio":
-            contentType = kUTTypeWaveformAudio
-        default:
-            contentType = contentTypeString as CFString
-        }
-
-        return contentType
     }
 }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -224,11 +224,16 @@ public class HomeAssistantAPI {
         )
     }
 
-    private func getTemporaryDownloadDataPath(_ downloadingURL: URL) -> URL? {
-        return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    public func temporaryDownloadFileURL(appropriateFor downloadingURL: URL? = nil) -> URL? {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             // using a random file name so we always have one, see https://github.com/home-assistant/iOS/issues/1068
             .appendingPathComponent(UUID().uuidString, isDirectory: false)
-            .appendingPathExtension(downloadingURL.pathExtension)
+
+        if let downloadingURL = downloadingURL {
+            return url.appendingPathExtension(downloadingURL.pathExtension)
+        } else {
+            return url
+        }
     }
 
     private func removeOldDownloadDirectory() {
@@ -259,7 +264,7 @@ public class HomeAssistantAPI {
                 Current.Log.verbose("Data download needs auth!")
             }
 
-            guard let downloadPath = self.getTemporaryDownloadDataPath(finalURL) else {
+            guard let downloadPath = temporaryDownloadFileURL(appropriateFor: finalURL) else {
                 Current.Log.error("Unable to get download path!")
                 seal.reject(APIError.cantBuildURL)
                 return

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentErrorImage.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentErrorImage.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+#if os(iOS)
+enum NotificationAttachmentErrorImage {
+    static func saveImage(
+        for error: Error,
+        savingTo destination: URL
+    ) throws -> String {
+        let string = Self.errorString(for: error)
+        try Self.saveImage(
+            for: Self.errorString(for: error),
+            writingToURL: destination
+        )
+        return string.string
+    }
+
+    private static func errorString(for error: Error) -> NSAttributedString {
+        let message = NSMutableAttributedString()
+
+        message.append(NSAttributedString(string: L10n.NotificationService.failedToLoad, attributes: [
+            .font: UIFont.preferredFont(forTextStyle: .title3),
+            .foregroundColor: UIColor.red
+        ]))
+        message.append(NSAttributedString(string: "\n" + error.localizedDescription, attributes: [
+            .font: UIFont.preferredFont(forTextStyle: .body),
+            .foregroundColor: UIColor.black
+        ]))
+
+        message.addAttributes([
+            .paragraphStyle: with(NSMutableParagraphStyle()) {
+                $0.alignment = .center
+            }
+        ], range: NSRange(location: 0, length: message.length))
+
+        return message
+    }
+
+    private static func saveImage(for message: NSAttributedString, writingToURL temporaryURL: URL) throws {
+        let padding: CGFloat = 20
+        let width: CGFloat = 320
+
+        let stringRect = message
+            .boundingRect(
+                with: CGSize(width: width, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin],
+                context: nil
+            )
+            .offsetBy(dx: padding, dy: padding)
+            .integral
+        let rendererRect = stringRect
+            .insetBy(dx: -padding, dy: -padding)
+
+        try UIGraphicsImageRenderer(size: rendererRect.size, format: UIGraphicsImageRendererFormat.preferred())
+            .pngData { context in
+                UIColor.white.setFill()
+                context.fill(rendererRect)
+                message.draw(with: stringRect, options: [.usesLineFragmentOrigin], context: nil)
+            }
+            .write(to: temporaryURL)
+    }
+}
+#endif

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
@@ -1,0 +1,139 @@
+import MobileCoreServices
+import Foundation
+import UserNotifications
+import PromiseKit
+import UIKit
+
+public class NotificationAttachmentManager {
+    let parsers: [NotificationAttachmentParser.Type]
+
+    public convenience init() {
+        self.init(parsers: [
+            NotificationAttachmentParserURL.self,
+            NotificationAttachmentParserCamera.self
+        ])
+    }
+
+    init(parsers: [NotificationAttachmentParser.Type]) {
+        self.parsers = parsers
+    }
+
+    public func content(
+        from originalContent: UNNotificationContent,
+        api: HomeAssistantAPI
+    ) -> Guarantee<UNNotificationContent> {
+        let attachmentPromise: Promise<UNNotificationAttachment> = firstly {
+            attachmentInfo(from: originalContent)
+        }.then { [self] attachmentInfo -> Promise<UNNotificationAttachment> in
+            Current.Log.info("using attachment info \(attachmentInfo)")
+            return attachment(from: attachmentInfo, api: api)
+        }.recover { [self] error -> Promise<UNNotificationAttachment> in
+            Current.Log.error("failed at getting attachment info: \(error)")
+
+            if case ServiceError.noAttachment = error {
+                throw error
+            } else {
+                #if os(iOS)
+                return .value(try self.attachment(for: error, api: api))
+                #else
+                throw error
+                #endif
+            }
+        }
+
+        return firstly {
+            Guarantee.value(originalContent)
+        }.map { content in
+            // swiftlint:disable:next force_cast
+            content.mutableCopy() as! UNMutableNotificationContent
+        }.then { content in
+            when(resolved: attachmentPromise.get { attachment in
+                Current.Log.info("adding attachment \(attachment)")
+                content.attachments.append(attachment)
+            }).map { _ in content }
+        }.map { content in
+            #if os(iOS)
+            // Attempt to fill in the summary argument with the thread or category ID if it doesn't exist in payload.
+            if content.summaryArgument.isEmpty {
+                if !content.threadIdentifier.isEmpty {
+                    content.summaryArgument = content.threadIdentifier
+                } else if !content.categoryIdentifier.isEmpty {
+                    content.summaryArgument = content.categoryIdentifier
+                }
+            }
+            #endif
+            return content
+        }.get { content in
+            Current.Log.info("delivering content \(content)")
+
+            withExtendedLifetime(self) {
+                // just in case we're not retained by our caller, keep alive through
+            }
+        }
+    }
+
+    private enum ServiceError: Error {
+        case noAttachment
+    }
+
+    private func attachmentInfo(from content: UNNotificationContent) -> Promise<NotificationAttachmentInfo> {
+        let concreteParsers = parsers.map { $0.init() }
+
+        return firstly {
+            when(fulfilled: concreteParsers.map { $0.attachmentInfo(from: content) })
+        }.ensure {
+            withExtendedLifetime(concreteParsers) {
+                // just to keep the instances alive until they're all done
+            }
+        }.map { results in
+            if let firstSuccess = results.compactMap(\.attachmentInfo).first {
+                return firstSuccess
+            } else {
+                // importantly not using 'missing' for values here
+                throw results.compactMap(\.error).first ?? ServiceError.noAttachment
+            }
+        }
+    }
+
+    private func attachment(
+        from attachmentInfo: NotificationAttachmentInfo,
+        api: HomeAssistantAPI
+    ) -> Promise<UNNotificationAttachment> {
+        return firstly {
+            api.DownloadDataAt(url: attachmentInfo.url, needsAuth: attachmentInfo.needsAuth)
+        }.map { url -> UNNotificationAttachment in
+            try UNNotificationAttachment(
+                identifier: url.lastPathComponent,
+                url: url,
+                options: attachmentInfo.attachmentOptions
+            )
+        }
+    }
+
+    #if os(iOS)
+    private func attachment(
+        for error: Error,
+        api: HomeAssistantAPI
+    ) throws -> UNNotificationAttachment {
+        guard let temporaryURL = api.temporaryDownloadFileURL() else {
+            throw error
+        }
+
+        let localizedString = try NotificationAttachmentErrorImage.saveImage(
+            for: error,
+            savingTo: temporaryURL
+        )
+
+        return with(try UNNotificationAttachment(
+            identifier: "error",
+            url: temporaryURL,
+            options: [
+                UNNotificationAttachmentOptionsTypeHintKey: kUTTypePNG
+            ]
+        )) {
+            // note: attachments don't actually support accessibility here (yet?) but this is used also for tests
+            $0.accessibilityLabel = localizedString
+        }
+    }
+    #endif
+}

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParser.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParser.swift
@@ -1,0 +1,97 @@
+import Foundation
+import PromiseKit
+import UserNotifications
+import CoreServices
+
+internal protocol NotificationAttachmentParser {
+    init()
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult>
+}
+
+internal enum NotificationAttachmentParserResult: Equatable {
+    case fulfilled(NotificationAttachmentInfo)
+    case missing
+    case rejected(Error)
+
+    var attachmentInfo: NotificationAttachmentInfo? {
+        switch self {
+        case .fulfilled(let info): return info
+        case .missing, .rejected: return nil
+        }
+    }
+
+    var error: Error? {
+        switch self {
+        case .rejected(let error): return error
+        case .missing, .fulfilled: return nil
+        }
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.missing, .missing):
+            return true
+        case (.fulfilled(let lhsValue), .fulfilled(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.rejected(let lhsError as NSError), .rejected(let rhsError as NSError)):
+            return lhsError.domain == rhsError.domain &&
+                lhsError.code == rhsError.code
+        default:
+            return false
+        }
+    }
+}
+
+internal struct NotificationAttachmentInfo: Equatable {
+    var url: URL
+    var needsAuth: Bool
+    var typeHint: CFString?
+    var hideThumbnail: Bool?
+
+    var attachmentOptions: [String: Any] {
+        var options = [String: Any]()
+
+        if let typeHint = typeHint {
+            options[UNNotificationAttachmentOptionsTypeHintKey] = typeHint
+        }
+
+        if let hideThumbnail = hideThumbnail {
+            options[UNNotificationAttachmentOptionsThumbnailHiddenKey] = hideThumbnail
+        }
+
+        return options
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    static func contentType(for contentTypeString: String) -> CFString {
+        let contentType: CFString
+        switch contentTypeString.lowercased() {
+        case "aiff":
+            contentType = kUTTypeAudioInterchangeFileFormat
+        case "avi":
+            contentType = kUTTypeAVIMovie
+        case "gif":
+            contentType = kUTTypeGIF
+        case "jpeg", "jpg":
+            contentType = kUTTypeJPEG
+        case "mp3":
+            contentType = kUTTypeMP3
+        case "mpeg":
+            contentType = kUTTypeMPEG
+        case "mpeg2":
+            contentType = kUTTypeMPEG2Video
+        case "mpeg4":
+            contentType = kUTTypeMPEG4
+        case "mpeg4audio":
+            contentType = kUTTypeMPEG4Audio
+        case "png":
+            contentType = kUTTypePNG
+        case "waveformaudio":
+            contentType = kUTTypeWaveformAudio
+        default:
+            contentType = contentTypeString as CFString
+        }
+
+        return contentType
+    }
+}

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserCamera.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserCamera.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UserNotifications
+import PromiseKit
+import CoreServices
+
+final class NotificationAttachmentParserCamera: NotificationAttachmentParser {
+    enum CameraError: LocalizedError {
+        case noEntity
+        case invalidEntity
+
+        var errorDescription: String? {
+            switch self {
+            case .noEntity: return L10n.NotificationService.Parser.Camera.noEntity
+            case .invalidEntity: return L10n.NotificationService.Parser.Camera.invalidEntity
+            }
+        }
+    }
+
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult> {
+        guard content.categoryIdentifier.lowercased().hasPrefix("camera") else {
+            return .value(.missing)
+        }
+
+        guard let entityId = content.userInfo["entity_id"] as? String else {
+            return .value(.rejected(CameraError.noEntity))
+        }
+
+        guard let proxyURL = URL(string: "/api/camera_proxy/\(entityId)") else {
+            return .value(.rejected(CameraError.invalidEntity))
+        }
+
+        let hideThumbnail = (content.userInfo["attachment"] as? [String: Any])?["hide-thumbnail"] as? Bool
+
+        return .value(.fulfilled(.init(
+            url: proxyURL,
+            needsAuth: true,
+            typeHint: kUTTypeJPEG,
+            hideThumbnail: hideThumbnail
+        )))
+    }
+}

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserURL.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserURL.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UserNotifications
+import PromiseKit
+
+final class NotificationAttachmentParserURL: NotificationAttachmentParser {
+    enum URLError: LocalizedError {
+        case noURL
+        case invalidURL
+
+        var errorDescription: String? {
+            switch self {
+            case .noURL: return L10n.NotificationService.Parser.Url.noUrl
+            case .invalidURL: return L10n.NotificationService.Parser.Url.invalidUrl
+            }
+        }
+    }
+
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult> {
+        guard let attachment = content.userInfo["attachment"] as? [String: Any] else {
+            return .value(.missing)
+        }
+
+        guard let urlString = attachment["url"] as? String else {
+            return .value(.rejected(URLError.noURL))
+        }
+
+        guard let url = URL(string: urlString) else {
+            return .value(.rejected(URLError.invalidURL))
+        }
+
+        let needsAuth: Bool = urlString.hasPrefix("/")
+        let contentType = (attachment["content-type"] as? String).flatMap(NotificationAttachmentInfo.contentType(for:))
+        let hideThumbnail = attachment["hide-thumbnail"] as? Bool
+
+        return .value(.fulfilled(.init(
+            url: url,
+            needsAuth: needsAuth,
+            typeHint: contentType,
+            hideThumbnail: hideThumbnail
+        )))
+    }
+}

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -607,6 +607,25 @@ public enum L10n {
     }
   }
 
+  public enum NotificationService {
+    /// Failed to load attachment
+    public static var failedToLoad: String { return L10n.tr("Localizable", "notification_service.failed_to_load") }
+    public enum Parser {
+      public enum Camera {
+        /// entity_id provided was invalid.
+        public static var invalidEntity: String { return L10n.tr("Localizable", "notification_service.parser.camera.invalid_entity") }
+        /// No entity_id was provided.
+        public static var noEntity: String { return L10n.tr("Localizable", "notification_service.parser.camera.no_entity") }
+      }
+      public enum Url {
+        /// The given URL was invalid.
+        public static var invalidUrl: String { return L10n.tr("Localizable", "notification_service.parser.url.invalid_url") }
+        /// No URL was provided.
+        public static var noUrl: String { return L10n.tr("Localizable", "notification_service.parser.url.no_url") }
+      }
+    }
+  }
+
   public enum NotificationsConfigurator {
     /// Identifier
     public static var identifier: String { return L10n.tr("Localizable", "notifications_configurator.identifier") }

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
@@ -1,0 +1,340 @@
+import Foundation
+@testable import Shared
+import XCTest
+import PromiseKit
+import OHHTTPStubs
+import CoreServices
+
+class NotificationAttachmentManagerTests: XCTestCase {
+    private var manager: NotificationAttachmentManager!
+    private var api: FakeHomeAssistantAPI!
+    private var parser1: FakeNotificationParser1.Type!
+    private var parser2: FakeNotificationParser2.Type!
+    private var parser3: FakeNotificationParser3.Type!
+
+    private var image1: Image!
+    private var image2: Image!
+
+    override func setUp() {
+        super.setUp()
+
+        Current.settingsStore.connectionInfo = .init(
+            externalURL: URL(string: "http://example.com")!,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhookid",
+            webhookSecret: "webhooksecret",
+            internalSSIDs: nil
+        )
+
+        image1 = .init()
+        image2 = .init()
+
+        api = FakeHomeAssistantAPI(
+            tokenInfo: .init(
+                accessToken: "atoken",
+                refreshToken: "refreshtoken",
+                expiration: Date(timeIntervalSinceNow: 10000)
+            )
+        )
+
+        parser1 = FakeNotificationParser1.self
+        parser1.reset()
+
+        parser2 = FakeNotificationParser2.self
+        parser2.reset()
+
+        parser3 = FakeNotificationParser3.self
+        parser3.reset()
+
+        manager = NotificationAttachmentManager(parsers: [parser1, parser2, parser3])
+    }
+
+    private func firstAttachment(for content: UNNotificationContent) throws -> UNNotificationAttachment {
+        let promise = manager.content(from: content, api: api)
+        let content = try hang(Promise(promise))
+        if let attachment =  content.attachments.first {
+            return attachment
+        } else {
+            enum NoAttachmentError: Error { case noAttachment }
+            throw NoAttachmentError.noAttachment
+        }
+    }
+
+    func testDefaultParsers() {
+        let parsers = NotificationAttachmentManager().parsers
+        XCTAssertFalse(parsers.isEmpty)
+    }
+
+    func testSummaryArgumentAlreadySet() throws {
+        let content = with(UNMutableNotificationContent()) {
+            $0.summaryArgument = "things"
+            $0.threadIdentifier = "thread_identifier"
+            $0.categoryIdentifier = "category_identifier"
+        }
+        let promise = manager.content(from: content, api: api)
+        let result = try hang(Promise(promise))
+        XCTAssertEqual(result.summaryArgument, "things")
+    }
+
+    func testSummaryArgumentArgumentFromThreadIdentifier() throws {
+        let content = with(UNMutableNotificationContent()) {
+            $0.summaryArgument = ""
+            $0.threadIdentifier = "thread_identifier"
+            $0.categoryIdentifier = "category_identifier"
+        }
+        let promise = manager.content(from: content, api: api)
+        let result = try hang(Promise(promise))
+        XCTAssertEqual(result.summaryArgument, "thread_identifier")
+    }
+
+    func testSummaryArgumentArgumentFromCategoryIdentifier() throws {
+        let content = with(UNMutableNotificationContent()) {
+            $0.summaryArgument = ""
+            $0.threadIdentifier = ""
+            $0.categoryIdentifier = "category_identifier"
+        }
+        let promise = manager.content(from: content, api: api)
+        let result = try hang(Promise(promise))
+        XCTAssertEqual(result.summaryArgument, "category_identifier")
+    }
+
+    func testAllMissing() {
+        parser1.result = .missing
+        parser2.result = .missing
+        parser3.result = .missing
+
+        let content = UNNotificationContent()
+        let promise = manager.content(from: content, api: api)
+        XCTAssertEqual(try hang(Promise(promise)), content)
+    }
+
+    func testOneContentUnauth() throws {
+        parser2.result = image1.successParserResult(needsAuth: false)
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+    }
+
+    func testOneContentAuth() throws {
+        parser2.result = image1.successParserResult(needsAuth: true)
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+    }
+
+    func testTwoContentUnauth() throws {
+        parser1.result = image1.successParserResult(needsAuth: false)
+        parser2.result = image2.successParserResult(needsAuth: false)
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+    }
+
+    func testTwoContentAuth() throws {
+        parser1.result = image1.successParserResult(needsAuth: false)
+        parser2.result = image2.successParserResult(needsAuth: true)
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+    }
+
+    func testContentTimesOut() throws {
+        let error = URLError(.timedOut)
+        parser1.result = image1.failureParserResult(failure: .error(error))
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertNotEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertTrue(attachment.accessibilityLabel?.contains(error.localizedDescription) == true)
+    }
+
+    func testContentNotFound() throws {
+        parser1.result = image1.failureParserResult(failure: .statusCode(404))
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertNotEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertTrue(attachment.accessibilityLabel?.contains("404") == true)
+    }
+
+    func testContentType() throws {
+        parser1.result = image1.successParserResult(
+            needsAuth: false,
+            typeHint: kUTTypeGIF,
+            hideThumbnail: nil
+        )
+
+        let attachment = try firstAttachment(for: .init())
+        XCTAssertEqual(attachment.type, kUTTypeGIF as String)
+    }
+
+    func testHideThumbnailDefault() throws {
+        parser1.result = image1.successParserResult(
+            needsAuth: false,
+            typeHint: nil,
+            hideThumbnail: nil
+        )
+
+        let attachment = try firstAttachment(for: .init())
+        // fragile? yes. lazy? yes. effective? ask me in an iOS release
+        XCTAssertTrue(attachment.debugDescription.contains("displayLocation: default"))
+    }
+
+
+    func testHideThumbnailTrue() throws {
+        parser1.result = image1.successParserResult(
+            needsAuth: false,
+            typeHint: nil,
+            hideThumbnail: true
+        )
+
+        let attachment = try firstAttachment(for: .init())
+        // fragile? yes. lazy? yes. effective? ask me in an iOS release
+        XCTAssertTrue(attachment.debugDescription.contains("displayLocation: long-look"))
+    }
+
+    func testHideThumbnailFalse() throws {
+        parser1.result = image1.successParserResult(
+            needsAuth: false,
+            typeHint: nil,
+            hideThumbnail: false
+        )
+
+        let attachment = try firstAttachment(for: .init())
+        // fragile? yes. lazy? yes. effective? ask me in an iOS release
+        XCTAssertTrue(attachment.debugDescription.contains("displayLocation: default"))
+    }
+}
+
+private class Image {
+    var image: UIImage
+    var data: Data
+    private var stubDescriptors: [HTTPStubsDescriptor] = []
+
+    private class func newURL() -> URL {
+        return URL(string: "http://example.com/" + UUID().uuidString + ".png")!
+    }
+
+    init() {
+        let size = CGSize(width: 10, height: 10)
+        let data = UIGraphicsImageRenderer(size: size).pngData { _ in
+            UIColor.randomBackgroundColor().setFill()
+            UIRectFill(CGRect(origin: .zero, size: size))
+        }
+
+        self.data = data
+        self.image = UIImage(data: data)!
+    }
+
+    deinit {
+        for descriptor in stubDescriptors {
+            HTTPStubs.removeStub(descriptor)
+        }
+    }
+
+    func successParserResult(
+        needsAuth: Bool = false,
+        typeHint: CFString? = nil,
+        hideThumbnail: Bool? = nil
+    ) -> NotificationAttachmentParserResult {
+        let url = Self.newURL()
+
+        stubDescriptors.append(stub(condition: { $0.url == url }, response: { [data] request in
+            if needsAuth {
+                if request.allHTTPHeaderFields?["Authorization"] == "Bearer atoken" {
+                    return .init(data: data, statusCode: 200, headers: [:])
+                } else {
+                    return .init(data: Data(), statusCode: 401, headers: [:])
+                }
+            } else {
+                if request.allHTTPHeaderFields?["Authorization"] == nil {
+                    return .init(data: data, statusCode: 200, headers: [:])
+                } else {
+                    return .init(data: Data(), statusCode: 401, headers: [:])
+                }
+            }
+        }))
+
+        return .fulfilled(.init(
+            url: url,
+            needsAuth: needsAuth,
+            typeHint: typeHint,
+            hideThumbnail: hideThumbnail
+        ))
+    }
+
+    enum FailureType {
+        case error(Error)
+        case statusCode(Int32)
+    }
+
+    func failureParserResult(
+        failure: FailureType,
+        needsAuth: Bool = false
+    ) -> NotificationAttachmentParserResult {
+        let url = Self.newURL()
+
+        stubDescriptors.append(stub(condition: { $0.url == url }, response: { request in
+            switch failure {
+            case .error(let error):
+                return .init(error: error)
+            case .statusCode(let statusCode):
+                return .init(data: Data(), statusCode: statusCode, headers: [:])
+            }
+        }))
+
+        return .fulfilled(.init(
+            url: url,
+            needsAuth: needsAuth,
+            typeHint: nil,
+            hideThumbnail: nil
+        ))
+    }
+}
+
+private enum UnSetError: Error {
+    case unset
+}
+
+private class FakeNotificationParser1: NotificationAttachmentParser {
+    required init() {}
+
+    static func reset() {
+        result = .rejected(UnSetError.unset)
+    }
+    static var result: NotificationAttachmentParserResult = .rejected(UnSetError.unset)
+
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult> {
+        return .value(Self.result)
+    }
+}
+
+private class FakeNotificationParser2: NotificationAttachmentParser {
+    required init() {}
+
+    static func reset() {
+        result = .rejected(UnSetError.unset)
+    }
+    static var result: NotificationAttachmentParserResult = .rejected(UnSetError.unset)
+
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult> {
+        return .value(Self.result)
+    }
+}
+
+private class FakeNotificationParser3: NotificationAttachmentParser {
+    required init() {}
+
+    static func reset() {
+        result = .rejected(UnSetError.unset)
+    }
+    static var result: NotificationAttachmentParserResult = .rejected(UnSetError.unset)
+
+    func attachmentInfo(from content: UNNotificationContent) -> Guarantee<NotificationAttachmentParserResult> {
+        return .value(Self.result)
+    }
+}
+
+private class FakeHomeAssistantAPI: HomeAssistantAPI {
+
+}

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentParserCamera.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentParserCamera.test.swift
@@ -1,0 +1,122 @@
+import Foundation
+@testable import Shared
+import XCTest
+import PromiseKit
+import CoreServices
+
+class NotificationAttachmentParserCameraTests: XCTestCase {
+    private typealias CameraError = NotificationAttachmentParserCamera.CameraError
+
+    private var parser: NotificationAttachmentParserCamera!
+
+    override func setUp() {
+        super.setUp()
+
+        parser = NotificationAttachmentParserCamera()
+    }
+
+    func testCameraIdentifiers() {
+        let validIdentifiers: [String] = [
+            "camera",
+            "CAMERA",
+            "camera1",
+            "CAMERA1",
+            "camera2",
+            "CAMERA2"
+        ]
+
+        let invalidIdentifiers: [String] = [
+            "", // same as no category in api
+            "cammy",
+            "alarm",
+            "alert"
+        ]
+
+        for valid in validIdentifiers {
+            let content = UNMutableNotificationContent()
+            content.categoryIdentifier = valid
+            let promise = parser.attachmentInfo(from: content)
+            XCTAssertNotEqual(promise.wait(), .missing)
+        }
+
+        for invalid in invalidIdentifiers {
+            let content = UNMutableNotificationContent()
+            content.categoryIdentifier = invalid
+            let promise = parser.attachmentInfo(from: content)
+            XCTAssertEqual(promise.wait(), .missing)
+        }
+    }
+
+    func testMissingEntityID() {
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = "camera"
+        let promise = parser.attachmentInfo(from: content)
+        XCTAssertEqual(promise.wait(), .rejected(CameraError.noEntity))
+    }
+
+    func testInvalidEntityID() {
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = "camera"
+        content.userInfo["entity_id"] = "\\"
+        let promise = parser.attachmentInfo(from: content)
+        XCTAssertEqual(promise.wait(), .rejected(CameraError.invalidEntity))
+    }
+
+    func testAttachmentHidden() {
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = "camera"
+        content.userInfo["entity_id"] = "camera.any"
+        content.userInfo["attachment"] = [
+            "hide-thumbnail": true
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/api/camera_proxy/camera.any"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, kUTTypeJPEG)
+        XCTAssertEqual(result.hideThumbnail, true)
+    }
+
+    func testAttachmentNotHidden() {
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = "camera"
+        content.userInfo["entity_id"] = "camera.any"
+        content.userInfo["attachment"] = [
+            "hide-thumbnail": false
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/api/camera_proxy/camera.any"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, kUTTypeJPEG)
+        XCTAssertEqual(result.hideThumbnail, false)
+    }
+
+
+    func testAttachmentInfo() {
+        let content = UNMutableNotificationContent()
+        content.categoryIdentifier = "camera"
+        content.userInfo["entity_id"] = "camera.any"
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/api/camera_proxy/camera.any"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, kUTTypeJPEG)
+        XCTAssertEqual(result.hideThumbnail, nil)
+    }
+}

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import Shared
+import XCTest
+import CoreServices
+
+class NotificationAttachmentParserURLTests: XCTestCase {
+    private typealias URLError = NotificationAttachmentParserURL.URLError
+
+    private var parser: NotificationAttachmentParserURL!
+
+    override func setUp() {
+        super.setUp()
+
+        parser = NotificationAttachmentParserURL()
+    }
+
+    func testNoAttachment() {
+        let content = UNMutableNotificationContent()
+        let promise = parser.attachmentInfo(from: content)
+        XCTAssertEqual(promise.wait(), .missing)
+    }
+
+    func testAttachmentNoURL() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [String: Any]()
+        let promise = parser.attachmentInfo(from: content)
+        XCTAssertEqual(promise.wait(), .rejected(URLError.noURL))
+    }
+
+    func testInvalidURL() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": ""
+        ]
+        let promise = parser.attachmentInfo(from: content)
+        XCTAssertEqual(promise.wait(), .rejected(URLError.invalidURL))
+    }
+
+    func testRelativeAttachmentURL() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png"
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, nil)
+    }
+
+    func testAbsoluteAttachmentURL() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "http://google.com/media/local/file.png"
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "http://google.com/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, false)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, nil)
+    }
+
+    func testContentType() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png",
+            "content-type": "png"
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, kUTTypePNG)
+        XCTAssertEqual(result.hideThumbnail, nil)
+    }
+
+    func testAttachmentHidden() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png",
+            "hide-thumbnail": true
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, true)
+    }
+
+    func testAttachmentNotHidden() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png",
+            "hide-thumbnail": false
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, false)
+    }
+}


### PR DESCRIPTION
## Summary
- Refactors notification attachment into smaller units. Adds tests.
- Adds an image attachment with whatever the error reason is when an attachment fails to download.
- Adds a Shared framework scheme which can run just its tests. It's a bit faster than doing the whole app which has a lot of extensions and watchOS targets.

## Screenshots
![Image](https://user-images.githubusercontent.com/74188/102575375-d4de8100-40a7-11eb-868f-d19b60710bf7.PNG)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
This does not (yet?) create the error images for the service timeout. Not sure how relevant that may end up. I haven't yet come across a case of this happening in logs and being confusing.