### PR TITLE
Add "Location History" to Settings

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		110FB4532499DC28000865B4 /* NotificationErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */; };
 		1110836824AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */; };
 		1110836924AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */; };
+		1112AE9B25F71775007A541A /* LocationHistoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1112AE9A25F71775007A541A /* LocationHistoryListViewController.swift */; };
+		1112AEBB25F717E9007A541A /* LocationHistoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1112AEBA25F717E9007A541A /* LocationHistoryDetailViewController.swift */; };
 		1115044E2528485200DCFA94 /* WatchHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D6B1F2227A2EA009D8B90 /* WatchHelpers.swift */; };
 		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
@@ -1013,6 +1015,8 @@
 		110FB4512499DB3A000865B4 /* map_notification.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = map_notification.apns; sourceTree = "<group>"; };
 		110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationErrorViewController.swift; sourceTree = "<group>"; };
 		1110836724AFEFA60027A67A /* Promise+WebhookJson.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.swift"; sourceTree = "<group>"; };
+		1112AE9A25F71775007A541A /* LocationHistoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHistoryListViewController.swift; sourceTree = "<group>"; };
+		1112AEBA25F717E9007A541A /* LocationHistoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHistoryDetailViewController.swift; sourceTree = "<group>"; };
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
@@ -3037,6 +3041,8 @@
 				D0FF79D420D87DB10034574D /* ClientEvents.storyboard */,
 				D0FF79D120D87D200034574D /* ClientEventTableViewController.swift */,
 				D0B25BD121323CA600678C2C /* ClientEventPayloadViewController.swift */,
+				1112AE9A25F71775007A541A /* LocationHistoryListViewController.swift */,
+				1112AEBA25F717E9007A541A /* LocationHistoryDetailViewController.swift */,
 			);
 			path = ClientEvents;
 			sourceTree = "<group>";
@@ -4632,6 +4638,7 @@
 				B616B299227ED68E00828165 /* Bonjour.swift in Sources */,
 				11A48D7F24CA7E820021BDD9 /* Action+Observation.swift in Sources */,
 				B6022213226DAC9D00E8DBFE /* ScaledFont.swift in Sources */,
+				1112AE9B25F71775007A541A /* LocationHistoryListViewController.swift in Sources */,
 				B68EDD03215F0E2900DD6B28 /* NotificationCategoryConfigurator.swift in Sources */,
 				D0FF79D220D87D200034574D /* ClientEventTableViewController.swift in Sources */,
 				117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */,
@@ -4640,6 +4647,7 @@
 				B626AAF11D8F972800A0D225 /* SettingsDetailViewController.swift in Sources */,
 				11DE823024FAE66F00E636B8 /* UIWindow+Additions.swift in Sources */,
 				1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */,
+				1112AEBB25F717E9007A541A /* LocationHistoryDetailViewController.swift in Sources */,
 				11BD7B4D25B53D7F001826F0 /* AppMacBridgeStatusItemConfiguration.swift in Sources */,
 				11F55EED25D3B088003977AC /* NotificationDebugNotificationsViewController.swift in Sources */,
 				B6022223226DBA3800E8DBFE /* OnboardingNavigationViewController.swift in Sources */,

