### PR TITLE
Add macOS-specific location permission description

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -590,6 +590,8 @@
 	<string>We always need access to your location for features like iBeacons, geofences, background location updates and accurate reporting.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Only allowing location access while app is in use will disable iBeacons, geofences, background location updates and accurate reporting.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>When enabled, your device location is sent to your Home Assistant server as a device tracker.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Motion is used to improve location updates with current motion type, as well as provide basic pedometer data.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/Sources/App/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/en.lproj/InfoPlist.strings
@@ -11,3 +11,4 @@
 "NSCameraUsageDescription" = "Take photos and send them to your Home Assistant server.";
 "NSCrossWebsiteTrackingUsageDescription" = "Optionally enable cross-website tracking if your configuration requires it.";
 "NSMicrophoneUsageDescription" = "Record audio using your Home Assistant frontend.";
+"NSLocationUsageDescription" = "When enabled, your device location is sent to your Home Assistant server as a device tracker.";


### PR DESCRIPTION
Required for Mac App Store review. This notably does not use the iOS keys (`NSLocationWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescription`, `NSLocationAlwaysAndWhenInUseUsageDescription`) but instead uses the deprecated key `NSLocationUsageDescription`.

<img width="372" alt="Screen Shot 2021-01-02 at 16 57 58" src="https://user-images.githubusercontent.com/74188/103469632-2d568500-4d1c-11eb-8d5c-2411c54276ef.png">
