### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,16 +16,16 @@ GEM
     atomos (0.1.3)
     aws-eventstream (1.1.0)
     aws-partitions (1.422.0)
-    aws-sdk-core (3.111.2)
+    aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.41.0)
-      aws-sdk-core (~> 3, >= 3.109.0)
+    aws-sdk-kms (1.42.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.87.0)
-      aws-sdk-core (~> 3, >= 3.109.0)
+    aws-sdk-s3 (1.88.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
@@ -91,7 +91,7 @@ GEM
     escape (0.0.4)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    excon (0.78.1)
+    excon (0.79.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
@@ -102,7 +102,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    fastimage (2.2.1)
+    fastimage (2.2.2)
     fastlane (2.172.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
@@ -144,7 +144,6 @@ GEM
       json
       mini_magick (>= 4.9.4, < 5.0.0)
     fastlane-plugin-clean_testflight_testers (0.3.0)
-    fastlane-plugin-sentry (1.8.0)
     ffi (1.14.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -196,7 +195,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
@@ -274,6 +273,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   cocoapods (>= 1.10.0.beta.1)
@@ -281,7 +281,6 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-appicon
   fastlane-plugin-clean_testflight_testers
-  fastlane-plugin-sentry
   synx
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary
Fixes the Gemfile.lock being out of sync.

## Any other notes
I removed the Sentry plugin from the Fastlane plugins list, but did not re-run bundle install, thus making it inconsistent. Also updates the dependencies 'cause why not.