### PR TITLE
Updates for iOS 14's "Precise" location setting

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -676,5 +676,10 @@
 	</array>
 	<key>NSCrossWebsiteTrackingUsageDescription</key>
 	<string>Optionally enable cross-website tracking if your configuration requires it.</string>
+	<key>NSLocationTemporaryUsageDescriptionDictionary</key>
+	<dict>
+		<key>TemporaryFullAccuracyReasonManualUpdate</key>
+		<string>[localized in strings file]</string>
+	</dict>
 </dict>
 </plist>

--- a/Sources/App/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/en.lproj/InfoPlist.strings
@@ -12,3 +12,4 @@
 "NSCrossWebsiteTrackingUsageDescription" = "Optionally enable cross-website tracking if your configuration requires it.";
 "NSMicrophoneUsageDescription" = "Record audio using your Home Assistant frontend.";
 "NSLocationUsageDescription" = "When enabled, your device location is sent to your Home Assistant server as a device tracker.";
+"TemporaryFullAccuracyReasonManualUpdate" = "Grant full accuracy to use your current location for your device tracker.";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -909,7 +909,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "notification_service.parser.url.invalid_url" = "The given URL was invalid.";
 "notification_service.parser.camera.no_entity" = "No entity_id was provided.";
 "notification_service.parser.camera.invalid_entity" = "entity_id provided was invalid.";
-"settings.connection_section.ssid_permission_and_accuracy_message" = "Accessing SSIDs in the background requires 'Always' location permission and 'Full' location precision. Tap here to change your settings.";
+"settings.connection_section.ssid_permission_and_accuracy_message" = "Accessing SSIDs in the background requires 'Always' location permission and 'Full' location accuracy. Tap here to change your settings.";
 "settings_details.location.location_accuracy.title" = "Location Accuracy";
 "settings_details.location.location_accuracy.full" = "Full";
 "settings_details.location.location_accuracy.reduced" = "Reduced";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -909,6 +909,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "notification_service.parser.url.invalid_url" = "The given URL was invalid.";
 "notification_service.parser.camera.no_entity" = "No entity_id was provided.";
 "notification_service.parser.camera.invalid_entity" = "entity_id provided was invalid.";
+"settings.connection_section.ssid_permission_and_accuracy_message" = "Accessing SSIDs in the background requires 'Always' location permission and 'Full' location precision. Tap here to change your settings.";
 "settings_details.location.location_accuracy.title" = "Location Accuracy";
 "settings_details.location.location_accuracy.full" = "Full";
 "settings_details.location.location_accuracy.reduced" = "Reduced";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -909,3 +909,6 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "notification_service.parser.url.invalid_url" = "The given URL was invalid.";
 "notification_service.parser.camera.no_entity" = "No entity_id was provided.";
 "notification_service.parser.camera.invalid_entity" = "entity_id provided was invalid.";
+"settings_details.location.location_accuracy.title" = "Location Accuracy";
+"settings_details.location.location_accuracy.full" = "Full";
+"settings_details.location.location_accuracy.reduced" = "Reduced";

