### PR TITLE
Switch from red to orange for alerts

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -619,7 +619,10 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         })
 
         let view = MessageView.viewFromNib(layout: .messageView)
-        view.configureTheme(.error)
+        view.configureTheme(
+            backgroundColor: UIColor(red: 1.000, green: 0.596, blue: 0.000, alpha: 1.0),
+            foregroundColor: .white
+        )
         view.configureContent(
             title: nil,
             body: alert.message,

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -4,9 +4,11 @@ coverage:
       shared:
         paths:
         - Sources/Shared
+        threshold: 5%
       app:
         paths:
         - Sources/App
+        informational: true
 ignore:
 - Sources/Shared/Resources
 - Sources/App/Resources


### PR DESCRIPTION
## Summary
Changes the alerts to be more distinct - orange (stolen from the home-assistant.io page) instead of red.

## Screenshots
![Image 2](https://user-images.githubusercontent.com/74188/105641887-3a5a2600-5e3b-11eb-88c0-acfae616f2fc.png)
<img width="400" alt="Screen Shot 2021-01-24 at 11 49 58" src="https://user-images.githubusercontent.com/74188/105641889-3dedad00-5e3b-11eb-8139-6071fcbc16fb.png"><img width="400" alt="Screen Shot 2021-01-24 at 11 49 50" src="https://user-images.githubusercontent.com/74188/105641890-3f1eda00-5e3b-11eb-8924-66496a63a2a9.png">