### PR TITLE
Update PromiseKit default map queue, fix crash performing action

### DIFF
--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -39,6 +39,22 @@ public var Current = Environment()
 /// unit tests.
 public class Environment {
     internal init() {
+        PromiseKit.conf.Q = (map: nil, return: .main)
+        PromiseKit.conf.logHandler = { event in
+            Current.Log.info {
+                switch event {
+                case .waitOnMainThread:
+                    return "PromiseKit: warning: `wait()` called on main thread!"
+                case .pendingPromiseDeallocated:
+                    return "PromiseKit: warning: pending promise deallocated"
+                case .pendingGuaranteeDeallocated:
+                    return "PromiseKit: warning: pending guarantee deallocated"
+                case .cauterized (let error):
+                    return "PromiseKit:cauterized-error: \(error)"
+                }
+            }
+        }
+
         let crashReporter = CrashReporterImpl()
         self.crashReporter = crashReporter
         crashReporter.setup(environment: self)


### PR DESCRIPTION
## Summary
Fixes a crash caused by #1390. Since all API was moved to use promises, and promises' default behavior for `then`/`map` is to dispatch to the main queue, this causes some `Current.api.then…` calls to become unnecessarily synchronous.

## Any other notes
I am not super sure why `.main` as the default for the map queue makes sense. Maybe it prevents some cases where a promise will over-use the thread it's called on. This may also produce some bugs where we previously accessed things on the main queue under the assumption that it defaulted to this behavior.

Also adds a logger to the default PromiseKit prints, so that it routes into normal logs.