### PR TITLE
Minor automatic build followup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
   test:
     runs-on: macos-latest
+    timeout-minutes: 60
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
     steps:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -47,8 +47,38 @@ jobs:
         # hard-coded so it doesn't cause 'ios' to be *** everywhere in the logs
         SENTRY_PROJECT: ios
 
+    - name: Dump Version Information
+      run: cat Configuration/Version.xcconfig
+
     - uses: actions/upload-artifact@v2
-      name: "Upload Builds"
+      name: "Upload iOS IPA"
+      if: success() && matrix.kind == 'ios'
       with:
-        name: ${{ matrix.kind }} Builds
-        path: build
+        name: ios-app-store.ipa
+        path: build/ios/Home Assistant.ipa
+    - uses: actions/upload-artifact@v2
+      name: "Upload iOS dSYMs"
+      if: success() && matrix.kind == 'ios'
+      with:
+        name: ios.dSYM.zip
+        path: build/ios/Home Assistant.app.dSYM.zip
+
+    - uses: actions/upload-artifact@v2
+      name: "Upload Mac Developer ID App"
+      if: success() && matrix.kind == 'mac'
+      with:
+        name: mac-developer-id.zip
+        path: build/macos/home-assistant-mac.zip
+    - uses: actions/upload-artifact@v2
+      name: "Upload Mac App Store Package"
+      if: success() && matrix.kind == 'mac'
+      with:
+        name: mac-app-store.pkg
+        path: build/macos/Home Assistant.pkg
+
+    - uses: actions/upload-artifact@v2
+      name: "Upload Mac dSYMs"
+      if: success() && matrix.kind == 'mac'
+      with:
+        name: mac.dSYM.zip
+        path: build/macos/Home Assistant.app.dSYM.zip

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,36 +79,6 @@ lane :update_dsyms do
   FileUtils.rm_r directory
 end
 
-lane :refresh_dsyms do
-  FileUtils.mkdir_p '../dSYMs'
-  download_dsyms(output_directory: "./dSYMs", app_identifier: bundle_id())
-  dir = "../dSYMS"
-  files = Dir.foreach(dir).map { |x| File.expand_path("#{dir}/#{x}") }.select { |x| File.file?(x) }
-  upload_symbols_to_crashlytics(gsp_path: "./Sources/App/Resources/GoogleService-Info-Release.plist",
-                                dsym_paths: files, dsym_worker_threads: 6)
-  clean_build_artifacts
-end
-
-lane :refresh_beta_dsyms do
-  FileUtils.mkdir_p '../dSYMs'
-  download_dsyms(output_directory: "./dSYMs", app_identifier: bundle_id("beta"))
-  dir = "../dSYMS"
-  files = Dir.foreach(dir).map { |x| File.expand_path("#{dir}/#{x}") }.select { |x| File.file?(x) }
-  upload_symbols_to_crashlytics(gsp_path: "./Sources/App/Resources/GoogleService-Info-Beta.plist",
-                                dsym_paths: files, dsym_worker_threads: 6)
-  clean_build_artifacts
-end
-
-desc "Fetches the push notification certificates and saves them as p12 files in push_certs/, perfect for direct upload to AWS SNS. p12 password is password."
-lane :push_certs do
-  pem(app_identifier: bundle_id(), output_path: "push_certs/", generate_p12: true, team_id: ENV["HOMEASSISTANT_TEAM_ID"], username: ENV["HOMEASSISTANT_APPLE_ID"], p12_password: "password")
-  pem(app_identifier: bundle_id(), development: true, output_path: "push_certs/", generate_p12: true, team_id: ENV["HOMEASSISTANT_TEAM_ID"], username: ENV["HOMEASSISTANT_APPLE_ID"], p12_password: "password")
-
-  pem(app_identifier: bundle_id("beta"), output_path: "push_certs/", generate_p12: true, team_id: ENV["HOMEASSISTANT_TEAM_ID"], username: ENV["HOMEASSISTANT_APPLE_ID"], p12_password: "password")
-
-  pem(app_identifier: bundle_id("dev"), development: true, output_path: "push_certs/", generate_p12: true, team_id: ENV["HOMEASSISTANT_TEAM_ID"], username: ENV["HOMEASSISTANT_APPLE_ID"], p12_password: "password")
-end
-
 desc "Generate proper icons for all build trains"
 lane :icons do
   appicon(appicon_path: "Sources/App/Resources/Assets.xcassets", appicon_image_file: "icons/dev.png", appicon_name: "AppIcon.dev.appiconset", appicon_devices: [:ipad, :iphone, :ios_marketing, :macos])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,20 @@ lane :import_provisioning_profiles do
   end
 end
 
+lane :update_dsyms do
+  directory = File.expand_path("dSYMs")
+  FileUtils.mkdir_p directory
+
+  download_dsyms(
+    after_uploaded_date: Date.today.prev_day(7).iso8601,
+    app_identifier: "io.robbie.HomeAssistant",
+    output_directory: directory
+  )
+
+  upload_path_to_sentry(path: directory)
+  FileUtils.rm_r directory
+end
+
 lane :refresh_dsyms do
   FileUtils.mkdir_p '../dSYMs'
   download_dsyms(output_directory: "./dSYMs", app_identifier: bundle_id())
@@ -320,6 +334,10 @@ private_lane :provisioning_profile_specifiers do |options|
   end
 
   specifiers
+end
+
+private_lane :upload_path_to_sentry do |options|
+  sh("sentry-cli", "upload-dif", options[:path])
 end
 
 private_lane :upload_archive_to_sentry do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,6 +30,11 @@ fastlane download_provisioning_profiles
 fastlane import_provisioning_profiles
 ```
 
+### update_dsyms
+```
+fastlane update_dsyms
+```
+
 ### refresh_dsyms
 ```
 fastlane refresh_dsyms

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -35,21 +35,6 @@ fastlane import_provisioning_profiles
 fastlane update_dsyms
 ```
 
-### refresh_dsyms
-```
-fastlane refresh_dsyms
-```
-
-### refresh_beta_dsyms
-```
-fastlane refresh_beta_dsyms
-```
-
-### push_certs
-```
-fastlane push_certs
-```
-Fetches the push notification certificates and saves them as p12 files in push_certs/, perfect for direct upload to AWS SNS. p12 password is password.
 ### icons
 ```
 fastlane icons


### PR DESCRIPTION
- Breaks apart artifacts from giant zips to smaller files.
- Adds dSYM download & sentry lane. Since this doesn't work with the ASC API, it's less easy to automate right now.
- Adds a default timeout for both testing and release building.
- Dumps the version info during a build since it's useful for constructing releases, for now.