### PR TITLE
Fix location settings for siglog changes & zones

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -278,7 +278,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 let updatePromise: Promise<Void>
 
                 if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState),
-                   prefs.bool(forKey: "locationUpdateOnBackgroundFetch") {
+                   Current.settingsStore.locationSources.backgroundFetch {
                     updatePromise = api.GetAndSendLocation(
                         trigger: .BackgroundFetch,
                         maximumBackgroundTime: remaining

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -49,7 +49,8 @@ class NotificationManager: NSObject {
            let hadict = userInfoDict["homeassistant"] as? [String: String], let command = hadict["command"] {
             switch command {
             case "request_location_update":
-                if prefs.bool(forKey: "locationUpdateOnNotification") == false {
+                guard Current.settingsStore.locationSources.pushNotifications else {
+                    Current.Log.info("ignoring request, location source of notifications is disabled")
                     completionHandler(.noData)
                     return
                 }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -211,16 +211,14 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 )
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Zone.title
-                    $0.value = prefs.bool(forKey: "locationUpdateOnZone")
+                    $0.value = Current.settingsStore.locationSources.zone
                     $0.disabled = .location(conditions: [.permissionNotAlways, .accuracyNotFull])
                 }.onChange({ row in
-                    if let val = row.value {
-                        prefs.set(val, forKey: "locationUpdateOnZone")
-                    }
+                    Current.settingsStore.locationSources.zone = row.value ?? true
                 })
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Background.title
-                    $0.value = prefs.bool(forKey: "locationUpdateOnBackgroundFetch")
+                    $0.value = Current.settingsStore.locationSources.backgroundFetch
                     $0.disabled = .location(conditions: [
                         .permissionNotAlways,
                         .accuracyNotFull,
@@ -228,27 +226,21 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     ])
                     $0.hidden = .isCatalyst
                 }.onChange({ row in
-                    if let val = row.value {
-                        prefs.set(val, forKey: "locationUpdateOnBackgroundFetch")
-                    }
+                    Current.settingsStore.locationSources.backgroundFetch = row.value ?? true
                 })
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Significant.title
-                    $0.value = prefs.bool(forKey: "locationUpdateOnSignificant")
+                    $0.value = Current.settingsStore.locationSources.significantLocationChange
                     $0.disabled = .location(conditions: [.permissionNotAlways, .accuracyNotFull])
                 }.onChange({ row in
-                    if let val = row.value {
-                        prefs.set(val, forKey: "locationUpdateOnSignificant")
-                    }
+                    Current.settingsStore.locationSources.significantLocationChange = row.value ?? true
                 })
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Notification.title
-                    $0.value = prefs.bool(forKey: "locationUpdateOnNotification")
+                    $0.value = Current.settingsStore.locationSources.pushNotifications
                     $0.disabled = .location(conditions: [.permissionNotAlways, .accuracyNotFull])
                 }.onChange({ row in
-                    if let val = row.value {
-                        prefs.set(val, forKey: "locationUpdateOnNotification")
-                    }
+                    Current.settingsStore.locationSources.pushNotifications = row.value ?? true
                 })
 
             let zoneEntities = realm.objects(RLMZone.self).map { $0 }

--- a/Sources/App/Utilities/Utils.swift
+++ b/Sources/App/Utilities/Utils.swift
@@ -81,22 +81,6 @@ func setDefaults() {
         prefs.setValue(true, forKey: "confirmBeforeOpeningUrl")
     }
 
-    if prefs.object(forKey: "locationUpdateOnZone") == nil {
-        prefs.set(true, forKey: "locationUpdateOnZone")
-    }
-
-    if prefs.object(forKey: "locationUpdateOnBackgroundFetch") == nil {
-        prefs.set(true, forKey: "locationUpdateOnBackgroundFetch")
-    }
-
-    if prefs.object(forKey: "locationUpdateOnSignificant") == nil {
-        prefs.set(true, forKey: "locationUpdateOnSignificant")
-    }
-
-    if prefs.object(forKey: "locationUpdateOnNotification") == nil {
-        prefs.set(true, forKey: "locationUpdateOnNotification")
-    }
-
     prefs.synchronize()
 }
 


### PR DESCRIPTION
## Summary
The "Significant Location Change" and "Zone enter/exit" settings for Locations' Update Sources previously did not work. This now watches both settings for changes and handles enabling or disabling their respective monitoring.

## Any other notes
- It takes a few seconds for the location-in-use arrow to disappear after disabling them.
- Users may be a little surprised if things _stop_ working, since they may have toggled these off for some reason in the past.