### PR TITLE
Remove Xcode hook of SwiftFormat lint

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 			buildPhases = (
 				111711F725B29AFC003C149E /* Run SwiftGen */,
 				115CF89325B29B64001DAECE /* Run SwiftLint */,
-				119C779C25CE581B00D41734 /* Run SwiftFormat Lint */,
 			);
 			dependencies = (
 			);
@@ -4180,25 +4179,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    # swiftlint as of 2021-01-21 (0.42.0) can't handle spaces in paths\n    # for the config arg, so we rely on relative here\n    # https://github.com/realm/SwiftLint/issues/3471\n    \"${SRCROOT}/Pods/SwiftLint/swiftlint\" \\\n       --config \".swiftlint.yml\" \\\n       --quiet \\\n       \"${SRCROOT}\"\nfi\n";
-		};
-		119C779C25CE581B00D41734 /* Run SwiftFormat Lint */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftFormat Lint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    \"${SRCROOT}/Pods/SwiftFormat/CommandLineTool/swiftformat\" \\\n       --config \"${SRCROOT}/.swiftformat\" \\\n       --lint --lenient \\\n       \"${SRCROOT}\"\nfi\n";
 		};
 		11F3820F2518795700494258 /* Unembed Lokalise for Catalyst */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
It is too annoying when writing new code for the editor to be constantly whining. During `fastlane lint` / `fastlane autocorrect` is good enough.