### PR TITLE
Add menu to status item on right-click

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 		11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */; };
 		11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */; };
 		11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */; };
-		11BD7B2D25B52E8D001826F0 /* MacBridgeStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
+		11BD7B2D25B52E8D001826F0 /* MacBridgeStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */; };
 		11BD7B4D25B53D7F001826F0 /* AppMacBridgeStatusItemConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B3C25B53D37001826F0 /* AppMacBridgeStatusItemConfiguration.swift */; };
 		11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */; };
 		11C05F2D254919210031D038 /* AccountInitialsImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C05F2C254919210031D038 /* AccountInitialsImage.swift */; };

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		1187DE4624D7E1BD00F0A6A6 /* SimulatorNFCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1187DE4524D7E1BD00F0A6A6 /* SimulatorNFCManager.swift */; };
 		11883CC524C12C8A0036A6C6 /* CLLocation+Extensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */; };
 		11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11883CC624C131EE0036A6C6 /* RealmZone.test.swift */; };
+		1188793F25BF8006003F4291 /* NSEvent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188793E25BF8006003F4291 /* NSEvent+Additions.swift */; };
 		118BDA8825A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */; };
 		118BDA8925A6DBBA00731016 /* FrontmostAppSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */; };
 		118F046924CB895A00CBBD5C /* UIColor+CSS3+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68FF7691F9D8637002BAADA /* UIColor+CSS3+Hex.swift */; };
@@ -228,7 +229,7 @@
 		11B7FD772493232400E60ED9 /* BackgroundTask.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD762493232400E60ED9 /* BackgroundTask.test.swift */; };
 		11BC9E5524FDB88200B9FBF7 /* ActiveStateManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */; };
 		11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */; };
-		11BD7B2D25B52E8D001826F0 /* MacBridgeStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */; };
+		11BD7B2D25B52E8D001826F0 /* MacBridgeStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */; settings = {COMPILER_FLAGS = "-Wno-deprecated-declarations"; }; };
 		11BD7B4D25B53D7F001826F0 /* AppMacBridgeStatusItemConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B3C25B53D37001826F0 /* AppMacBridgeStatusItemConfiguration.swift */; };
 		11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */; };
 		11C05F2D254919210031D038 /* AccountInitialsImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C05F2C254919210031D038 /* AccountInitialsImage.swift */; };
@@ -1070,6 +1071,7 @@
 		1187DE4524D7E1BD00F0A6A6 /* SimulatorNFCManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorNFCManager.swift; sourceTree = "<group>"; };
 		11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocation+Extensions.test.swift"; sourceTree = "<group>"; };
 		11883CC624C131EE0036A6C6 /* RealmZone.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmZone.test.swift; sourceTree = "<group>"; };
+		1188793E25BF8006003F4291 /* NSEvent+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSEvent+Additions.swift"; sourceTree = "<group>"; };
 		118A93322520411100227076 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		118BDA8725A6DBBA00731016 /* FrontmostAppSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostAppSensor.swift; sourceTree = "<group>"; };
 		119385A3249E8E360097F497 /* StorageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSensor.swift; sourceTree = "<group>"; };
@@ -1982,6 +1984,7 @@
 				110ED55325A5604F00489AF7 /* MacBridgeScreenImpl.swift */,
 				110ED5AC25A6826300489AF7 /* MacBridgeNetworkMonitor.swift */,
 				11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */,
+				1188793E25BF8006003F4291 /* NSEvent+Additions.swift */,
 			);
 			path = MacBridge;
 			sourceTree = "<group>";
@@ -4542,6 +4545,7 @@
 				1194B4162519BEE900AA01C3 /* MacBridgeNetworkConnectivityImpl.swift in Sources */,
 				110ED55425A5604F00489AF7 /* MacBridgeScreenImpl.swift in Sources */,
 				1167408E251990D500F51626 /* MacBridgeImpl.swift in Sources */,
