### PR TITLE
Fix a couple issues in server alert

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -401,9 +401,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func checkForAlerts() {
         firstly {
-            when(fulfilled: Current.serverAlerter.check(), sceneManager.webViewWindowControllerPromise)
-        }.done { alert, controller in
-            controller.show(alert: alert)
+            Current.serverAlerter.check()
+        }.done { [sceneManager] alert in
+            sceneManager.webViewWindowControllerPromise.done { controller in
+                controller.show(alert: alert)
+            }
         }.catch { error in
             Current.Log.error("check error: \(error)")
         }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -631,6 +631,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             buttonTitle: L10n.openLabel,
             buttonTapHandler: { _ in
                 UIApplication.shared.open(alert.url, options: [:], completionHandler: nil)
+                SwiftMessages.hide()
             }
         )
 


### PR DESCRIPTION
- Fixes opening a second webview window on startup, due to trying to grab the webview promise before normal state restoration.
- Fixes not hiding the alert when tapping the 'open' button, as intended.
