### PR TITLE
Clean up Battery Level & Battery State sensor attributes/classes

### DIFF
--- a/Sources/App/Settings/Sensors/SensorDetailViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorDetailViewController.swift
@@ -27,10 +27,6 @@ class SensorDetailViewController: FormViewController {
 
         let baseSection = Section()
         baseSection <<< LabelRow {
-            $0.title = L10n.SettingsSensors.Detail.uniqueId
-            $0.value = sensor.UniqueID
-        }
-        baseSection <<< LabelRow {
             $0.title = L10n.SettingsSensors.Detail.state
             $0.value = sensor.StateDescription
         }
@@ -55,7 +51,7 @@ class SensorDetailViewController: FormViewController {
             form.append(Self.settingsSection(from: sensor.Settings))
         }
 
-        if let attributes = sensor.Attributes {
+        if let attributes = sensor.Attributes, !attributes.isEmpty {
             let attributesSection = Section(header: L10n.SettingsSensors.Detail.attributes, footer: nil)
             let attributeRows = attributes
                 .sorted(by: { lhs, rhs in lhs.0 < rhs.0 })

--- a/Sources/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -52,10 +52,7 @@ public class BatterySensor: SensorProvider {
             deviceClass: .battery,
             state: battery.level
         )) {
-            $0.Attributes = [
-                "Battery State": battery.state.description,
-                "Low Power Mode": isLowPowerMode
-            ].merging(battery.attributes, uniquingKeysWith: { a, _ in a })
+            $0.Attributes = battery.attributes
             $0.UnitOfMeasurement = "%"
         }
 
@@ -63,11 +60,9 @@ public class BatterySensor: SensorProvider {
             name: "\(sensorNamePrefix) State",
             uniqueID: "\(sensorIDPrefix)_state",
             icon: icon,
-            deviceClass: .battery,
             state: battery.state.description
         )) {
             $0.Attributes = [
-                "Battery Level": battery.level,
                 "Low Power Mode": isLowPowerMode
             ].merging(battery.attributes, uniquingKeysWith: { a, _ in a })
         }

--- a/Tests/Shared/Sensors/BatterySensor.test.swift
+++ b/Tests/Shared/Sensors/BatterySensor.test.swift
@@ -262,7 +262,6 @@ class BatterySensorTests: XCTestCase {
     ) {
         XCTAssertEqual(sensor.Name, "\(name ?? "Battery") State", file: file, line: line)
         XCTAssertEqual(sensor.UniqueID, "\(uniqueId ?? "battery")_state", file: file, line: line)
-        XCTAssertEqual(sensor.DeviceClass, .battery, file: file, line: line)
     }
 
     func sensors(
@@ -328,11 +327,9 @@ class BatterySensorTests: XCTestCase {
             let uState = uSensors[idx + 1]
 
             XCTAssertLevel(uLevel, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2], file: file, line: line)
-            XCTAssertEqual(uLevel.Attributes?["Battery State"] as? String, uState.State as? String, file: file, line: line)
             XCTAssertEqual(uLevel.Attributes?["Low Power Mode"] as? Bool, true)
 
             XCTAssertState(uState, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2], file: file, line: line)
-            XCTAssertEqual(uState.Attributes?["Battery Level"] as? Int, uLevel.State as? Int, file: file, line: line)
             XCTAssertEqual(uState.Attributes?["Low Power Mode"] as? Bool, true)
 
             uReturn.append((level: uLevel, state: uState))
@@ -375,11 +372,8 @@ class BatterySensorTests: XCTestCase {
             let cState = cSensors[idx + 1]
 
             XCTAssertLevel(cLevel, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2],file: file, line: line)
-            XCTAssertEqual(cLevel.Attributes?["Battery State"] as? String, cState.State as? String, file: file, line: line)
-            XCTAssertEqual(cLevel.Attributes?["Low Power Mode"] as? Bool, true)
 
             XCTAssertState(cState, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2],file: file, line: line)
-            XCTAssertEqual(cState.Attributes?["Battery Level"] as? Int, cLevel.State as? Int, file: file, line: line)
             XCTAssertEqual(cState.Attributes?["Low Power Mode"] as? Bool, true)
 
             cReturn.append((level: cLevel, state: cState))

--- a/Tests/Shared/Sensors/BatterySensor.test.swift
+++ b/Tests/Shared/Sensors/BatterySensor.test.swift
@@ -327,7 +327,6 @@ class BatterySensorTests: XCTestCase {
             let uState = uSensors[idx + 1]
 
             XCTAssertLevel(uLevel, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2], file: file, line: line)
-            XCTAssertEqual(uLevel.Attributes?["Low Power Mode"] as? Bool, true)
 
             XCTAssertState(uState, name: names.isEmpty ? nil : names[idx/2], uniqueId: uniqueIds.isEmpty ? nil : uniqueIds[idx/2], file: file, line: line)
             XCTAssertEqual(uState.Attributes?["Low Power Mode"] as? Bool, true)


### PR DESCRIPTION
Fixes #1311.

## Summary
Removes duplicate attributes from both (so they do not refer to each other in attributes) and stops using `device_class` of `battery` on the state sensor.

## Screenshots
![Image](https://user-images.githubusercontent.com/74188/104554534-2d466700-55f1-11eb-8eff-2dcd55889ece.png)
![Image 2](https://user-images.githubusercontent.com/74188/104554635-549d3400-55f1-11eb-8642-4deba335d034.png)

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#430

## Any other notes
Also stops showing the non-user-facing-anywhere-else "unique id" in the sensor detail list, and fixes an empty set of attributes (but non-nil dictionary) showing an empty section.