### PR TITLE
Add server-driven alerts based on client or server versions

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		1109F81F24A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82024A1C011002590F2 /* SensorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F81E24A1C011002590F2 /* SensorProvider.swift */; };
 		1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1109F82324A25A41002590F2 /* SensorContainer.test.swift */; };
+		110AA55C25B36630005061A0 /* ServerAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110AA55B25B36630005061A0 /* ServerAlerter.swift */; };
+		110AA55D25B36630005061A0 /* ServerAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110AA55B25B36630005061A0 /* ServerAlerter.swift */; };
+		110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110AA57A25B38C02005061A0 /* ServerAlerter.test.swift */; };
 		110E694224E7710E004AA96D /* WidgetActionsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694124E7710E004AA96D /* WidgetActionsContainerView.swift */; };
 		110E694424E77125004AA96D /* WidgetActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694324E77125004AA96D /* WidgetActionsProvider.swift */; };
 		110E694624E771AB004AA96D /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110E694524E771AB004AA96D /* Color+Hex.swift */; };
@@ -955,6 +958,8 @@
 		1109B6BD25263F1D005D51C2 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1109F81E24A1C011002590F2 /* SensorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorProvider.swift; sourceTree = "<group>"; };
 		1109F82324A25A41002590F2 /* SensorContainer.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorContainer.test.swift; sourceTree = "<group>"; };
+		110AA55B25B36630005061A0 /* ServerAlerter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAlerter.swift; sourceTree = "<group>"; };
+		110AA57A25B38C02005061A0 /* ServerAlerter.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerAlerter.test.swift; sourceTree = "<group>"; };
 		110E694124E7710E004AA96D /* WidgetActionsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsContainerView.swift; sourceTree = "<group>"; };
 		110E694324E77125004AA96D /* WidgetActionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsProvider.swift; sourceTree = "<group>"; };
 		110E694524E771AB004AA96D /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
@@ -2900,6 +2905,7 @@
 				111D295424F30D2C00C8A7D1 /* Updater.swift */,
 				11521BBB25400284009C5C72 /* CrashReporter.swift */,
 				110ED58E25A6743900489AF7 /* ConnectivityWrapper.swift */,
+				110AA55B25B36630005061A0 /* ServerAlerter.swift */,
 			);
 			path = Environment;
 			sourceTree = "<group>";
@@ -2967,6 +2973,7 @@
 				11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */,
 				1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */,
 				11F2F28D2587285300F61F7C /* NotificationAttachment */,
+				110AA57A25B38C02005061A0 /* ServerAlerter.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -4684,6 +4691,7 @@
 				B658AA7F2250B2A100C9BFE3 /* MobileAppUpdateRegistrationRequest.swift in Sources */,
 				11A48D7C24CA7D7F0021BDD9 /* NotificationAction.swift in Sources */,
 				B67CE8BA22200F220034C1D0 /* Constants.swift in Sources */,
+				110AA55D25B36630005061A0 /* ServerAlerter.swift in Sources */,
 				B67CE8B222200F220034C1D0 /* CMMotion+StringExtensions.swift in Sources */,
 				B6B74CB92283983300D58A68 /* WatchComplication.swift in Sources */,
 				11C65CC1249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */,
@@ -4840,6 +4848,7 @@
 				111858DA24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */,
 				D0EEF317214DD7A400D1D360 /* DiscoveryInfo.swift in Sources */,
 				117675EF252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */,
+				110AA55C25B36630005061A0 /* ServerAlerter.swift in Sources */,
 				11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
 				D03D893B20E0B2E300D4F28D /* Constants.swift in Sources */,
 				D03D893520E0AEF100D4F28D /* Realm+Initialization.swift in Sources */,
@@ -4950,6 +4959,7 @@
 				11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */,
 				11F2F2A92587288200F61F7C /* NotificationAttachmentParserCamera.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
+				110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
 				110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */,
 			);

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -130,6 +130,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         lifecycleManager.didFinishLaunching()
 
         checkForUpdate()
+        checkForAlerts()
 
         return true
     }
@@ -395,6 +396,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     $0.present(alert, animated: true, completion: nil)
                 }
             }
+        }
+    }
+
+    func checkForAlerts() {
+        firstly {
+            when(fulfilled: Current.serverAlerter.check(), sceneManager.webViewWindowControllerPromise)
+        }.done { alert, controller in
+            controller.show(alert: alert)
+        }.catch { error in
+            Current.Log.error("check error: \(error)")
         }
     }
 

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -604,6 +604,39 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         updateSensors()
     }
 
