### PR TITLE
Fix MJPEG streaming in beta

### DIFF
--- a/Sources/Extensions/NotificationContent/CameraStreamMJPEGViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamMJPEGViewController.swift
@@ -16,14 +16,11 @@ class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
 
     enum MJPEGError: LocalizedError {
         case noPath
-        case noStreamer
         case networkError(path: String, error: Error?)
 
         var errorDescription: String? {
             switch self {
             case .noPath:
-                return L10n.Extensions.NotificationContent.Error.Request.authFailed
-            case .noStreamer:
                 return L10n.Extensions.NotificationContent.Error.Request.authFailed
             case .networkError(let path, let error):
                 if let error = error as? AFError, let responseCode = error.responseCode {
@@ -47,14 +44,10 @@ class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
             throw MJPEGError.noPath
         }
 
-        guard let streamer = api.VideoStreamer() else {
-            throw MJPEGError.noStreamer
-        }
-
         self.api = api
         self.connectionInfo = try api.connectionInfo()
         self.response = response
-        self.streamer = streamer
+        self.streamer = api.VideoStreamer()
         self.imageView = UIImageView()
         (self.promise, self.seal) = Promise<Void>.pending()
         super.init(nibName: nil, bundle: nil)

--- a/Sources/Extensions/Watch/CameraNotificationController.swift
+++ b/Sources/Extensions/Watch/CameraNotificationController.swift
@@ -68,14 +68,8 @@ class CameraNotificationController: WKUserNotificationInterfaceController {
             return
         }
 
-        Current.api.compactMap { api in
-            if let streamer = api.VideoStreamer() {
-                return (streamer, api)
-            } else {
-                return nil
-            }
-        }.done { [self] streamer, api in
-            setup(streamer: streamer, api: api, entityId: entityId)
+        Current.api.done { [self] api in
+            setup(streamer: api.VideoStreamer(), api: api, entityId: entityId)
         }.cauterize()
     }
 

--- a/Sources/Shared/API/MJPEGStreamer.swift
+++ b/Sources/Shared/API/MJPEGStreamer.swift
@@ -2,40 +2,83 @@ import Foundation
 import UIKit
 import Alamofire
 
-class ImageStreamSerializer: DataStreamSerializer {
-    func serialize(_ data: Data) throws -> UIImage? {
-        if let image = UIImage(data: data) {
-            return image
-        } else {
-            return nil
+class MJPEGStreamerSessionDelegate: SessionDelegate {
+    static var didReceiveResponse: Notification.Name = .init(rawValue: "MJPEGStreamerSessionDelegateDidReceiveResponse")
+    static var taskUserInfoKey: AnyHashable = "taskUserInfoKey"
+
+    // if/when alamofire also implements this again, we need to update to handle it as the breakpoint between images
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        NotificationCenter.default.post(
+            name: Self.didReceiveResponse,
+            object: self,
+            userInfo: [Self.taskUserInfoKey: dataTask]
+        )
+        completionHandler(.allow)
+    }
+}
+
+enum MJPEGEvent: CustomStringConvertible {
+    case data(Data)
+    case endOfResponse
+    case endOfStream(AFError?)
+
+    var description: String {
+        switch self {
+        case .data(let data):
+            return "data(\(data.count))"
+        case .endOfStream(let error):
+            return "endOfStream(\(String(describing: error)))"
+        case .endOfResponse:
+            return "endOfResponse"
         }
     }
 }
 
 public class MJPEGStreamer {
     let manager: Alamofire.Session
+    let queue = DispatchQueue(label: "mjpegstreamer-process")
     var data: Data = Data()
     var request: DataStreamRequest?
     var callback: ((UIImage?, Error?) -> Void)?
 
+    enum MJPEGError: Error {
+        case unknownEndOfStream
+    }
+
     init(manager: Alamofire.Session) {
         self.manager = manager
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveResponse(_:)),
+            name: MJPEGStreamerSessionDelegate.didReceiveResponse,
+            object: manager.delegate
+        )
     }
 
     public func streamImages(fromURL url: URL, callback: @escaping (UIImage?, Error?) -> Void) {
         self.callback = callback
 
         self.request?.cancel()
-        self.request = self.manager.streamRequest(url).responseStream(using: ImageStreamSerializer()) { result in
-            switch result.result ?? .success(nil) {
-            case .success(let image):
-                if let image = image {
-                    callback(image, nil)
+        self.request = self.manager
+            .streamRequest(url)
+            .validate()
+            .responseStream(on: queue, stream: { [weak self] stream in
+                switch stream.event {
+                case .complete(let completion):
+                    self?.handle(event: .endOfStream(completion.error))
+                case .stream(let result):
+                    switch result {
+                    case .success(let data):
+                        self?.handle(event: .data(data))
+                    }
                 }
-            case .failure(let error):
-                callback(nil, error)
-            }
-        }
+            })
     }
 
     public var isActive: Bool {
@@ -44,5 +87,37 @@ public class MJPEGStreamer {
     public func cancel() {
         self.request?.cancel()
         self.request = nil
+    }
+
+    @objc private func didReceiveResponse(_ note: Notification) {
+        queue.async { [self] in
+            if note.userInfo?[MJPEGStreamerSessionDelegate.taskUserInfoKey] as? URLSessionTask == request?.task {
+                handle(event: .endOfResponse)
+            }
+        }
+    }
+
+    private var pendingData = Data()
+    private func handle(event: MJPEGEvent) {
+        dispatchPrecondition(condition: .onQueue(queue))
+
+        Current.Log.info(event)
+
+        switch event {
+        case .data(let data):
+            pendingData.append(data)
+        case .endOfStream(let error):
+            DispatchQueue.main.async { [self] in
+                callback?(nil, error ?? MJPEGError.unknownEndOfStream)
+            }
+        case .endOfResponse:
+            let image = UIImage(data: pendingData)
+            pendingData.removeAll(keepingCapacity: true)
+            if let image = image {
+                DispatchQueue.main.async { [self] in
+                    callback?(image, nil)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes attempting to use partial `Data` to construct the images in the MJPEG streaming. When I updated this code to a newer version of Alamofire, I did so without realizing the boundary conditions for when the data in memory is available.

## Any other notes
Alamofire 6 may include a way to do this without having to implement the URLSession delegate method ourselves. See Alamofire/Alamofire#3401.