### PR TITLE
Location updates for reduced accuracy

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		111D295724F30E2500C8A7D1 /* Updater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111D295424F30D2C00C8A7D1 /* Updater.swift */; };
 		11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11267D0825BBA9FE00F28E5C /* Updater.test.swift */; };
 		1127381C2622B6F300F5E312 /* DebugSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1127381B2622B6F300F5E312 /* DebugSettingsViewController.swift */; };
+		1127383C2625512600F5E312 /* ButtonRowWithLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1127383B2625512600F5E312 /* ButtonRowWithLoading.swift */; };
 		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
 		1130F532253A1E7400F371BE /* ComplicationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F531253A1E7400F371BE /* ComplicationListViewController.swift */; };
 		1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */; };
@@ -1018,6 +1019,7 @@
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
 		11267D0825BBA9FE00F28E5C /* Updater.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.test.swift; sourceTree = "<group>"; };
 		1127381B2622B6F300F5E312 /* DebugSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsViewController.swift; sourceTree = "<group>"; };
+		1127383B2625512600F5E312 /* ButtonRowWithLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonRowWithLoading.swift; sourceTree = "<group>"; };
 		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
 		1130F531253A1E7400F371BE /* ComplicationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationListViewController.swift; sourceTree = "<group>"; };
 		1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFamilySelectViewController.swift; sourceTree = "<group>"; };
@@ -2123,6 +2125,7 @@
 				11C05F2C254919210031D038 /* AccountInitialsImage.swift */,
 				1164DA3125FBF5D600515E8A /* UITextView+CodeRow.swift */,
 				1101D7F82621479200AAE617 /* SettingsButtonRow.swift */,
+				1127383B2625512600F5E312 /* ButtonRowWithLoading.swift */,
 			);
 			path = Eureka;
 			sourceTree = "<group>";
@@ -4647,6 +4650,7 @@
 				B626AAF11D8F972800A0D225 /* SettingsDetailViewController.swift in Sources */,
 				1127381C2622B6F300F5E312 /* DebugSettingsViewController.swift in Sources */,
 				11DE823024FAE66F00E636B8 /* UIWindow+Additions.swift in Sources */,
+				1127383C2625512600F5E312 /* ButtonRowWithLoading.swift in Sources */,
 				1130F57E253A2ED500F371BE /* ComplicationFamilySelectViewController.swift in Sources */,
 				1112AEBB25F717E9007A541A /* LocationHistoryDetailViewController.swift in Sources */,
 				11BD7B4D25B53D7F001826F0 /* AppMacBridgeStatusItemConfiguration.swift in Sources */,

--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -87,6 +87,18 @@ final class LocationHistoryDetailViewController: UIViewController, TypedRowContr
             accuracyNote = ""
         }
 
+        let accuracyAuthorization: String
+
+        if let authorization = entry.accuracyAuthorization {
+            switch authorization {
+            case .fullAccuracy: accuracyAuthorization = "full"
+            case .reducedAccuracy: accuracyAuthorization = "reduced"
+            @unknown default: accuracyAuthorization = "unknown"
+            }
+        } else {
+            accuracyAuthorization = "missing"
+        }
+
         func latLongString(_ value: Double) -> String {
             String(format: "%.06lf", value)
         }
@@ -105,6 +117,7 @@ final class LocationHistoryDetailViewController: UIViewController, TypedRowContr
             ## Location
             - Center: (\(latLongString(entry.Latitude)), \(latLongString(entry.Longitude)))
             - Accuracy: \(distanceString(entry.Accuracy))\(accuracyNote)
