### PR TITLE
Move Cloud setting into External URL

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -59,7 +59,7 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
             +++ Section(L10n.Settings.ConnectionSection.details)
             <<< LabelRow("connectionPath") {
                 $0.title = L10n.Settings.ConnectionSection.connectingVia
-                $0.value = Current.settingsStore.connectionInfo?.activeURLType.description
+                $0.displayValueFor = { _ in Current.settingsStore.connectionInfo?.activeURLType.description }
             }
 
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
@@ -73,7 +73,6 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                 row.presentationMode = .show(controllerProvider: .callback(builder: {
                     ConnectionURLViewController(urlType: .internal, row: row)
                 }), onDismiss: { [navigationController] _ in
-                    row.updateCell()
                     navigationController?.popViewController(animated: true)
                 })
 
@@ -85,7 +84,7 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                 row.title = L10n.Settings.ConnectionSection.ExternalBaseUrl.title
                 row.displayValueFor = { _ in
                     if let connectionInfo = Current.settingsStore.connectionInfo {
-                        if connectionInfo.useCloud {
+                        if connectionInfo.useCloud && connectionInfo.canUseCloud {
                             return L10n.Settings.ConnectionSection.HomeAssistantCloud.title
                         } else {
                             return Current.settingsStore.connectionInfo?.externalURL?.absoluteString
@@ -97,7 +96,6 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
                 row.presentationMode = .show(controllerProvider: .callback(builder: {
                     ConnectionURLViewController(urlType: .external, row: row)
                 }), onDismiss: { [navigationController] _ in
-                    row.updateCell()
                     navigationController?.popViewController(animated: true)
                 })
             }
@@ -113,8 +111,8 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
     }
 
     @objc func connectionInfoDidChange(_ notification: Notification) {
-        guard let pathRow = self.form.rowBy(tag: "connectionPath") as? LabelRow else { return }
-        pathRow.value = Current.settingsStore.connectionInfo?.activeURLType.description
-        pathRow.updateCell()
+        DispatchQueue.main.async { [self] in
+            form.allRows.forEach { $0.updateCell() }
+        }
     }
 }

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -23,10 +23,12 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
 
         self.title = L10n.Settings.ConnectionSection.header
 
-        NotificationCenter.default.addObserver(self, selector: #selector(ActiveURLTypeChanged(_:)),
-                                               // swiftlint:disable:next line_length
-                                               name: NSNotification.Name(rawValue: "connectioninfo.activeurltype_changed"),
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(connectionInfoDidChange(_:)),
+            name: SettingsStore.connectionInfoDidChange,
+            object: nil
+        )
 
         form
             +++ Section(header: L10n.Settings.StatusSection.header, footer: "") {
@@ -140,7 +142,7 @@ class ConnectionSettingsViewController: FormViewController, RowControllerType {
         }
     }
 
-    @objc func ActiveURLTypeChanged(_ notification: Notification) {
+    @objc func connectionInfoDidChange(_ notification: Notification) {
         guard let pathRow = self.form.rowBy(tag: "connectionPath") as? LabelRow else { return }
         pathRow.value = Current.settingsStore.connectionInfo?.activeURLType.description
         pathRow.updateCell()

--- a/Sources/App/Settings/Connection/ConnectionURLViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLViewController.swift
@@ -96,6 +96,10 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
         firstly { () -> Promise<Void> in
             try check(url: givenURL, useCloud: useCloud)
 
+            if useCloud == true, let url = Current.settingsStore.connectionInfo?.remoteUIURL {
+                return Current.webhooks.sendTest(baseURL: url)
+            }
+
             if let givenURL = givenURL, useCloud != true {
                 return Current.webhooks.sendTest(baseURL: givenURL)
             }
@@ -174,7 +178,7 @@ final class ConnectionURLViewController: FormViewController, TypedRowControllerT
 
         updateNavigationItems(isChecking: false)
 
-        if urlType.isAffectedByCloud, Current.settingsStore.connectionInfo?.remoteUIURL != nil {
+        if urlType.isAffectedByCloud, Current.settingsStore.connectionInfo?.canUseCloud == true {
             form +++ SwitchRow {
                 $0.title = L10n.Settings.ConnectionSection.HomeAssistantCloud.title
                 $0.tag = RowTag.useCloud.rawValue

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -65,6 +65,9 @@ public class ConnectionInfo: Codable {
             Current.settingsStore.connectionInfo = self
         }
     }
+    public var canUseCloud: Bool {
+        remoteUIURL != nil
+    }
     public var useCloud: Bool = false {
         didSet {
             guard useCloud != oldValue else { return }
@@ -116,7 +119,7 @@ public class ConnectionInfo: Codable {
         if self.internalURL != nil && self.internalSSIDs != nil && self.isOnInternalNetwork {
             self.activeURLType = .internal
         } else {
-            if self.useCloud && self.remoteUIURL != nil {
+            if self.useCloud && self.canUseCloud {
                 self.activeURLType = .remoteUI
             } else {
                 self.activeURLType = .external
@@ -201,7 +204,7 @@ public class ConnectionInfo: Codable {
         case .internal:
             if let url = self.internalURL {
                 guard self.isOnInternalNetwork else {
-                    if self.useCloud && self.remoteUIURL != nil {
+                    if self.useCloud && self.canUseCloud {
                         self.activeURLType = .remoteUI
                     } else if self.externalURL != nil {
                         self.activeURLType = .external
@@ -214,7 +217,7 @@ public class ConnectionInfo: Codable {
                 return sanitize(url)
             } else {
                 // No internal URL available, so fallback to an external URL
-                if self.useCloud && self.remoteUIURL != nil {
+                if self.useCloud && self.canUseCloud {
                     self.activeURLType = .remoteUI
                 } else {
                     self.activeURLType = .external
@@ -233,7 +236,7 @@ public class ConnectionInfo: Codable {
                 return self.activeURL
             }
         case .external:
-            if self.useCloud, self.remoteUIURL != nil {
+            if self.useCloud, self.canUseCloud {
                 self.activeURLType = .remoteUI
                 return self.activeURL
             } else if let url = self.externalURL {
@@ -317,7 +320,7 @@ public class ConnectionInfo: Codable {
         case .internal:
             self.internalURL = address
             if self.internalURL == nil {
-                if self.useCloud && self.remoteUIURL != nil {
+                if self.useCloud && self.canUseCloud {
                     self.activeURLType = .remoteUI
                 } else {
                     self.activeURLType = .external
@@ -330,7 +333,7 @@ public class ConnectionInfo: Codable {
             if self.externalURL == nil {
                 if self.internalURL != nil && self.isOnInternalNetwork {
                     self.activeURLType = .internal
-                } else if self.useCloud && self.remoteUIURL != nil {
+                } else if self.useCloud && self.canUseCloud {
                     self.activeURLType = .remoteUI
                 }
             } else if self.activeURLType != .internal {

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -233,15 +233,15 @@ public class ConnectionInfo: Codable {
                 return self.activeURL
             }
         case .external:
-            if let url = self.externalURL {
+            if self.useCloud, self.remoteUIURL != nil {
+                self.activeURLType = .remoteUI
+                return self.activeURL
+            } else if let url = self.externalURL {
                 if let internalURL = self.internalURL, self.isOnInternalNetwork {
                     self.activeURLType = .internal
                     return sanitize(internalURL)
                 }
                 return sanitize(url)
-            } else if self.useCloud, self.remoteUIURL != nil {
-                self.activeURLType = .remoteUI
-                return self.activeURL
             }
         }
 


### PR DESCRIPTION
Fixes #1366.

## Summary
External URL and Cloud are mutually exclusive; better illustrates this fact in the UI by putting them next to each other.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Image](https://user-images.githubusercontent.com/74188/104283291-2f7bba80-5465-11eb-95ad-715bd03d8949.png)
![Image-3](https://user-images.githubusercontent.com/74188/104283504-749fec80-5465-11eb-9a34-a3a228465085.png)
![Image-5](https://user-images.githubusercontent.com/74188/104283897-16273e00-5466-11eb-9e57-ad091e588cf8.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- Fixes an issue where external wouldn't be promoted to remote at runtime.
- Fixes the 'connected via' not updating correctly when transitions happened, especially when saving.