### PR TITLE
Live-update account row in settings

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -180,7 +180,7 @@ CHECKOUT OPTIONS:
     :commit: ff5b4ccf9bb424cb454e76ee91e32165d2d9c12c
     :git: https://github.com/hirokimu/EMTLoadingIndicator
   HAKit:
-    :commit: 3ec2886caaf0837b9bfda4eea07555a3735368a9
+    :commit: 523f7f1596d733168c95bd932aff1a4528707132
     :git: https://github.com/home-assistant/HAKit.git
   ObjectMapper:
     :commit: a593b4d647a970b3d184d046f8f52b945083ccf9

--- a/Sources/App/Settings/Eureka/AccountRow.swift
+++ b/Sources/App/Settings/Eureka/AccountRow.swift
@@ -105,6 +105,7 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
             oldValue?.cancel()
         }
     }
+
     private var avatarSubscription: HACancellable? {
         didSet {
             oldValue?.cancel()
@@ -149,13 +150,13 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
                     entity.attributes["entity_picture"] as? String
                 }.compactMap { path -> URL? in
                     let url = Current.settingsStore.connectionInfo?.activeURL.appendingPathComponent(path)
-                    if let lastTask = lastTask, lastTask.error == nil && lastTask.originalRequest?.url == url {
+                    if let lastTask = lastTask, lastTask.error == nil, lastTask.originalRequest?.url == url {
                         return nil
                     }
                     return url
                 }.then { url -> Promise<Data> in
                     Promise<Data> { seal in
-                        lastTask = URLSession.shared.dataTask(with: url, completionHandler: { data, response, error in
+                        lastTask = URLSession.shared.dataTask(with: url, completionHandler: { data, _, error in
                             seal.resolve(data, error)
                         })
                     }

--- a/Sources/App/Settings/SettingsViewController.swift
+++ b/Sources/App/Settings/SettingsViewController.swift
@@ -171,7 +171,7 @@ class SettingsViewController: FormViewController {
                 } else {
                     $0.title = L10n.Settings.Developer.ExportLogFiles.title
                 }
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 Current.Log.verbose("Logs directory is: \(Constants.LogsDirectory)")
 
                 guard !Current.isCatalyst else {
@@ -240,7 +240,7 @@ class SettingsViewController: FormViewController {
                             try? fileManager.removeItem(at: zipDest)
                         }
                     }
-                    self.present(activityViewController, animated: true, completion: {})
+                    self?.present(activityViewController, animated: true, completion: {})
                     if let popOver = activityViewController.popoverPresentationController {
                         popOver.sourceView = cell
                     }
@@ -255,7 +255,7 @@ class SettingsViewController: FormViewController {
                 $0.title = L10n.Settings.ResetSection.ResetRow.title
             }.cellUpdate { cell, _ in
                 cell.textLabel?.textColor = .red
-            }.onCellSelection { cell, row in
+            }.onCellSelection { [weak self] cell, row in
                 let alert = UIAlertController(
                     title: L10n.Settings.ResetSection.ResetAlert.title,
                     message: L10n.Settings.ResetSection.ResetAlert.message,
@@ -270,11 +270,11 @@ class SettingsViewController: FormViewController {
                     handler: { _ in
                         row.hidden = true
                         row.evaluateHidden()
-                        self.ResetApp()
+                        self?.ResetApp()
                     }
                 ))
 
-                self.present(alert, animated: true, completion: nil)
+                self?.present(alert, animated: true, completion: nil)
                 alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
             }
 
@@ -313,7 +313,7 @@ class SettingsViewController: FormViewController {
 
             <<< ButtonRow {
                 $0.title = L10n.Settings.Developer.SyncWatchContext.title
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 if let syncError = HomeAssistantAPI.SyncWatchContext() {
                     let alert = UIAlertController(
                         title: L10n.errorLabel,
@@ -323,14 +323,14 @@ class SettingsViewController: FormViewController {
 
                     alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
 
-                    self.present(alert, animated: true, completion: nil)
+                    self?.present(alert, animated: true, completion: nil)
                     alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
                 }
             }
 
             <<< ButtonRow {
                 $0.title = L10n.Settings.Developer.CopyRealm.title
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 guard let backupURL = Realm.backup() else {
                     fatalError("Unable to get Realm backup")
                 }
@@ -366,21 +366,21 @@ class SettingsViewController: FormViewController {
 
                 alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
 
-                self.present(alert, animated: true, completion: nil)
+                self?.present(alert, animated: true, completion: nil)
 
                 alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
             }
 
             <<< ButtonRow {
                 $0.title = L10n.Settings.Developer.DebugStrings.title
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 prefs.set(!prefs.bool(forKey: "showTranslationKeys"), forKey: "showTranslationKeys")
 
                 let alert = UIAlertController(title: L10n.okLabel, message: nil, preferredStyle: .alert)
 
                 alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
 
-                self.present(alert, animated: true, completion: nil)
+                self?.present(alert, animated: true, completion: nil)
 
                 alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
             }
@@ -396,7 +396,7 @@ class SettingsViewController: FormViewController {
             }
             <<< ButtonRow {
                 $0.title = L10n.Settings.Developer.CrashlyticsTest.NonFatal.title
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 let alert = UIAlertController(
                     title: L10n.Settings.Developer.CrashlyticsTest.NonFatal.Notification.title,
                     message: L10n.Settings.Developer.CrashlyticsTest.NonFatal.Notification.body,
@@ -419,12 +419,12 @@ class SettingsViewController: FormViewController {
                     Current.crashReporter.logError(error)
                 }))
 
-                self.present(alert, animated: true, completion: nil)
+                self?.present(alert, animated: true, completion: nil)
                 alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
             }
             <<< ButtonRow {
                 $0.title = L10n.Settings.Developer.CrashlyticsTest.Fatal.title
-            }.onCellSelection { cell, _ in
+            }.onCellSelection { [weak self] cell, _ in
                 let alert = UIAlertController(
                     title: L10n.Settings.Developer.CrashlyticsTest.Fatal.Notification.title,
                     message: L10n.Settings.Developer.CrashlyticsTest.Fatal.Notification.body,
@@ -435,7 +435,7 @@ class SettingsViewController: FormViewController {
                     SentrySDK.crash()
                 }))
 
-                self.present(alert, animated: true, completion: nil)
+                self?.present(alert, animated: true, completion: nil)
                 alert.popoverPresentationController?.sourceView = cell.formViewController()?.view
             }
 


### PR DESCRIPTION
## Summary
Uses the `caches.user` added to HAKit to observe the user and live-update the account row whenever the user or their avatar changes.

## Screenshots
https://user-images.githubusercontent.com/74188/111947182-25e08580-8a9a-11eb-8778-09cf5eea5d86.mov

## Any other notes
There does not currently appear to be any events that fire when a user is renamed, and in fact the frontend doesn't show new names until refresh, so the name part here does not update.

This also doesn't yet pull the location name from WebSocket so that is still loaded initially once.

Also resolves a few circular references which prevented settings from deallocing, which would have kept these subscriptions around indefinitely.