### PR TITLE
Watch for App termination and update Active Status

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1104FD05253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FD04253292CD00B8BE34 /* Guarantee+Additions.swift */; };
 		1104FD06253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FD04253292CD00B8BE34 /* Guarantee+Additions.swift */; };
 		1104FD07253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1104FD04253292CD00B8BE34 /* Guarantee+Additions.swift */; };
+		1108BC4325A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1108BC4225A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift */; };
 		1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82024A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F82324A25A41002590F2 /* SensorContainer.test.swift */; };
@@ -909,6 +910,7 @@
 		1104FCBE2532755400B8BE34 /* WatchBackgroundRefreshScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBackgroundRefreshScheduler.swift; sourceTree = "<group>"; };
 		1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchBackgroundRefreshScheduler.test.swift; sourceTree = "<group>"; };
 		1104FD04253292CD00B8BE34 /* Guarantee+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Guarantee+Additions.swift"; sourceTree = "<group>"; };
+		1108BC4225A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeAppDelegateHandler.swift; sourceTree = "<group>"; };
 		1109B6BA25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Intents.strings; sourceTree = "<group>"; };
 		1109B6BB25263EEE005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Onboarding.strings; sourceTree = "<group>"; };
 		1109B6BC25263EEF005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1886,6 +1888,7 @@
 				1194B3EB2519B48500AA01C3 /* Resources */,
 				1167408D251990D500F51626 /* MacBridgeImpl.swift */,
 				1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */,
+				1108BC4225A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift */,
 			);
 			path = MacBridge;
 			sourceTree = "<group>";
@@ -4394,6 +4397,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1167409B251991AB00F51626 /* MacBridgeProtocol.swift in Sources */,
+				1108BC4325A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift in Sources */,
 				1194B4162519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift in Sources */,
 				1167408E251990D500F51626 /* MacBridgeImpl.swift in Sources */,
 			);

--- a/Sources/MacBridge/MacBridgeAppDelegateHandler.swift
+++ b/Sources/MacBridge/MacBridgeAppDelegateHandler.swift
@@ -1,0 +1,52 @@
+import Foundation
+import AppKit
+import ObjectiveC.runtime
+
+enum MacBridgeAppDelegateHandler {
+    static let terminationWillBeginNotification: Notification.Name = .init("ha_terminationWillBegin")
+
+    static func swizzleAppDelegate() {
+        guard let delegate = NSApplication.shared.delegate else {
+            // this likely only happens one time; the delegate is set after initial setup but before the runloop starts
+            DispatchQueue.main.async {
+                swizzleAppDelegate()
+            }
+            return
+        }
+
+        struct SwizzleMethods {
+            let original: Selector
+            let replacement: Selector
+        }
+
+        let allMethods: [SwizzleMethods] = [
+            .init(
+                original: #selector(NSApplicationDelegate.applicationShouldTerminate(_:)),
+                replacement: #selector(NSObject.ha_applicationShouldTerminate(_:))
+            )
+        ]
+
+        let klass = type(of: delegate)
+
+        for methods in allMethods {
+            guard let original = class_getInstanceMethod(klass, methods.original),
+                  let replacement = class_getInstanceMethod(klass, methods.replacement) else {
+                fatalError("couldn't get methods for \(methods)")
+            }
+
+            method_exchangeImplementations(original, replacement)
+        }
+    }
+}
+
+private extension NSObject {
+    @objc func ha_applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // we need to do this (a) long before actual termination, because we need to prevent it from happening
+        // and (b) before we ask the NSUIApplicationDelegate what its response is, in case it doesn't delay otherwise
+        // since we're going to (in effect) end up enqueueing background tasks as a result of this notification
+        NotificationCenter.default.post(.init(name: MacBridgeAppDelegateHandler.terminationWillBeginNotification))
+
+        // refers to the non-swizzled method
+        return ha_applicationShouldTerminate(sender)
+    }
+}

--- a/Sources/MacBridge/MacBridgeImpl.swift
+++ b/Sources/MacBridge/MacBridgeImpl.swift
@@ -9,6 +9,12 @@ import CoreWLAN
         self.wifiClient = CWWiFiClient.shared()
 
         super.init()
+
+        MacBridgeAppDelegateHandler.swizzleAppDelegate()
+    }
+
+    var terminationWillBeginNotification: Notification.Name {
+        MacBridgeAppDelegateHandler.terminationWillBeginNotification
     }
 
     var distributedNotificationCenter: NotificationCenter {

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -8,6 +8,8 @@ import Foundation
     var workspaceNotificationCenter: NotificationCenter { get }
 
     var wifiConnectivity: MacBridgeWiFiConnectivity? { get }
+
+    var terminationWillBeginNotification: Notification.Name { get }
 }
 
 @objc(MacBridgeWiFiConnectivity) public protocol MacBridgeWiFiConnectivity: NSObjectProtocol {

--- a/Tests/Shared/ActiveStateManager.test.swift
+++ b/Tests/Shared/ActiveStateManager.test.swift
@@ -124,6 +124,14 @@ class ActiveStateManagerTests: XCTestCase {
         XCTAssertEqual(manager.idleTimer?.isValid, true)
     }
 
+    func testTerminate() {
+        notificationCenter.post(name: .init("NonMac_terminationWillBeginNotification"), object: nil)
+        XCTAssertTrue(observer.didUpdate)
+        XCTAssertFalse(manager.isActive)
+        XCTAssertTrue(manager.states.isTerminating)
+        XCTAssertNil(manager.idleTimer)
+    }
+
     func testIdleTimeWithoutAnythingElse() {
         Current.device.idleTime = { .init(value: 99, unit: .seconds) }
         manager.minimumIdleTime = .init(value: 100, unit: .seconds)


### PR DESCRIPTION
Fixes #1270.

## Summary
Sends a webhook update with the active status as 'off' when the app is terminating. This doesn't work if, of course, the app crashes or is force quit.

## Screenshots
<img width="430" alt="image" src="https://user-images.githubusercontent.com/74188/103612124-9682f780-4ed8-11eb-8ae2-7c0c9a9f383d.png">

## Any other notes
In a normal Mac app, to do something when Termination is about to happen, you tell the system to hold on a sec, you do the thing, and then you tell the system you're done. Easy, right?

Well, we're a Catalyst app, so no: it definitely is not that easy. Why should we have access to an `NSApplicationDelegate` instance to do this exchange?

After quite a bit of investigation, I'm reasonably sure that `NSUIApplicationDelegate` does termination like so: if there are any existing `UIApplication` background tasks, delay termination, wait for them to complete, then complete termination.

The trick then becomes trying to get a background task started before termination starts. However, there's a problem here: the `UIApplication.willTerminateNotification` will only fire when it's about to respond to the "terminate later" with "GO!" This means we need to get in there sooner. However, there's nothing else that we can access publicly that happens sooner. In fact, there isn't even a private notification that fires for this case that we could piggyback off of, not that that's likely to be stable going forward.

One path that seemed hopeful was the `UIApplication.willResignActiveNotification` which does fire at the right time. However, it also fires when Hiding the app, so we can't use it as a "termination is gonna happen" indicator since we don't want to set active status to 'off' incorrectly.

In the end, the easiest route I could get working is to swizzle the app delegate and when we're asked whether we should do a normal termination and use this to kick off the background task. Our teed-up background task for the webhook update, live-signaled by the active status changing, both prevents the termination and does the update.

In my testing this works for every mechanism of clean termination I could think of: Quit menu item, "Quit" from Activity Monitor, system shutdown.