### PR TITLE
"Check for Updates" & "Alerts" settings

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		111858DF24CB83DF00B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		111D295624F30E2400C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
+		11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11267D0825BBA9FE00F28E5C /* Updater.test.swift */; };
 		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
 		1130F532253A1E7400F371BE /* ComplicationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F531253A1E7400F371BE /* ComplicationListViewController.swift */; };
 		1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */; };
@@ -1001,6 +1002,7 @@
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
+		11267D0825BBA9FE00F28E5C /* Updater.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.test.swift; sourceTree = "<group>"; };
 		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
 		1130F531253A1E7400F371BE /* ComplicationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationListViewController.swift; sourceTree = "<group>"; };
 		1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFamilySelectViewController.swift; sourceTree = "<group>"; };
@@ -3027,6 +3029,7 @@
 				1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */,
 				11F2F28D2587285300F61F7C /* NotificationAttachment */,
 				110AA57A25B38C02005061A0 /* ServerAlerter.test.swift */,
+				11267D0825BBA9FE00F28E5C /* Updater.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -5033,6 +5036,7 @@
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11F2F2B8258728B200F61F7C /* NotificationAttachmentParserURL.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
+				11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */,
 				11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */,
 				11CB98CD249E637300B05222 /* Version+HA.test.swift in Sources */,
 				11AF4D2E249DA5AF006C74C0 /* GeocoderSensor.test.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -363,7 +363,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Private helpers
 
     @objc func checkForUpdate(_ sender: AnyObject? = nil) {
-        Current.updater.check().done { [sceneManager] update in
+        let dueToUserInteraction = sender != nil
+
+        Current.updater.check(dueToUserInteraction: dueToUserInteraction).done { [sceneManager] update in
             let alert = UIAlertController(
                 title: L10n.Updater.UpdateAvailable.title,
                 message: update.body,
@@ -384,8 +386,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }.catch { [sceneManager] error in
             Current.Log.error("check error: \(error)")
 
-            if sender != nil {
-                // sender means it's from a ui element, so give a result
+            if dueToUserInteraction {
                 let alert = UIAlertController(
                     title: L10n.Updater.NoUpdatesAvailable.title,
                     message: error.localizedDescription,
@@ -402,7 +403,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func checkForAlerts() {
         firstly {
-            Current.serverAlerter.check()
+            Current.serverAlerter.check(dueToUserInteraction: false)
         }.done { [sceneManager] alert in
             sceneManager.webViewWindowControllerPromise.done { controller in
                 controller.show(alert: alert)

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -925,7 +925,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings_details.general.visibility.options.menu_bar" = "Menu Bar";
 "settings_details.general.visibility.options.dock_and_menu_bar" = "Dock and Menu Bar";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";
-"settings_details.updates.check_for_updates.title" = "Check for Updates";
+"settings_details.updates.check_for_updates.title" = "Automatically Check for Updates";
 "settings_details.updates.check_for_updates.include_betas" = "Include Beta Releases";
 "settings_details.privacy.alerts.title" = "Alerts";
 "settings_details.privacy.alerts.description" = "Allows checking for important alerts like security vulnerabilities.";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -925,3 +925,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings_details.general.visibility.options.menu_bar" = "Menu Bar";
 "settings_details.general.visibility.options.dock_and_menu_bar" = "Dock and Menu Bar";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";
+"settings_details.updates.check_for_updates.title" = "Check for Updates";
+"settings_details.updates.check_for_updates.include_betas" = "Include Beta Releases";
+"settings_details.privacy.alerts.title" = "Alerts";
+"settings_details.privacy.alerts.description" = "Allows checking for important alerts like security vulnerabilities.";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -155,13 +155,6 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Updates.CheckForUpdates.includeBetas
                     $0.value = Current.settingsStore.privacy.updatesIncludeBetas
-                    $0.hidden = .function(["checkForUpdates"], { form in
-                        if let row = form.rowBy(tag: "checkForUpdates") as? SwitchRow, let value = row.value {
-                            return value == false
-                        } else {
-                            return true
-                        }
-                    })
                     $0.onChange { row in
                         Current.settingsStore.privacy.updatesIncludeBetas = row.value ?? true
                     }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -143,7 +143,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 }
 
                 +++ Section {
-                    $0.hidden = .isNotCatalyst
+                    $0.hidden = .function([], { _ in !Current.updater.isSupported })
                 }
                 <<< SwitchRow("checkForUpdates") {
                     $0.title = L10n.SettingsDetails.Updates.CheckForUpdates.title

--- a/Sources/Shared/Common/Extensions/Version+HA.swift
+++ b/Sources/Shared/Common/Extensions/Version+HA.swift
@@ -22,4 +22,20 @@ extension Version {
         let parser = VersionParser(strict: false)
         self = try parser.parse(string: sanitized)
     }
+
+    public func compare(buildOf other: Version) -> ComparisonResult {
+        // Build can effectively be a sub-version
+        guard let buildVersion = build.flatMap({ try? Version.init(hassVersion: $0) }),
+              let otherBuildVersion = other.build.flatMap({ try? Version.init(hassVersion: $0) }) else {
+            return .orderedAscending
+        }
+
+        if buildVersion < otherBuildVersion {
+            return .orderedAscending
+        } else if buildVersion == otherBuildVersion {
+            return .orderedSame
+        } else {
+            return .orderedDescending
+        }
+    }
 }

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -73,7 +73,7 @@ public struct ServerAlert: Codable, Equatable {
 public class ServerAlerter {
     private var apiUrl: URL { URL(string: "https://alerts.home-assistant.io/mobile.json")! }
 
-    private enum AlerterError: LocalizedError {
+    internal enum AlerterError: LocalizedError {
         case privacyDisabled
 
         var errorDescription: String? {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1994,6 +1994,12 @@ public enum L10n {
     public enum Privacy {
       /// Privacy
       public static var title: String { return L10n.tr("Localizable", "settings_details.privacy.title") }
+      public enum Alerts {
+        /// Allows checking for important alerts like security vulnerabilities.
+        public static var description: String { return L10n.tr("Localizable", "settings_details.privacy.alerts.description") }
+        /// Alerts
+        public static var title: String { return L10n.tr("Localizable", "settings_details.privacy.alerts.title") }
+      }
       public enum Analytics {
         /// Allows collection of basic information about your device and interactions with the app. No user identifiable data is shared with Google, including your Home Assistant URLs and tokens. You must restart the app for changes to this setting to take effect.
         public static var description: String { return L10n.tr("Localizable", "settings_details.privacy.analytics.description") }
@@ -2049,6 +2055,14 @@ public enum L10n {
           /// Services
           public static var title: String { return L10n.tr("Localizable", "settings_details.siri.section.services.title") }
         }
+      }
+    }
+    public enum Updates {
+      public enum CheckForUpdates {
+        /// Include Beta Releases
+        public static var includeBetas: String { return L10n.tr("Localizable", "settings_details.updates.check_for_updates.include_betas") }
+        /// Check for Updates
+        public static var title: String { return L10n.tr("Localizable", "settings_details.updates.check_for_updates.title") }
       }
     }
     public enum Watch {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2061,7 +2061,7 @@ public enum L10n {
       public enum CheckForUpdates {
         /// Include Beta Releases
         public static var includeBetas: String { return L10n.tr("Localizable", "settings_details.updates.check_for_updates.include_betas") }
-        /// Check for Updates
+        /// Automatically Check for Updates
         public static var title: String { return L10n.tr("Localizable", "settings_details.updates.check_for_updates.title") }
       }
     }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -330,12 +330,18 @@ public class SettingsStore {
         public var messaging: Bool
         public var crashes: Bool
         public var analytics: Bool
+        public var alerts: Bool
+        public var updates: Bool
+        public var updatesIncludeBetas: Bool
 
         internal static func key(for keyPath: KeyPath<Privacy, Bool>) -> String {
             switch keyPath {
             case \.messaging: return "messagingEnabled"
             case \.crashes: return "crashesEnabled"
             case \.analytics: return "analyticsEnabled"
+            case \.alerts: return "alertsEnabled"
+            case \.updates: return "updateCheckingEnabled"
+            case \.updatesIncludeBetas: return "updatesIncludeBetas"
             default: return ""
             }
         }
@@ -355,13 +361,19 @@ public class SettingsStore {
             return .init(
                 messaging: boolValue(for: \.messaging),
                 crashes: boolValue(for: \.crashes),
-                analytics: boolValue(for: \.analytics)
+                analytics: boolValue(for: \.analytics),
+                alerts: boolValue(for: \.alerts),
+                updates: boolValue(for: \.updates),
+                updatesIncludeBetas: boolValue(for: \.updatesIncludeBetas)
             )
         }
         set {
             prefs.set(newValue.messaging, forKey: Privacy.key(for: \.messaging))
             prefs.set(newValue.crashes, forKey: Privacy.key(for: \.crashes))
             prefs.set(newValue.analytics, forKey: Privacy.key(for: \.analytics))
+            prefs.set(newValue.alerts, forKey: Privacy.key(for: \.alerts))
+            prefs.set(newValue.updates, forKey: Privacy.key(for: \.updates))
+            prefs.set(newValue.updatesIncludeBetas, forKey: Privacy.key(for: \.updatesIncludeBetas))
             Current.Log.info("privacy updated to \(newValue)")
         }
     }

--- a/Tests/Shared/ServerAlerter.test.swift
+++ b/Tests/Shared/ServerAlerter.test.swift
@@ -61,7 +61,7 @@ class ServerAlerterTests: XCTestCase {
 
     func testNoAlerts() {
         setUp(response: .success([]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testNoVersionedAlerts() {
@@ -77,7 +77,7 @@ class ServerAlerterTests: XCTestCase {
                 core: .init(min: nil, max: nil)
             )
         ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testEarlieriOSDoesntApply() {
@@ -93,7 +93,7 @@ class ServerAlerterTests: XCTestCase {
                 core: .init(min: nil, max: nil)
             )
         ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testLateriOSDoesntApply() {
@@ -109,7 +109,7 @@ class ServerAlerterTests: XCTestCase {
                 core: .init(min: nil, max: nil)
             )
         ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testMiddleiOSShouldApply() {
@@ -125,12 +125,12 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
         // trying again should still work
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
 
         alerter.markHandled(alert: alert)
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testLowerBoundOnlyiOSShouldApply() {
@@ -146,12 +146,12 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
         // trying again should still work
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
 
         alerter.markHandled(alert: alert)
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testLowerBoundOnlyiOSShouldntApply() {
@@ -167,7 +167,7 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testUpperBoundOnlyiOSShouldApply() {
@@ -183,12 +183,12 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
         // trying again should still work
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
 
         alerter.markHandled(alert: alert)
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testUpperBoundOnlyiOSShouldntApply() {
@@ -204,7 +204,7 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testEarlierCoreDoesntApply() {
@@ -220,7 +220,7 @@ class ServerAlerterTests: XCTestCase {
                 core: .init(min: .init(major: 50), max: .init(major: 99))
             )
         ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testLaterCoreDoesntApply() {
@@ -236,7 +236,7 @@ class ServerAlerterTests: XCTestCase {
                 core: .init(min: .init(major: 101), max: .init(major: 150))
             )
         ]))
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testMiddleCoreShouldApply() {
@@ -252,12 +252,12 @@ class ServerAlerterTests: XCTestCase {
         )
 
         setUp(response: .success([ alert ]))
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
         // trying again should still work
-        XCTAssertEqual(try hang(alerter.check()), alert)
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alert)
 
         alerter.markHandled(alert: alert)
-        XCTAssertThrowsError(try hang(alerter.check()))
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false)))
     }
 
     func testMultipleApplyGivesFirst() {
@@ -284,15 +284,15 @@ class ServerAlerterTests: XCTestCase {
         ]
 
         setUp(response: .success(alerts))
-        XCTAssertEqual(try hang(alerter.check()), alerts[0])
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alerts[0])
         alerter.markHandled(alert: alerts[0])
-        XCTAssertEqual(try hang(alerter.check()), alerts[1])
+        XCTAssertEqual(try hang(alerter.check(dueToUserInteraction: false)), alerts[1])
     }
 
     func testErroredRequestsDoesntAlert() {
         let expectedError = URLError(.timedOut)
         setUp(response: .failure(expectedError))
-        XCTAssertThrowsError(try hang(alerter.check())) { error in
+        XCTAssertThrowsError(try hang(alerter.check(dueToUserInteraction: false))) { error in
             XCTAssertEqual((error as? URLError)?.code, expectedError.code)
         }
     }

--- a/Tests/Shared/Updater.test.swift
+++ b/Tests/Shared/Updater.test.swift
@@ -1,0 +1,277 @@
+@testable import Shared
+import XCTest
+import Version
+import PromiseKit
+import OHHTTPStubs
+
+class UpdaterTest: XCTestCase {
+    private var stubDescriptors: [HTTPStubsDescriptor] = []
+    private var updater: Updater!
+
+    override func setUp() {
+        super.setUp()
+
+        updater = Updater()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        removeDescriptors()
+    }
+
+    private func removeDescriptors() {
+        for descriptor in stubDescriptors {
+            HTTPStubs.removeStub(descriptor)
+        }
+    }
+
+    private enum Expected {
+        case updateError(Updater.UpdateError)
+        case networkError(URLError.Code)
+        case hasUpdate(Int)
+    }
+
+    func testNetworkError() {
+        compare(
+            versions: .failure(URLError(.timedOut)),
+            currentVersion: .init(major: 2021, minor: 1, patch: 0, build: "1"),
+            expecting: .networkError(.timedOut)
+        )
+    }
+
+    func testNoVersions() {
+        compare(
+            versions: .success([]),
+            currentVersion: .init(major: 2021, minor: 1, patch: 0, build: "1"),
+            expecting: .updateError(.onLatestVersion)
+        )
+    }
+
+    func testLatestAvailableSameBuild() {
+        compare(
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "5"),
+            expecting: .updateError(.onLatestVersion)
+        )
+    }
+
+    func testLatestAvailableOlderBuilds() {
+        compare(
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "1"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "2"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "3"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "4"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "5"),
+            expecting: .updateError(.onLatestVersion)
+        )
+    }
+
+    func testLatestAvailableNewerBuild() {
+        compare(
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "1"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "2"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "3"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "4"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "3"),
+            expecting: .hasUpdate(3)
+        )
+    }
+
+    func testLatestAvailableNewerVersion() {
+        compare(
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "1"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "2"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "3"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "4"),
+                .init(hasAsset: true, prerelease: false, version: "2021.6", build: "1"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "3"),
+            expecting: .hasUpdate(4)
+        )
+    }
+
+    func testPrereleaseChecking() {
+        let versions: [AvailableUpdate] = [
+            .init(hasAsset: true, prerelease: false, version: "2021.5", build: "1"),
+            .init(hasAsset: true, prerelease: false, version: "2021.5", build: "2"),
+            .init(hasAsset: true, prerelease: false, version: "2021.5", build: "3"),
+            .init(hasAsset: true, prerelease: true, version: "2021.5", build: "4"),
+        ]
+
+        compare(
+            allowPrerelease: false,
+            versions: .success(versions),
+            currentVersion: .init(major: 2021, minor: 5, build: "2"),
+            expecting: .hasUpdate(2)
+        )
+
+        compare(
+            allowPrerelease: true,
+            versions: .success(versions),
+            currentVersion: .init(major: 2021, minor: 5, build: "2"),
+            expecting: .hasUpdate(3)
+        )
+    }
+
+    func testIgnoresWithoutAssets() {
+        compare(
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "4"),
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+                .init(hasAsset: false, prerelease: false, version: "2021.5", build: "6"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "4"),
+            expecting: .hasUpdate(1)
+        )
+    }
+
+    func testUpdatePreference() {
+        compare(
+            dueToUserInteraction: false,
+            allowUpdates: false,
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "1"),
+            expecting: .updateError(.privacyDisabled)
+        )
+
+        compare(
+            dueToUserInteraction: true,
+            allowUpdates: false,
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "1"),
+            expecting: .hasUpdate(0)
+        )
+    }
+
+    func testAppStore() {
+        compare(
+            isAppStore: true,
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "1"),
+            expecting: .updateError(.unsupportedPlatform)
+        )
+    }
+
+    func testNotCatalyst() {
+        compare(
+            isCatalyst: false,
+            versions: .success([
+                .init(hasAsset: true, prerelease: false, version: "2021.5", build: "5"),
+            ]),
+            currentVersion: .init(major: 2021, minor: 5, build: "1"),
+            expecting: .updateError(.unsupportedPlatform)
+        )
+    }
+
+    private func compare(
+        isCatalyst: Bool = true,
+        isAppStore: Bool = false,
+        dueToUserInteraction: Bool = false,
+        allowUpdates: Bool = true,
+        allowPrerelease: Bool = true,
+        versions: Swift.Result<[AvailableUpdate], Error>,
+        currentVersion: Version,
+        expecting: Expected
+    ) {
+        Current.isCatalyst = isCatalyst
+        Current.isAppStore = isAppStore
+        Current.clientVersion = { currentVersion }
+        Current.settingsStore.privacy.updates = allowUpdates
+        Current.settingsStore.privacy.updatesIncludeBetas = allowPrerelease
+
+        let url = URL(string: "https://api.github.com/repos/home-assistant/ios/releases?per_page=25")!
+        removeDescriptors()
+        stubDescriptors.append(stub(condition: { $0.url == url }, response: { request in
+            switch versions {
+            case .success(let versions):
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = .prettyPrinted
+                encoder.keyEncodingStrategy = .convertToSnakeCase
+
+                let stuffedVersions: [AvailableUpdate]
+
+                if versions.isEmpty == false {
+                    // stuff a bunch of random older and invalid versions in, in random places
+                    stuffedVersions = versions + [
+                        .init(hasAsset: true, prerelease: true, version: "101.1", build: "1"),
+                        .init(hasAsset: true, prerelease: false, version: "101.2", build: "1"),
+                        .init(hasAsset: false, prerelease: true, version: "101.3", build: "1"),
+                        .init(hasAsset: false, prerelease: false, version: "101.4", build: "1"),
+                        .init(hasAsset: true, prerelease: true, version: "101.5", build: "1"),
+                        .init(hasAsset: true, prerelease: false, version: "50.1", build: "1"),
+                        .init(hasAsset: false, prerelease: true, version: "50.2", build: "1"),
+                        .init(hasAsset: false, prerelease: false, version: "50.3", build: "1"),
+                        .init(hasAsset: false, prerelease: false, version: "2019.1", build: "100000"),
+                        .init(hasAsset: false, prerelease: false, version: "2019.100000", build: "100000"),
+                        .init(hasAsset: false, prerelease: false, version: "-1", build: "-1"),
+                        .init(hasAsset: false, prerelease: false, version: "", build: ""),
+                    ].shuffled()
+                } else {
+                    stuffedVersions = versions
+                }
+
+                return HTTPStubsResponse(
+                    data: try! encoder.encode(stuffedVersions),
+                    statusCode: 200,
+                    headers: [:]
+                )
+            case .failure(let error):
+                return HTTPStubsResponse(error: error)
+            }
+        }))
+
+        let promise = updater.check(dueToUserInteraction: dueToUserInteraction)
+        switch expecting {
+        case .hasUpdate(let version):
+            XCTAssertEqual(try hang(promise), try! versions.get()[version])
+        case .updateError(let expectedError):
+            XCTAssertThrowsError(try hang(promise)) { error in
+                XCTAssertEqual(error as? Updater.UpdateError, expectedError)
+            }
+        case .networkError(let code):
+            XCTAssertThrowsError(try hang(promise)) { error in
+                XCTAssertEqual((error as? URLError)?.code, code)
+            }
+        }
+    }
+}
+
+private extension AvailableUpdate {
+    init(
+        hasAsset: Bool,
+        prerelease: Bool,
+        version: String,
+        build: String
+    ) {
+        var assets = [Asset]()
+        if hasAsset {
+            assets.append(.init(
+                browserDownloadUrl: URL(string: "https://example.com/downloadUrl")!,
+                name: "Asset Name"
+            ))
+        }
+
+        self.init(
+            id: Int.random(in: 0..<Int.max),
+            htmlUrl: URL(string: "https://example.com/htmlUrl")!,
+            tagName: "release/\(version)/\(build)",
+            name: "\(version) (\(build))",
+            body: "example body",
+            prerelease: prerelease,
+            assets: assets
+        )
+    }
+}


### PR DESCRIPTION
Fixes #1378.

## Summary
- Adds a setting to control the automatic update checking, and an option to not include betas. 
- Adds a privacy option to disable server-side alerts.

## Screenshots
![image](https://user-images.githubusercontent.com/74188/105568347-754e4380-5ced-11eb-8640-45cc36faab48.png)
<img width="400" alt="Screen Shot 2021-01-22 at 20 32 04" src="https://user-images.githubusercontent.com/74188/105568780-e93e1b00-5cf0-11eb-8211-a19f228704bd.png"><img width="400" alt="Screen Shot 2021-01-22 at 20 31 59" src="https://user-images.githubusercontent.com/74188/105568782-eb07de80-5cf0-11eb-8dd3-214c5d0f54a4.png">
