### PR TITLE
Add sensors for Mac displays

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		110E694624E771AB004AA96D /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694524E771AB004AA96D /* Color+Hex.swift */; };
 		110EC9FD251708D5009C9A1B /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
 		110EC9FE251708D5009C9A1B /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		110ED55425A5604F00489AF7 /* MacBridgeScreenImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ED55325A5604F00489AF7 /* MacBridgeScreenImpl.swift */; };
+		110ED56325A563D600489AF7 /* DisplaySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ED56225A563D600489AF7 /* DisplaySensor.swift */; };
+		110ED56425A563D600489AF7 /* DisplaySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ED56225A563D600489AF7 /* DisplaySensor.swift */; };
+		110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ED57F25A570F100489AF7 /* DisplaySensor.test.swift */; };
 		110FB44C2499C1A3000865B4 /* CameraStreamHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44B2499C1A3000865B4 /* CameraStreamHandler.swift */; };
 		110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44D2499C1CF000865B4 /* CameraStreamHLSViewController.swift */; };
 		110FB4502499CE34000865B4 /* CameraStreamMJPEGViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */; };
@@ -920,6 +924,9 @@
 		110E694124E7710E004AA96D /* WidgetActionsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsContainerView.swift; sourceTree = "<group>"; };
 		110E694324E77125004AA96D /* WidgetActionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsProvider.swift; sourceTree = "<group>"; };
 		110E694524E771AB004AA96D /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
+		110ED55325A5604F00489AF7 /* MacBridgeScreenImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeScreenImpl.swift; sourceTree = "<group>"; };
+		110ED56225A563D600489AF7 /* DisplaySensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySensor.swift; sourceTree = "<group>"; };
+		110ED57F25A570F100489AF7 /* DisplaySensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySensor.test.swift; sourceTree = "<group>"; };
 		110FB44B2499C1A3000865B4 /* CameraStreamHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraStreamHandler.swift; sourceTree = "<group>"; };
 		110FB44D2499C1CF000865B4 /* CameraStreamHLSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraStreamHLSViewController.swift; sourceTree = "<group>"; };
 		110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraStreamMJPEGViewController.swift; sourceTree = "<group>"; };
@@ -1889,6 +1896,7 @@
 				1167408D251990D500F51626 /* MacBridgeImpl.swift */,
 				1194B4152519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift */,
 				1108BC4225A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift */,
+				110ED55325A5604F00489AF7 /* MacBridgeScreenImpl.swift */,
 			);
 			path = MacBridge;
 			sourceTree = "<group>";
@@ -2146,6 +2154,7 @@
 				1109F81E24A1C011002590F2 /* SensorProvider.swift */,
 				B613936824F728F8002B8C5D /* InputDeviceSensor.swift */,
 				11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */,
+				110ED56225A563D600489AF7 /* DisplaySensor.swift */,
 				118261F624F8D6B0000795C6 /* SensorProviderDependencies.swift */,
 				118261FF24F9C3D6000795C6 /* CoreMedia and CoreAudio Helpers */,
 			);
@@ -2165,6 +2174,7 @@
 				1109F82324A25A41002590F2 /* SensorContainer.test.swift */,
 				1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */,
 				11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */,
+				110ED57F25A570F100489AF7 /* DisplaySensor.test.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -4399,6 +4409,7 @@
 				1167409B251991AB00F51626 /* MacBridgeProtocol.swift in Sources */,
 				1108BC4325A2FB5A006B3C83 /* MacBridgeAppDelegateHandler.swift in Sources */,
 				1194B4162519BEE900AA01C3 /* MacBridgeWiFiConnectivityImpl.swift in Sources */,
+				110ED55425A5604F00489AF7 /* MacBridgeScreenImpl.swift in Sources */,
 				1167408E251990D500F51626 /* MacBridgeImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4641,6 +4652,7 @@
 				111858DB24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */,
 				B6B74CBE228399AC00D58A68 /* Action.swift in Sources */,
 				11358AF024FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
+				110ED56425A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				B67CE8B922200F220034C1D0 /* Environment.swift in Sources */,
 				B6723342225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				B67CE8B122200F220034C1D0 /* CLError+DebugDescription.swift in Sources */,