--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -1,0 +1,193 @@
+import UIKit
+import Shared
+import MapKit
+import RealmSwift
+
+private class RegionCircle: MKCircle {}
+private class ZoneCircle: MKCircle {}
+private class GPSCircle: MKCircle {}
+
+class LocationHistoryDetailViewController: UIViewController {
+    let entry: LocationHistoryEntry
+    private let map = MKMapView()
+
+    init(entry: LocationHistoryEntry) {
+        self.entry = entry
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    @objc private func center(_ sender: AnyObject?) {
+        map.setRegion(
+            .init(
+                center: entry.clLocation.coordinate,
+                latitudinalMeters: 300,
+                longitudinalMeters: 300
+            ),
+            animated: sender != nil
+        )
+    }
+
+    private func report() -> String {
+        var value = ""
+
+        value.append("location\n--------\n")
+        value.append("""
+            latitude: \(entry.Latitude)
+            longitude: \(entry.Longitude)
+            accuracy: \(entry.Accuracy)
+            ^ note: accuracy of 65m is from Wi-Fi, 1414m is is from cell tower
+        """)
+        value.append("\n\n")
+
+        value.append("regions\n-------\n")
+
+        let allRegions = Current.realm().objects(RLMZone.self)
+            .flatMap(\.circularRegionsForMonitoring)
+        for region in allRegions {
+            let regionLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+            let distance = regionLocation.distance(from: entry.clLocation)
+            let contains = distance <= (region.radius + entry.Accuracy)
+
+            value.append("""
+                \(region.identifier): (\(region.center.latitude), \(region.center.longitude)) \(region.radius)m
+                \(String(format: "%.02lf", distance))m away, \(contains ? "inside" : "outside")
+            """)
+
+            value.append("\n\n")
+        }
+
+        return value
+    }
+
+    @objc private func help(_ sender: AnyObject?) {
+        let alert = UIAlertController(
+            title: nil,
+            message: L10n.Settings.LocationHistory.Detail.explanation,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: L10n.cancelLabel, style: .cancel, handler: nil))
+        present(alert, animated: true, completion: nil)
+    }
+
+    @objc private func share(_ sender: AnyObject?) {
+        let bounds = CGRect(x: 0, y: 0, width: map.bounds.width, height: map.bounds.height)
+        let snapshot = UIGraphicsImageRenderer(bounds: bounds).image { context in
+            map.drawHierarchy(in: bounds, afterScreenUpdates: true)
+        }
+
+        let controller = UIActivityViewController(activityItems: [ snapshot, report() ], applicationActivities: nil)
+        present(controller, animated: true, completion: nil)
+    }
+
+    private static func overlays<T: Collection>(for zones: T) -> [MKOverlay] where T.Element: RLMZone {
+        zones.flatMap { zone -> [MKOverlay] in
+            var overlays = [MKOverlay]()
+
+            let regions = zone.circularRegionsForMonitoring
+            if regions.count > 1 {
+                // for non-single-region zones, show the <100m as well
+                overlays.append(contentsOf: regions.map { RegionCircle(center: $0.center, radius: $0.radius) })
+            }
+
+            overlays.append(ZoneCircle(center: zone.center, radius: zone.Radius))
+            return overlays
+        }
+    }
+
+    private static func overlays(for location: CLLocation) -> [MKOverlay] {
+        [
+            GPSCircle(center: location.coordinate, radius: location.horizontalAccuracy)
+        ]
+    }
+
+    private static func annotations(for location: CLLocation) -> [MKAnnotation] {
+        [
+            with(MKPointAnnotation()) {
+                $0.coordinate = location.coordinate
+            }
+        ]
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                image: MaterialDesignIcons.crosshairsGpsIcon.image(ofSize: CGSize(width: 30, height: 30), color: nil),
+                style: .plain,
+                target: self,
+                action: #selector(center(_:))
+            ),
+            with(Constants.helpBarButtonItem) {
+                $0.target = self
+                $0.action = #selector(help(_:))
+            },
+            UIBarButtonItem(
+                image: MaterialDesignIcons.exportVariantIcon.image(ofSize: CGSize(width: 30, height: 30), color: nil),
+                style: .plain,
+                target: self,
+                action: #selector(share(_:))
+            ),
+        ]
+
+        if #available(iOS 13, *) {
+            map.pointOfInterestFilter = .excludingAll
+        } else {
+            map.showsPointsOfInterest = false
+        }
+
+        map.showsBuildings = true
+        map.showsCompass = false
+        map.showsTraffic = false
+        map.showsUserLocation = false
+        map.showsScale = false
+
+        map.delegate = self
+        map.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(map)
+        NSLayoutConstraint.activate([
+            map.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            map.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            map.topAnchor.constraint(equalTo: view.topAnchor),
+            map.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        map.addOverlays(Self.overlays(for: Current.realm().objects(RLMZone.self)))
+        map.addOverlays(Self.overlays(for: entry.clLocation))
+        map.addAnnotations(Self.annotations(for: entry.clLocation))
+
+        center(nil)
+    }
+}
+
+extension LocationHistoryDetailViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        let view = MKPinAnnotationView(annotation: annotation, reuseIdentifier: nil)
+        view.pinTintColor = .purple
+        return view
+    }
+
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        if let overlay = overlay as? MKCircle {
+            let renderer = MKCircleRenderer(circle: overlay)
+
+            switch overlay {
+            case is ZoneCircle:
+                renderer.fillColor = Constants.tintColor
+            case is RegionCircle:
+                renderer.fillColor = UIColor.orange.withAlphaComponent(0.25)
+            case is GPSCircle:
+                renderer.fillColor = UIColor.purple.withAlphaComponent(0.75)
+            default: break
+            }
+
+            return renderer
+        } else {
+            fatalError()
+        }
+    }
+}

