### PR TITLE
Add sensor for frontmost app on Mac

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 		1187DE4624D7E1BD00F0A6A6 /* SimulatorNFCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1187DE4524D7E1BD00F0A6A6 /* SimulatorNFCManager.swift */; };
 		11883CC524C12C8A0036A6C6 /* CLLocation+Extensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */; };
 		11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11883CC624C131EE0036A6C6 /* RealmZone.test.swift */; };
+		118BDA8825A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */; };
+		118BDA8925A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */; };
 		118F046924CB895A00CBBD5C /* UIColor+CSS3+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68FF7691F9D8637002BAADA /* UIColor+CSS3+Hex.swift */; };
 		118F046A24CB895B00CBBD5C /* UIColor+CSS3+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68FF7691F9D8637002BAADA /* UIColor+CSS3+Hex.swift */; };
 		119385A4249E8E360097F497 /* StorageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119385A3249E8E360097F497 /* StorageSensor.swift */; };
@@ -1008,6 +1010,7 @@
 		11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocation+Extensions.test.swift"; sourceTree = "<group>"; };
 		11883CC624C131EE0036A6C6 /* RealmZone.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmZone.test.swift; sourceTree = "<group>"; };
 		118A93322520411100227076 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostAppSensor.swift; sourceTree = "<group>"; };
 		119385A3249E8E360097F497 /* StorageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.swift; sourceTree = "<group>"; };
 		119385A6249E9F930097F497 /* StorageSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.test.swift; sourceTree = "<group>"; };
 		11948E8824DA5D50006F5657 /* InfoLabelRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabelRow.swift; sourceTree = "<group>"; };
@@ -2161,6 +2164,7 @@
 				B613936824F728F8002B8C5D /* InputDeviceSensor.swift */,
 				11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */,
 				110ED56225A563D600489AF7 /* DisplaySensor.swift */,
+				118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */,
 				118261F624F8D6B0000795C6 /* SensorProviderDependencies.swift */,
 				118261FF24F9C3D6000795C6 /* CoreMedia and CoreAudio Helpers */,
 			);
@@ -4605,6 +4609,7 @@
 				118F046A24CB895B00CBBD5C /* UIColor+CSS3+Hex.swift in Sources */,
 				B6A258492232539900ADD202 /* WebhookUpdateLocation.swift in Sources */,
 				11C4628324B053A800031902 /* WebhookResponseUpdateSensors.swift in Sources */,
+				118BDA8925A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */,
 				11EE9B4724C4E01500404AF8 /* SharedPlist.swift in Sources */,
 				B67CE8AB22200F220034C1D0 /* TokenInfo.swift in Sources */,
 				B67CE87722200F220034C1D0 /* Strings.swift in Sources */,
@@ -4760,6 +4765,7 @@
 				118F046924CB895A00CBBD5C /* UIColor+CSS3+Hex.swift in Sources */,
 				1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */,
 				1141182A24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */,
+				118BDA8825A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */,
 				11EE9B4624C4E01500404AF8 /* SharedPlist.swift in Sources */,
 				D0EEF327214DF31D00D1D360 /* Notifications.swift in Sources */,
 				1110836824AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */,

--- a/Sources/MacBridge/MacBridgeImpl.swift
+++ b/Sources/MacBridge/MacBridgeImpl.swift
@@ -37,4 +37,14 @@ import AppKit
     var screensWillChangeNotification: Notification.Name {
         NSApplication.didChangeScreenParametersNotification
     }
+
+    var frontmostApplication: MacBridgeRunningApplication? {
+        NSWorkspace.shared.frontmostApplication
+    }
+
+    var frontmostApplicationDidChangeNotification: Notification.Name {
+        NSWorkspace.didActivateApplicationNotification
+    }
 }
+
+extension NSRunningApplication: MacBridgeRunningApplication {}

