### PR TITLE
Fix non-background-session webhook request replacement

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -181,6 +181,7 @@ public class HomeAssistantAPI {
             case .noApi,
                  .unregisteredIdentifier,
                  .unacceptableStatusCode,
+                 .replaced,
                  .none:
                 // not a WebhookError, or not one we think requires reintegration
                 Current.Log.info("not re-registering, but failed to update registration: \(error)")

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -3,12 +3,20 @@ import ObjectMapper
 import PromiseKit
 import UserNotifications
 
-internal enum WebhookError: LocalizedError, Equatable {
+internal enum WebhookError: LocalizedError, Equatable, CancellableError {
     case noApi
     case unregisteredIdentifier(handler: String)
     case unexpectedType(given: String, desire: String)
     case unacceptableStatusCode(Int)
     case unmappableValue
+    case replaced
+
+    var isCancelled: Bool {
+        switch self {
+        case .replaced: return true
+        default: return false
+        }
+    }
 
     var errorDescription: String? {
         switch self {
@@ -22,6 +30,9 @@ internal enum WebhookError: LocalizedError, Equatable {
             return L10n.HaApi.ApiError.unacceptableStatusCode(statusCode)
         case .unmappableValue:
             return L10n.HaApi.ApiError.invalidResponse
+        case .replaced:
+            // this shouldn't be user-facing
+            return "<replaced>"
         }
     }
 }
@@ -391,9 +402,9 @@ public class WebhookManager: NSObject {
         persisted newPersisted: WebhookPersisted,
         with newPromise: Promise<Void>
     ) {
-        currentBackgroundSessionInfo.session.getAllTasks { tasks in
+        let evaluate = { [self] (session: WebhookSessionInfo, tasks: [URLSessionTask]) in
             tasks.filter { thisTask in
-                guard let (thisType, thisPersisted) = self.responseInfo(from: thisTask) else {
+                guard let (thisType, thisPersisted) = responseInfo(from: thisTask) else {
                     Current.Log.error("cancelling request without persistence info: \(thisTask)")
                     thisTask.cancel()
                     return false
@@ -405,12 +416,22 @@ public class WebhookManager: NSObject {
                     return false
                 }
             }.forEach { existingTask in
-                let taskKey = TaskKey(sessionInfo: self.currentBackgroundSessionInfo, task: existingTask)
-                if let existingResolver = self.resolverForTask[taskKey] {
-                    // connect the task we're about to cancel's promise to the replacement
-                    newPromise.pipe { existingResolver.resolve($0) }
+                let taskKey = TaskKey(sessionInfo: session, task: existingTask)
+                if let existingResolver = resolverForTask[taskKey] {
+                    existingResolver.reject(WebhookError.replaced)
                 }
                 existingTask.cancel()
+            }
+        }
+
+        currentRegularSessionInfo.session.getAllTasks { [self] tasks in
+            dataQueue.async {
+                evaluate(currentRegularSessionInfo, tasks)
+            }
+        }
+        currentBackgroundSessionInfo.session.getAllTasks { [self] tasks in
+            dataQueue.async {
+                evaluate(currentBackgroundSessionInfo, tasks)
             }
         }
     }

--- a/Tests/Shared/Webhook/WebhookManager.test.swift
+++ b/Tests/Shared/Webhook/WebhookManager.test.swift
@@ -406,7 +406,7 @@ class WebhookManagerTests: XCTestCase {
         XCTAssertNoThrow(try hang(manager.send(request: expectedRequest)))
     }
 
-    func testSendingPersistentWithExistingCallsBothPromises() throws {
+    func testSendingPersistentWithExistingResolvesBothPromises() throws {
         let request1 = WebhookRequest(type: "webhook_name", data: ["json": true])
         let request2 = WebhookRequest(type: "webhook_name", data: ["elephant": true])
 
@@ -447,7 +447,67 @@ class WebhookManagerTests: XCTestCase {
             return
         }
 
-        XCTAssertNoThrow(try hang(promise1))
+        XCTAssertThrowsError(try hang(promise1)) { error in
+            XCTAssertEqual(error as? WebhookError, .replaced)
+        }
+        XCTAssertNoThrow(try hang(promise2))
+
+        request1Blocking.fulfill()
+
+        XCTAssertEqual(ReplacingTestHandler.createdHandlers.count, 1)
+        let request = try hang(ReplacingTestHandler.createdHandlers[0].request!)
+        let result = try hang(ReplacingTestHandler.createdHandlers[0].result!)
+
+        XCTAssertEqualWebhookRequest(request, request2)
+        XCTAssertEqual((result as? [String: Any])?["result"] as? Int, 2)
+    }
+
+    func testSendingPersistentOnRegularSessionWithExistingResolvesBothPromises() throws {
+        Current.isBackgroundRequestsImmediate = { false }
+
+        let request1 = WebhookRequest(type: "webhook_name", data: ["json": true])
+        let request2 = WebhookRequest(type: "webhook_name", data: ["elephant": true])
+
+        let request1Expectation = expectation(description: "request1")
+        let request1Blocking = expectation(description: "request1-blocking")
+
+        let identifier = WebhookResponseIdentifier(rawValue: "replacing")
+        manager.register(responseHandler: ReplacingTestHandler.self, for: identifier)
+
+        var pendingPromise1: Promise<Void>?
+        var pendingPromise2: Promise<Void>?
+
+        stub(condition: { [webhookURL] req in req.url == webhookURL }, response: { request in
+            // second one, the one we want to not be cancelled
+            XCTAssertEqualWebhookRequest(request.ohhttpStubs_httpBody, request2)
+            return HTTPStubsResponse(jsonObject: ["result": 2], statusCode: 200, headers: nil)
+        })
+
+        var stub1: HTTPStubsDescriptor?
+        stub1 = stub(condition: { [webhookURL] req in req.url == webhookURL }, response: { [manager] request in
+            XCTAssertEqualWebhookRequest(request.ohhttpStubs_httpBody, request1)
+            HTTPStubs.removeStub(stub1!)
+
+            // first one, the one we want to cancel
+            pendingPromise2 = manager!.send(identifier: identifier, request: request2)
+            request1Expectation.fulfill()
+
+            self.wait(for: [request1Blocking], timeout: 100.0)
+            return HTTPStubsResponse(jsonObject: ["result": 1], statusCode: 200, headers: nil)
+        })
+
+        pendingPromise1 = manager.send(identifier: identifier, request: request1)
+
+        wait(for: [request1Expectation], timeout: 10.0)
+
+        guard let promise1 = pendingPromise1, let promise2 = pendingPromise2 else {
+            XCTFail("expected promises")
+            return
+        }
+
+        XCTAssertThrowsError(try hang(promise1)) { error in
+            XCTAssertEqual(error as? WebhookError, .replaced)
+        }
         XCTAssertNoThrow(try hang(promise2))
 
         request1Blocking.fulfill()


### PR DESCRIPTION
Fixes #1473. Again.

## Summary
When we issue webhook requests, we were failing to cancel any previous requests (which want to be cancelled) that were executed on not-the-background session. This moves to now checking both the background and non-background for cancellable requests.

## Any other notes
- Moves to explicitly cancelling, rather than silently replacing and succeeding, replaced requests. For example, a sensor update will now be explicitly cancelled if a new sensor update comes through, rather than following the success path.
- This resolves an issue where a sensor update occurs, fails on the non-background session, and retries with the same request data on the background session. This can lead to an older sensor update request, with outdated information, happening long after the most recent and correct one finishing.