### PR TITLE
Improve messages for Webhook errors

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -917,3 +917,5 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings.connection_section.internal_url_hardware_addresses.footer" = "Internal URL will be used when the primary network interface has a MAC address matching one of these hardware addresses.";
 "settings.connection_section.internal_url_hardware_addresses.add_new_ssid" = "Add New Hardware Address";
 "settings.connection_section.internal_url_hardware_addresses.invalid" = "Hardware addresses much look like aa:bb:cc:dd:ee:ff";
+"ha_api.api_error.unexpected_type" = "Received response with result of type %1$@ but expected type %2$@.";
+"ha_api.api_error.unacceptable_status_code" = "Unacceptable status code %1$i.";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -380,6 +380,14 @@ public enum L10n {
       }
       /// HA API not configured
       public static var notConfigured: String { return L10n.tr("Localizable", "ha_api.api_error.not_configured") }
+      /// Unacceptable status code %1$i.
+      public static func unacceptableStatusCode(_ p1: Int) -> String {
+        return L10n.tr("Localizable", "ha_api.api_error.unacceptable_status_code", p1)
+      }
+      /// Received response with result of type %1$@ but expected type %2$@.
+      public static func unexpectedType(_ p1: Any, _ p2: Any) -> String {
+        return L10n.tr("Localizable", "ha_api.api_error.unexpected_type", String(describing: p1), String(describing: p2))
+      }
       /// An unknown error occurred.
       public static var unknown: String { return L10n.tr("Localizable", "ha_api.api_error.unknown") }
       /// Operation could not be performed.


### PR DESCRIPTION
## Summary
Instead of saying something like `Shared.WebhookError code 1` when the webhook is responding back with status code 503, gives a more appropriate error.

## Any other notes
What's really fun is the order of the enum appears to not matter for the debug error code. Reading the enum, you might think status code 1 was the 2nd error in the Error enum, but it's actually the 4th error in the list.