### PR TITLE
Add admin-only filtering for server-based alerts

### DIFF
--- a/Sources/Shared/API/WebSocket/AuthenticatedUser.swift
+++ b/Sources/Shared/API/WebSocket/AuthenticatedUser.swift
@@ -21,6 +21,13 @@ public class AuthenticatedUser: Codable, CustomStringConvertible {
         case IsAdmin = "is_admin"
     }
 
+    internal init(id: String, name: String, isOwner: Bool, isAdmin: Bool) {
+        self.ID = id
+        self.Name = name
+        self.IsOwner = isOwner
+        self.IsAdmin = isAdmin
+    }
+
     public init?(_ dictionary: [String: Any]) {
         guard let id = dictionary["id"] as? String, let name = dictionary["name"] as? String else {
             return nil

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -118,8 +118,8 @@ public class ServerAlerter {
             }
             .decode([FailableServerAlert].self, from: data)
             .compactMap(\.alert)
-        }.get { updates in
-            Current.Log.info("found alerts: \(updates)")
+        }.get { alerts in
+            Current.Log.info("found alerts: \(alerts)")
         }.filterValues {
             $0.ios.shouldTrigger(for: Current.clientVersion()) || $0.core.shouldTrigger(for: Current.serverVersion())
         }.filterValues {

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -72,6 +72,24 @@ public struct ServerAlert: Codable, Equatable {
         core = try container.decodeIfPresent(VersionRequirement.self, forKey: .core) ?? .init(min: nil, max: nil)
     }
 
+    internal init(
+        id: String,
+        date: Date,
+        url: URL,
+        message: String,
+        adminOnly: Bool,
+        ios: VersionRequirement,
+        core: VersionRequirement
+    ) {
+        self.id = id
+        self.date = date
+        self.url = url
+        self.message = message
+        self.adminOnly = adminOnly
+        self.ios = ios
+        self.core = core
+    }
+
     public static func == (lhs: ServerAlert, rhs: ServerAlert) -> Bool {
         return lhs.id == rhs.id
             && abs(lhs.date.timeIntervalSince(rhs.date)) < 1

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -57,14 +57,27 @@ public struct ServerAlert: Codable, Equatable {
     public var date: Date
     public var url: URL
     public var message: String
+    public var adminOnly: Bool
     public var ios: VersionRequirement
     public var core: VersionRequirement
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        date = try container.decode(Date.self, forKey: .date)
+        url = try container.decode(URL.self, forKey: .url)
+        message = try container.decode(String.self, forKey: .message)
+        adminOnly = try container.decodeIfPresent(Bool.self, forKey: .adminOnly) ?? false
+        ios = try container.decodeIfPresent(VersionRequirement.self, forKey: .ios) ?? .init(min: nil, max: nil)
+        core = try container.decodeIfPresent(VersionRequirement.self, forKey: .core) ?? .init(min: nil, max: nil)
+    }
 
     public static func == (lhs: ServerAlert, rhs: ServerAlert) -> Bool {
         return lhs.id == rhs.id
             && abs(lhs.date.timeIntervalSince(rhs.date)) < 1
             && lhs.url == rhs.url
             && lhs.message == rhs.message
+            && lhs.adminOnly == rhs.adminOnly
             && lhs.ios == rhs.ios
             && lhs.core == rhs.core
     }
@@ -101,6 +114,7 @@ public class ServerAlerter {
             }
             return try with(JSONDecoder()) {
                 $0.dateDecodingStrategy = .iso8601
+                $0.keyDecodingStrategy = .convertFromSnakeCase
             }
             .decode([FailableServerAlert].self, from: data)
             .compactMap(\.alert)
@@ -108,6 +122,12 @@ public class ServerAlerter {
             Current.Log.info("found alerts: \(updates)")
         }.filterValues {
             $0.ios.shouldTrigger(for: Current.clientVersion()) || $0.core.shouldTrigger(for: Current.serverVersion())
+        }.filterValues {
+            if $0.adminOnly {
+                return Current.settingsStore.authenticatedUser?.IsAdmin == true
+            } else {
+                return true
+            }
         }.filterValues { [self] alert in
             !isHandled(alert: alert)
         }.firstValue

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -116,8 +116,14 @@ public class SettingsStore {
         }
     }
 
+    private var testAuthenticatedUser: AuthenticatedUser?
+
     public var authenticatedUser: AuthenticatedUser? {
         get {
+            if Current.isRunningTests {
+                return testAuthenticatedUser
+            }
+
             guard let userData = ((try? keychain.getData("authenticatedUser")) as Data??),
                 let unwrappedData = userData else {
                     return nil
@@ -126,6 +132,11 @@ public class SettingsStore {
             return try? JSONDecoder().decode(AuthenticatedUser.self, from: unwrappedData)
         }
         set {
+            if Current.isRunningTests {
+                testAuthenticatedUser = newValue
+                return
+            }
+
             guard let info = newValue else {
                 keychain["authenticatedUser"] = nil
                 return


### PR DESCRIPTION
Fixes #1391.

## Summary
Adds optional flag `admin_only` to the alert definition. Doesn't show them when it's set and the current user isn't an admin.

## Link to pull request in Documentation repository
n/a