--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -1,7 +1,7 @@
-import UIKit
-import Shared
 import MapKit
 import RealmSwift
+import Shared
+import UIKit
 
 private class RegionCircle: MKCircle {}
 private class ZoneCircle: MKCircle {}
@@ -16,6 +16,7 @@ class LocationHistoryDetailViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError()
     }
@@ -75,11 +76,11 @@ class LocationHistoryDetailViewController: UIViewController {
 
     @objc private func share(_ sender: AnyObject?) {
         let bounds = CGRect(x: 0, y: 0, width: map.bounds.width, height: map.bounds.height)
-        let snapshot = UIGraphicsImageRenderer(bounds: bounds).image { context in
+        let snapshot = UIGraphicsImageRenderer(bounds: bounds).image { _ in
             map.drawHierarchy(in: bounds, afterScreenUpdates: true)
         }
 
-        let controller = UIActivityViewController(activityItems: [ snapshot, report() ], applicationActivities: nil)
+        let controller = UIActivityViewController(activityItems: [snapshot, report()], applicationActivities: nil)
         present(controller, animated: true, completion: nil)
     }
 
@@ -100,7 +101,7 @@ class LocationHistoryDetailViewController: UIViewController {
 
     private static func overlays(for location: CLLocation) -> [MKOverlay] {
         [
-            GPSCircle(center: location.coordinate, radius: location.horizontalAccuracy)
+            GPSCircle(center: location.coordinate, radius: location.horizontalAccuracy),
         ]
     }
 
@@ -108,7 +109,7 @@ class LocationHistoryDetailViewController: UIViewController {
         [
             with(MKPointAnnotation()) {
                 $0.coordinate = location.coordinate
-            }
+            },
         ]
     }
 

--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -178,7 +178,7 @@ extension LocationHistoryDetailViewController: MKMapViewDelegate {
 
             switch overlay {
             case is ZoneCircle:
-                renderer.fillColor = Constants.tintColor
+                renderer.fillColor = Constants.tintColor.withAlphaComponent(0.75)
             case is RegionCircle:
                 renderer.fillColor = UIColor.orange.withAlphaComponent(0.25)
             case is GPSCircle:

--- a/Sources/App/ClientEvents/LocationHistoryListViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryListViewController.swift
@@ -1,7 +1,7 @@
-import UIKit
-import Shared
-import RealmSwift
 import Eureka
+import RealmSwift
+import Shared
+import UIKit
 
 class LocationHistoryListViewController: FormViewController {
     @objc private func clear(_ sender: AnyObject?) {
@@ -22,7 +22,7 @@ class LocationHistoryListViewController: FormViewController {
                 style: .plain,
                 target: self,
                 action: #selector(clear(_:))
-            )
+            ),
         ]
 
         let history = Current.realm()
@@ -42,7 +42,7 @@ class LocationHistoryListViewController: FormViewController {
                 with(InfoLabelRow()) {
                     $0.displayType = .secondary
                     $0.title = L10n.Settings.LocationHistory.empty
-                }
+                },
             ], getter: { entry in
                 with(ButtonRow()) {
                     $0.cellStyle = .subtitle
@@ -59,10 +59,8 @@ class LocationHistoryListViewController: FormViewController {
                     $0.presentationMode = .show(controllerProvider: .callback(builder: {
                         LocationHistoryDetailViewController(entry: entry)
                     }), onDismiss: nil)
-
                 }
             }, didUpdate: { _, _ in
-
             }
         )
     }

--- a/Sources/App/ClientEvents/LocationHistoryListViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryListViewController.swift
@@ -1,0 +1,69 @@
+import UIKit
+import Shared
+import RealmSwift
+import Eureka
+
+class LocationHistoryListViewController: FormViewController {
+    @objc private func clear(_ sender: AnyObject?) {
+        let realm = Current.realm()
+        try? realm.write {
+            realm.delete(realm.objects(LocationHistoryEntry.self))
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.Settings.LocationHistory.title
+
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                title: L10n.ClientEvents.View.clear,
+                style: .plain,
+                target: self,
+                action: #selector(clear(_:))
+            )
+        ]
+
+        let history = Current.realm()
+            .objects(LocationHistoryEntry.self)
+            .sorted(byKeyPath: "CreatedAt", ascending: false)
+
+        let formatter = with(DateFormatter()) {
+            $0.dateStyle = .medium
+            $0.timeStyle = .medium
+        }
+
+        form +++ RealmSection(
+            header: nil,
+            footer: nil,
+            collection: AnyRealmCollection(history),
+            emptyRows: [
+                with(InfoLabelRow()) {
+                    $0.displayType = .secondary
+                    $0.title = L10n.Settings.LocationHistory.empty
+                }
+            ], getter: { entry in
+                with(ButtonRow()) {
+                    $0.cellStyle = .subtitle
+                    $0.title = formatter.string(from: entry.CreatedAt)
+                    $0.cellUpdate { cell, _ in
+                        cell.detailTextLabel?.text = "\(entry.Latitude), \(entry.Longitude)"
+                        cell.accessoryType = .disclosureIndicator
+                        if #available(iOS 13, *) {
+                            cell.detailTextLabel?.textColor = .secondaryLabel
+                        } else {
+                            cell.detailTextLabel?.textColor = .gray
+                        }
+                    }
+                    $0.presentationMode = .show(controllerProvider: .callback(builder: {
+                        LocationHistoryDetailViewController(entry: entry)
+                    }), onDismiss: nil)
+
+                }
+            }, didUpdate: { _, _ in
+
+            }
+        )
+    }
+}

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -950,3 +950,7 @@ Thank you.\
 "settings.connection_section.websocket.status.disconnected.retry_count" = "Retry Count: %1$li";
 /* first parameter is the date of the next retry in absolute, e.g. 2021 Jan 23 04:33 */
 "settings.connection_section.websocket.status.disconnected.next_retry" = "Next Retry: %1$@";