+				1188793F25BF8006003F4291 /* NSEvent+Additions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -180,7 +180,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     @available(iOS 13, *)
-    @objc internal func openActionsPreferences(_ command: UICommand) {
+    @objc internal func openActionsPreferences() {
         precondition(Current.sceneManager.supportsMultipleScenes)
         let delegate: Guarantee<SettingsSceneDelegate> = sceneManager.scene(for: .init(activity: .settings))
         delegate.done { $0.pushDetail(group: "actions", animated: true) }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -929,3 +929,5 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings_details.updates.check_for_updates.include_betas" = "Include Beta Releases";
 "settings_details.privacy.alerts.title" = "Alerts";
 "settings_details.privacy.alerts.description" = "Allows checking for important alerts like security vulnerabilities.";
+"menu.status_item.toggle" = "Toggle %1$@";
+"menu.status_item.quit" = "Quit";

--- a/Sources/App/Utilities/AppMacBridgeStatusItemConfiguration.swift
+++ b/Sources/App/Utilities/AppMacBridgeStatusItemConfiguration.swift
@@ -7,13 +7,15 @@ class AppMacBridgeStatusItemConfiguration: MacBridgeStatusItemConfiguration {
         image: CGImage,
         imageSize: CGSize,
         accessibilityLabel: String,
-        items: [MacBridgeStatusItemMenuItem]
+        items: [MacBridgeStatusItemMenuItem],
+        primaryActionHandler: @escaping (MacBridgeStatusItemCallbackInfo) -> Void
     ) {
         self.isVisible = isVisible
         self.image = image
         self.imageSize = imageSize
         self.accessibilityLabel = accessibilityLabel
         self.items = items
+        self.primaryActionHandler = primaryActionHandler
     }
 
     var isVisible: Bool
@@ -21,6 +23,7 @@ class AppMacBridgeStatusItemConfiguration: MacBridgeStatusItemConfiguration {
     var imageSize: CGSize
     var accessibilityLabel: String
     var items: [MacBridgeStatusItemMenuItem]
+    var primaryActionHandler: (MacBridgeStatusItemCallbackInfo) -> Void
 }
 
 final class AppMacBridgeStatusItemMenuItem: MacBridgeStatusItemMenuItem {

--- a/Sources/App/Utilities/AppMacBridgeStatusItemConfiguration.swift
+++ b/Sources/App/Utilities/AppMacBridgeStatusItemConfiguration.swift
@@ -7,18 +7,62 @@ class AppMacBridgeStatusItemConfiguration: MacBridgeStatusItemConfiguration {
         image: CGImage,
         imageSize: CGSize,
         accessibilityLabel: String,
-        primaryActionHandler: @escaping (MacBridgeStatusItemCallbackInfo) -> Void
+        items: [MacBridgeStatusItemMenuItem]
     ) {
         self.isVisible = isVisible
         self.image = image
         self.imageSize = imageSize
         self.accessibilityLabel = accessibilityLabel
-        self.primaryActionHandler = primaryActionHandler
+        self.items = items
     }
 
     var isVisible: Bool
     var image: CGImage
     var imageSize: CGSize
     var accessibilityLabel: String
+    var items: [MacBridgeStatusItemMenuItem]
+}
+
+final class AppMacBridgeStatusItemMenuItem: MacBridgeStatusItemMenuItem {
+    class func separator() -> Self {
+        .init(isSeparator: true)
+    }
+
+    init(
+        name: String? = nil,
+        image: UIImage? = nil,
+        isSeparator: Bool = false,
+        keyEquivalentModifier: [MacBridgeStatusModifierMask] = [],
+        keyEquivalent: String? = nil,
+        subitems: [MacBridgeStatusItemMenuItem] = [],
+        primaryActionHandler: @escaping (MacBridgeStatusItemCallbackInfo) -> Void = { _ in }
+    ) {
+        self.name = name ?? ""
+        self.backingImage = image
+        self.isSeparator = isSeparator
+        self.keyEquivalentModifierMask = keyEquivalentModifier.reduce(into: Int(0)) { val, new in
+            val |= new.rawValue
+        }
+        self.keyEquivalent = keyEquivalent ?? ""
+        self.subitems = subitems
+        self.primaryActionHandler = primaryActionHandler
+    }
+
+    var backingImage: UIImage?
+    var name: String
+    var image: CGImage? {
+        if let image = backingImage {
+            return image.cgImage!
+        } else {
+            return nil
+        }
+    }
+    var imageSize: CGSize {
+        backingImage?.size ?? .zero
+    }
+    var isSeparator: Bool
+    var keyEquivalentModifierMask: Int
+    var keyEquivalent: String
+    var subitems: [MacBridgeStatusItemMenuItem]
     var primaryActionHandler: (MacBridgeStatusItemCallbackInfo) -> Void
 }

--- a/Sources/App/Utilities/MenuManager.swift
+++ b/Sources/App/Utilities/MenuManager.swift
@@ -330,7 +330,15 @@ class MenuManager {
             image: Asset.statusItemIcon.image.cgImage!,
             imageSize: Asset.statusItemIcon.image.size,
             accessibilityLabel: appName,
-            items: menuItems
+            items: menuItems,
+            primaryActionHandler: { callbackInfo in
+                if callbackInfo.isActive {
+                    callbackInfo.deactivate()
+                } else {
+                    Current.sceneManager.activateAnyScene(for: .webView)
+                    callbackInfo.activate()
+                }
+            }
         ))
         #endif
     }

--- a/Sources/App/Utilities/MenuManager.swift
+++ b/Sources/App/Utilities/MenuManager.swift
@@ -13,6 +13,8 @@ private extension UIMenu.Identifier {
     static var haFile: Self { .init(rawValue: "ha.file") }
 }
 
+// swiftlint:disable type_body_length
+
 @available(iOS 13, *)
 class MenuManager {
     let builder: UIMenuBuilder

--- a/Sources/MacBridge/MacBridgeStatusItem.swift
+++ b/Sources/MacBridge/MacBridgeStatusItem.swift
@@ -5,8 +5,7 @@ class MacBridgeStatusItem {
     private var lastConfiguration: MacBridgeStatusItemConfiguration?
 
     init() {
-        statusItem.button?.target = self
-        statusItem.button?.action = #selector(statusItemTapped(_:))
+
     }
 
     func configure(using configuration: MacBridgeStatusItemConfiguration) {
@@ -18,14 +17,75 @@ class MacBridgeStatusItem {
         let image = NSImage(cgImage: configuration.image, size: configuration.imageSize)
         image.isTemplate = true
         statusItem.button?.image = image
+
+        statusItem.menu = menu(for: configuration.items)
     }
 
-    @objc private func statusItemTapped(_ sender: NSStatusBarButton) {
-        lastConfiguration?.primaryActionHandler(MacBridgeStatusItemCallbackInfoImpl())
+    private func modifierKeys(for uglyMask: Int) -> NSEvent.ModifierFlags {
+        var modifierMask: NSEvent.ModifierFlags = []
+        let pairings: [(MacBridgeStatusModifierMask, NSEvent.ModifierFlags)] = [
+            (.capsLock, .capsLock),
+            (.shift, .shift),
+            (.control, .control),
+            (.option, .option),
+            (.command, .command),
+            (.numericPad, .numericPad),
+            (.help, .help),
+            (.function, .function)
+        ]
+
+        for (ugly, good) in pairings where uglyMask & ugly.rawValue != 0 {
+            modifierMask.insert(good)
+        }
+
+        return modifierMask
+    }
+
+    private func menu(for items: [MacBridgeStatusItemMenuItem]) -> NSMenu {
+        let menu = NSMenu()
+
+        for item in items {
+            guard !item.isSeparator else {
+                menu.addItem(.separator())
+                continue
+            }
+
+            let menuItem = NSMenuItem(
+                title: item.name,
+                action: #selector(actionTapped(_:)),
+                keyEquivalent: item.keyEquivalent
+            )
+            menu.addItem(menuItem)
+
+            menuItem.keyEquivalentModifierMask = modifierKeys(for: item.keyEquivalentModifierMask)
+            menuItem.target = self
+            menuItem.representedObject = item
+
+            if let image = item.image, case let imageSize = item.imageSize, imageSize != .zero {
+                menuItem.image = NSImage(cgImage: image, size: imageSize)
+            }
+
+            if !item.subitems.isEmpty {
+                menuItem.submenu = self.menu(for: item.subitems)
+            }
+        }
+
+        return menu
+    }
+
+    @objc private func actionTapped(_ sender: NSMenuItem) {
+        guard let representedObject = sender.representedObject as? MacBridgeStatusItemMenuItem else { return }
+        representedObject.primaryActionHandler(MacBridgeStatusItemCallbackInfoImpl(sender: sender))
     }
 }
 
 class MacBridgeStatusItemCallbackInfoImpl: MacBridgeStatusItemCallbackInfo {
+    let sender: Any?
+
+    init(sender: Any?) {
+        self.sender = sender
+    }
+
     var isActive: Bool {
         NSApp.isActive
     }
@@ -35,6 +95,10 @@ class MacBridgeStatusItemCallbackInfoImpl: MacBridgeStatusItemCallbackInfo {
     }
 
     func deactivate() {
-        NSApp.hide(nil)
+        NSApp.hide(sender)
+    }
+
+    func terminate() {
+        NSApp.terminate(sender)
     }
 }

--- a/Sources/MacBridge/NSEvent+Additions.swift
+++ b/Sources/MacBridge/NSEvent+Additions.swift
@@ -1,0 +1,11 @@
+import AppKit
+
+extension NSEvent {
+    var isRightClickEquivalentEvent: Bool {
+        switch type {
+        case .rightMouseUp, .rightMouseDown: return true
+        case .leftMouseUp, .leftMouseDown: return modifierFlags.contains(.control)
+        default: return false
+        }
+    }
+}

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -29,6 +29,30 @@ import Foundation
     var isActive: Bool { get }
     func activate()
     func deactivate()
+    func terminate()
+}
+
+// not actually possible to represent, via swift into objc and back into swift, the OptionSet import of this
+@objc(MacBridgeStatusModifierMask) public enum MacBridgeStatusModifierMask: Int {
+    case capsLock = 0b1 // Set if Caps Lock key is pressed.
+    case shift = 0b10 // Set if Shift key is pressed.
+    case control = 0b100 // Set if Control key is pressed.
+    case option = 0b1000 // Set if Option or Alternate key is pressed.
+    case command = 0b10000 // Set if Command key is pressed.
+    case numericPad = 0b100000 // Set if any key in the numeric keypad is pressed.
+    case help = 0b1000000 // Set if the Help key is pressed.
+    case function = 0b10000000 // Set if any function key is pressed.
+}
+
+@objc(MacBridgeStatusItemActionInfo) public protocol MacBridgeStatusItemMenuItem {
+    var name: String { get }
+    var image: CGImage? { get }
+    var imageSize: CGSize { get }
+    var isSeparator: Bool { get }
+    var keyEquivalentModifierMask: Int { get }
+    var keyEquivalent: String { get }
+    var subitems: [MacBridgeStatusItemMenuItem] { get }
+    var primaryActionHandler: (MacBridgeStatusItemCallbackInfo) -> Void { get }
 }
 
 @objc(MacBridgeStatusItemConfiguration) public protocol MacBridgeStatusItemConfiguration {
@@ -36,7 +60,7 @@ import Foundation
     var image: CGImage { get }
     var imageSize: CGSize { get }
     var accessibilityLabel: String { get }
-    var primaryActionHandler: (MacBridgeStatusItemCallbackInfo) -> Void { get }
+    var items: [MacBridgeStatusItemMenuItem] { get }
 }
 
 @objc(MacBridgeActivationPolicy) public enum MacBridgeActivationPolicy: Int {

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -61,6 +61,7 @@ import Foundation
     var imageSize: CGSize { get }
     var accessibilityLabel: String { get }
     var items: [MacBridgeStatusItemMenuItem] { get }
+    var primaryActionHandler: (MacBridgeStatusItemCallbackInfo) -> Void { get }
 }
 
 @objc(MacBridgeActivationPolicy) public enum MacBridgeActivationPolicy: Int {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -526,6 +526,14 @@ public enum L10n {
         return L10n.tr("Localizable", "menu.help.help", String(describing: p1))
       }
     }
+    public enum StatusItem {
+      /// Quit
+      public static var quit: String { return L10n.tr("Localizable", "menu.status_item.quit") }
+      /// Toggle %1$@
+      public static func toggle(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "menu.status_item.toggle", String(describing: p1))
+      }
+    }
     public enum View {
       /// Reload Page
       public static var reloadPage: String { return L10n.tr("Localizable", "menu.view.reload_page") }

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,7 +10,8 @@ coverage:
         - Sources/App
         informational: true
     patch:
-      informational: true
+      default:
+        informational: true
 ignore:
 - Sources/Shared/Resources
 - Sources/App/Resources


### PR DESCRIPTION
## Summary
Adds a basic menu structure to the status item. This includes:

- Toggling the app (e.g. activate or deactivate)
- Performing actions
- Opening About, Checking for Updates, opening Preferences and Quitting

## Screenshots
<img width="259" alt="Screen Shot 2021-01-24 at 22 51 24" src="https://user-images.githubusercontent.com/74188/105670916-b59cf580-5e96-11eb-9143-19ac5d4af92c.png"><img width="260" alt="Screen Shot 2021-01-24 at 22 51 16" src="https://user-images.githubusercontent.com/74188/105670921-b6ce2280-5e96-11eb-9c25-eddf4bb7ae12.png">

## Any other notes
There's not a clean way to do the left/right click handling. There's a few ways, all with their own pluses and negatives:
- Calling `popUpMenu(_:)` programmatically works, but it's marked as deprecated and it's tough to get Swift to not care.
- Handling `menuWillOpen` to instead do the left-click behavior and abort the menu display.