@@ -4754,6 +4766,7 @@
 				11AF4D1F249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,
 				B6723341225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				11C4629124B14E6B00031902 /* XCGLogger+UNNotification.swift in Sources */,
+				110ED56325A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				D0EEF318214DD7A400D1D360 /* Events.swift in Sources */,
 				11AF4D16249C8083006C74C0 /* With.swift in Sources */,
 				1182620124F9C3F7000795C6 /* HACoreBlahObject.swift in Sources */,
@@ -4899,6 +4912,7 @@
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				1104FD07253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
+				110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MacBridge/MacBridgeImpl.swift
+++ b/Sources/MacBridge/MacBridgeImpl.swift
@@ -32,4 +32,12 @@ import CoreWLAN
             return nil
         }
     }
+
+    var screens: [MacBridgeScreen] {
+        NSScreen.screens.map(MacBridgeScreenImpl.init(screen:))
+    }
+
+    var screensWillChangeNotification: Notification.Name {
+        NSApplication.didChangeScreenParametersNotification
+    }
 }

--- a/Sources/MacBridge/MacBridgeScreenImpl.swift
+++ b/Sources/MacBridge/MacBridgeScreenImpl.swift
@@ -1,0 +1,22 @@
+import AppKit
+
+class MacBridgeScreenImpl: NSObject, MacBridgeScreen {
+    let screen: NSScreen
+
+    init(screen: NSScreen) {
+        self.screen = screen
+    }
+
+    var identifier: String {
+        guard let displayID = screen.deviceDescription[.init("NSScreenNumber")] as? CGDirectDisplayID,
+              let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue() else {
+            return "(error)"
+        }
+
+        return CFUUIDCreateString(nil, uuid) as String
+    }
+
+    var name: String {
+        screen.localizedName
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/DisplaySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/DisplaySensor.swift
@@ -1,0 +1,75 @@
+import Foundation
+import PromiseKit
+
+final class DisplaySensorUpdateSignaler: SensorProviderUpdateSignaler {
+    static var notificationName: Notification.Name {
+        #if targetEnvironment(macCatalyst)
+        return Current.macBridge.screensWillChangeNotification
+        #else
+        return .init(rawValue: "test_screensWillChangeNotification")
+        #endif
+    }
+
+    let signal: () -> Void
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(screensDidChange(_:)),
+            name: Self.notificationName,
+            object: nil
+        )
+    }
+
+    @objc private func screensDidChange(_ note: Notification) {
+        signal()
+    }
+}
+
+final class DisplaySensor: SensorProvider {
+    public enum DisplayError: Error, Equatable {
+        case unsupportedPlatform
+    }
+
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        guard let screens = Current.device.screens() else {
+            return .init(error: DisplayError.unsupportedPlatform)
+        }
+
+        var sensors = [WebhookSensor]()
+
+        sensors.append(with(WebhookSensor(
+            name: "Displays",
+            uniqueID: "displays_count",
+            icon: "mdi:monitor-multiple",
+            state: screens.count
+        )) {
+            $0.Attributes = [
+                "Display IDs": screens.map(\.identifier),
+                "Display Names": screens.map(\.name)
+            ]
+        })
+
+        sensors.append(with(WebhookSensor(
+            name: "Primary Display",
+            uniqueID: "primary_display",
+            icon: "mdi:monitor-star",
+            state: screens.first.map(\.name) ?? "None"
+        )) {
+            $0.Attributes = [
+                "Display ID": screens.first.map(\.identifier) ?? "None"
+            ]
+        })
+
+        // Set up our observer
+        let _: DisplaySensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+
+        return .value(sensors)
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/DisplaySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/DisplaySensor.swift
@@ -56,16 +56,19 @@ final class DisplaySensor: SensorProvider {
             ]
         })
 