--- a/Sources/App/Settings/Connection/ConnectionURLViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLViewController.swift
@@ -262,7 +262,11 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
         }
 
         section <<< InfoLabelRow {
-            $0.title = L10n.Settings.ConnectionSection.ssidPermissionAndAccuracyMessage
+            if #available(iOS 14, *) {
+                $0.title = L10n.Settings.ConnectionSection.ssidPermissionAndAccuracyMessage
+            } else {
+                $0.title = L10n.Settings.ConnectionSection.ssidPermissionMessage
+            }
 
             $0.cellUpdate { cell, _ in
                 cell.accessibilityTraits.insert(.button)

--- a/Sources/App/Utilities/Permissions.swift
+++ b/Sources/App/Utilities/Permissions.swift
@@ -261,6 +261,15 @@ private class PermissionsLocationDelegate: NSObject, CLLocationManagerDelegate {
         super.init()
     }
 
+    @available(iOS 14, *)
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        if manager.authorizationStatus == .notDetermined {
+            return
+        }
+
+        completionHandler?(manager.authorizationStatus.genericStatus)
+    }
+
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status == .notDetermined {
             return

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1171,6 +1171,8 @@ public enum L10n {
       public static var nabuCasaCloud: String { return L10n.tr("Localizable", "settings.connection_section.nabu_casa_cloud") }
       /// Remote UI Available
       public static var remoteUiAvailable: String { return L10n.tr("Localizable", "settings.connection_section.remote_ui_available") }
+      /// Accessing SSIDs in the background requires 'Always' location permission and 'Full' location precision. Tap here to change your settings.
+      public static var ssidPermissionAndAccuracyMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_and_accuracy_message") }
       /// Accessing SSIDs in the background requires 'Always' location permission. Tap here to change your settings.
       public static var ssidPermissionMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_message") }
       public enum ApiPasswordRow {
@@ -1637,6 +1639,14 @@ public enum L10n {
         public static var enabled: String { return L10n.tr("Localizable", "settings_details.location.background_refresh.enabled") }
         /// Background Refresh
         public static var title: String { return L10n.tr("Localizable", "settings_details.location.background_refresh.title") }
+      }
+      public enum LocationAccuracy {
+        /// Full
+        public static var full: String { return L10n.tr("Localizable", "settings_details.location.location_accuracy.full") }
+        /// Reduced
+        public static var reduced: String { return L10n.tr("Localizable", "settings_details.location.location_accuracy.reduced") }
+        /// Location Accuracy
+        public static var title: String { return L10n.tr("Localizable", "settings_details.location.location_accuracy.title") }
       }
       public enum LocationPermission {
         /// Always

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1171,7 +1171,7 @@ public enum L10n {
       public static var nabuCasaCloud: String { return L10n.tr("Localizable", "settings.connection_section.nabu_casa_cloud") }
       /// Remote UI Available
       public static var remoteUiAvailable: String { return L10n.tr("Localizable", "settings.connection_section.remote_ui_available") }
-      /// Accessing SSIDs in the background requires 'Always' location permission and 'Full' location precision. Tap here to change your settings.
+      /// Accessing SSIDs in the background requires 'Always' location permission and 'Full' location accuracy. Tap here to change your settings.
       public static var ssidPermissionAndAccuracyMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_and_accuracy_message") }
       /// Accessing SSIDs in the background requires 'Always' location permission. Tap here to change your settings.
       public static var ssidPermissionMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_message") }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -180,7 +180,23 @@ public class SettingsStore {
 
     #if os(iOS)
     public func isLocationEnabled(for state: UIApplication.State) -> Bool {
-        switch CLLocationManager.authorizationStatus() {
+        let authorizationStatus: CLAuthorizationStatus
+        let hasFullAccuracy: Bool
+
+        if #available(iOS 14, *) {
+            let locationManager = CLLocationManager()
+            authorizationStatus = locationManager.authorizationStatus
+            hasFullAccuracy = locationManager.accuracyAuthorization == .fullAccuracy
+        } else {
+            authorizationStatus = CLLocationManager.authorizationStatus()
+            hasFullAccuracy = true
+        }
+
+        if !hasFullAccuracy {
+            return false
+        }
+
+        switch authorizationStatus {
         case .authorizedAlways:
             return true
         case .authorizedWhenInUse:


### PR DESCRIPTION
Fixes #776.

## Summary
- Adds a temporary request for full accuracy when pulling-to-refresh.
- Prevents delays when sending sensor updates trying to get accurate locations when accuracy isn't full; we no longer consider ourselves having location permission when accuracy isn't full.
- Add "Location Accuracy" setting to Location settings, showing current state.
- Adds a warning to the Internal URL editing when accuracy isn't full, since it is required to get SSID information.
- Updates to use newer CLLocationManager "authorization changed!" methods in various places.

## Screenshots
![Image](https://user-images.githubusercontent.com/74188/103495255-02893100-4def-11eb-880c-bfd8c5f295bf.png)
![Image 2](https://user-images.githubusercontent.com/74188/103495181-bc33d200-4dee-11eb-8bcd-d00ba191cab9.png)
![Image-4](https://user-images.githubusercontent.com/74188/103495490-c99d8c00-4def-11eb-8b8e-b81a4900a4c6.png)
![Image-3](https://user-images.githubusercontent.com/74188/103495278-1a60b500-4def-11eb-9139-2666cc46bc2a.png)