### PR TITLE
Fix crash on last location history item

### DIFF
--- a/Sources/App/ClientEvents/LocationHistoryListViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryListViewController.swift
@@ -95,7 +95,7 @@ extension LocationHistoryListViewController: LocationHistoryDetailMoveDelegate {
 
         switch direction {
         case .up where section.startIndex < indexPath.row: nextIndex = section.index(before: indexPath.row)
-        case .down where section.endIndex > indexPath.row: nextIndex = section.index(after: indexPath.row)
+        case .down where section.endIndex - 1 > indexPath.row: nextIndex = section.index(after: indexPath.row)
         default: nextIndex = nil
         }
 


### PR DESCRIPTION
## Summary
Fixes crash due to out-of-bounds array access.

## Any other notes
Not the first time, and definitely not the last time, that endIndex being non-inclusive tricks me.