### PR TITLE
Fix crash in Mac extensions

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		119A7E0E2529769A00D7000D /* UIImageView+UIActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC0221C890600370A59 /* UIImageView+UIActivityIndicator.swift */; };
 		119A7E0F2529769A00D7000D /* UIImageView+UIActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC0221C890600370A59 /* UIImageView+UIActivityIndicator.swift */; };
 		119A827C252A3C4700D7000D /* NFCNDEFPayload+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A827B252A3C4700D7000D /* NFCNDEFPayload+Additions.swift */; };
+		119C77F825CF166400D41734 /* Bundle+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C77F725CF166400D41734 /* Bundle+Additions.swift */; };
 		119C9B2124A44DA500308A54 /* ZoneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C9B1E24A448A600308A54 /* ZoneManager.swift */; };
 		119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */; };
 		119DC15824B6A33F00AAB204 /* ZeroLatitude.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */; };
@@ -1085,6 +1086,7 @@
 		1194B4152519BEE900AA01C3 /* MacBridgeNetworkConnectivityImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeNetworkConnectivityImpl.swift; sourceTree = "<group>"; };
 		11993D2324E78A3700627944 /* WidgetActionsActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsActionView.swift; sourceTree = "<group>"; };
 		119A827B252A3C4700D7000D /* NFCNDEFPayload+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NFCNDEFPayload+Additions.swift"; sourceTree = "<group>"; };
+		119C77F725CF166400D41734 /* Bundle+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Additions.swift"; sourceTree = "<group>"; };
 		119C9B1E24A448A600308A54 /* ZoneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManager.swift; sourceTree = "<group>"; };
 		119D765E2492F8FA00183C5F /* UIApplication+BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+BackgroundTask.swift"; sourceTree = "<group>"; };
 		119DC15724B6A33E00AAB204 /* ZeroLatitude.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = ZeroLatitude.gpx; sourceTree = "<group>"; };
@@ -1989,6 +1991,7 @@
 				110ED5AC25A6826300489AF7 /* MacBridgeNetworkMonitor.swift */,
 				11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */,
 				1188793E25BF8006003F4291 /* NSEvent+Additions.swift */,
+				119C77F725CF166400D41734 /* Bundle+Additions.swift */,
 			);
 			path = MacBridge;
 			sourceTree = "<group>";
@@ -4571,6 +4574,7 @@
 				1194B4162519BEE900AA01C3 /* MacBridgeNetworkConnectivityImpl.swift in Sources */,
 				110ED55425A5604F00489AF7 /* MacBridgeScreenImpl.swift in Sources */,
 				1167408E251990D500F51626 /* MacBridgeImpl.swift in Sources */,
+				119C77F825CF166400D41734 /* Bundle+Additions.swift in Sources */,
 				1188793F25BF8006003F4291 /* NSEvent+Additions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/MacBridge/Bundle+Additions.swift
+++ b/Sources/MacBridge/Bundle+Additions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Bundle {
+    var isRunningInExtension: Bool {
+        Bundle.main.bundlePath.contains("PlugIns")
+    }
+}

--- a/Sources/MacBridge/MacBridgeAppDelegateHandler.swift
+++ b/Sources/MacBridge/MacBridgeAppDelegateHandler.swift
@@ -6,7 +6,7 @@ enum MacBridgeAppDelegateHandler {
     static let terminationWillBeginNotification: Notification.Name = .init("ha_terminationWillBegin")
 
     static func swizzleAppDelegate() {
-        guard !Bundle.main.bundlePath.contains("PlugIns") else {
+        guard !Bundle.main.isRunningInExtension else {
             // Don't try and swizzle the App Delegate in an extension; there won't be one.
             return
         }

--- a/Sources/MacBridge/MacBridgeImpl.swift
+++ b/Sources/MacBridge/MacBridgeImpl.swift
@@ -3,10 +3,19 @@ import Foundation
 import ServiceManagement
 
 @objc(HAMacBridgeImpl) final class MacBridgeImpl: NSObject, MacBridge {
-    let networkMonitor = MacBridgeNetworkMonitor()
-    let statusItem = MacBridgeStatusItem()
+    let networkMonitor: MacBridgeNetworkMonitor
+    let statusItem: MacBridgeStatusItem?
 
     override init() {
+        if Bundle.main.isRunningInExtension {
+            // status item can't talk to the status bar in an extension or it will crash
+            self.statusItem = nil
+        } else {
+            self.statusItem = MacBridgeStatusItem()
+        }
+
+        self.networkMonitor = MacBridgeNetworkMonitor()
+
         super.init()
 
         MacBridgeAppDelegateHandler.swizzleAppDelegate()
@@ -72,7 +81,7 @@ import ServiceManagement
     }
 
     func configureStatusItem(using configuration: MacBridgeStatusItemConfiguration) {
-        statusItem.configure(using: configuration)
+        statusItem?.configure(using: configuration)
     }
 
     private static func userDefaultsKey(forLoginItemBundleIdentifier identifier: String) -> String {


### PR DESCRIPTION
## Summary
Accessing the NSStatusBar in an extension causes a crash; this avoids calling it in extensions. We also should not be touching the status bar in an extension either way.

## Any other notes
Didn't show up during the betas, nor does it show up in Sentry. I'm guessing it's crashing so early in the MacBridge code that it doesn't have an opportunity to deal with crash logs.

Crashes look like:

```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
Assertion failed: (CGAtomicGet(&is_initialized)), function CGSConnectionByID, file /AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/SkyLight/SkyLight-570.7/SkyLight/Services/Connection/CGSConnection.mm, line 133.
 

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff20504462 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff20532610 pthread_kill + 263
2   libsystem_c.dylib             	0x00007fff20485720 abort + 120
3   libsystem_c.dylib             	0x00007fff204849d6 __assert_rtn + 314
4   com.apple.SkyLight            	0x00007fff24dad771 CGSConnectionByID + 423
5   com.apple.SkyLight            	0x00007fff24f9f58a SLSRegisterConnectionNotifyProc + 31
6   com.apple.AppKit              	0x00007fff236a476c +[NSCGSStatusItem addNavigationChangedNotificationHandler:] + 121
7   com.apple.AppKit              	0x00007fff230fe170 -[NSStatusBar init] + 202
8   com.apple.Foundation          	0x00007fff2136104c _NSFaultInObject + 27
9   io.robbie.HomeAssistant.dev.MacBridge	0x0000000107090389 MacBridgeStatusItem.init() + 105 (MacBridgeStatusItem.swift:4)
10  io.robbie.HomeAssistant.dev.MacBridge	0x0000000107090973 @objc MacBridgeStatusItem.init() + 19
11  io.robbie.HomeAssistant.dev.MacBridge	0x000000010709031b MacBridgeStatusItem.__allocating_init() + 27
12  io.robbie.HomeAssistant.dev.MacBridge	0x000000010709a295 MacBridgeImpl.init() + 213 (MacBridgeImpl.swift:12)
13  io.robbie.HomeAssistant.dev.MacBridge	0x000000010709a383 @objc MacBridgeImpl.init() + 19
14  io.robbie.HomeAssistant.dev.Shared	0x00000001037be6d9 closure #1 in variable initialization expression of Environment.macBridge + 2073 (Environment.swift:141)
15  io.robbie.HomeAssistant.dev.Shared	0x00000001037b9ad6 Environment.init() + 2150 (Environment.swift:132)
```