--- a/Sources/Shared/API/Webhook/Sensors/FrontmostAppSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FrontmostAppSensor.swift
@@ -1,0 +1,75 @@
+import Foundation
+import PromiseKit
+
+final class FrontmostAppSensorUpdateSignaler: SensorProviderUpdateSignaler {
+    let signal: () -> Void
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+
+        #if targetEnvironment(macCatalyst)
+        Current.macBridge.workspaceNotificationCenter.addObserver(
+            self,
+            selector: #selector(frontmostAppDidChange(_:)),
+            name: Current.macBridge.frontmostApplicationDidChangeNotification,
+            object: nil
+        )
+        #endif
+    }
+
+    @objc private func frontmostAppDidChange(_ note: Notification) {
+        signal()
+    }
+}
+
+final class FrontmostAppSensor: SensorProvider {
+    public enum FrostmostAppError: Error, Equatable {
+        case unsupportedPlatform
+    }
+
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        #if targetEnvironment(macCatalyst)
+        var sensors = [WebhookSensor]()
+
+        let frontmost = Current.macBridge.frontmostApplication
+
+        /*
+         var localizedName: String? { get }
+         var bundleIdentifier: String? { get }
+         var launchDate: Date? { get }
+         var isHidden: Bool { get }
+         var ownsMenuBar: Bool { get }
+         */
+        sensors.append(with(WebhookSensor(
+            name: "Frontmost App",
+            uniqueID: "frontmost_app",
+            icon: "mdi:traffic-light",
+            state: frontmost?.localizedName ?? "None"
+        )) {
+            var attributes = [String: Any]()
+
+            attributes["Bundle Identifier"] = frontmost?.bundleIdentifier ?? "N/A"
+            attributes["Launch Date"] = frontmost?.launchDate.map {
+                ISO8601DateFormatter.string(from: $0, timeZone: .current, formatOptions: [
+                    .withInternetDateTime
+                ])
+            } ?? "N/A"
+            attributes["Is Hidden"] = frontmost?.isHidden ?? "N/A"
+            attributes["Owns Menu Bar"] = frontmost?.ownsMenuBar ?? "N/A"
+
+            $0.Attributes = attributes
+        })
+
+        // Set up our observer
+        let _: FrontmostAppSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+
+        return .value(sensors)
+        #else
+        return .init(error: FrostmostAppError.unsupportedPlatform)
+        #endif
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/FrontmostAppSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FrontmostAppSensor.swift
@@ -37,13 +37,6 @@ final class FrontmostAppSensor: SensorProvider {
 
         let frontmost = Current.macBridge.frontmostApplication
 
-        /*
-         var localizedName: String? { get }
-         var bundleIdentifier: String? { get }
-         var launchDate: Date? { get }
-         var isHidden: Bool { get }
-         var ownsMenuBar: Bool { get }
-         */
         sensors.append(with(WebhookSensor(
             name: "Frontmost App",
             uniqueID: "frontmost_app",

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -85,6 +85,7 @@ public class Environment {
         $0.register(provider: InputDeviceSensor.self)
         $0.register(provider: DisplaySensor.self)
         $0.register(provider: ActiveSensor.self)
+        $0.register(provider: FrontmostAppSensor.self)
         $0.register(provider: LastUpdateSensor.self)
     }
 

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -14,6 +14,9 @@ import Foundation
 
     var screens: [MacBridgeScreen] { get }
     var screensWillChangeNotification: Notification.Name { get }
+
+    var frontmostApplication: MacBridgeRunningApplication? { get }
+    var frontmostApplicationDidChangeNotification: Notification.Name { get }
 }
 
 @objc(MacBridgeNetworkType) public enum MacBridgeNetworkType: Int {
@@ -43,4 +46,12 @@ import Foundation
 @objc(MacBridgeScreen) public protocol MacBridgeScreen: NSObjectProtocol {
     var identifier: String { get }
     var name: String { get }
+}
+
+@objc(MacBridgeRunningApplication) public protocol MacBridgeRunningApplication: NSObjectProtocol {
+    var localizedName: String? { get }
+    var bundleIdentifier: String? { get }
+    var launchDate: Date? { get }
+    var isHidden: Bool { get }
+    var ownsMenuBar: Bool { get }
 }


### PR DESCRIPTION
Fixes #977.

## Summary
Adds a sensor for the current frontmost app, also known as the current foreground or active app. 

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#425

## Any other notes
Creates `sensor.frontmost_app` which has a state of the name of the current frontmost app, or None if there isn't one. I'm really not sure how that can happen, but it's definitely possible. This updates via a signal when it changes, so it happens immediately.