### PR TITLE
Fix crash when Map notification is provided invalid latitude/longitude

### DIFF
--- a/Sources/Extensions/NotificationContent/MapViewController.swift
+++ b/Sources/Extensions/NotificationContent/MapViewController.swift
@@ -33,6 +33,18 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         }
     }
 
+    private class func degrees(from value: Any?) -> CLLocationDegrees? {
+        if let value = value as? String {
+            return CLLocationDegrees(value)
+        } else if let value = value as? Double {
+            return CLLocationDegrees(value)
+        } else if let value = value as? Int {
+            return CLLocationDegrees(value)
+        } else {
+            return nil
+        }
+    }
+
     // swiftlint:disable:next function_body_length
     func didReceive(notification: UNNotification, extensionContext: NSExtensionContext?) -> Promise<Void> {
         let userInfo = notification.request.content.userInfo
@@ -40,14 +52,12 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         guard let haDict = userInfo["homeassistant"] as? [String: Any] else {
             return .init(error: MapError.missingPayload)
         }
-        guard let latitudeString = haDict["latitude"] as? String else {
+        guard let latitude = Self.degrees(from: haDict["latitude"]) else {
             return .init(error: MapError.missingLatitude)
         }
-        guard let longitudeString = haDict["longitude"] as? String else {
+        guard let longitude = Self.degrees(from: haDict["longitude"]) else {
             return .init(error: MapError.missingLongitude)
         }
-        let latitude = Double.init(latitudeString)! as CLLocationDegrees
-        let longitude = Double.init(longitudeString)! as CLLocationDegrees
         let location = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
         self.mapView = MKMapView()
 
@@ -71,10 +81,8 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         let dropPin = MKPointAnnotation()
         dropPin.coordinate = location
 
-        if let secondLatitudeString = haDict["second_latitude"] as? String,
-            let secondLongitudeString = haDict["second_longitude"] as? String {
-            let secondLatitude = Double.init(secondLatitudeString)! as CLLocationDegrees
-            let secondLongitude = Double.init(secondLongitudeString)! as CLLocationDegrees
+        if let secondLatitude = Self.degrees(from: haDict["second_latitude"]),
+           let secondLongitude = Self.degrees(from: haDict["second_longitude"]) {
             let secondDropPin = MKPointAnnotation()
             secondDropPin.coordinate = CLLocationCoordinate2D(latitude: secondLatitude, longitude: secondLongitude)
             secondDropPin.title = L10n.Extensions.Map.Location.new


### PR DESCRIPTION
- Fixes a crash when `latitude` or `longitude` are String types but not able to be converted to Double/CLLocationDegrees.
- Adds support for Int or Float-based `latitude` or `longitude`, e.g. what native templates would provide were it not currently broken.