### PR TITLE
Make server version optional, fixing an alert issue

### DIFF
--- a/Sources/App/Settings/NFC/NFCTagViewController.swift
+++ b/Sources/App/Settings/NFC/NFCTagViewController.swift
@@ -96,7 +96,7 @@ class NFCTagViewController: FormViewController {
             tag: "example-triger",
             header: L10n.Nfc.Detail.exampleTrigger,
             yamlGetter: { [identifier] () -> String in
-                if Current.serverVersion() < .tagPlatformTrigger {
+                if let version = Current.serverVersion(), version < .tagPlatformTrigger {
                     let data = HomeAssistantAPI.tagEvent(tagPath: identifier)
                     let eventDataStrings = data.eventData.map { $0 + ": " + $1 }.sorted()
 

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -341,7 +341,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 }
             }
 
-            if Current.serverVersion() >= .actionSyncing {
+            if let version = Current.serverVersion(), version >= .actionSyncing {
                 form +++ RealmSection(
                     header: L10n.SettingsDetails.Actions.ActionsSynced.header,
                     footer: nil,

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -451,7 +451,7 @@ public class HomeAssistantAPI {
 
     public func GetMobileAppConfig() -> Promise<MobileAppConfig> {
         return firstly { () -> Promise<MobileAppConfig> in
-            if Current.serverVersion() < .actionSyncing {
+            if let version = Current.serverVersion(), version < .actionSyncing {
                 let old: Promise<MobileAppConfigPush> = requestImmutable(
                     path: "ios/push",
                     callingFunctionName: "\(#function)"
@@ -481,7 +481,7 @@ public class HomeAssistantAPI {
         let ident = mobileAppRegistrationRequestModel()
         var json = Mapper().toJSON(ident)
 
-        if Current.serverVersion() < .canSendDeviceID {
+        if let version = Current.serverVersion(), version < .canSendDeviceID {
             // device_id was added in 0.104, but prior it would error for unknown keys
             json.removeValue(forKey: "device_id")
         }
@@ -679,7 +679,7 @@ public class HomeAssistantAPI {
     ) -> (eventType: String, eventData: [String: String]) {
         var eventData = [String: String]()
         eventData["tag_id"] = tagPath
-        if Current.serverVersion() < .tagWebhookAvailable {
+        if let version = Current.serverVersion(), version < .tagWebhookAvailable {
             eventData["device_id"] = Current.settingsStore.integrationDeviceID
         }
         return (eventType: "tag_scanned", eventData: eventData)

--- a/Sources/Shared/API/Webhook/Sensors/PedometerSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/PedometerSensor.swift
@@ -107,16 +107,16 @@ public class PedometerSensor: SensorProvider {
             switch self {
             case .distance: return "mdi:hiking"
             case .floorsAscended:
-                if Current.serverVersion() >= .pedometerIconsAvailable {
-                    return "mdi:stairs-up"
-                } else {
+                if let version = Current.serverVersion(), version < .pedometerIconsAvailable {
                     return "mdi:slope-uphill"
+                } else {
+                    return "mdi:stairs-up"
                 }
             case .floorsDescended:
-                if Current.serverVersion() >= .pedometerIconsAvailable {
-                    return "mdi:stairs-down"
-                } else {
+                if let version = Current.serverVersion(), version < .pedometerIconsAvailable {
                     return "mdi:slope-downhill"
+                } else {
+                    return "mdi:stairs-down"
                 }
             case .steps: return "mdi:walk"
             case .averageActivePace: return "mdi:speedometer"

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -140,7 +140,7 @@ public class Environment {
 
     public lazy var activeState: ActiveStateManager = { ActiveStateManager() }()
 
-    public lazy var serverVersion: () -> Version = { [settingsStore] in settingsStore.serverVersion }
+    public lazy var serverVersion: () -> Version? = { [settingsStore] in settingsStore.serverVersion }
     public lazy var clientVersion: () -> Version = { Constants.clientVersion }
 
     public var onboardingObservation = OnboardingStateObservation()

--- a/Sources/Shared/Environment/ServerAlerter.swift
+++ b/Sources/Shared/Environment/ServerAlerter.swift
@@ -138,8 +138,16 @@ public class ServerAlerter {
             .compactMap(\.alert)
         }.get { alerts in
             Current.Log.info("found alerts: \(alerts)")
-        }.filterValues {
-            $0.ios.shouldTrigger(for: Current.clientVersion()) || $0.core.shouldTrigger(for: Current.serverVersion())
+        }.filterValues { alert in
+            if case let version = Current.clientVersion(), alert.ios.shouldTrigger(for: version) {
+                return true
+            }
+
+            if let version = Current.serverVersion(), alert.core.shouldTrigger(for: version) {
+                return true
+            }
+
+            return false
         }.filterValues {
             if $0.adminOnly {
                 return Current.settingsStore.authenticatedUser?.IsAdmin == true

--- a/Sources/Shared/Environment/TagManagerProtocol.swift
+++ b/Sources/Shared/Environment/TagManagerProtocol.swift
@@ -39,7 +39,7 @@ public extension TagManager {
     }
 
     func fireEvent(tag: String) -> Promise<Void> {
-        if Current.serverVersion() < .tagWebhookAvailable {
+        if let version = Current.serverVersion(), version < .tagWebhookAvailable {
             return Current.api.then { api -> Promise<Void> in
                 let event = HomeAssistantAPI.tagEvent(tagPath: tag)
                 return api.CreateEvent(eventType: event.eventType, eventData: event.eventData)

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -99,20 +99,18 @@ public class SettingsStore {
         }
     }
 
-    internal var serverVersion: Version {
+    internal var serverVersion: Version? {
         // access this publicly using Environment
-        let fallback = HomeAssistantAPI.minimumRequiredVersion
-
         guard let string = prefs.string(forKey: "version") else {
             Current.Log.info("couldn't find version string, falling back")
-            return fallback
+            return nil
         }
 
         do {
             return try Version(hassVersion: string)
         } catch {
             Current.Log.error("couldn't parse version '\(string)': \(error)")
-            return fallback
+            return nil
         }
     }
 


### PR DESCRIPTION
Fixes #1397.

## Summary
Makes server version optional, returning nil when we don't know rather than a fallback version.

## Screenshots
n/a

## Link to pull request in Documentation repository
n/a

## Any other notes
Prevents an issue where we'd alert about the fallback version being old enough to have an alert, rather than the actual version which comes later. Amusingly the work I did to make sure that we'd handle app-launch-to-web-view events supporting an onboarding flow in the middle causes the alerts to be delayed until the webview loads after initial login.