### PR TITLE
Handle my.home-assistant.io links on iOS

### DIFF
--- a/Configuration/Entitlements/App-ios.entitlements
+++ b/Configuration/Entitlements/App-ios.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>applinks:home-assistant.io</string>
 		<string>applinks:*.home-assistant.io</string>
+		<string>applinks:my.home-assistant.io</string>
 	</array>
 	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -192,7 +192,9 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         }
 
         if let openURLRaw = userInfo["url"] as? String {
-            Current.sceneManager.webViewWindowControllerPromise.done { $0.open(urlString: openURLRaw) }
+            Current.sceneManager.webViewWindowControllerPromise.done {
+                $0.open(from: .notification, urlString: openURLRaw)
+            }
         } else if let openURLDictionary = userInfo["url"] as? [String: String] {
             let url = openURLDictionary.compactMap { key, value -> String? in
                 if response.actionIdentifier == UNNotificationDefaultActionIdentifier,
@@ -206,7 +208,9 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             }.first
 
             if let url = url {
-                Current.sceneManager.webViewWindowControllerPromise.done { $0.open(urlString: url) }
+                Current.sceneManager.webViewWindowControllerPromise.done {
+                    $0.open(from: .notification, urlString: url)
+                }
             } else {
                 Current.Log.error(
                     "couldn't make openable url out of \(openURLDictionary) for \(response.actionIdentifier)"

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -35,8 +35,10 @@
 "alerts.confirm.ok" = "OK";
 "alerts.open_url_from_notification.message" = "Open URL (%@) found in notification?";
 "alerts.open_url_from_notification.title" = "Open URL?";
+"alerts.open_url_from_deep_link.message" = "Open URL (%@) from deep link?";
 "alerts.prompt.cancel" = "Cancel";
 "alerts.prompt.ok" = "OK";
+"always_open_label" = "Always Open";
 "app_transfer_warning_notification.body" = "Please open this notification for an important update about upcoming changes to Home Assistant Companion";
 "app_transfer_warning_notification.title" = "⚠️ Notice of upcoming major app change";
 "cancel_label" = "Cancel";

--- a/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
+++ b/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
@@ -67,15 +67,7 @@ class NotificationSettingsViewController: FormViewController {
                 }, onDismiss: nil)
             }
 
-            +++ SwitchRow("confirmBeforeOpeningUrl") {
-                $0.title = L10n.SettingsDetails.Notifications.PromptToOpenUrls.title
-                $0.value = prefs.bool(forKey: "confirmBeforeOpeningUrl")
-            }.onChange { row in
-                prefs.setValue(row.value, forKey: "confirmBeforeOpeningUrl")
-                prefs.synchronize()
-            }
-
-            <<< ButtonRow {
+            +++ ButtonRow {
                 $0.title = L10n.SettingsDetails.Notifications.BadgeSection.Button.title
                 $0.onCellSelection { cell, _ in
                     UIApplication.shared.applicationIconBadgeNumber = 0

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -170,7 +170,14 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 prefs.synchronize()
             }
 
-                <<< SwitchRow {
+                <<< SwitchRow("confirmBeforeOpeningUrl") {
+                    $0.title = L10n.SettingsDetails.Notifications.PromptToOpenUrls.title
+                    $0.value = prefs.bool(forKey: "confirmBeforeOpeningUrl")
+                }.onChange { row in
+                    prefs.setValue(row.value, forKey: "confirmBeforeOpeningUrl")
+                }
+
+                +++ SwitchRow {
                     // mac has a system-level setting for state restoration
                     $0.hidden = .isCatalyst
 

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -2,6 +2,7 @@ import CallbackURLKit
 import Foundation
 import PromiseKit
 import Shared
+import SafariServices
 
 class IncomingURLHandler {
     let windowController: WebViewWindowController
@@ -35,6 +36,27 @@ class IncomingURLHandler {
                 object: nil,
                 userInfo: ["url": url]
             )
+        case "navigate": // homeassistant://navigate/lovelace/dashboard
+            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                return false
+            }
+
+            components.scheme = nil
+            components.host = nil
+
+            guard let rawURL = components.url?.absoluteString else {
+                return false
+            }
+
+            Current.sceneManager.webViewWindowControllerPromise.done { controller in
+                controller.open(urlString: rawURL)
+
+                if let presenting = controller.presentedViewController,
+                   presenting is SFSafariViewController {
+                    // Dismiss my.* controller if it's on top - we don't get any other indication
+                    presenting.dismiss(animated: true, completion: nil)
+                }
+            }
         default:
             Current.Log.warning("Can't route incoming URL: \(url)")
             showAlert(title: L10n.errorLabel, message: L10n.UrlHandler.NoService.message(url.host!))
@@ -59,11 +81,16 @@ class IncomingURLHandler {
 
             Current.sceneManager.showFullScreenConfirm(icon: icon, text: text)
             return true
-        case .unhandled:
-            return false
         case let .open(url):
             // NFC-based URL
             return handle(url: url)
+        case .unhandled:
+            // not a tag
+            if let url = userActivity.webpageURL, url.host == "my.home-assistant.io" {
+                return showMy(for: url)
+            } else {
+                return false
+            }
         }
     }
 
@@ -89,6 +116,28 @@ class IncomingURLHandler {
         windowController.webViewControllerPromise.done {
             $0.present(alert, animated: true, completion: nil)
         }
+    }
+
+    private func showMy(for url: URL) -> Bool {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            Current.Log.info("couldn't create url components out of \(url)")
+            return false
+        }
+
+        var queryItems = components.queryItems ?? []
+        queryItems.append(.init(name: "mobile", value: "1"))
+        components.queryItems = queryItems
+
+        guard let updatedURL = components.url else {
+            return false
+        }
+
+        windowController.webViewControllerPromise.done { controller in
+            // not animated in because it looks weird during the app launch animation
+            controller.present(SFSafariViewController(url: updatedURL), animated: false, completion: nil)
+        }
+
+        return true
     }
 }
 

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -49,13 +49,19 @@ class IncomingURLHandler {
             }
 
             Current.sceneManager.webViewWindowControllerPromise.done { controller in
-                controller.open(urlString: rawURL)
+                let wasPresentingSafari: Bool
 
                 if let presenting = controller.presentedViewController,
                    presenting is SFSafariViewController {
                     // Dismiss my.* controller if it's on top - we don't get any other indication
                     presenting.dismiss(animated: true, completion: nil)
+
+                    wasPresentingSafari = true
+                } else {
+                    wasPresentingSafari = false
                 }
+
+                controller.open(from: .deeplink, urlString: rawURL, skipConfirm: wasPresentingSafari)
             }
         default:
             Current.Log.warning("Can't route incoming URL: \(url)")
@@ -132,10 +138,8 @@ class IncomingURLHandler {
             return false
         }
 
-        windowController.webViewControllerPromise.done { controller in
-            // not animated in because it looks weird during the app launch animation
-            controller.present(SFSafariViewController(url: updatedURL), animated: false, completion: nil)
-        }
+        // not animated in because it looks weird during the app launch animation
+        windowController.present(SFSafariViewController(url: updatedURL), animated: false, completion: nil)
 
         return true
     }

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -1,8 +1,8 @@
 import CallbackURLKit
 import Foundation
 import PromiseKit
-import Shared
 import SafariServices
+import Shared
 
 class IncomingURLHandler {
     let windowController: WebViewWindowController

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -92,7 +92,7 @@ class IncomingURLHandler {
             return handle(url: url)
         case .unhandled:
             // not a tag
-            if let url = userActivity.webpageURL, url.host == "my.home-assistant.io" {
+            if let url = userActivity.webpageURL, url.host?.lowercased() == "my.home-assistant.io" {
                 return showMy(for: url)
             } else {
                 return false

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -106,7 +106,7 @@ class WebViewWindowController {
         }
     }
 
-    var presentingViewController: UIViewController? {
+    var presentedViewController: UIViewController? {
         var currentController = window.rootViewController
         while let controller = currentController?.presentedViewController {
             currentController = controller
@@ -145,7 +145,7 @@ class WebViewWindowController {
         }
 
         let triggerOpen = {
-            openURLInBrowser(url, self.presentingViewController)
+            openURLInBrowser(url, self.presentedViewController)
         }
 
         if prefs.bool(forKey: "confirmBeforeOpeningUrl") {

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -148,7 +148,7 @@ class WebViewWindowController {
 
     func open(from: OpenSource, urlString openUrlRaw: String, skipConfirm: Bool = false) {
         let webviewURL = Current.settingsStore.connectionInfo?.webviewURL(from: openUrlRaw)
-        let externalURL = webviewURL ?? URL(string: openUrlRaw)
+        let externalURL = URL(string: openUrlRaw)
 
         guard webviewURL != nil || externalURL != nil else {
             return

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -12,6 +12,8 @@ import Foundation
 public enum L10n {
   /// Add
   public static var addButtonLabel: String { return L10n.tr("Localizable", "addButtonLabel") }
+  /// Always Open
+  public static var alwaysOpenLabel: String { return L10n.tr("Localizable", "always_open_label") }
   /// Cancel
   public static var cancelLabel: String { return L10n.tr("Localizable", "cancel_label") }
   /// Copy
@@ -173,6 +175,12 @@ public enum L10n {
       public static var cancel: String { return L10n.tr("Localizable", "alerts.confirm.cancel") }
       /// OK
       public static var ok: String { return L10n.tr("Localizable", "alerts.confirm.ok") }
+    }
+    public enum OpenUrlFromDeepLink {
+      /// Open URL (%@) from deep link?
+      public static func message(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "alerts.open_url_from_deep_link.message", String(describing: p1))
+      }
     }
     public enum OpenUrlFromNotification {
       /// Open URL (%@) found in notification?


### PR DESCRIPTION
## Summary
Handles being launched by universal links (e.g. https://my.home-assistant.io/redirect/logs) or via the url scheme `homeassistant://navigate/path/to/lovelace`.

## Screenshots
https://user-images.githubusercontent.com/74188/109757851-7487b780-7b9f-11eb-923d-5388964d85a5.mov

## Any other notes
This doesn't yet work on Mac, because my initial `WKWebView` implementation doesn't want to give us any events about URL schemes like `homeassistant://…` being tapped. I'm unsure how useful it'll be on Mac either way, but at least the `homeassistant://navigate/xyz` will still work there.