### PR TITLE
Fix another sub-100m zone fuzzed accuracy enter issue

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
 		117D8A0A24A9381F00580913 /* UIColor+CSSRGB.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0924A9381F00580913 /* UIColor+CSSRGB.test.swift */; };
 		117EB15C2569AD4600049541 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117EB15B2569AD4600049541 /* NotificationManager.swift */; };
+		117EBC32261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117EBC31261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift */; };
 		11810D4A249EAF8D00E741A4 /* rainbow@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 11810D40249EAF8B00E741A4 /* rainbow@2x.png */; };
 		11810D4B249EAF8D00E741A4 /* trans@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 11810D41249EAF8C00E741A4 /* trans@3x.png */; };
 		11810D4C249EAF8D00E741A4 /* trans@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 11810D42249EAF8C00E741A4 /* trans@2x.png */; };
@@ -1071,6 +1072,7 @@
 		117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.swift"; sourceTree = "<group>"; };
 		117D8A0924A9381F00580913 /* UIColor+CSSRGB.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.test.swift"; sourceTree = "<group>"; };
 		117EB15B2569AD4600049541 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		117EBC31261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoneManagerAccuracyFuzzer.swift; sourceTree = "<group>"; };
 		11810D40249EAF8B00E741A4 /* rainbow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "rainbow@2x.png"; sourceTree = "<group>"; };
 		11810D41249EAF8C00E741A4 /* trans@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "trans@3x.png"; sourceTree = "<group>"; };
 		11810D42249EAF8C00E741A4 /* trans@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "trans@2x.png"; sourceTree = "<group>"; };
@@ -2087,6 +2089,7 @@
 				11A71C8824A5844300D9565F /* ZoneManagerCollector.swift */,
 				11A71C8A24A5848B00D9565F /* ZoneManagerProcessor.swift */,
 				11ADB13D24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift */,
+				117EBC31261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift */,
 			);
 			path = ZoneManager;
 			sourceTree = "<group>";
@@ -4700,6 +4703,7 @@
 				B605C891226E9DAC00EF46DD /* Permissions.swift in Sources */,
 				1169B7AD25AA76E30035F2AE /* MaterialDesignIcons+Eureka.swift in Sources */,
 				11F55ECD25D3A364003977AC /* NotificationRateLimitViewController.swift in Sources */,
+				117EBC32261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift in Sources */,
 				B65B15052273188300635D5C /* Assets.swift in Sources */,
 				113FB1132515A065000AC680 /* ScaleFactorMutator.swift in Sources */,
 				B661FB7C226C199200E541DD /* PermissionsViewController.swift in Sources */,

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/App-Debug.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/App-Debug.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>
          <BuildableReference

