### PR TITLE
Move render template (non-complication) to WebSocket API

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -341,42 +341,6 @@ public class HomeAssistantAPI {
         )
     }
 
-    public enum TemplateError: LocalizedError {
-        case unknownError
-        case error(String)
-
-        public var errorDescription: String? {
-            switch self {
-            case let .error(error): return error
-            case .unknownError: return L10n.HaApi.ApiError.unknown
-            }
-        }
-    }
-
-    public func RenderTemplate(templateStr: String, variables: [String: Any] = [:]) -> Promise<Any> {
-        firstly { () -> Promise<Any> in
-            Current.webhooks.sendEphemeral(
-                request: .init(type: "render_template", data: [
-                    "tpl": [
-                        "template": templateStr,
-                        "variables": variables,
-                    ],
-                ])
-            )
-        }.map { value in
-            if let value = value as? [String: Any], let rendered = value["tpl"] {
-                return rendered
-            } else {
-                throw TemplateError.unknownError
-            }
-        }.get { value in
-            if let value = value as? [String: Any], let error = value["error"] as? String {
-                // the only error response for the template is {"error": "message"}
-                throw TemplateError.error(error)
-            }
-        }
-    }
-
     public func GetCameraImage(cameraEntityID: String) -> Promise<UIImage> {
         Promise { seal in
             let connectionInfo = try self.connectionInfo()

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1512,7 +1512,7 @@ public enum L10n {
       /// Location History
       public static var title: String { return L10n.tr("Localizable", "settings.location_history.title") }
       public enum Detail {
-        /// The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are addition regions used for sub-100m zones.
+        /// The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are additional regions used for sub-100 m zones.
         public static var explanation: String { return L10n.tr("Localizable", "settings.location_history.detail.explanation") }
       }
     }


### PR DESCRIPTION
## Summary
Moves over the directly-render templates. Complications can never be moved over because they need to work cleanly with the background session logic on the watch.

## Any other notes
Slightly poorly ergonomic about subscribing and then cancelling; might be nice to provide a "send this subscription and unsubscribe after the first event" flag, but nothing great for how to do that comes to mind.