### PR TITLE
Use with-seconds time in location history detail

### DIFF
--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -43,7 +43,7 @@ final class LocationHistoryDetailViewController: UIViewController, TypedRowContr
         title = DateFormatter.localizedString(
             from: entry.CreatedAt,
             dateStyle: .short,
-            timeStyle: .short
+            timeStyle: .medium
         )
     }
 


### PR DESCRIPTION
## Summary
The list shows seconds, and this should too.

## Screenshots
<img width="350" src="https://user-images.githubusercontent.com/74188/110998268-6a9a4d00-8333-11eb-814b-e2bb60b97c3f.png">
<img width="350" src="https://user-images.githubusercontent.com/74188/110998272-6bcb7a00-8333-11eb-95ec-d53007ef8a32.png">