### PR TITLE
Fix a sub-100m zone stuck-outside issue & a iOS pre-13.4 issue

### DIFF
--- a/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
@@ -55,3 +55,20 @@ public extension CLLocationDegrees {
         }
     }
 }
+
+public extension CLCircularRegion {
+    func distanceWithAccuracy(from location: CLLocation) -> CLLocationDistance {
+        let centerLocation = CLLocation(latitude: center.latitude, longitude: center.longitude)
+        return
+            // how far away from the center we are
+            location.distance(from: centerLocation)
+            // to get to the outer radius (perimeter)
+            - radius
+            // adding the accuracy amount we have already
+            - location.horizontalAccuracy
+    }
+
+    func containsWithAccuracy(_ location: CLLocation) -> Bool {
+        distanceWithAccuracy(from: location) <= 0
+    }
+}

--- a/Tests/Shared/CLLocation+Extensions.test.swift
+++ b/Tests/Shared/CLLocation+Extensions.test.swift
@@ -60,4 +60,48 @@ class CLLocationExtensionsTests: XCTestCase {
             XCTAssertFalse(regionInside.contains(moved))
         }
     }
+
+    func testDistanceWithAccuracy() {
+        let region = CLCircularRegion(center: coordinate, radius: 20, identifier: "")
+        let offsetCoordinate = coordinate.moving(
+            distance: .init(value: 50, unit: .meters),
+            direction: .init(value: 0, unit: .degrees)
+        )
+
+        let locationNoAccuracy = CLLocation(
+            latitude: offsetCoordinate.latitude,
+            longitude: offsetCoordinate.longitude
+        )
+        let locationWithAccuracy = CLLocation(
+            coordinate: offsetCoordinate,
+            altitude: 0,
+            horizontalAccuracy: 10,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertEqual(region.distanceWithAccuracy(from: locationNoAccuracy), 30, accuracy: 0.1)
+        XCTAssertEqual(region.distanceWithAccuracy(from: locationWithAccuracy), 20, accuracy: 0.1)
+    }
+
+    func testContainsWithAccuracy() {
+        let region = CLCircularRegion(center: coordinate, radius: 20, identifier: "")
+        let offsetCoordinate = coordinate.moving(
+            distance: .init(value: 25, unit: .meters),
+            direction: .init(value: 0, unit: .degrees)
+        )
+
+        let locationNoAccuracy = CLLocation(
+            latitude: offsetCoordinate.latitude,
+            longitude: offsetCoordinate.longitude
+        )
+        let locationWithAccuracy = CLLocation(
+            coordinate: offsetCoordinate,
+            altitude: 0,
+            horizontalAccuracy: 10,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertFalse(region.containsWithAccuracy(locationNoAccuracy))
+        XCTAssertTrue(region.containsWithAccuracy(locationWithAccuracy))
+    }
 }


### PR DESCRIPTION
Fixes #1520.

## Summary
Fixes a case where entering the 3-region overlap with extremely good accuracy wouldn't trigger an update to inside the zone. Also fixes not using the fuzzed accuracy at all on older than iOS 13.4.