### PR TITLE
Fix crash on iOS 14.5 due to invalid location data

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -79,6 +79,9 @@
 		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
 		1130F532253A1E7400F371BE /* ComplicationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F531253A1E7400F371BE /* ComplicationListViewController.swift */; };
 		1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */; };
+		1133F59C25F1DA5D00AD776F /* CLLocation+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133F59B25F1DA5D00AD776F /* CLLocation+Sanitize.swift */; };
+		1133F59D25F1DA5D00AD776F /* CLLocation+Sanitize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133F59B25F1DA5D00AD776F /* CLLocation+Sanitize.swift */; };
+		1133F5F625F1DBF000AD776F /* CLLocation+Sanitize.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133F5E425F1DBEA00AD776F /* CLLocation+Sanitize.test.swift */; };
 		11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */; };
 		11358AEF24FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */; };
@@ -1016,6 +1019,8 @@
 		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
 		1130F531253A1E7400F371BE /* ComplicationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationListViewController.swift; sourceTree = "<group>"; };
 		1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFamilySelectViewController.swift; sourceTree = "<group>"; };
+		1133F59B25F1DA5D00AD776F /* CLLocation+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocation+Sanitize.swift"; sourceTree = "<group>"; };
+		1133F5E425F1DBEA00AD776F /* CLLocation+Sanitize.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocation+Sanitize.test.swift"; sourceTree = "<group>"; };
 		11358AEB24FC9F300074C4E2 /* ActiveSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.swift; sourceTree = "<group>"; };
 		11358AEE24FCA8BE0074C4E2 /* ActiveStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveStateManager.swift; sourceTree = "<group>"; };
 		113D04E124D76CD3003CE877 /* NFCReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReader.swift; sourceTree = "<group>"; };
@@ -3050,6 +3055,7 @@
 				11F2F28D2587285300F61F7C /* NotificationAttachment */,
 				110AA57A25B38C02005061A0 /* ServerAlerter.test.swift */,
 				11267D0825BBA9FE00F28E5C /* Updater.test.swift */,
+				1133F5E425F1DBEA00AD776F /* CLLocation+Sanitize.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -3086,6 +3092,7 @@
 			children = (
 				D0EEF321214DE56B00D1D360 /* LocationTrigger.swift */,
 				113D29DD24946ED90014067C /* CLLocationManager+OneShotLocation.swift */,
+				1133F59B25F1DA5D00AD776F /* CLLocation+Sanitize.swift */,
 			);
 			path = Location;
 			sourceTree = "<group>";
@@ -4822,6 +4829,7 @@
 				11EE9B5224C62E7800404AF8 /* Scene.swift in Sources */,
 				B67CE8B622200F220034C1D0 /* UIColor+HA.swift in Sources */,
 				1115044E2528485200DCFA94 /* WatchHelpers.swift in Sources */,
+				1133F59D25F1DA5D00AD776F /* CLLocation+Sanitize.swift in Sources */,
 				B67CE8B522200F220034C1D0 /* String+HA.swift in Sources */,
 				B672334B225DDF410031D629 /* Event.swift in Sources */,
 				11521BBD25400284009C5C72 /* CrashReporter.swift in Sources */,
@@ -4980,6 +4988,7 @@
 				B613936924F728F8002B8C5D /* InputDeviceSensor.swift in Sources */,
 				11C4629624B19FC700031902 /* URLSessionTask+WebhookPersisted.swift in Sources */,
 				11F2F25E25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */,
+				1133F59C25F1DA5D00AD776F /* CLLocation+Sanitize.swift in Sources */,
 				11AF4D1C249C8AA0006C74C0 /* BatterySensor.swift in Sources */,
 				D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */,
 				11AF4D14249C7E09006C74C0 /* ActivitySensor.swift in Sources */,
@@ -5107,6 +5116,7 @@
 				11F2F2A92587288200F61F7C /* NotificationAttachmentParserCamera.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */,
+				1133F5F625F1DBF000AD776F /* CLLocation+Sanitize.test.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
 				110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */,
 			);