+            - Accuracy Authorization: \(accuracyAuthorization)
 
             ## Regions
             """ + "\n"

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -389,6 +389,7 @@ Your actions and local configuration will still be available after logging in.";
 "settings_details.location.background_refresh.disabled" = "Disabled";
 "settings_details.location.background_refresh.enabled" = "Enabled";
 "settings_details.location.background_refresh.title" = "Background Refresh";
+"settings_details.location.update_location" = "Update Location";
 "settings_details.location.location_accuracy.full" = "Full";
 "settings_details.location.location_accuracy.reduced" = "Reduced";
 "settings_details.location.location_accuracy.title" = "Location Accuracy";

--- a/Sources/App/Settings/Eureka/ButtonRowWithLoading.swift
+++ b/Sources/App/Settings/Eureka/ButtonRowWithLoading.swift
@@ -1,0 +1,29 @@
+import Eureka
+
+public final class ButtonRowWithLoading: _ButtonRowOf<Bool>, RowType {
+    public required init(tag: String?) {
+        super.init(tag: tag)
+    }
+
+    let activityIndicator: UIActivityIndicatorView = {
+        if #available(iOS 13, *) {
+            return UIActivityIndicatorView(style: .medium)
+        } else {
+            return UIActivityIndicatorView(style: .gray)
+        }
+    }()
+
+    override public func updateCell() {
+        super.updateCell()
+
+        if value == true {
+            cell.accessoryView = activityIndicator
+            activityIndicator.startAnimating()
+        } else {
+            cell.accessoryView = nil
+            cell.accessoryType = .none
+        }
+
+        cell.textLabel?.textAlignment = .natural
+    }
+}

--- a/Sources/App/Settings/Sensors/SensorListViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorListViewController.swift
@@ -79,14 +79,8 @@ class SensorListViewController: FormViewController, SensorObserver {
     @objc private func refresh() {
         refreshControl.beginRefreshing()
 
-        Current.backgroundTask(withName: "manual-location-update-settings") { _ in
-            Current.api.then(on: nil) { api -> Promise<Void> in
-                if Current.settingsStore.isLocationEnabled(for: UIApplication.shared.applicationState) {
-                    return api.GetAndSendLocation(trigger: .Manual).asVoid()
-                } else {
-                    return api.UpdateSensors(trigger: .Manual).asVoid()
-                }
-            }
+        Current.api.then { api in
+            api.manuallyUpdate(applicationState: UIApplication.shared.applicationState)
         }.ensure { [refreshControl] in
             refreshControl.endRefreshing()
         }.cauterize()

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -356,8 +356,9 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     }
             }
             if zoneEntities.count > 0 {
-                form
-                    +++ Section(header: "", footer: L10n.SettingsDetails.Location.Zones.footer)
+                form +++ InfoLabelRow {
+                    $0.title = L10n.SettingsDetails.Location.Zones.footer
+                }
             }
 
         case "actions":

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -256,6 +256,25 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     }), onDismiss: nil)
                 }
 
+                <<< ButtonRowWithLoading {
+                    $0.title = L10n.SettingsDetails.Location.updateLocation
+                    $0.onCellSelection { [weak self] cell, row in
+                        row.value = true
+                        row.updateCell()
+
+                        Current.api.then { api in
+                            api.manuallyUpdate(applicationState: UIApplication.shared.applicationState)
+                        }.ensure {
+                            row.value = false
+                            row.updateCell()
+                        }.catch { error in
+                            let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
+                            alert.addAction(UIAlertAction(title: L10n.okLabel, style: .cancel, handler: nil))
+                            self?.present(alert, animated: true, completion: nil)
+                        }
+                    }
+                }
+
                 +++ Section(
                     header: L10n.SettingsDetails.Location.Updates.header,
                     footer: L10n.SettingsDetails.Location.Updates.footer

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -258,7 +258,7 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
 
                 <<< ButtonRowWithLoading {
                     $0.title = L10n.SettingsDetails.Location.updateLocation
-                    $0.onCellSelection { [weak self] cell, row in
+                    $0.onCellSelection { [weak self] _, row in
                         row.value = true
                         row.updateCell()
 
@@ -268,7 +268,11 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                             row.value = false
                             row.updateCell()
                         }.catch { error in
-                            let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
+                            let alert = UIAlertController(
+                                title: nil,
+                                message: error.localizedDescription,
+                                preferredStyle: .alert
+                            )
                             alert.addAction(UIAlertAction(title: L10n.okLabel, style: .cancel, handler: nil))
                             self?.present(alert, animated: true, completion: nil)
                         }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -272,7 +272,6 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                     $0.value = Current.settingsStore.locationSources.backgroundFetch
                     $0.disabled = .location(conditions: [
                         .permissionNotAlways,
-                        .accuracyNotFull,
                         .backgroundRefreshNotAvailable,
                     ])
                     $0.hidden = .isCatalyst
@@ -282,14 +281,14 @@ class SettingsDetailViewController: FormViewController, TypedRowControllerType {
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Significant.title
                     $0.value = Current.settingsStore.locationSources.significantLocationChange
-                    $0.disabled = .location(conditions: [.permissionNotAlways, .accuracyNotFull])
+                    $0.disabled = .location(conditions: [.permissionNotAlways])
                 }.onChange({ row in
                     Current.settingsStore.locationSources.significantLocationChange = row.value ?? true
                 })
                 <<< SwitchRow {
                     $0.title = L10n.SettingsDetails.Location.Updates.Notification.title
                     $0.value = Current.settingsStore.locationSources.pushNotifications
-                    $0.disabled = .location(conditions: [.permissionNotAlways, .accuracyNotFull])
+                    $0.disabled = .location(conditions: [.permissionNotAlways])
                 }.onChange({ row in
                     Current.settingsStore.locationSources.pushNotifications = row.value ?? true
                 })

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -340,7 +340,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             }
 
             if !error.isCancelled {
-                openSettingsWithError(error: error)
+                showSwiftMessage(error: error)
             }
         }
     }
@@ -353,7 +353,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
             }
 
             if !error.isCancelled {
-                openSettingsWithError(error: error)
+                showSwiftMessage(error: error)
             }
         }
     }
@@ -552,9 +552,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         updateSensors()
     }
 
-    func show(alert: ServerAlert) {
-        Current.Log.info("showing alert \(alert)")
-
+    private func swiftMessagesConfig() -> SwiftMessages.Config {
         var config = SwiftMessages.Config()
 
         config.presentationContext = .viewController(self)
@@ -562,6 +560,14 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         config.presentationStyle = .bottom
         config.dimMode = .gray(interactive: true)
         config.dimModeAccessibilityLabel = L10n.cancelLabel
+
+        return config
+    }
+
+    func show(alert: ServerAlert) {
+        Current.Log.info("showing alert \(alert)")
+
+        var config = swiftMessagesConfig()
         config.eventListeners.append({ event in
             if event == .didHide {
                 Current.serverAlerter.markHandled(alert: alert)
@@ -589,36 +595,31 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         SwiftMessages.show(config: config, view: view)
     }
 
-    func showSwiftMessageError(_ body: String, duration: SwiftMessages.Duration = .automatic) {
-        var config = SwiftMessages.Config()
+    func showSwiftMessage(error: Error, duration: SwiftMessages.Duration = .seconds(seconds: 15)) {
+        Current.Log.error(error)
 
-        config.presentationContext = .window(windowLevel: .statusBar)
+        let nsError = error as NSError
+
+        var config = swiftMessagesConfig()
         config.duration = duration
 
-        let view = MessageView.viewFromNib(layout: .statusLine)
+        let view = MessageView.viewFromNib(layout: .messageView)
         view.configureTheme(.error)
-        view.configureContent(body: body)
+        view.configureContent(
+            title: error.localizedDescription,
+            body: "\(nsError.domain) \(nsError.code)",
+            iconImage: nil,
+            iconText: nil,
+            buttonImage: nil,
+            buttonTitle: L10n.okLabel,
+            buttonTapHandler: { _ in
+                SwiftMessages.hide()
+            }
+        )
+        view.titleLabel?.numberOfLines = 0
+        view.bodyLabel?.numberOfLines = 0
 
         SwiftMessages.show(config: config, view: view)
-    }
-
-    func openSettingsWithError(error: Error) {
-        showSwiftMessageError(error.localizedDescription, duration: SwiftMessages.Duration.seconds(seconds: 10))
-        showSwiftMessageError(error.localizedDescription)
-
-//        let alert = UIAlertController(title: L10n.errorLabel, message: error.localizedDescription,
-//                                      preferredStyle: .alert)
-//        alert.addAction(UIAlertAction(title: L10n.okLabel, style: UIAlertAction.Style.default, handler: nil))
-//        self.navigationController?.present(alert, animated: true, completion: nil)
-//        alert.popoverPresentationController?.sourceView = self.webView
-
-        /* let settingsView = SettingsViewController()
-         settingsView.showErrorConnectingMessage = true
-         settingsView.showErrorConnectingMessageError = error
-         settingsView.doneButton = true
-         settingsView.delegate = self
-         let navController = UINavigationController(rootViewController: settingsView)
-         self.navigationController?.present(navController, animated: true, completion: nil) */
     }
 
     @objc func openSettingsView(_ sender: UIButton) {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -491,10 +491,19 @@ public class HomeAssistantAPI {
                     jsonPayload = p
                 }
 
+                let accuracyAuthorization: CLAccuracyAuthorization
+
+                if #available(iOS 14, watchOS 7, *) {
+                    accuracyAuthorization = CLLocationManager().accuracyAuthorization
+                } else {
+                    accuracyAuthorization = .fullAccuracy
+                }
+
                 realm.add(LocationHistoryEntry(
                     updateType: updateType,
                     location: location,
                     zone: zone,
+                    accuracyAuthorization: accuracyAuthorization,
                     payload: jsonPayload
                 ))
             }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -746,6 +746,57 @@ public class HomeAssistantAPI {
             }
         }
     }
+
+    #if os(iOS)
+    public func manuallyUpdate(applicationState: UIApplication.State) -> Promise<Void> {
+        Current.backgroundTask(withName: "manual-location-update") { remaining in
+            firstly { () -> Guarantee<Void> in
+                Guarantee { seal in
+                    guard #available(iOS 14, *) else {
+                        return seal(())
+                    }
+
+                    let locationManager = CLLocationManager()
+
+                    guard locationManager.accuracyAuthorization != .fullAccuracy else {
+                        // already have full accuracy, don't need to request
+                        seal(())
+                        return
+                    }
+
+                    Current.Log.info("requesting full accuracy for manual update")
+                    locationManager.requestTemporaryFullAccuracyAuthorization(
+                        withPurposeKey: "TemporaryFullAccuracyReasonManualUpdate"
+                    ) { error in
+                        Current.Log.info("got temporary full accuracy result: \(String(describing: error))")
+
+                        withExtendedLifetime(locationManager) {
+                            seal(())
+                        }
+                    }
+                }
+            }.then { [self] () -> Promise<Void> in
+                func updateWithoutLocation() -> Promise<Void> {
+                    UpdateSensors(trigger: .Manual)
+                }
+
+                if Current.settingsStore.isLocationEnabled(for: applicationState) {
+                    return GetAndSendLocation(trigger: .Manual, maximumBackgroundTime: remaining)
+                        .recover { error -> Promise<Void> in
+                            if error is CLError {
+                                Current.Log.info("couldn't get location, sending remaining sensor data")
+                                return updateWithoutLocation()
+                            } else {
+                                throw error
+                            }
+                        }
+                } else {
+                    return updateWithoutLocation()
+                }
+            }
+        }
+    }
+    #endif
 }
 
 extension HomeAssistantAPI.APIError: LocalizedError {

--- a/Sources/Shared/API/Models/LocationHistory.swift
+++ b/Sources/Shared/API/Models/LocationHistory.swift
@@ -10,8 +10,23 @@ public class LocationHistoryEntry: Object {
     @objc public dynamic var Accuracy = 0.0
     @objc public dynamic var Payload: String = ""
     @objc public dynamic var CreatedAt = Date()
+    private let rawAccuracyAuthorization = RealmOptional<CLAccuracyAuthorization.RawValue>()
+    public var accuracyAuthorization: CLAccuracyAuthorization? {
+        get {
+            rawAccuracyAuthorization.value.flatMap(CLAccuracyAuthorization.init(rawValue:))
+        }
+        set {
+            rawAccuracyAuthorization.value = newValue?.rawValue
+        }
+    }
 
-    public convenience init(updateType: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?, payload: String) {
+    public convenience init(
+        updateType: LocationUpdateTrigger,
+        location: CLLocation?,
+        zone: RLMZone?,
+        accuracyAuthorization: CLAccuracyAuthorization,
+        payload: String
+    ) {
         self.init()
 
         var loc = CLLocation()
@@ -27,6 +42,7 @@ public class LocationHistoryEntry: Object {
         self.Trigger = updateType.rawValue
         self.Zone = zone
         self.Payload = payload
+        self.accuracyAuthorization = accuracyAuthorization
     }
 
     public var clLocation: CLLocation {

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -73,9 +73,10 @@ public extension Realm {
         // 13 - 2020-10-17 v2020.7 (allow multiple complications)
         // 14 - 2020-10-29 v2020.8 (complication privacy)
         // 15 - 2021-03-21 v2021.4 (scene properties)
+        // 16 - 2021-04-12 v2021.5 (accuracy authorization on location history entries)
         let config = Realm.Configuration(
             fileURL: storeURL,
-            schemaVersion: 15,
+            schemaVersion: 16,
             migrationBlock: { migration, oldVersion in
                 Current.Log.info("migrating from \(oldVersion)")
                 if oldVersion < 9 {
@@ -162,6 +163,10 @@ public extension Realm {
                             newObject?["name"] = attributes["friendly_name"] as? String
                         }
                     }
+                }
+
+                if oldVersion < 16 {
+                    // nothing, it added an optional
                 }
             },
             deleteRealmIfMigrationNeeded: false

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -55,6 +55,7 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
         @unknown default: return 100.0
         }
     }
+
     static func invalidAccuracyThreshold(for accuracy: CLAccuracyAuthorization) -> CLLocationAccuracy {
         switch accuracy {
         case .fullAccuracy: return 1500.0
@@ -62,6 +63,7 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
         @unknown default: return .greatestFiniteMagnitude
         }
     }
+
     static var desiredAge: TimeInterval { 30.0 }
     static var invalidAgeThreshold: TimeInterval { 600.0 }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1746,6 +1746,8 @@ public enum L10n {
     public enum Location {
       /// Location
       public static var title: String { return L10n.tr("Localizable", "settings_details.location.title") }
+      /// Update Location
+      public static var updateLocation: String { return L10n.tr("Localizable", "settings_details.location.update_location") }
       public enum BackgroundRefresh {
         /// Disabled
         public static var disabled: String { return L10n.tr("Localizable", "settings_details.location.background_refresh.disabled") }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -148,19 +148,12 @@ public class SettingsStore {
     #if os(iOS)
     public func isLocationEnabled(for state: UIApplication.State) -> Bool {
         let authorizationStatus: CLAuthorizationStatus
-        let hasFullAccuracy: Bool
 
         if #available(iOS 14, *) {
             let locationManager = CLLocationManager()
             authorizationStatus = locationManager.authorizationStatus
-            hasFullAccuracy = locationManager.accuracyAuthorization == .fullAccuracy
         } else {
             authorizationStatus = CLLocationManager.authorizationStatus()
-            hasFullAccuracy = true
-        }
-
-        if !hasFullAccuracy {
-            return false
         }
 
         switch authorizationStatus {

--- a/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
+++ b/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
@@ -386,6 +386,39 @@ class OneShotLocationTests: XCTestCase {
         }
     }
 
+    @available(iOS 14, *)
+    func testInvalidAccuracyOnlyUntilTimeoutWhenReducedAccuracy() {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let location1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 12, longitude: -12),
+            altitude: 0,
+            horizontalAccuracy: 1501,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-30)
+        )
+        let location2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -123),
+            altitude: 0,
+            horizontalAccuracy: 2500,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-5)
+        )
+
+        locationManager.overrideAccuracyAuthorization = .reducedAccuracy
+
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise
+        ).promise
+
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1])
+        locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location2])
+        timeoutSeal(())
+
+        XCTAssertEqual(try hang(promise), location1)
+    }
+
+
     func testInvalidLatOrLongOnlyUntilTimeout() {
         let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
         let location1 = CLLocation(
@@ -555,8 +588,8 @@ class OneShotLocationTests: XCTestCase {
             self.location2 = location2
             // cheating a little so it's not constants hard-coded in two places
             self.hasPerfect =
-                PotentialLocation(location: location1).quality == .perfect ||
-                PotentialLocation(location: location2).quality == .perfect
+                PotentialLocation(location: location1, accuracyAuthorization: .fullAccuracy).quality == .perfect ||
+                PotentialLocation(location: location2, accuracyAuthorization: .fullAccuracy).quality == .perfect
             self.reason = reason
             self.file = file
             self.line = line
@@ -667,6 +700,16 @@ private class FakeLocationManager: CLLocationManager {
         set {
             overrideDelegate = newValue
         }
+    }
+
+    var overrideAccuracyAuthorization: CLAccuracyAuthorization = .fullAccuracy
+    override var accuracyAuthorization: CLAccuracyAuthorization {
+        overrideAccuracyAuthorization
+    }
+
+    var overrideAuthorizationStatus: CLAuthorizationStatus = .authorizedAlways
+    override var authorizationStatus: CLAuthorizationStatus {
+        overrideAuthorizationStatus
     }
 
     var isUpdatingLocation = false

--- a/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
+++ b/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
@@ -418,7 +418,6 @@ class OneShotLocationTests: XCTestCase {
         XCTAssertEqual(try hang(promise), location1)
     }
 
-
     func testInvalidLatOrLongOnlyUntilTimeout() {
         let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
         let location1 = CLLocation(


### PR DESCRIPTION
## Summary
Updates to reduced location accuracy, manual updates, and error message display.

## Screenshots
<img width="300" src="https://user-images.githubusercontent.com/74188/114497723-9a10d380-9bd7-11eb-8980-5fff8364424e.png">

![Image](https://user-images.githubusercontent.com/74188/114497774-b57bde80-9bd7-11eb-8a76-24814ea2dc70.png)
![Image-2](https://user-images.githubusercontent.com/74188/114497839-d04e5300-9bd7-11eb-9e4a-9b5e5edf0532.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- Shows error messages on the bottom of the screen, with as much room as they need. Fixes #311.
- Allows the reduced accuracy setting to send those poor accuracy results to the server. This should cut down on people who accidentally disabled full but don't realize it; seeing a location update with 3km precision should hopefully let 'em know.
- Adds a "Update Location" button to the Location settings.
- Updates the display of the "track_ios" hint (this one's for you Tom 😛).