### PR TITLE
Fix not doing a 'warm' connect on Big Sur

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -25,12 +25,24 @@ class LifecycleManager {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(willEnterForeground),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
+        if Current.isCatalyst {
+            // on macOS, background/foreground is less of a concept
+            // on catalina, the app will 'background' and 'foreground' when hidden
+            // on big sur and beyond, the background/foreground lifecycle never seems to happen
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(willEnterForeground),
+                name: .init(rawValue: "NSApplicationDidBecomeActiveNotification"),
+                object: nil
+            )
+        } else {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(willEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+        }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(didEnterBackground),


### PR DESCRIPTION
The 'warm' connect was keying off background/foreground, which doesn't happen at all on Big Sur, and only happened in limited cases on Catalina. This now does it a lot more often.