### PR TITLE
Fix a couple iPad crashes due to popover source

### DIFF
--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -148,13 +148,16 @@ final class LocationHistoryDetailViewController: UIViewController, TypedRowContr
         present(alert, animated: true, completion: nil)
     }
 
-    @objc private func share(_ sender: AnyObject?) {
+    @objc private func share(_ sender: UIBarButtonItem?) {
         let bounds = CGRect(x: 0, y: 0, width: map.bounds.width, height: map.bounds.height)
         let snapshot = UIGraphicsImageRenderer(bounds: bounds).image { _ in
             map.drawHierarchy(in: bounds, afterScreenUpdates: true)
         }
 
         let controller = UIActivityViewController(activityItems: [snapshot, report()], applicationActivities: nil)
+        with(controller.popoverPresentationController) {
+            $0?.barButtonItem = sender
+        }
         present(controller, animated: true, completion: nil)
     }
 

--- a/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
+++ b/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
@@ -142,10 +142,14 @@ class NotificationSettingsViewController: FormViewController {
                     cell.selectionStyle = .default
                 }
 
-                $0.onCellSelection { [weak self] _, row in
+                $0.onCellSelection { [weak self] cell, row in
                     guard let id = Current.settingsStore.pushID else { return }
 
                     let vc = UIActivityViewController(activityItems: [id], applicationActivities: nil)
+                    with(vc.popoverPresentationController) {
+                        $0?.sourceView = cell
+                        $0?.sourceRect = cell.bounds
+                    }
                     self?.present(vc, animated: true, completion: nil)
                     row.deselect(animated: true)
                 }


### PR DESCRIPTION
Fixes a crash in the new location history when tapping share, fixes another when tapping push ID.
