### PR TITLE
Fix crash on macOS 11.3

### DIFF
--- a/Sources/App/WebView/ScaleFactorMutator.swift
+++ b/Sources/App/WebView/ScaleFactorMutator.swift
@@ -9,29 +9,44 @@ class ScaleFactorMutator {
     }
 
     private static var hasSwizzled = false
+    fileprivate static var didSwizzleScaleFactor = false
+    fileprivate static var didSwizzleSceneIdentifier = false
+
     private static func swizzleIfNeeded() {
         guard !hasSwizzled else { return }
         defer { hasSwizzled = true }
 
         #if targetEnvironment(macCatalyst)
-        func exchange(for klassString: String, original: Selector, with replacement: Selector) {
+        func exchange(for klassString: String, original: Selector, with replacement: Selector) -> Bool {
             guard
                 let klass = objc_getClass(klassString) as? AnyClass,
                 let originalMethod = class_getInstanceMethod(klass, original),
                 let replacementMethod = class_getInstanceMethod(klass, replacement) else {
                 Current.Log.error("couldn't get \(klassString) method \(original) and \(replacement)")
-                return
+                return false
             }
 
             method_exchangeImplementations(originalMethod, replacementMethod)
+            return true
         }
 
-        exchange(
+        // macOS 10.15 through 11.2
+        didSwizzleScaleFactor = exchange(
             for: "UINSSceneView",
             original: Selector(("setScaleFactor:")),
             with: #selector(NSObject.setHa_scaleFactor(_:))
         )
-        exchange(
+
+        if !didSwizzleScaleFactor {
+            // macOS 11.3+
+            didSwizzleScaleFactor = exchange(
+                for: "UINSSceneView",
+                original: Selector(("setFixedSceneToSceneViewScaleFactor:")),
+                with: #selector(NSObject.setHa_scaleFactor(_:))
+            )
+        }
+
+        didSwizzleSceneIdentifier = exchange(
             for: "UINSSceneView",
             original: Selector(("setSceneIdentifier:")),
             with: #selector(NSObject.setHa_sceneIdentifier(_:))
@@ -51,6 +66,10 @@ fileprivate extension NSObject {
     }
 
     @objc func setHa_scaleFactor(_ scaleFactor: CGFloat) {
+        guard ScaleFactorMutator.didSwizzleScaleFactor else {
+            return
+        }
+
         if let identifier = sceneIdentifier, ScaleFactorMutator.sceneIdentifiers.contains(identifier) {
             setHa_scaleFactor(1.0)
         } else {
@@ -59,6 +78,10 @@ fileprivate extension NSObject {
     }
 
     @objc func setHa_sceneIdentifier(_ identifier: String) {
+        guard ScaleFactorMutator.didSwizzleSceneIdentifier else {
+            return
+        }
+
         setHa_sceneIdentifier(identifier)
 
         if ScaleFactorMutator.sceneIdentifiers.contains(identifier) {


### PR DESCRIPTION
Fixes #1499.

## Summary
Fixes a crash caused by infinitely cursing into `setHa_scaleFactor(_:)` due to (of course) swizzling!

## Any other notes
Apple renamed (which is totally their prerogative, but it's also my prerogative to swizzle if they aren't going to make public API to do what I want 😈 ) the `scaleFactor` multiple for non-Mac optimized Catalyst builds, renaming it to `sceneToSceneViewScaleFactor`. Since we weren't checking if the swizzle was successful, the code path where we attempt to call into the swizzled variant calls itself infinitely until it gets killed.

Verified that the scale factor using this new property correctly doesn't make the webview super tiny, and hopefully made this less likely to break in the future.