### PR TITLE
Use correct constant for status item creation

### DIFF
--- a/Sources/MacBridge/MacBridgeStatusItem.swift
+++ b/Sources/MacBridge/MacBridgeStatusItem.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 class MacBridgeStatusItem {
-    private let statusItem = NSStatusBar.system.statusItem(withLength: 24)
+    private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private var lastConfiguration: MacBridgeStatusItemConfiguration?
 
     init() {


### PR DESCRIPTION
This length argument wants to be either the 'square' or 'variable'. Ours is slightly wider than it is tall, so using variable.