### PR TITLE
Add an event log entry when webhooks 4xx or 5xx

### DIFF
--- a/Sources/Shared/API/Webhook/Request&Response/Promise+WebhookJson.swift
+++ b/Sources/Shared/API/Webhook/Request&Response/Promise+WebhookJson.swift
@@ -64,6 +64,11 @@ extension Promise where T == Data {
                 return .value(())
             case 400...:
                 // some other error occurred that we don't want to parse as success
+                Current.clientEventStore.addEvent(ClientEvent(
+                    text: "Webhook failed with status code \(statusCode)",
+                    type: .networkRequest,
+                    payload: nil
+                ))
                 return .init(error: WebhookError.unacceptableStatusCode(statusCode))
             default:
                 break


### PR DESCRIPTION
Fixes #1398.

## Summary
There's a core bug somewhere that's causing webhooks to start 5xx-ing. I haven't been able to reproduce it locally yet. Adding this log should help users who run into this bug, since we don't otherwise share these network failures for webhooks.

## Screenshots
(Pretend like 200 is really a failure here.)
![Image](https://user-images.githubusercontent.com/74188/105571689-fa922200-5d06-11eb-9d01-4116c6b11650.png)
