### PR TITLE
Revert PromiseKit threading change

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -276,7 +276,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Current.Log.verbose("Background fetch activated at \(timestamp)!")
 
         Current.backgroundTask(withName: "background-fetch") { remaining in
-            Current.api.then { api -> Promise<Void> in
+            Current.api.then(on: nil) { api -> Promise<Void> in
                 let updatePromise: Promise<Void>
 
                 if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState),
@@ -449,7 +449,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     return
                 }
 
-                Current.api.then { api in
+                Current.api.then(on: nil) { api in
                     api.HandleAction(actionID: actionID, source: .Watch)
                 }.done { _ in
                     message.reply(.init(identifier: responseIdentifier, content: ["fired": true]))

--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -53,7 +53,7 @@ class LifecycleManager {
 
     func didFinishLaunching() {
         Current.backgroundTask(withName: "lifecycle-manager-didFinishLaunching") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(
                     eventType: "ios.finished_launching",
                     eventData: HomeAssistantAPI.sharedEventDeviceInfo
@@ -76,7 +76,7 @@ class LifecycleManager {
 
     @objc private func didEnterBackground() {
         Current.backgroundTask(withName: "lifecycle-manager-didEnterBackground") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(
                     eventType: "ios.entered_background",
                     eventData: HomeAssistantAPI.sharedEventDeviceInfo
@@ -104,7 +104,7 @@ class LifecycleManager {
 
     @objc private func didBecomeActive() {
         Current.backgroundTask(withName: "lifecycle-manager-didBecomeActive") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(
                     eventType: "ios.became_active",
                     eventData: HomeAssistantAPI.sharedEventDeviceInfo
@@ -142,7 +142,7 @@ class LifecycleManager {
 
     private func connectAPI(reason: HomeAssistantAPI.ConnectReason) {
         return Current.backgroundTask(withName: "connect-api") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.Connect(reason: reason)
             }
         }.done {

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -57,7 +57,7 @@ class NotificationManager: NSObject {
                     Current.Log.verbose("Received remote request to provide a location update")
 
                     Current.backgroundTask(withName: "push-location-request") { remaining in
-                        Current.api.then { api in
+                        Current.api.then(on: nil) { api in
                             api.GetAndSendLocation(trigger: .PushNotification, maximumBackgroundTime: remaining)
                         }
                     }.done { success in
@@ -106,7 +106,7 @@ class NotificationManager: NSObject {
 
                 Current.Log.verbose("Success, sending data \(eventData)")
 
-                Current.api.then { api in
+                Current.api.then(on: nil) { api in
                     api.CreateEvent(eventType: eventName, eventData: eventData)
                 }.catch { error -> Void in
                     Current.Log.error("Received error from createEvent during shortcut run \(error)")
@@ -118,7 +118,7 @@ class NotificationManager: NSObject {
             eventData["status"] = "failure"
             eventData["error"] = error.XCUErrorParameters
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(eventType: eventName, eventData: eventData)
             }.catch { error -> Void in
                 Current.Log.error("Received error from createEvent during shortcut run \(error)")
@@ -128,7 +128,7 @@ class NotificationManager: NSObject {
         let cancelHandler: CallbackURLKit.CancelCallback = {
             eventData["status"] = "cancelled"
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(eventType: eventName, eventData: eventData)
             }.catch { error -> Void in
                 Current.Log.error("Received error from createEvent during shortcut run \(error)")
@@ -145,7 +145,7 @@ class NotificationManager: NSObject {
             eventData["status"] = "error"
             eventData["error"] = error.localizedDescription
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(eventType: eventName, eventData: eventData)
             }.catch { error -> Void in
                 Current.Log.error("Received error from CallbackURLKit perform \(error)")
@@ -218,7 +218,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         }
 
         Current.backgroundTask(withName: "handle-push-action") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.handlePushAction(
                     identifier: response.actionIdentifier,
                     category: response.notification.request.content.categoryIdentifier,
@@ -297,7 +297,7 @@ extension NotificationManager: MessagingDelegate {
         Current.settingsStore.pushID = fcmToken
 
         Current.backgroundTask(withName: "notificationManager-didReceiveRegistrationToken") { _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.UpdateRegistration()
             }
         }.cauterize()

--- a/Sources/App/Onboarding/ConnectInstanceViewController.swift
+++ b/Sources/App/Onboarding/ConnectInstanceViewController.swift
@@ -137,7 +137,7 @@ class ConnectInstanceViewController: UIViewController {
     public func Connect() -> Promise<Void> {
         Current.resetAPI()
 
-        return Current.api.then { api in
+        return Current.api.then(on: nil) { api in
             api.Register().map { (api, $0) }
         }.map { api, regResponse -> HomeAssistantAPI in
             self.setAnimationStatus(self.integrationCreated, state: .success)

--- a/Sources/App/Settings/ActionConfigurator.swift
+++ b/Sources/App/Settings/ActionConfigurator.swift
@@ -358,7 +358,7 @@ class ActionPreview: UIView {
 
         self.imageView.showActivityIndicator()
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.HandleAction(actionID: action.ID, source: .Preview)
         }.done { _ in
             feedbackGenerator.notificationOccurred(.success)

--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -69,7 +69,7 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
             Current.Log.error(error)
         }
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.updateComplications(passively: false)
         }.cauterize()
 
@@ -99,7 +99,7 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
                 Current.Log.error(error)
             }
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.updateComplications(passively: false)
             }.cauterize()
 
@@ -488,7 +488,7 @@ class ComplicationEditViewController: FormViewController, TypedRowControllerType
     }
 
     func renderTemplateValue(_ value: String, _ row: BaseRow, expectingPercentile: Bool) {
-        Current.api.then {
+        Current.api.then(on: nil) {
             $0.RenderTemplate(templateStr: value)
         }.get { result in
             if expectingPercentile {

--- a/Sources/App/Settings/Eureka/AccountRow.swift
+++ b/Sources/App/Settings/Eureka/AccountRow.swift
@@ -108,7 +108,7 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
             return
         }
 
-        Current.api.then {
+        Current.api.then(on: nil) {
             $0.GetStates()
         }.firstValue {
             $0.Attributes["user_id"] as? String == user.ID

--- a/Sources/App/Settings/Sensors/SensorListViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorListViewController.swift
@@ -67,7 +67,7 @@ class SensorListViewController: FormViewController, SensorObserver {
         refreshControl.beginRefreshing()
 
         Current.backgroundTask(withName: "manual-location-update-settings") { _ in
-            Current.api.then { api -> Promise<Void> in
+            Current.api.then(on: nil) { api -> Promise<Void> in
                 if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState) {
                     return api.GetAndSendLocation(trigger: .Manual).asVoid()
                 } else {

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -67,7 +67,7 @@ class IncomingURLHandler {
 
     func handle(shortcutItem: UIApplicationShortcutItem) -> Promise<Void> {
         return Current.backgroundTask(withName: "shortcut-item") { remaining -> Promise<Void> in
-            Current.api.then { api -> Promise<Void> in
+            Current.api.then(on: nil) { api -> Promise<Void> in
                 if shortcutItem.type == "sendLocation" {
                     return api.GetAndSendLocation(trigger: .AppShortcut, maximumBackgroundTime: remaining)
                 } else {
@@ -138,7 +138,7 @@ extension IncomingURLHandler {
             cleanParamters.removeValue(forKey: "eventName")
             let eventData = cleanParamters
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CreateEvent(eventType: eventName, eventData: eventData)
             }.done { _ in
                 success(nil)
@@ -162,7 +162,7 @@ extension IncomingURLHandler {
             cleanParamters.removeValue(forKey: "service")
             let serviceData = cleanParamters
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.CallService(domain: serviceDomain, service: serviceName, serviceData: serviceData)
             }.done { _ in
                 success(nil)
@@ -173,7 +173,7 @@ extension IncomingURLHandler {
         }
 
         Manager.shared["send_location"] = { _, success, failure, _ in
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.GetAndSendLocation(trigger: .XCallbackURL)
             }.done { _ in
                 success(nil)
@@ -193,7 +193,7 @@ extension IncomingURLHandler {
             cleanParamters.removeValue(forKey: "template")
             let variablesDict = cleanParamters
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.RenderTemplate(templateStr: template, variables: variablesDict)
             }.done { rendered in
                 success(["rendered": String(describing: rendered)])
@@ -207,7 +207,7 @@ extension IncomingURLHandler {
     private func fireEventURLHandler(_ url: URL, _ serviceData: [String: String]) {
         // homeassistant://fire_event/custom_event?entity_id=device_tracker.entity
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.CreateEvent(eventType: url.pathComponents[1], eventData: serviceData)
         }.done { _ in
             self.showAlert(title: L10n.UrlHandler.FireEvent.Success.title,
@@ -224,7 +224,7 @@ extension IncomingURLHandler {
         let domain = url.pathComponents[1].components(separatedBy: ".")[0]
         let service = url.pathComponents[1].components(separatedBy: ".")[1]
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.CallService(domain: domain, service: service, serviceData: serviceData)
         }.done { _ in
             self.showAlert(title: L10n.UrlHandler.CallService.Success.title,
@@ -238,7 +238,7 @@ extension IncomingURLHandler {
 
     private func sendLocationURLHandler() {
         // homeassistant://send_location/
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.GetAndSendLocation(trigger: .URLScheme)
         }.done { _ in
             self.showAlert(title: L10n.UrlHandler.SendLocation.Success.title,
@@ -276,7 +276,7 @@ extension IncomingURLHandler {
         Current.sceneManager
             .showFullScreenConfirm(icon: MaterialDesignIcons(named: action.IconName), text: action.Text)
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.HandleAction(actionID: actionID, source: source)
         }.cauterize()
     }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -549,7 +549,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
     @objc private func updateSensors() {
         // called via menu/keyboard shortcut too
         Current.backgroundTask(withName: "manual-location-update") { remaining in
-            Current.api.then { api -> Promise<HomeAssistantAPI> in
+            Current.api.then(on: nil) { api -> Promise<HomeAssistantAPI> in
                 guard #available(iOS 14, *) else {
                     return .value(api)
                 }

--- a/Sources/App/ZoneManager/ZoneManager.swift
+++ b/Sources/App/ZoneManager/ZoneManager.swift
@@ -99,7 +99,7 @@ class ZoneManager {
             return
         }
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.CreateEvent(eventType: eventInfo.eventType, eventData: eventInfo.eventData)
         }.cauterize()
     }

--- a/Sources/App/ZoneManager/ZoneManagerProcessor.swift
+++ b/Sources/App/ZoneManager/ZoneManagerProcessor.swift
@@ -44,7 +44,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
                         return nil
                     }
                 }.then { location in
-                    Current.api.then { api in
+                    Current.api.then(on: nil) { api in
                         api.SubmitLocation(
                             updateType: trigger,
                             location: location,

--- a/Sources/Extensions/Intents/CallService.swift
+++ b/Sources/Extensions/Intents/CallService.swift
@@ -34,7 +34,7 @@ class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
     }
 
     func provideServiceOptions(for intent: CallServiceIntent, with completion: @escaping ([String]?, Error?) -> Void) {
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.GetServices()
         }.done { serviceResp in
             var allServices: [String] = []
@@ -109,7 +109,7 @@ class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
 
         Current.Log.verbose("Handling call service shortcut \(domain), \(service)")
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.CallService(domain: domain, service: service, serviceData: payloadDict, shouldLog: true)
         }.done { _ in
             Current.Log.verbose("Successfully called service during shortcut")

--- a/Sources/Extensions/Intents/FireEvent.swift
+++ b/Sources/Extensions/Intents/FireEvent.swift
@@ -85,7 +85,7 @@ class FireEventIntentHandler: NSObject, FireEventIntentHandling {
             }
         }
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.CreateEvent(eventType: intent.eventName!, eventData: eventDataDict)
         }.done { _ in
             Current.Log.verbose("Successfully fired event during shortcut")

--- a/Sources/Extensions/Intents/GetCameraImage.swift
+++ b/Sources/Extensions/Intents/GetCameraImage.swift
@@ -27,7 +27,7 @@ class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
 
     func provideCameraIDOptions(for intent: GetCameraImageIntent,
                                 with completion: @escaping ([String]?, Error?) -> Void) {
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.GetStates()
         }.compactMapValues { entity -> String? in
             if entity.Domain == "camera" {
@@ -55,7 +55,7 @@ class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
         if let cameraID = intent.cameraID {
             Current.Log.verbose("Getting camera frame for \(cameraID)")
 
-            Current.api.then { api in
+            Current.api.then(on: nil) { api in
                 api.GetCameraImage(cameraEntityID: cameraID)
             }.done { frame in
                 Current.Log.verbose("Successfully got camera image during shortcut")

--- a/Sources/Extensions/Intents/PerformAction.swift
+++ b/Sources/Extensions/Intents/PerformAction.swift
@@ -13,7 +13,7 @@ class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
             return
         }
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.HandleAction(actionID: result.action.ID, source: .SiriShortcut)
         }.done {
             completion(.success(action: result.updated))

--- a/Sources/Extensions/Intents/RenderTemplate.swift
+++ b/Sources/Extensions/Intents/RenderTemplate.swift
@@ -35,7 +35,7 @@ class RenderTemplateIntentHandler: NSObject, RenderTemplateIntentHandling {
 
         Current.Log.verbose("Rendering template \(templateStr)")
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.RenderTemplate(templateStr: templateStr)
         }.done { rendered in
             Current.Log.verbose("Successfully renderedTemplate")

--- a/Sources/Extensions/Intents/SendLocation.swift
+++ b/Sources/Extensions/Intents/SendLocation.swift
@@ -28,7 +28,7 @@ class SendLocationIntentHandler: NSObject, SendLocationIntentHandling {
     func handle(intent: SendLocationIntent, completion: @escaping (SendLocationIntentResponse) -> Void) {
         Current.Log.verbose("Handling send location")
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.SubmitLocation(updateType: .Siri, location: intent.location?.location, zone: nil)
         }.done { _ in
             Current.Log.verbose("Successfully submitted location")

--- a/Sources/Extensions/Intents/UpdateSensors.swift
+++ b/Sources/Extensions/Intents/UpdateSensors.swift
@@ -6,7 +6,7 @@ class UpdateSensorsIntentHandler: NSObject, UpdateSensorsIntentHandling {
     func handle(intent: UpdateSensorsIntent, completion: @escaping (UpdateSensorsIntentResponse) -> Void) {
         Current.Log.info("starting")
 
-        Current.api.then {
+        Current.api.then(on: nil) {
             $0.UpdateSensors(trigger: .Siri)
         }.done {
             Current.Log.info("finished successfully")

--- a/Sources/Extensions/NotificationContent/CameraViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraViewController.swift
@@ -60,7 +60,7 @@ class CameraViewController: UIViewController, NotificationCategory {
             return .init(error: CameraError.missingEntityId)
         }
 
-        return Current.api.then { (api: HomeAssistantAPI) -> Promise<(HomeAssistantAPI, StreamCameraResponse)> in
+        return Current.api.then(on: nil) { api -> Promise<(HomeAssistantAPI, StreamCameraResponse)> in
             return firstly {
                 api.StreamCamera(entityId: entityId)
             }.recover { error -> Promise<StreamCameraResponse> in

--- a/Sources/Extensions/NotificationService/NotificationService.swift
+++ b/Sources/Extensions/NotificationService/NotificationService.swift
@@ -9,7 +9,7 @@ final class NotificationService: UNNotificationServiceExtension {
     ) {
         Current.Log.info("didReceive \(request), user info \(request.content.userInfo)")
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             NotificationAttachmentManager().content(from: request.content, api: api)
         }.recover { error in
             Current.Log.error("failed to get content, giving default: \(error)")

--- a/Sources/Extensions/Today/TodayViewController.swift
+++ b/Sources/Extensions/Today/TodayViewController.swift
@@ -150,7 +150,7 @@ class TodayViewController: UICollectionViewController, UICollectionViewDelegateF
 
         let action = self.actions[indexPath.row]
 
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             api.HandleAction(actionID: action.ID, source: .Widget)
         }.done { _ in
             feedbackGenerator.notificationOccurred(.success)

--- a/Sources/Extensions/Watch/CameraNotificationController.swift
+++ b/Sources/Extensions/Watch/CameraNotificationController.swift
@@ -68,7 +68,7 @@ class CameraNotificationController: WKUserNotificationInterfaceController {
             return
         }
 
-        Current.api.done { [self] api in
+        Current.api.done(on: nil) { [self] api in
             setup(streamer: api.VideoStreamer(), api: api, entityId: entityId)
         }.cauterize()
     }

--- a/Sources/Extensions/Watch/ExtensionDelegate.swift
+++ b/Sources/Extensions/Watch/ExtensionDelegate.swift
@@ -252,7 +252,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
     }
 
     func updateComplications() -> Guarantee<Void> {
-        Current.api.then {
+        Current.api.then(on: nil) {
             $0.updateComplications(passively: true)
         }.recover { _ in
             ()

--- a/Sources/Extensions/Watch/InterfaceController.swift
+++ b/Sources/Extensions/Watch/InterfaceController.swift
@@ -146,7 +146,7 @@ class InterfaceController: WKInterfaceController {
             }
         }.recover { error -> Promise<Void> in
             Current.Log.error("recovering error \(error) by trying locally")
-            return Current.api.then { api -> Promise<Void> in
+            return Current.api.then(on: nil) { api -> Promise<Void> in
                 return api.HandleAction(actionID: selectedAction.ID, source: .Watch)
             }
         }.done {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -724,7 +724,7 @@ public class HomeAssistantAPI {
 
         Current.Log.verbose("Sending action: \(action.eventType) payload: \(action.eventData)")
 
-        return Current.api.then { api in
+        return Current.api.then(on: nil) { api in
             api.CreateEvent(eventType: action.eventType, eventData: action.eventData)
         }
     }
@@ -743,7 +743,7 @@ public class HomeAssistantAPI {
             let actionInfo = Self.actionEvent(actionID: action.ID, actionName: action.Name, source: source)
             Current.Log.verbose("Sending action: \(actionInfo.eventType) payload: \(actionInfo.eventData)")
 
-            return Current.api.then { api in
+            return Current.api.then(on: nil) { api in
                 api.CreateEvent(
                     eventType: actionInfo.eventType,
                     eventData: actionInfo.eventData
@@ -753,7 +753,7 @@ public class HomeAssistantAPI {
             let serviceInfo = Self.actionScene(actionID: action.ID, source: source)
             Current.Log.verbose("activating scene: \(action.ID)")
 
-            return Current.api.then { api in
+            return Current.api.then(on: nil) { api in
                 api.CallService(
                     domain: serviceInfo.serviceDomain,
                     service: serviceInfo.serviceName,

--- a/Sources/Shared/API/Models/ModelManager.swift
+++ b/Sources/Shared/API/Models/ModelManager.swift
@@ -126,7 +126,7 @@ public final class ModelManager {
         definitions: [FetchDefinition] = FetchDefinition.defaults,
         on queue: DispatchQueue = .global(qos: .utility)
     ) -> Promise<Void> {
-        Current.api.then { api in
+        Current.api.then(on: nil) { api in
             when(fulfilled: definitions.map { $0.update(api, queue, self) })
         }
     }

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -547,7 +547,7 @@ extension WebhookManager: URLSessionDataDelegate {
         Current.Log.notify("starting \(request.type) (\(handlerType))")
         sessionInfo.eventGroup.enter()
 
-        Current.api.then { (api: HomeAssistantAPI) -> Promise<Void> in
+        Current.api.then(on: nil) { (api: HomeAssistantAPI) -> Promise<Void> in
             let handler = handlerType.init(api: api)
             let handlerPromise = firstly {
                 handler.handle(request: .value(request), result: result)

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -39,7 +39,6 @@ public var Current = Environment()
 /// unit tests.
 public class Environment {
     internal init() {
-        PromiseKit.conf.Q = (map: nil, return: .main)
         PromiseKit.conf.logHandler = { event in
             Current.Log.info {
                 switch event {

--- a/Sources/Shared/Environment/TagManagerProtocol.swift
+++ b/Sources/Shared/Environment/TagManagerProtocol.swift
@@ -40,7 +40,7 @@ public extension TagManager {
 
     func fireEvent(tag: String) -> Promise<Void> {
         if let version = Current.serverVersion(), version < .tagWebhookAvailable {
-            return Current.api.then { api -> Promise<Void> in
+            return Current.api.then(on: nil) { api -> Promise<Void> in
                 let event = HomeAssistantAPI.tagEvent(tagPath: tag)
                 return api.CreateEvent(eventType: event.eventType, eventData: event.eventData)
             }


### PR DESCRIPTION
- Reverts #1418 - there's enough logic that is relying on the single-threadedness of then/map-ing on a shared queue.
- Forces all `Current.api` access to be done not on a queue intentionally, to avoid thread jumping when we don't expect, which is the core crash that this was trying to fix.