### PR TITLE
Reduce how often performing an action is retried

### DIFF
--- a/Sources/Extensions/Watch/InterfaceController.swift
+++ b/Sources/Extensions/Watch/InterfaceController.swift
@@ -142,6 +142,10 @@ class InterfaceController: WKInterfaceController {
                 })
             }
         }.recover { error -> Promise<Void> in
+            guard error == SendError.notImmediate else {
+                throw error
+            }
+            
             Current.Log.error("recovering error \(error) by trying locally")
             return Current.api.then(on: nil) { api -> Promise<Void> in
                 api.HandleAction(actionID: selectedAction.ID, source: .Watch)

--- a/Sources/Extensions/Watch/InterfaceController.swift
+++ b/Sources/Extensions/Watch/InterfaceController.swift
@@ -145,7 +145,7 @@ class InterfaceController: WKInterfaceController {
             guard error == SendError.notImmediate else {
                 throw error
             }
-            
+
             Current.Log.error("recovering error \(error) by trying locally")
             return Current.api.then(on: nil) { api -> Promise<Void> in
                 api.HandleAction(actionID: selectedAction.ID, source: .Watch)

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -209,8 +209,7 @@ public class HomeAssistantAPI {
         let intent = FireEventIntent(eventName: eventType, payload: eventData)
         INInteraction(intent: intent, response: nil).donate(completion: nil)
 
-        return Current.webhooks.send(
-            identifier: .unhandled,
+        return Current.webhooks.sendEphemeral(
             request: .init(type: "fire_event", data: [
                 "event_type": eventType,
                 "event_data": eventData,


### PR DESCRIPTION
Fixes #1552.

## Summary
Only fires on the watch if sending via phone is not an option, and only allows ephemerally sending an action.

## Any other notes
Ephemerally sending doesn't retry nearly as much, and doesn't enter into any background URL session for possible persistent retry.