### PR TITLE
Fix compiling with spaces in paths

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -4145,7 +4145,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    ${SRCROOT}/Pods/SwiftLint/swiftlint --config ${SRCROOT}/.swiftlint.yml --quiet ${SRCROOT}\nfi\n";
+			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    # swiftlint as of 2021-01-21 (0.42.0) can't handle spaces in paths\n    # for the config arg, so we rely on relative here\n    # https://github.com/realm/SwiftLint/issues/3471\n    \"${SRCROOT}/Pods/SwiftLint/swiftlint\" \\\n       --config \".swiftlint.yml\" \\\n       --quiet \\\n       \"${SRCROOT}\"\nfi\n";
 		};
 		11F3820F2518795700494258 /* Unembed Lokalise for Catalyst */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Fixes #1393.

Two issues:
1. SwiftLint doesn't support spaces in the config path (seemingly as of 0.42.0, see realm/SwiftLint#3471)

```bash
> Pods/SwiftLint/swiftlint --config "/Users/zac/Sources/hass ios/.swiftlint.yml"
error: SwiftLint Configuration Error: Could not read file at path: /Users/zac/Sources/hass
```

2. We were invoking it and passing things without spaces around the paths.