-        sensors.append(with(WebhookSensor(
-            name: "Primary Display",
-            uniqueID: "primary_display",
+        sensors.append(WebhookSensor(
+            name: "Primary Display Name",
+            uniqueID: "primary_display_name",
             icon: "mdi:monitor-star",
             state: screens.first.map(\.name) ?? "None"
-        )) {
-            $0.Attributes = [
-                "Display ID": screens.first.map(\.identifier) ?? "None"
-            ]
-        })
+        ))
+
+        sensors.append(WebhookSensor(
+            name: "Primary Display ID",
+            uniqueID: "primary_display_id",
+            icon: "mdi:monitor-star",
+            state: screens.first.map(\.identifier) ?? "None"
+        ))
 
         // Set up our observer
         let _: DisplaySensorUpdateSignaler = request.dependencies.updateSignaler(for: self)

--- a/Sources/Shared/Environment/DeviceWrapper.swift
+++ b/Sources/Shared/Environment/DeviceWrapper.swift
@@ -9,6 +9,11 @@ import UIKit
 import WatchKit
 #endif
 
+public struct DeviceScreen {
+    var identifier: String
+    var name: String
+}
+
 /// Wrapper around UIDevice/WKInterfaceDevice
 public class DeviceWrapper {
     public lazy var batteryNotificationCenter = DeviceWrapperBatteryNotificationCenter()
@@ -154,6 +159,14 @@ public class DeviceWrapper {
             }()
         )
         return .init(value: seconds, unit: .seconds)
+        #else
+        return nil
+        #endif
+    }
+
+    public var screens: () -> [DeviceScreen]? = {
+        #if targetEnvironment(macCatalyst)
+        return Current.macBridge.screens.map { .init(identifier: $0.identifier, name: $0.name) }
         #else
         return nil
         #endif

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -86,9 +86,10 @@ public class Environment {
         $0.register(provider: StorageSensor.self)
         $0.register(provider: ConnectivitySensor.self)
         $0.register(provider: GeocoderSensor.self)
-        $0.register(provider: LastUpdateSensor.self)
         $0.register(provider: InputDeviceSensor.self)
+        $0.register(provider: DisplaySensor.self)
         $0.register(provider: ActiveSensor.self)
+        $0.register(provider: LastUpdateSensor.self)
     }
 
     public var localized = LocalizedManager()

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -10,9 +10,17 @@ import Foundation
     var wifiConnectivity: MacBridgeWiFiConnectivity? { get }
 
     var terminationWillBeginNotification: Notification.Name { get }
+
+    var screens: [MacBridgeScreen] { get }
+    var screensWillChangeNotification: Notification.Name { get }
 }
 
 @objc(MacBridgeWiFiConnectivity) public protocol MacBridgeWiFiConnectivity: NSObjectProtocol {
     var ssid: String? { get }
     var bssid: String? { get }
+}
+
+@objc(MacBridgeScreen) public protocol MacBridgeScreen: NSObjectProtocol {
+    var identifier: String { get }
+    var name: String { get }
 }

