### PR TITLE
Allow disabling individual sensors

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -511,10 +511,12 @@ Your actions and local configuration will still be available after logging in.";
 "settings_details.watch.title" = "Apple Watch";
 "settings_sensors.detail.attributes" = "Attributes";
 "settings_sensors.detail.device_class" = "Device Class";
+"settings_sensors.detail.enabled" = "Enabled";
 "settings_sensors.detail.icon" = "Icon";
 "settings_sensors.detail.state" = "State";
 "settings_sensors.detail.unique_id" = "Unique ID";
 "settings_sensors.last_updated.footer" = "Last Updated %@";
+"settings_sensors.disabled_state_replacement" = "Disabled";
 "settings_sensors.loading_error.title" = "Failed to load sensors";
 "settings_sensors.periodic_update.description" = "When enabled, these sensors will update with this frequency while the app is open in the foreground.";
 "settings_sensors.periodic_update.description_mac" = "When enabled, these sensors will update with this frequency while the app is open. Some sensors will update automatically more often.";
@@ -935,3 +937,4 @@ Thank you.\
 "widgets.actions.not_configured" = "No Actions Configured";
 "widgets.actions.title" = "Actions";
 "yes_label" = "Yes";
+

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -853,7 +853,10 @@ extension HomeAssistantAPI.APIError: LocalizedError {
 }
 
 extension HomeAssistantAPI: SensorObserver {
-    public func sensorContainerDidSignalForUpdate(_ container: SensorContainer) {
+    public func sensorContainer(
+        _ container: SensorContainer,
+        didSignalForUpdateBecause reason: SensorContainerUpdateReason
+    ) {
         Current.backgroundTask(withName: "signaled-update-sensors") { _ in
             UpdateSensors(trigger: .Signaled)
         }.cauterize()

--- a/Sources/Shared/API/Models/WebhookSensor.swift
+++ b/Sources/Shared/API/Models/WebhookSensor.swift
@@ -34,6 +34,14 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
 
     public required init?(map: Map) {}
 
+    convenience init(redacting sensor: WebhookSensor) {
+        self.init()
+        self.Name = sensor.Name
+        self.UniqueID = sensor.UniqueID
+        self.State = "unavailable"
+        self.Icon = "mdi:dots-square"
+    }
+
     convenience init(name: String, uniqueID: String) {
         self.init()
         self.Name = name

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2098,6 +2098,8 @@ public enum L10n {
   }
 
   public enum SettingsSensors {
+    /// Disabled
+    public static var disabledStateReplacement: String { return L10n.tr("Localizable", "settings_sensors.disabled_state_replacement") }
     /// Sensors
     public static var title: String { return L10n.tr("Localizable", "settings_sensors.title") }
     public enum Detail {
@@ -2105,6 +2107,8 @@ public enum L10n {
       public static var attributes: String { return L10n.tr("Localizable", "settings_sensors.detail.attributes") }
       /// Device Class
       public static var deviceClass: String { return L10n.tr("Localizable", "settings_sensors.detail.device_class") }
+      /// Enabled
+      public static var enabled: String { return L10n.tr("Localizable", "settings_sensors.detail.enabled") }
       /// Icon
       public static var icon: String { return L10n.tr("Localizable", "settings_sensors.detail.icon") }
       /// State


### PR DESCRIPTION
Fixes #358.

## Summary
Allows toggling on or off certain sensors. This does not currently delete the sensor but instead sets its state to 'unavailable'.

## Screenshots
### App
![Image](https://user-images.githubusercontent.com/74188/107861269-bd96e800-6df9-11eb-93c4-682eab17b157.png)
![Image 2](https://user-images.githubusercontent.com/74188/107861298-d8695c80-6df9-11eb-9496-dc89cdc892c0.png)

### Frontend
<img width="334" alt="entities" src="https://user-images.githubusercontent.com/74188/107861381-5c234900-6dfa-11eb-86c5-27b7f6ea2c2e.png">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- Sensors are still only showing up in the sensor list if they have been generated during the app lifecycle. So for example the Geocode sensor doesn't show up unless a location update happened, and motion sensors do not show up if motion permission is disabled.
- Avoids removing items from the cache when they aren't around anymore, or when we think they are stale.