### PR TITLE
Reset push ID when resetting everything else

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -33,6 +33,9 @@ extension Environment {
     var sceneManager: SceneManager {
         UIApplication.shared.typedDelegate.sceneManager
     }
+    var notificationManager: NotificationManager {
+        UIApplication.shared.typedDelegate.notificationManager
+    }
 }
 
 @UIApplicationMain

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -33,6 +33,7 @@ extension Environment {
     var sceneManager: SceneManager {
         UIApplication.shared.typedDelegate.sceneManager
     }
+
     var notificationManager: NotificationManager {
         UIApplication.shared.typedDelegate.notificationManager
     }

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -11,6 +11,18 @@ class NotificationManager: NSObject {
         UNUserNotificationCenter.current().delegate = self
     }
 
+    func resetPushID() -> Promise<String> {
+        firstly {
+            Promise<Void> { seal in
+                Messaging.messaging().deleteToken(completion: seal.resolve)
+            }
+        }.then {
+            Promise<String> { seal in
+                Messaging.messaging().token(completion: seal.resolve)
+            }
+        }
+    }
+
     func setupFirebase() {
         Current.Log.verbose("Calling UIApplication.shared.registerForRemoteNotifications()")
         UIApplication.shared.registerForRemoteNotifications()

--- a/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
+++ b/Sources/App/Settings/Notifications/NotificationSettingsViewController.swift
@@ -163,9 +163,8 @@ class NotificationSettingsViewController: FormViewController {
             }.onCellSelection { cell, _ in
                 Current.Log.verbose("Resetting push token!")
                 firstly {
-                    self.resetInstanceID()
+                    Current.notificationManager.resetPushID()
                 }.done { token in
-                    Current.settingsStore.pushID = token
                     guard let idRow = self.form.rowBy(tag: "pushID") as? LabelRow else { return }
                     idRow.value = token
                     idRow.updateCell()
@@ -189,26 +188,6 @@ class NotificationSettingsViewController: FormViewController {
 
     @objc func closeSettingsDetailView(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
-    }
-
-    func deleteInstanceID() -> Promise<Void> {
-        Promise { seal in
-            Messaging.messaging().deleteToken(completion: seal.resolve)
-        }
-    }
-
-    func createInstanceID() -> Promise<String> {
-        Promise { seal in
-            Messaging.messaging().token(completion: seal.resolve)
-        }
-    }
-
-    func resetInstanceID() -> Promise<String> {
-        firstly {
-            self.deleteInstanceID()
-        }.then { _ in
-            self.createInstanceID()
-        }
     }
 
     private func notificationPermissionRow() -> BaseRow {

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -200,7 +200,6 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
             }.onChange { row in
                 guard let browserChoice = row.value else { return }
                 prefs.setValue(browserChoice.rawValue, forKey: "openInBrowser")
-                prefs.synchronize()
             }
 
                 <<< SwitchRow("confirmBeforeOpeningUrl") {

--- a/Sources/App/Settings/SettingsViewController.swift
+++ b/Sources/App/Settings/SettingsViewController.swift
@@ -475,19 +475,17 @@ class SettingsViewController: FormViewController {
             )
         }.then {
             waitAtLeast
-        }.done {
-            hud.hide(animated: true)
+        }.get {
+            Current.apiConnection.disconnect()
 
             resetStores()
             setDefaults()
-            let bundleId = Bundle.main.bundleIdentifier!
-            UserDefaults.standard.removePersistentDomain(forName: bundleId)
-            UserDefaults.standard.synchronize()
-            prefs.removePersistentDomain(forName: bundleId)
-            prefs.synchronize()
-
+        }.then {
+            Current.notificationManager.resetPushID().asVoid().recover { _ in }
+        }.ensure {
+            hud.hide(animated: true)
             Current.onboardingObservation.needed(.logout)
-        }
+        }.cauterize()
     }
 
     override var canBecomeFirstResponder: Bool {

--- a/Sources/App/Utilities/Utils.swift
+++ b/Sources/App/Utilities/Utils.swift
@@ -12,12 +12,9 @@ func resetStores() {
         Current.Log.error("Error when trying to delete everything from Keychain!")
     }
 
-    if let groupDefaults = UserDefaults(suiteName: Constants.AppGroupID) {
-        for key in groupDefaults.dictionaryRepresentation().keys {
-            groupDefaults.removeObject(forKey: key)
-        }
-        groupDefaults.synchronize()
-    }
+    let bundleId = Bundle.main.bundleIdentifier!
+    UserDefaults.standard.removePersistentDomain(forName: bundleId)
+    UserDefaults.standard.removePersistentDomain(forName: Constants.AppGroupID)
 
     Realm.reset()
 }
@@ -80,8 +77,6 @@ func setDefaults() {
     if prefs.object(forKey: "confirmBeforeOpeningUrl") == nil {
         prefs.setValue(true, forKey: "confirmBeforeOpeningUrl")
     }
-
-    prefs.synchronize()
 }
 
 extension UIImage {


### PR DESCRIPTION
Fixes #1312.

## Summary
After resetting user defaults, where we store the push ID, this sets a new value through so it'll be used during the next registration.