--- a/Tests/Shared/Sensors/DisplaySensor.test.swift
+++ b/Tests/Shared/Sensors/DisplaySensor.test.swift
@@ -1,0 +1,110 @@
+@testable import Shared
+import XCTest
+import PromiseKit
+
+class DeviceSensorTests: XCTestCase {
+    private var request: SensorProviderRequest = .init(
+        reason: .trigger("unit-test"),
+        dependencies: .init(),
+        location: nil
+    )
+
+    private func sensors(for screens: [DeviceScreen]) throws -> (displays: WebhookSensor, primary: WebhookSensor) {
+        Current.device.screens = { screens }
+        let promise = DisplaySensor(request: request).sensors()
+        let sensors = try hang(promise)
+        XCTAssertEqual(sensors.count, 2)
+        return (displays: sensors[0], primary: sensors[1])
+    }
+
+    func testNotAvailable() {
+        Current.device.screens = { nil }
+
+        let promise = DisplaySensor(request: request).sensors()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? DisplaySensor.DisplayError, .unsupportedPlatform)
+        }
+    }
+
+    func testSignaler() {
+        var didSignal = false
+        let signaler = DisplaySensorUpdateSignaler(signal: {
+            didSignal = true
+        })
+
+        withExtendedLifetime(signaler) {
+            NotificationCenter.default.post(name: DisplaySensorUpdateSignaler.notificationName, object: nil)
+            XCTAssertTrue(didSignal)
+        }
+    }
+
+    func testUpdateSignalerCreated() throws {
+        Current.device.batteries = { [ DeviceBattery(level: 100, state: .unplugged, attributes: [:]) ] }
+
+        let dependencies = SensorProviderDependencies()
+        let provider = DisplaySensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: dependencies,
+            location: nil
+        ))
+        let promise = provider.sensors()
+        _ = try hang(promise)
+
+        let signaler: DisplaySensorUpdateSignaler? = dependencies.existingSignaler(for: provider)
+        XCTAssertNotNil(signaler)
+    }
+
+    func testNoDisplay() throws {
+        let (displays, primary) = try sensors(for: [])
+
+        XCTAssertEqual(displays.UniqueID, "displays_count")
+        XCTAssertEqual(displays.Icon, "mdi:monitor-multiple")
+        XCTAssertEqual(displays.Name, "Displays")
+        XCTAssertEqual(displays.State as? Int, 0)
+        XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], [])
+        XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], [])
+
+        XCTAssertEqual(primary.UniqueID, "primary_display")
+        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primary.Name, "Primary Display")
+        XCTAssertEqual(primary.State as? String, "None")
+        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "None")
+    }
+
+    func testOneDisplay() throws {
+        let (displays, primary) = try sensors(for: [.init(identifier: "identifier", name: "name")])
+
+        XCTAssertEqual(displays.UniqueID, "displays_count")
+        XCTAssertEqual(displays.Icon, "mdi:monitor-multiple")
+        XCTAssertEqual(displays.Name, "Displays")
+        XCTAssertEqual(displays.State as? Int, 1)
+        XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], ["identifier"])
+        XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], ["name"])
+
+        XCTAssertEqual(primary.UniqueID, "primary_display")
+        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primary.Name, "Primary Display")
+        XCTAssertEqual(primary.State as? String, "name")
+        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "identifier")
+    }
+
+    func testTwoDisplay() throws {
+        let (displays, primary) = try sensors(for: [
+            .init(identifier: "identifier1", name: "name1"),
+            .init(identifier: "identifier2", name: "name2")
+        ])
+
+        XCTAssertEqual(displays.UniqueID, "displays_count")
+        XCTAssertEqual(displays.Icon, "mdi:monitor-multiple")
+        XCTAssertEqual(displays.Name, "Displays")
+        XCTAssertEqual(displays.State as? Int, 2)
+        XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], ["identifier1", "identifier2"])
+        XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], ["name1", "name2"])
+
+        XCTAssertEqual(primary.UniqueID, "primary_display")
+        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primary.Name, "Primary Display")
+        XCTAssertEqual(primary.State as? String, "name1")
+        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "identifier1")
+    }
+}

--- a/Tests/Shared/Sensors/DisplaySensor.test.swift
+++ b/Tests/Shared/Sensors/DisplaySensor.test.swift
@@ -9,12 +9,16 @@ class DeviceSensorTests: XCTestCase {
         location: nil
     )
 
-    private func sensors(for screens: [DeviceScreen]) throws -> (displays: WebhookSensor, primary: WebhookSensor) {
+    private func sensors(for screens: [DeviceScreen]) throws -> (
+        displays: WebhookSensor,
+        primaryName: WebhookSensor,
+        primaryID: WebhookSensor
+    ) {
         Current.device.screens = { screens }
         let promise = DisplaySensor(request: request).sensors()
         let sensors = try hang(promise)
-        XCTAssertEqual(sensors.count, 2)
-        return (displays: sensors[0], primary: sensors[1])
+        XCTAssertEqual(sensors.count, 3)
+        return (displays: sensors[0], primaryName: sensors[1], primaryID: sensors[2])
     }
 
     func testNotAvailable() {
@@ -55,7 +59,7 @@ class DeviceSensorTests: XCTestCase {
     }
 
     func testNoDisplay() throws {
-        let (displays, primary) = try sensors(for: [])
+        let (displays, primaryName, primaryID) = try sensors(for: [])
 
         XCTAssertEqual(displays.UniqueID, "displays_count")
         XCTAssertEqual(displays.Icon, "mdi:monitor-multiple")
@@ -64,15 +68,19 @@ class DeviceSensorTests: XCTestCase {
         XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], [])
         XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], [])
 