+"settings.location_history.title" = "Location History";
+"settings.location_history.empty" = "No Location History";
+"settings.location_history.description" = "No Location History";
+"settings.location_history.detail.explanation" = "The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are addition regions used for sub-100m zones.";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -212,6 +212,13 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
             form
                 +++ locationPermissionsSection()
 
+                +++ ButtonRow {
+                    $0.title = L10n.Settings.LocationHistory.title
+                    $0.presentationMode = .show(controllerProvider: .callback(builder: {
+                        LocationHistoryListViewController()
+                    }), onDismiss: nil)
+                }
+
                 +++ Section(
                     header: L10n.SettingsDetails.Location.Updates.header,
                     footer: L10n.SettingsDetails.Location.Updates.footer

--- a/Sources/App/Settings/SettingsViewController.swift
+++ b/Sources/App/Settings/SettingsViewController.swift
@@ -166,13 +166,6 @@ class SettingsViewController: FormViewController {
             }
 
             <<< ButtonRow {
-                $0.title = L10n.Settings.LocationHistory.title
-                $0.presentationMode = .show(controllerProvider: .callback(builder: {
-                    LocationHistoryListViewController()
-                }), onDismiss: nil)
-            }
-
-            <<< ButtonRow {
                 if Current.isCatalyst {
                     $0.title = L10n.Settings.Developer.ShowLogFiles.title
                 } else {

--- a/Sources/App/Settings/SettingsViewController.swift
+++ b/Sources/App/Settings/SettingsViewController.swift
@@ -166,6 +166,13 @@ class SettingsViewController: FormViewController {
             }
 
             <<< ButtonRow {
+                $0.title = L10n.Settings.LocationHistory.title
+                $0.presentationMode = .show(controllerProvider: .callback(builder: {
+                    LocationHistoryListViewController()
+                }), onDismiss: nil)
+            }
+
+            <<< ButtonRow {
                 if Current.isCatalyst {
                     $0.title = L10n.Settings.Developer.ShowLogFiles.title
                 } else {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -550,7 +550,7 @@ public class HomeAssistantAPI {
 
                 realm.add(LocationHistoryEntry(
                     updateType: updateType,
-                    location: payload.cllocation,
+                    location: location,
                     zone: zone,
                     payload: jsonPayload
                 ))

--- a/Sources/Shared/API/Models/LocationHistory.swift
+++ b/Sources/Shared/API/Models/LocationHistory.swift
@@ -30,7 +30,13 @@ public class LocationHistoryEntry: Object {
     }
 
     public var clLocation: CLLocation {
-        CLLocation(latitude: Latitude, longitude: Longitude)
+        CLLocation(
+            coordinate: .init(latitude: Latitude, longitude: Longitude),
+            altitude: 0,
+            horizontalAccuracy: Accuracy,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
     }
 }
 

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -116,22 +116,6 @@ public class WebhookUpdateLocation: Mappable {
         VerticalAccuracy = nil
     }
 
-    public var cllocation: CLLocation? {
-        if let location = Location, let altitude = Altitude, let hAccuracy = HorizontalAccuracy,
-           let vAccuracy = VerticalAccuracy {
-            return CLLocation(
-                coordinate: location,
-                altitude: altitude,
-                horizontalAccuracy: hAccuracy,
-                verticalAccuracy: vAccuracy,
-                timestamp: Date()
-            )
-        } else if let location = Location {
-            return CLLocation(latitude: location.latitude, longitude: location.longitude)
-        }
-        return nil
-    }
-
     // Mappable
     public func mapping(map: Map) {
         Battery <- map["battery"]

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1504,6 +1504,16 @@ public enum L10n {
       /// General
       public static var title: String { return L10n.tr("Localizable", "settings.general_settings_button.title") }
     }
+    public enum LocationHistory {
+      /// No Location History
+      public static var empty: String { return L10n.tr("Localizable", "settings.location_history.empty") }
+      /// Location History
+      public static var title: String { return L10n.tr("Localizable", "settings.location_history.title") }
+      public enum Detail {
+        /// The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are addition regions used for sub-100m zones.
+        public static var explanation: String { return L10n.tr("Localizable", "settings.location_history.detail.explanation") }
+      }
+    }
     public enum NavigationBar {
       /// Settings
       public static var title: String { return L10n.tr("Localizable", "settings.navigation_bar.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1506,6 +1506,8 @@ public enum L10n {
     }
     public enum LocationHistory {
       /// No Location History
+      public static var description: String { return L10n.tr("Localizable", "settings.location_history.description") }
+      /// No Location History
       public static var empty: String { return L10n.tr("Localizable", "settings.location_history.empty") }
       /// Location History
       public static var title: String { return L10n.tr("Localizable", "settings.location_history.title") }


### PR DESCRIPTION
## Summary
Hopefully improve debugging location issues by providing a visualization of what we know about a location update.

## Screenshots
<img width="350" src="https://user-images.githubusercontent.com/74188/110420951-5ca5ad00-8051-11eb-82d9-b81dc28e20b7.png"><img width="350" src="https://user-images.githubusercontent.com/74188/110420954-5dd6da00-8051-11eb-9d78-61783873b08a.png">
<img width="350" src="https://user-images.githubusercontent.com/74188/110420959-60393400-8051-11eb-906c-74e19096e274.png"><img width="350" src="https://user-images.githubusercontent.com/74188/110420961-616a6100-8051-11eb-9aee-334234a6c59c.png">
<img width="350" src="https://user-images.githubusercontent.com/74188/110420972-63ccbb00-8051-11eb-855c-4e7d41a4e16f.png"><img width="350" src="https://user-images.githubusercontent.com/74188/110420975-64fde800-8051-11eb-9876-c0cb0f682727.png">
<img width="350" src="https://user-images.githubusercontent.com/74188/110420986-692a0580-8051-11eb-976b-1e2be659bcae.png"><img width="350" src="https://user-images.githubusercontent.com/74188/110420988-6af3c900-8051-11eb-982c-aaa903f4af5d.png">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- Shows a blue circle for zones, an orange circle for non-single-region zones' regions, a purple circle for location and its accuracy.
- Allows sharing a bunch of debug data about the location and region states.
- Allows clearing of location history.