--- a/Sources/Shared/Location/CLLocation+Sanitize.swift
+++ b/Sources/Shared/Location/CLLocation+Sanitize.swift
@@ -1,0 +1,76 @@
+import CoreLocation
+
+extension CLLocation {
+    private enum SanitizeFailure: Error {
+        case invalid(String)
+        case invalidKeyPath
+    }
+
+    func sanitized() throws -> CLLocation {
+        // FB9030164 iOS 14.5 (at least betas) started reporting vertical accuracy as non-finite
+        var doubleKeyPaths: [KeyPath<CLLocation, Double>: Result<Double, SanitizeFailure>] = [
+            \.horizontalAccuracy: .failure(.invalid("horizontalAccuracy")),
+            \.verticalAccuracy: .success(-1),
+            \.altitude: .success(0),
+            \.coordinate.latitude: .failure(.invalid("latitude")),
+            \.coordinate.longitude: .failure(.invalid("longitude")),
+            \.course: .success(-1),
+            \.speed: .success(-1),
+            \.speedAccuracy: .success(-1),
+        ]
+
+        if #available(iOS 13.4, watchOS 6.2, *) {
+            doubleKeyPaths[\.courseAccuracy] = .success(-1)
+        }
+
+        func isValid(_ value: Double) -> Bool {
+            value.isFinite && !value.isNaN
+        }
+
+        func sanitize(_ keyPath: KeyPath<CLLocation, Double>) throws -> Double {
+            let value = self[keyPath: keyPath]
+            if isValid(value) {
+                return value
+            } else {
+                if let fallback = doubleKeyPaths[keyPath] {
+                    return try fallback.get()
+                } else {
+                    throw SanitizeFailure.invalidKeyPath
+                }
+            }
+        }
+
+        let needsSanitization = !doubleKeyPaths.keys.allSatisfy({ isValid(self[keyPath: $0]) })
+
+        guard needsSanitization else { return self }
+
+        let sanitizedCoordinate = try CLLocationCoordinate2D(
+            latitude: sanitize(\.coordinate.latitude),
+            longitude: sanitize(\.coordinate.longitude)
+        )
+
+        if #available(iOS 13.4, watchOS 6.2, *) {
+            return try CLLocation(
+                coordinate: sanitizedCoordinate,
+                altitude: sanitize(\.altitude),
+                horizontalAccuracy: sanitize(\.horizontalAccuracy),
+                verticalAccuracy: sanitize(\.verticalAccuracy),
+                course: sanitize(\.course),
+                courseAccuracy: sanitize(\.courseAccuracy),
+                speed: sanitize(\.speed),
+                speedAccuracy: sanitize(\.speedAccuracy),
+                timestamp: timestamp
+            )
+        } else {
+            return try CLLocation(
+                coordinate: sanitizedCoordinate,
+                altitude: sanitize(\.altitude),
+                horizontalAccuracy: sanitize(\.horizontalAccuracy),
+                verticalAccuracy: sanitize(\.verticalAccuracy),
+                course: sanitize(\.course),
+                speed: sanitize(\.speed),
+                timestamp: timestamp
+            )
+        }
+    }
+}

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -43,7 +43,14 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
     let quality: Quality
 
     init(location: CLLocation) {
-        self.location = location
+        do {
+            self.location = try location.sanitized()
+        } catch {
+            Current.Log.error("Location \(location.coordinate) couldn't be sanitized: \(error)")
+            self.quality = .invalid
+            self.location = location
+            return
+        }
 
         if location.coordinate.latitude == 0 || location.coordinate.longitude == 0 {
             // iOS 13.5? seems to occasionally report 0 lat/long, so ignore these locations

--- a/Tests/Shared/CLLocation+Sanitize.test.swift
+++ b/Tests/Shared/CLLocation+Sanitize.test.swift
@@ -1,0 +1,177 @@
+import CoreLocation
+@testable import Shared
+import XCTest
+
+class CLLocationSanitizeTests: XCTestCase {
+    private var coordinate: CLLocationCoordinate2D!
+    private var altitude: Double!
+    private var horizontalAccuracy: Double!
+    private var verticalAccuracy: Double!
+    private var course: Double!
+    private var courseAccuracy: Double!
+    private var speed: Double!
+    private var speedAccuracy: Double!
+    private var timestamp: Date!
+    private var unmodified: CLLocation!
+    private var invalids: [Double]!
+
+    override func setUp() {
+        super.setUp()
+
+        invalids = [.nan, .infinity]
+
+        coordinate = .init(latitude: 1.23, longitude: 4.56)
+        altitude = 30
+        horizontalAccuracy = 65
+        verticalAccuracy = 10
+        course = 180
+        courseAccuracy = 10
+        speed = 12
+        speedAccuracy = 1
+        timestamp = Date()
+        unmodified = make()
+    }
+
+    private func make() -> CLLocation {
+        if #available(iOS 13.4, *) {
+            return .init(
+                coordinate: coordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                courseAccuracy: courseAccuracy,
+                speed: speed,
+                speedAccuracy: speedAccuracy,
+                timestamp: timestamp
+            )
+        } else {
+            return .init(
+                coordinate: coordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                speed: speed,
+                timestamp: timestamp
+            )
+        }
+    }
+
+    func testUnmodified() throws {
+        let location = make()
+        let sanitized = try location.sanitized()
+        // it should not re-create for no reason
+        XCTAssertTrue(location === sanitized)
+
+        assertValid(unmodified)
+        assertValid(make())
+    }
+
+    func testHorizontalAccuracyCannotSanitize() throws {
+        for invalid in invalids {
+            horizontalAccuracy = invalid
+            XCTAssertThrowsError(try make().sanitized())
+        }
+    }
+
+    func testVerticalAccuracyCanSanitize() throws {
+        for invalid in invalids {
+            verticalAccuracy = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.verticalAccuracy)
+            XCTAssertEqual(location.verticalAccuracy, -1)
+        }
+    }
+
+    func testAltitude() throws {
+        for invalid in invalids {
+            altitude = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.altitude)
+            XCTAssertEqual(location.altitude, 0)
+        }
+    }
+
+    func testLatitude() throws {
+        for invalid in invalids {
+            coordinate.latitude = invalid
+            XCTAssertThrowsError(try make().sanitized())
+        }
+    }
+
+    func testLongitude() throws {
+        for invalid in invalids {
+            coordinate.longitude = invalid
+            XCTAssertThrowsError(try make().sanitized())
+        }
+    }
+
+    func testCourse() throws {
+        for invalid in invalids {
+            course = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.course)
+            XCTAssertEqual(location.course, -1)
+        }
+    }
+
+    @available(iOS 13.4, *)
+    func testCourseAccuracy() throws {
+        for invalid in invalids {
+            courseAccuracy = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.courseAccuracy)
+            XCTAssertEqual(location.courseAccuracy, -1)
+        }
+    }
+
+    func testSpeed() throws {
+        for invalid in invalids {
+            speed = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.speed)
+            XCTAssertEqual(location.speed, -1)
+        }
+    }
+
+    func testSpeedAccuracy() throws {
+        for invalid in invalids {
+            speedAccuracy = invalid
+            let location = try make().sanitized()
+            assertValid(location, notEqual: \.speedAccuracy)
+            XCTAssertEqual(location.speedAccuracy, -1)
+        }
+    }
+
+    private var checkKeyPaths: [(KeyPath<CLLocation, Double>, Double)] {
+        var values: [(KeyPath<CLLocation, Double>, Double)] = [
+            (\.horizontalAccuracy, horizontalAccuracy),
+            (\.verticalAccuracy, verticalAccuracy),
+            (\.altitude, altitude),
+            (\.coordinate.latitude, coordinate.latitude),
+            (\.coordinate.longitude, coordinate.longitude),
+            (\.course, course),
+            (\.speed, speed),
+            (\.speedAccuracy, speedAccuracy),
+        ]
+
+        if #available(iOS 13.4, *) {
+            values.append((\.courseAccuracy, courseAccuracy))
+        }
+
+        return values
+    }
+
+    private func assertValid(_ location: CLLocation, notEqual: KeyPath<CLLocation, Double>...) {
+        for (keyPath, expectedValue) in checkKeyPaths {
+            let value = location[keyPath: keyPath]
+            XCTAssertTrue(value.isFinite)
+            XCTAssertTrue(!value.isNaN)
+
+            if !notEqual.contains(keyPath) {
+                XCTAssertEqual(value, expectedValue)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1498.

## Summary
Ignores secondary location data (like vertical accuracy) which is NaN or infinite; the latter of which CLLocationManager is happily delivering at least in the iOS 14.5 betas.

## Any other notes
The problem with values like infinity is that they can't be represented in JSON, which means the system will raise an exception during JSON serialization. What's extra troublesome and ridiculous is that the JSONSerialization methods are marked `throws` -- as in, they throw Swift errors -- but the only error scenarios I can fathom (or can see in the [public implementation](https://github.com/apple/swift-corelibs-foundation/blob/99d6439016c008962d1b1cfc299dbbfd207c6454/Sources/Foundation/JSONSerialization.swift)) are ones that it raises exceptions for. Effectively, it never throws; it always raises an Objective-C exception.