-        XCTAssertEqual(primary.UniqueID, "primary_display")
-        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
-        XCTAssertEqual(primary.Name, "Primary Display")
-        XCTAssertEqual(primary.State as? String, "None")
-        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "None")
+        XCTAssertEqual(primaryName.UniqueID, "primary_display_name")
+        XCTAssertEqual(primaryName.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryName.Name, "Primary Display Name")
+        XCTAssertEqual(primaryName.State as? String, "None")
+
+        XCTAssertEqual(primaryID.UniqueID, "primary_display_id")
+        XCTAssertEqual(primaryID.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryID.Name, "Primary Display ID")
+        XCTAssertEqual(primaryID.State as? String, "None")
     }
 
     func testOneDisplay() throws {
-        let (displays, primary) = try sensors(for: [.init(identifier: "identifier", name: "name")])
+        let (displays, primaryName, primaryID) = try sensors(for: [.init(identifier: "identifier", name: "name")])
 
         XCTAssertEqual(displays.UniqueID, "displays_count")
         XCTAssertEqual(displays.Icon, "mdi:monitor-multiple")
@@ -81,15 +89,19 @@ class DeviceSensorTests: XCTestCase {
         XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], ["identifier"])
         XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], ["name"])
 
-        XCTAssertEqual(primary.UniqueID, "primary_display")
-        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
-        XCTAssertEqual(primary.Name, "Primary Display")
-        XCTAssertEqual(primary.State as? String, "name")
-        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "identifier")
+        XCTAssertEqual(primaryName.UniqueID, "primary_display_name")
+        XCTAssertEqual(primaryName.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryName.Name, "Primary Display Name")
+        XCTAssertEqual(primaryName.State as? String, "name")
+
+        XCTAssertEqual(primaryID.UniqueID, "primary_display_id")
+        XCTAssertEqual(primaryID.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryID.Name, "Primary Display ID")
+        XCTAssertEqual(primaryID.State as? String, "identifier")
     }
 
     func testTwoDisplay() throws {
-        let (displays, primary) = try sensors(for: [
+        let (displays, primaryName, primaryID) = try sensors(for: [
             .init(identifier: "identifier1", name: "name1"),
             .init(identifier: "identifier2", name: "name2")
         ])
@@ -101,10 +113,14 @@ class DeviceSensorTests: XCTestCase {
         XCTAssertEqual(displays.Attributes?["Display IDs"] as? [String], ["identifier1", "identifier2"])
         XCTAssertEqual(displays.Attributes?["Display Names"] as? [String], ["name1", "name2"])
 
-        XCTAssertEqual(primary.UniqueID, "primary_display")
-        XCTAssertEqual(primary.Icon, "mdi:monitor-star")
-        XCTAssertEqual(primary.Name, "Primary Display")
-        XCTAssertEqual(primary.State as? String, "name1")
-        XCTAssertEqual(primary.Attributes?["Display ID"] as? String, "identifier1")
+        XCTAssertEqual(primaryName.UniqueID, "primary_display_name")
+        XCTAssertEqual(primaryName.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryName.Name, "Primary Display Name")
+        XCTAssertEqual(primaryName.State as? String, "name1")
+
+        XCTAssertEqual(primaryID.UniqueID, "primary_display_id")
+        XCTAssertEqual(primaryID.Icon, "mdi:monitor-star")
+        XCTAssertEqual(primaryID.Name, "Primary Display ID")
+        XCTAssertEqual(primaryID.State as? String, "identifier1")
     }
 }


### PR DESCRIPTION
Fixes #1247.

## Summary
Adds 3 sensors for displays: "Displays" (a count), "Primary Display Name" (the name of the display with the menu bar on it), and "Primary Display ID" (the ID of the primary).

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#421

## Any other notes
- `sensor.displays` 
  - states like `0`, `1`, `2`, …
  - attributes of `"Display IDs": ["id1", "id2", …]` and `"Display Names": ["name1", "name2", …]`
- `sensor.primary_display_name`
  - states like `"None"`, `"Built-in Retina Display"`, etc.
- `sensor.primary_display_id`
  - states like `"BE82E2E6-EA40-4963-93AD-A0BDC9D2F18F"`, `"1AB60A12-6BB3-4503-96BD-F5B481F5830E"` etc.