### PR TITLE
Add setting to control pinch-to-zoom in frontend, defaulted off

### DIFF
--- a/Sources/App/Resources/WebSocketBridge.js
+++ b/Sources/App/Resources/WebSocketBridge.js
@@ -2,7 +2,7 @@ const notifyThemeColors = () => {
     function doWait() {
         var colors = {};
 
-        let element = document.createElement('div');
+        const element = document.createElement('div');
         document.body.appendChild(element);
         element.style.display = 'none';
 
@@ -46,6 +46,31 @@ const checkForMissingHassConnectionAndReload = () => {
         // this is the action taken by the frontend when the user taps, anyway -- we're just doing it for them
         location.reload();
     });
+};
+
+const setOverrideZoomEnabled = (shouldZoom) => {
+    // we know that the HA frontend creates this meta tag, so we can be lazy
+    const element = document.querySelector('meta[name="viewport"]');
+    if (element === null) {
+        return;
+    }
+
+    const ignoredBits = ['user-scalable', 'minimum-scale', 'maximum-scale'];
+    const elements = element['content']
+        .split(',')
+        .filter(contentItem => {
+            return ignoredBits.every(ignoredBit => !contentItem.includes(ignoredBit));
+        });
+
+    if (shouldZoom) {
+        elements.push('user-scalable=yes');
+    } else {
+        // setting minimum/maximum scale resets existing zoom if there is one
+        elements.push('user-scalable=no', 'minimum-scale=1.0', 'maximum-scale=1.0');
+    }
+
+    element['content'] = elements.join(',');
+    console.log(`adjusted viewport to ${element['content']}`);
 };
 
 waitForHassConnection().then(({ conn }) => {

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -374,6 +374,7 @@ Your actions and local configuration will still be available after logging in.";
 "settings_details.general.open_in_browser.title" = "Open Links In";
 "settings_details.general.page_zoom.default" = "%@ (Default)";
 "settings_details.general.page_zoom.title" = "Page Zoom";
+"settings_details.general.pinch_to_zoom.title" = "Pinch to Zoom";
 "settings_details.general.restoration.title" = "Remember Last Page";
 "settings_details.general.title" = "General";
 "settings_details.general.visibility.options.dock" = "Dock";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -191,6 +191,15 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     }
                 }
 
+                <<< SwitchRow {
+                    $0.title = L10n.SettingsDetails.General.PinchToZoom.title
+                    $0.hidden = .isCatalyst
+                    $0.value = Current.settingsStore.pinchToZoom
+                    $0.onChange { row in
+                        Current.settingsStore.pinchToZoom = row.value ?? false
+                    }
+                }
+
         case "location":
             title = L10n.SettingsDetails.Location.title
             form

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1656,6 +1656,10 @@ public enum L10n {
         /// Page Zoom
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.page_zoom.title") }
       }
+      public enum PinchToZoom {
+        /// Pinch to Zoom
+        public static var title: String { return L10n.tr("Localizable", "settings_details.general.pinch_to_zoom.title") }
+      }
       public enum Restoration {
         /// Remember Last Page
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.restoration.title") }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -293,6 +293,16 @@ public class SettingsStore {
         }
     }
 
+    public var pinchToZoom: Bool {
+        get {
+            prefs.bool(forKey: "pinchToZoom")
+        }
+        set {
+            prefs.set(newValue, forKey: "pinchToZoom")
+            NotificationCenter.default.post(name: Self.webViewRelatedSettingDidChange, object: nil)
+        }
+    }
+
     public var restoreLastURL: Bool {
         get {
             if let value = prefs.object(forKey: "restoreLastURL") as? NSNumber {


### PR DESCRIPTION
Refs home-assistant/frontend#8192.

## Summary
When enabled, pinch to zoom is allowed in the frontend. When disabled, which is the default, it is not allowed. This does not respect what the frontend sends for the values of `minimum-scale`, `maximum-scale` and `user-scalable` and instead overrides them.

## Screenshots
![Image](https://user-images.githubusercontent.com/74188/107317381-68e91b00-6a4f-11eb-9b14-ee5b4a3e7603.png)

## Any other notes
In home-assistant/frontend#7180, the frontend was changed to enable pinch to zoom in the app by removing the `user-scalable` flag. Browsers ignore this flag, but our UI is meant to feel like an app, not like a webpage. The accessibility part of the argument doesn't mirror iOS accessibility: dynamic type is how the system behaves and it doesn't scale elements like navigation or tab bars. To achieve an iOS-like accessibility experience, we have a setting to adjust only the text size in the frontend.

But we are not in total control over the contents of the users' dashboards or pages. There's layout and design choices that users may make which inherently don't work well on mobile without zooming on non-text elements, including other webapps. I believe this is a rare enough that disabled as a default is acceptable, but also common enough that the preference itself existing is worthwhile.

This works in all versions of iOS that we support, iOS 12 and above.