--- a/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
+++ b/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
@@ -24,7 +24,7 @@ extension Sequence where Element == ZoneManagerAccuracyFuzzer {
 struct ZoneManagerAccuracyFuzzerRegionEnter: ZoneManagerAccuracyFuzzer {
     func additionalAccuracy(for location: CLLocation, for event: ZoneManagerEvent) -> CLLocationDistance? {
         guard case let .region(region as CLCircularRegion, .inside) = event.eventType,
-           !region.containsWithAccuracy(location) else {
+              !region.containsWithAccuracy(location) else {
             return nil
         }
 
@@ -47,7 +47,7 @@ struct ZoneManagerAccuracyFuzzerMultiRegionOverlap: ZoneManagerAccuracyFuzzer {
         }
 
         guard !zoneRegion.containsWithAccuracy(location) else {
-           // but the zone doesn't
+            // but the zone doesn't
             return nil
         }
 

--- a/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
+++ b/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
@@ -1,0 +1,45 @@
+import CoreLocation
+import Foundation
+
+protocol ZoneManagerAccuracyFuzzer {
+    func additionalAccuracy(
+        for location: CLLocation,
+        for event: ZoneManagerEvent
+    ) -> CLLocationDistance?
+}
+
+/// if we're getting a region monitoring event saying that we're inside, but we're not from GPS perspective
+struct ZoneManagerAccuracyFuzzerRegionEnter: ZoneManagerAccuracyFuzzer {
+    func additionalAccuracy(for location: CLLocation, for event: ZoneManagerEvent) -> CLLocationDistance? {
+        guard case let .region(region as CLCircularRegion, .inside) = event.eventType,
+           !region.containsWithAccuracy(location) else {
+            return nil
+        }
+
+        return region.distanceWithAccuracy(from: location)
+    }
+}
+
+/// if we're inside the overlap of the zone's monitored regions, but not in the zone
+struct ZoneManagerAccuracyFuzzerMultiRegionOverlap: ZoneManagerAccuracyFuzzer {
+    func additionalAccuracy(for location: CLLocation, for event: ZoneManagerEvent) -> CLLocationDistance? {
+        guard let zone = event.associatedZone else {
+            return nil
+        }
+
+        let zoneRegion = zone.circularRegion
+
+        guard zone.circularRegionsForMonitoring.allSatisfy({ $0.containsWithAccuracy(location) }) else {
+            // all of the regions think we're in the zone
+            return nil
+        }
+
+        guard !zoneRegion.containsWithAccuracy(location) else {
+           // but the zone doesn't
+            return nil
+        }
+
+        // from https://github.com/home-assistant/iOS/issues/1520
+        return zoneRegion.distanceWithAccuracy(from: location)
+    }
+}

--- a/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
+++ b/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
@@ -8,6 +8,18 @@ protocol ZoneManagerAccuracyFuzzer {
     ) -> CLLocationDistance?
 }
 
+extension Sequence where Element == ZoneManagerAccuracyFuzzer {
+    func fuzz(location originalLocation: CLLocation, for event: ZoneManagerEvent) -> CLLocation {
+        reduce(originalLocation) { location, fuzzer in
+            if let additional = fuzzer.additionalAccuracy(for: location, for: event) {
+                return location.fuzzingAccuracy(by: additional)
+            } else {
+                return location
+            }
+        }
+    }
+}
+
 /// if we're getting a region monitoring event saying that we're inside, but we're not from GPS perspective
 struct ZoneManagerAccuracyFuzzerRegionEnter: ZoneManagerAccuracyFuzzer {
     func additionalAccuracy(for location: CLLocation, for event: ZoneManagerEvent) -> CLLocationDistance? {

--- a/Sources/App/ZoneManager/ZoneManagerProcessor.swift
+++ b/Sources/App/ZoneManager/ZoneManagerProcessor.swift
@@ -44,7 +44,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
                     }
                 }.map { location in
                     if let location = location {
-                        return Self.fuzz(using: accuracyFuzzers, location: location, for: event)
+                        return accuracyFuzzers.fuzz(location: location, for: event)
                     } else {
                         return nil
                     }
@@ -136,19 +136,5 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
         }
 
         return .value(())
-    }
-
-    private static func fuzz(
-        using fuzzers: [ZoneManagerAccuracyFuzzer],
-        location originalLocation: CLLocation,
-        for event: ZoneManagerEvent
-    ) -> CLLocation {
-        fuzzers.reduce(originalLocation) { location, fuzzer in
-            if let additional = fuzzer.additionalAccuracy(for: location, for: event) {
-                return location.fuzzingAccuracy(by: additional)
-            } else {
-                return location
-            }
-        }
     }
 }

--- a/Sources/App/ZoneManager/ZoneManagerProcessor.swift
+++ b/Sources/App/ZoneManager/ZoneManagerProcessor.swift
@@ -16,6 +16,11 @@ protocol ZoneManagerProcessor: AnyObject {
 class ZoneManagerProcessorImpl: ZoneManagerProcessor {
     weak var delegate: ZoneManagerProcessorDelegate?
 
+    var accuracyFuzzers: [ZoneManagerAccuracyFuzzer] = [
+        ZoneManagerAccuracyFuzzerRegionEnter(),
+        ZoneManagerAccuracyFuzzerMultiRegionOverlap(),
+    ]
+
     func perform(event: ZoneManagerEvent) -> Promise<Void> {
         firstly {
             evaluate(event: event)
@@ -26,7 +31,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
             case let .rejected(error):
                 self.delegate?.processor(self, didLog: .didIgnore(event, error))
             }
-        }.then {
+        }.then { [accuracyFuzzers] in
             Current.backgroundTask(withName: event.backgroundTaskDescription) { remaining in
                 let trigger = event.asTrigger()
                 return firstly { () -> Promise<CLLocation?> in
@@ -39,7 +44,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
                     }
                 }.map { location in
                     if let location = location {
-                        return Self.sanitize(location: location, for: event)
+                        return Self.fuzz(using: accuracyFuzzers, location: location, for: event)
                     } else {
                         return nil
                     }
@@ -133,53 +138,17 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
         return .value(())
     }
 
-    private static func sanitize(location: CLLocation, for event: ZoneManagerEvent) -> CLLocation {
-        var fuzzedAccuracy: CLLocationDistance = 0
-
-        // if we're getting a region monitoring event saying that we're inside, but we're not from GPS perspective
-        if case let .region(region as CLCircularRegion, .inside) = event.eventType,
-           !region.containsWithAccuracy(location) {
-            fuzzedAccuracy += region.distanceWithAccuracy(from: location)
-        }
-
-        // if we're inside the overlap of the zone's monitored regions, but not in the zone
-        if let zone = event.associatedZone,
-           // convenience so we reuse the region
-           case let zoneRegion = zone.circularRegion,
-           // all of which contain this location
-           zone.circularRegionsForMonitoring.allSatisfy({ $0.containsWithAccuracy(location) }),
-           // but the zone doesn't
-           !zoneRegion.containsWithAccuracy(location) {
-            // from https://github.com/home-assistant/iOS/issues/1520
-            fuzzedAccuracy += zoneRegion.distanceWithAccuracy(from: location)
-        }
-
-        guard fuzzedAccuracy > 0 else {
-            return location
-        }
-
-        if #available(iOS 13.4, *) {
-            return CLLocation(
-                coordinate: location.coordinate,
-                altitude: location.altitude,
-                horizontalAccuracy: location.horizontalAccuracy + fuzzedAccuracy + 1.0,
-                verticalAccuracy: location.verticalAccuracy,
-                course: location.course,
-                courseAccuracy: location.courseAccuracy,
-                speed: location.speed,
-                speedAccuracy: location.speedAccuracy,
-                timestamp: location.timestamp
-            )
-        } else {
-            return CLLocation(
-                coordinate: location.coordinate,
-                altitude: location.altitude,
-                horizontalAccuracy: location.horizontalAccuracy + fuzzedAccuracy + 1.0,
-                verticalAccuracy: location.verticalAccuracy,
-                course: location.course,
-                speed: location.speed,
-                timestamp: location.timestamp
-            )
+    private static func fuzz(
+        using fuzzers: [ZoneManagerAccuracyFuzzer],
+        location originalLocation: CLLocation,
+        for event: ZoneManagerEvent
+    ) -> CLLocation {
+        fuzzers.reduce(originalLocation) { location, fuzzer in
+            if let additional = fuzzer.additionalAccuracy(for: location, for: event) {
+                return location.fuzzingAccuracy(by: additional)
+            } else {
+                return location
+            }
         }
     }
 }

--- a/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
@@ -72,3 +72,31 @@ public extension CLCircularRegion {
         distanceWithAccuracy(from: location) <= 0
     }
 }
+
+public extension CLLocation {
+    func fuzzingAccuracy(by amount: CLLocationDistance) -> CLLocation {
+        if #available(iOS 13.4, watchOS 6.2, *) {
+            return CLLocation(
+                coordinate: coordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy + amount + 1,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                courseAccuracy: courseAccuracy,
+                speed: speed,
+                speedAccuracy: speedAccuracy,
+                timestamp: timestamp
+            )
+        } else {
+            return CLLocation(
+                coordinate: coordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy + amount + 1,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                speed: speed,
+                timestamp: timestamp
+            )
+        }
+    }
+}

--- a/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
@@ -607,13 +607,13 @@ class ZoneManagerProcessorTests: XCTestCase {
         })
 
         // grab the region that's the direction we're going in the one shot location below
-        let region = try XCTUnwrap(
+        let eventRegion = try XCTUnwrap(
             circularRegionZone?.circularRegionsForMonitoring
-                .first(where: { $0.identifier.contains("000") })
+                .first(where: { $0.identifier.contains("240") })
         )
 
         let event = ZoneManagerEvent(
-            eventType: .region(region, .inside),
+            eventType: .region(eventRegion, .inside),
             associatedZone: circularRegionZone
         )
         let promise = processor.perform(event: event)
@@ -623,26 +623,34 @@ class ZoneManagerProcessorTests: XCTestCase {
             expectation.fulfill()
         }.cauterize()
 
-        let distanceOut: CLLocationDistance = 20
+        let distanceOut: CLLocationDistance = 14
 
         let oneShotLocation = try { () -> CLLocation in
             // moving toward one of the circle's centers guarantees we're pointed toward the intersection of all zones
             let coordinate = circularRegion.center.moving(
                 distance: .init(value: circularRegion.radius + distanceOut, unit: .meters),
-                direction: .init(value: 0, unit: .degrees)
+                direction: .init(value: 30, unit: .degrees)
             )
             let location = CLLocation(
                 coordinate: coordinate,
                 altitude: 0,
-                horizontalAccuracy: distanceOut / 2 - 1,
+                horizontalAccuracy: distanceOut / 2.0 - 1,
                 // less than distance to zone, big enough to overlap all 3 other zones
                 verticalAccuracy: 0,
                 timestamp: Date()
             )
 
             XCTAssertTrue(try XCTUnwrap(circularRegionZone?.circularRegionsForMonitoring.allSatisfy({ region in
-                // this test case is assuming the location touches _all_ the zones
-                region.containsWithAccuracy(location)
+                if region == eventRegion {
+                    // we want to both fudge the accuracy for this region _and_ separately for the zone
+                    return !region.containsWithAccuracy(location) &&
+                        !circularRegion.containsWithAccuracy(
+                            location.fuzzingAccuracy(by: region.distanceWithAccuracy(from: location)
+                        ))
+                } else {
+                    // this test case is assuming the location touches _all_ the regions except for the one entering
+                    return region.containsWithAccuracy(location)
+                }
             })))
 
             // this test case is assuming this location does _not_ intersect the zone

--- a/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
@@ -645,8 +645,10 @@ class ZoneManagerProcessorTests: XCTestCase {
                     // we want to both fudge the accuracy for this region _and_ separately for the zone
                     return !region.containsWithAccuracy(location) &&
                         !circularRegion.containsWithAccuracy(
-                            location.fuzzingAccuracy(by: region.distanceWithAccuracy(from: location)
-                        ))
+                            location.fuzzingAccuracy(
+                                by: region.distanceWithAccuracy(from: location)
+                            )
+                        )
                 } else {
                     // this test case is assuming the location touches _all_ the regions except for the one entering
                     return region.containsWithAccuracy(location)


### PR DESCRIPTION
## Summary
When the accuracy is fuzzed based on a region enter, we need to use that fuzzed location for the next fuzzer.

## Any other notes
To make it less easy to make this bug happen again (where the intermediary fuzz value is ignored), this moves them to be reducing the same variable in a row.

Also fixed the test case for this flow to explicitly have this double-up requirement.
