### PR TITLE
Rename Safari "Open Links In" setting on iOS 14

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -919,3 +919,4 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings.connection_section.internal_url_hardware_addresses.invalid" = "Hardware addresses much look like aa:bb:cc:dd:ee:ff";
 "ha_api.api_error.unexpected_type" = "Received response with result of type %1$@ but expected type %2$@.";
 "ha_api.api_error.unacceptable_status_code" = "Unacceptable status code %1$i.";
+"settings_details.general.open_in_browser.default" = "System Default";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -858,7 +858,11 @@ enum OpenInBrowser: String, CaseIterable {
         case .Firefox:
             return L10n.SettingsDetails.General.OpenInBrowser.firefox
         case .Safari:
-            return L10n.SettingsDetails.General.OpenInBrowser.safari
+            if #available(iOS 14, *) {
+                return L10n.SettingsDetails.General.OpenInBrowser.default
+            } else {
+                return L10n.SettingsDetails.General.OpenInBrowser.safari
+            }
         case .SafariInApp:
             return L10n.SettingsDetails.General.OpenInBrowser.safariInApp
         }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1625,6 +1625,8 @@ public enum L10n {
       public enum OpenInBrowser {
         /// Google Chrome
         public static var chrome: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.chrome") }
+        /// System Default
+        public static var `default`: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.default") }
         /// Mozilla Firefox
         public static var firefox: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.firefox") }
         /// Apple Safari


### PR DESCRIPTION
Fixes #1340.

## Summary
Still allows selecting alternates. There doesn't appear to be any obvious url scheme that we can use to force Safari, so take over the Safari entry with just whatever `https://…` opens, which is the default browser.

## Screenshots
![Image 3](https://user-images.githubusercontent.com/74188/104797418-b1742800-5772-11eb-88a1-b9369a30936c.png)