### PR TITLE
Use English as fallback when L10n key doesn't exist

### DIFF
--- a/Sources/Shared/Environment/LocalizedManager.swift
+++ b/Sources/Shared/Environment/LocalizedManager.swift
@@ -6,24 +6,38 @@ public class LocalizedManager {
 
     init() {
         bundle = Bundle(for: Self.self)
+
+        if let fallbackBundle = bundle.url(forResource: "en", withExtension: "lproj").flatMap(Bundle.init(url:)) {
+            add(stringProvider: { request in
+                if request.key == request.defaultValue {
+                    // fall back to the english language version if Localizable.strings is missing this key
+                    // this should only happen if we don't pull new strings before cutting a release
+                    return fallbackBundle.localizedString(forKey: request.key, value: nil, table: request.table)
+                } else {
+                    return nil
+                }
+            })
+        }
     }
 
     public struct StringProviderRequest {
         public var key: String
         public var table: String
+        public var defaultValue: String
     }
     public func add(stringProvider: @escaping (StringProviderRequest) -> String?) {
         stringProviders.insert(stringProvider, at: 0)
     }
 
     public func string(_ key: String, _ table: String) -> String {
-        let request = StringProviderRequest(key: key, table: table)
+        let defaultValue = bundle.localizedString(forKey: key, value: nil, table: table)
+        let request = StringProviderRequest(key: key, table: table, defaultValue: defaultValue)
         let override = stringProviders.lazy.compactMap { $0(request) }.first
 
         if let override = override {
             return override
-        } else {
-            return bundle.localizedString(forKey: key, value: nil, table: table)
         }
+
+        return defaultValue
     }
 }


### PR DESCRIPTION
## Summary
Fixes e.g. using the key like `settings_detail.general.…` as the fallback if we cut a release without updating localized strings.

## Screenshots

Before, after.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/74188/105289609-05b14a80-5b6d-11eb-9741-6c399ff75ca2.png"><img width="300" alt="image" src="https://user-images.githubusercontent.com/74188/105288922-d995c980-5b6c-11eb-8c36-66c343522b28.png">