+    func show(alert: ServerAlert) {
+        Current.Log.info("showing alert \(alert)")
+
+        var config = SwiftMessages.Config()
+
+        config.presentationContext = .viewController(self)
+        config.duration = .forever
+        config.presentationStyle = .bottom
+        config.dimMode = .gray(interactive: true)
+        config.dimModeAccessibilityLabel = L10n.cancelLabel
+        config.eventListeners.append({ event in
+            if event == .didHide {
+                Current.serverAlerter.markHandled(alert: alert)
+            }
+        })
+
+        let view = MessageView.viewFromNib(layout: .messageView)
+        view.configureTheme(.error)
+        view.configureContent(
+            title: nil,
+            body: alert.message,
+            iconImage: nil,
+            iconText: nil,
+            buttonImage: nil,
+            buttonTitle: L10n.openLabel,
+            buttonTapHandler: { _ in
+                UIApplication.shared.open(alert.url, options: [:], completionHandler: nil)
+            }
+        )
+
+        SwiftMessages.show(config: config, view: view)
+    }
+
     func showSwiftMessageError(_ body: String, duration: SwiftMessages.Duration = .automatic) {
         var config = SwiftMessages.Config()
 

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -101,6 +101,12 @@ class WebViewWindowController {
         window.rootViewController?.present(viewController, animated: animated, completion: completion)
     }
 
+    func show(alert: ServerAlert) {
+        webViewControllerPromise.done { webViewController in
+            webViewController.show(alert: alert)
+        }
+    }
+
     var presentingViewController: UIViewController? {
         var currentController = window.rootViewController
         while let controller = currentController?.presentedViewController {

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -125,6 +125,13 @@ public struct Constants {
     static public var version: String {
         SharedPlistFiles.Info.cfBundleShortVersionString
     }
+
+    static internal var clientVersion: Version {
+        // swiftlint:disable:next force_try
+        var clientVersion = try! Version(version)
+        clientVersion.build = build
+        return clientVersion
+    }
 }
 
 public extension Version {

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -94,6 +94,7 @@ public class Environment {
     public var tags: TagManager = EmptyTagManager()
 
     public var updater: Updater = Updater()
+    public var serverAlerter: ServerAlerter = ServerAlerter()
 
     #if os(watchOS)
     public var backgroundRefreshScheduler = WatchBackgroundRefreshScheduler()
@@ -120,6 +121,7 @@ public class Environment {
     public lazy var activeState: ActiveStateManager = { ActiveStateManager() }()
 
     public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
+    public lazy var clientVersion: () -> Version = { Constants.clientVersion }
 
     public var onboardingObservation = OnboardingStateObservation()
 

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -1,0 +1,105 @@
+import Foundation
+import PromiseKit
+import Version
+
+public struct ServerAlert: Codable, Equatable {
+    public struct VersionRequirement: Codable, Equatable {
+        var min: Version?
+        var max: Version?
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: CodingKey {
+            case min, max
+        }
+
+        public init(min: Version?, max: Version?) {
+            self.min = min
+            self.max = max
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            if let minString = try container.decodeIfPresent(String.self, forKey: .min) {
+                self.min = try? Version(hassVersion: minString)
+            } else {
+                self.min = nil
+            }
+
+            if let maxString = try container.decodeIfPresent(String.self, forKey: .max) {
+                self.max = try? Version(hassVersion: maxString)
+            } else {
+                self.max = nil
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(min?.description, forKey: .min)
+            try container.encode(max?.description, forKey: .max)
+        }
+
+        public func shouldTrigger(for compare: Version) -> Bool {
+            if let min = min, let max = max {
+                return compare >= min && compare <= max
+            } else if let min = min {
+                return compare >= min
+            } else if let max = max {
+                return compare <= max
+            } else {
+                // no provided min or max means it doesn't affect this version at all
+                return false
+            }
+        }
+    }
+
+    public var url: URL
+    public var message: String
+    public var ios: VersionRequirement
+    public var core: VersionRequirement
+}
+
+public class ServerAlerter {
+    private var apiUrl: URL { URL(string: "https://companion.home-assistant.io/alerts.json")! }
+
+    public func check() -> Promise<ServerAlert> {
+        return firstly {
+            URLSession.shared.dataTask(.promise, with: apiUrl)
+        }.map { data, _ -> [ServerAlert] in
+            // allows individual alerts to fail to parse, in case e.g. somebody typos something
+            struct FailableServerAlert: Decodable {
+                var alert: ServerAlert?
+                init(from decoder: Decoder) throws {
+                    alert = try? ServerAlert(from: decoder)
+                }
+            }
+            return try JSONDecoder()
+                .decode([FailableServerAlert].self, from: data)
+                .compactMap(\.alert)
+        }.get { updates in
+            Current.Log.info("found alerts: \(updates)")
+        }.filterValues {
+            $0.ios.shouldTrigger(for: Current.clientVersion()) || $0.core.shouldTrigger(for: Current.serverVersion())
+        }.filterValues { [self] alert in
+            !isHandled(alert: alert)
+        }.firstValue
+    }
+
+    private var allHandledKeys: String { "ServerAlerterViewedAlerts" }
+
+    public func markHandled(alert: ServerAlert) {
+        var viewed = Current.settingsStore.prefs.stringArray(forKey: allHandledKeys) ?? []
+        viewed.append(alert.handledKey)
+        Current.settingsStore.prefs.set(viewed, forKey: allHandledKeys)
+    }
+
+    private func isHandled(alert: ServerAlert) -> Bool {
+        Current.settingsStore.prefs.stringArray(forKey: allHandledKeys)?.contains(alert.handledKey) == true
+    }
+}
+
+private extension ServerAlert {
+    var handledKey: String {
+        "alert-viewed-\(url.absoluteString)"
+    }
+}

--- a/Tests/Shared/ServerAlerter.test.swift
+++ b/Tests/Shared/ServerAlerter.test.swift
@@ -121,6 +121,72 @@ class ServerAlerterTests: XCTestCase {
         XCTAssertThrowsError(try hang(alerter.check()))
     }
 
+    func testLowerBoundOnlyiOSShouldApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: .init(major: 75), max: nil),
+            core: .init(min: nil, max: nil)
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertEqual(try hang(alerter.check()), alert)
+        // trying again should still work
+        XCTAssertEqual(try hang(alerter.check()), alert)
+
+        alerter.markHandled(alert: alert)
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testLowerBoundOnlyiOSShouldntApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: .init(major: 125), max: nil),
+            core: .init(min: nil, max: nil)
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testUpperBoundOnlyiOSShouldApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: nil, max: .init(major: 150)),
+            core: .init(min: nil, max: nil)
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertEqual(try hang(alerter.check()), alert)
+        // trying again should still work
+        XCTAssertEqual(try hang(alerter.check()), alert)
+
+        alerter.markHandled(alert: alert)
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testUpperBoundOnlyiOSShouldntApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: nil, max: .init(major: 99)),
+            core: .init(min: nil, max: nil)
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
     func testEarlierCoreDoesntApply() {
         Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
 

--- a/Tests/Shared/ServerAlerter.test.swift
+++ b/Tests/Shared/ServerAlerter.test.swift
@@ -1,0 +1,195 @@
+import XCTest
+import OHHTTPStubs
+import PromiseKit
+import Version
+@testable import Shared
+
+class ServerAlerterTests: XCTestCase {
+    private var alerter: ServerAlerter!
+    private var stubDescriptors: [HTTPStubsDescriptor] = []
+
+    private func randomURL() -> URL {
+        return URL(string: "https://example.com/\(UUID().uuidString)")!
+    }
+
+    override func setUp() {
+        super.setUp()
+        alerter = ServerAlerter()
+    }
+
+    private func setUp(response: Swift.Result<[ServerAlert], Error>) {
+        let url = URL(string: "https://companion.home-assistant.io/alerts.json")!
+        stubDescriptors.append(stub(condition: { $0.url == url }, response: { request in
+            switch response {
+            case .success(let value):
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = .prettyPrinted
+                return HTTPStubsResponse(
+                    data: try! encoder.encode(value),
+                    statusCode: 200,
+                    headers: [:]
+                )
+            case .failure(let error):
+                return HTTPStubsResponse(error: error)
+            }
+        }))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        for descriptor in stubDescriptors {
+            HTTPStubs.removeStub(descriptor)
+        }
+    }
+
+    func testEncoderSinceTestsRelyOnItsFormat() throws {
+        let alert = ServerAlert(
+            url: URL(string: "http://example.com")!,
+            message: "Some message",
+            ios: .init(min: .init(major: 100, minor: 1, patch: 0), max: nil),
+            core: .init(min: nil, max: .init(major: 20, minor: 0, patch: nil))
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let result = String(data: try encoder.encode(alert), encoding: .utf8)
+        XCTAssertEqual(result, "{\"core\":{\"max\":\"20.0\",\"min\":null},\"ios\":{\"max\":null,\"min\":\"100.1.0\"},\"message\":\"Some message\",\"url\":\"http:\\/\\/example.com\"}")
+    }
+
+    func testNoAlerts() {
+        setUp(response: .success([]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testNoVersionedAlerts() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+        
+        setUp(response: .success([
+            ServerAlert(
+                url: randomURL(),
+                message: "msg",
+                ios: .init(min: nil, max: nil),
+                core: .init(min: nil, max: nil)
+            )
+        ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testEarlieriOSDoesntApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        setUp(response: .success([
+            ServerAlert(
+                url: randomURL(),
+                message: "msg",
+                ios: .init(min: .init(major: 50), max: .init(major: 99)),
+                core: .init(min: nil, max: nil)
+            )
+        ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testLateriOSDoesntApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        setUp(response: .success([
+            ServerAlert(
+                url: randomURL(),
+                message: "msg",
+                ios: .init(min: .init(major: 101), max: .init(major: 150)),
+                core: .init(min: nil, max: nil)
+            )
+        ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testMiddleiOSShouldApply() {
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: .init(major: 75), max: .init(major: 125)),
+            core: .init(min: nil, max: nil)
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertEqual(try hang(alerter.check()), alert)
+        // trying again should still work
+        XCTAssertEqual(try hang(alerter.check()), alert)
+
+        alerter.markHandled(alert: alert)
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testEarlierCoreDoesntApply() {
+        Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        setUp(response: .success([
+            ServerAlert(
+                url: randomURL(),
+                message: "msg",
+                ios: .init(min: nil, max: nil),
+                core: .init(min: .init(major: 50), max: .init(major: 99))
+            )
+        ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testLaterCoreDoesntApply() {
+        Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        setUp(response: .success([
+            ServerAlert(
+                url: randomURL(),
+                message: "msg",
+                ios: .init(min: nil, max: nil),
+                core: .init(min: .init(major: 101), max: .init(major: 150))
+            )
+        ]))
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testMiddleCoreShouldApply() {
+        Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alert = ServerAlert(
+            url: randomURL(),
+            message: "msg",
+            ios: .init(min: nil, max: nil),
+            core: .init(min: .init(major: 75), max: .init(major: 125))
+        )
+
+        setUp(response: .success([ alert ]))
+        XCTAssertEqual(try hang(alerter.check()), alert)
+        // trying again should still work
+        XCTAssertEqual(try hang(alerter.check()), alert)
+
+        alerter.markHandled(alert: alert)
+        XCTAssertThrowsError(try hang(alerter.check()))
+    }
+
+    func testMultipleApplyGivesFirst() {
+        Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
+        Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
+
+        let alerts = [
+            ServerAlert(
+                url: randomURL(),
+                message: "msg1",
+                ios: .init(min: .init(major: 75), max: .init(major: 125)),
+                core: .init(min: nil, max: nil)
+            ),
+            ServerAlert(
+                url: randomURL(),
+                message: "msg2",
+                ios: .init(min: nil, max: nil),
+                core: .init(min: .init(major: 75), max: .init(major: 125))
+            )
+        ]
+
+        setUp(response: .success(alerts))
+        XCTAssertEqual(try hang(alerter.check()), alerts[0])
+        alerter.markHandled(alert: alerts[0])
+        XCTAssertEqual(try hang(alerter.check()), alerts[1])
+    }
+}

--- a/Tests/Shared/ServerAlerter.test.swift
+++ b/Tests/Shared/ServerAlerter.test.swift
@@ -18,11 +18,12 @@ class ServerAlerterTests: XCTestCase {
     }
 
     private func setUp(response: Swift.Result<[ServerAlert], Error>) {
-        let url = URL(string: "https://companion.home-assistant.io/alerts.json")!
+        let url = URL(string: "https://alerts.home-assistant.io/mobile.json")!
         stubDescriptors.append(stub(condition: { $0.url == url }, response: { request in
             switch response {
             case .success(let value):
                 let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
                 encoder.outputFormatting = .prettyPrinted
                 return HTTPStubsResponse(
                     data: try! encoder.encode(value),
@@ -44,6 +45,8 @@ class ServerAlerterTests: XCTestCase {
 
     func testEncoderSinceTestsRelyOnItsFormat() throws {
         let alert = ServerAlert(
+            id: "id",
+            date: Date(timeIntervalSince1970: 1610837683),
             url: URL(string: "http://example.com")!,
             message: "Some message",
             ios: .init(min: .init(major: 100, minor: 1, patch: 0), max: nil),
@@ -51,8 +54,9 @@ class ServerAlerterTests: XCTestCase {
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
         let result = String(data: try encoder.encode(alert), encoding: .utf8)
-        XCTAssertEqual(result, "{\"core\":{\"max\":\"20.0\",\"min\":null},\"ios\":{\"max\":null,\"min\":\"100.1.0\"},\"message\":\"Some message\",\"url\":\"http:\\/\\/example.com\"}")
+        XCTAssertEqual(result, "{\"core\":{\"max\":\"20.0\",\"min\":null},\"date\":\"2021-01-16T22:54:43Z\",\"id\":\"id\",\"ios\":{\"max\":null,\"min\":\"100.1.0\"},\"message\":\"Some message\",\"url\":\"http:\\/\\/example.com\"}")
     }
 
     func testNoAlerts() {
@@ -65,6 +69,8 @@ class ServerAlerterTests: XCTestCase {
         
         setUp(response: .success([
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg",
                 ios: .init(min: nil, max: nil),
@@ -79,6 +85,8 @@ class ServerAlerterTests: XCTestCase {
 
         setUp(response: .success([
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg",
                 ios: .init(min: .init(major: 50), max: .init(major: 99)),
@@ -93,6 +101,8 @@ class ServerAlerterTests: XCTestCase {
 
         setUp(response: .success([
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg",
                 ios: .init(min: .init(major: 101), max: .init(major: 150)),
@@ -106,6 +116,8 @@ class ServerAlerterTests: XCTestCase {
         Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: .init(major: 75), max: .init(major: 125)),
@@ -125,6 +137,8 @@ class ServerAlerterTests: XCTestCase {
         Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: .init(major: 75), max: nil),
@@ -144,6 +158,8 @@ class ServerAlerterTests: XCTestCase {
         Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: .init(major: 125), max: nil),
@@ -158,6 +174,8 @@ class ServerAlerterTests: XCTestCase {
         Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: nil, max: .init(major: 150)),
@@ -177,6 +195,8 @@ class ServerAlerterTests: XCTestCase {
         Current.clientVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: nil, max: .init(major: 99)),
@@ -192,6 +212,8 @@ class ServerAlerterTests: XCTestCase {
 
         setUp(response: .success([
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg",
                 ios: .init(min: nil, max: nil),
@@ -206,6 +228,8 @@ class ServerAlerterTests: XCTestCase {
 
         setUp(response: .success([
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg",
                 ios: .init(min: nil, max: nil),
@@ -219,6 +243,8 @@ class ServerAlerterTests: XCTestCase {
         Current.serverVersion = { Version(major: 100, minor: 0, patch: 0) }
 
         let alert = ServerAlert(
+            id: UUID().uuidString,
+            date: Date(timeIntervalSinceNow: -100),
             url: randomURL(),
             message: "msg",
             ios: .init(min: nil, max: nil),
@@ -240,12 +266,16 @@ class ServerAlerterTests: XCTestCase {
 
         let alerts = [
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg1",
                 ios: .init(min: .init(major: 75), max: .init(major: 125)),
                 core: .init(min: nil, max: nil)
             ),
             ServerAlert(
+                id: UUID().uuidString,
+                date: Date(timeIntervalSinceNow: -100),
                 url: randomURL(),
                 message: "msg2",
                 ios: .init(min: nil, max: nil),

--- a/Tests/Shared/ServerAlerter.test.swift
+++ b/Tests/Shared/ServerAlerter.test.swift
@@ -258,4 +258,12 @@ class ServerAlerterTests: XCTestCase {
         alerter.markHandled(alert: alerts[0])
         XCTAssertEqual(try hang(alerter.check()), alerts[1])
     }
+
+    func testErroredRequestsDoesntAlert() {
+        let expectedError = URLError(.timedOut)
+        setUp(response: .failure(expectedError))
+        XCTAssertThrowsError(try hang(alerter.check())) { error in
+            XCTAssertEqual((error as? URLError)?.code, expectedError.code)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Shows an alert based on an alerts site JSON array, allowing us to customize alerts based on client or server version.

## Screenshots
<img width="400" alt="Screen Shot 2021-01-16 at 14 06 40" src="https://user-images.githubusercontent.com/74188/104824399-2e041680-5806-11eb-93a7-c8c01990f424.png"><img width="400" alt="Screen Shot 2021-01-16 at 14 06 24" src="https://user-images.githubusercontent.com/74188/104824401-2f354380-5806-11eb-9b61-7d4614606a4f.png">
![Image 4](https://user-images.githubusercontent.com/74188/104824421-699ee080-5806-11eb-8396-65e716c9b77e.png)

## Link to pull request in Documentation repository
Not quite documentation, but the server-side JSON for this is here: home-assistant/alerts.home-assistant.io#269

## Any other notes
- Does not send any local information anywhere. This only pulls the JSON remotely.
- Dismissing (by tapping the background, or swiping down) or opening the alert prevents it from displaying again.
- Supports any number of alerts, showing only the relevant and unseen ones.