### PR TITLE
Fix crash in share extension

### DIFF
--- a/Sources/Extensions/Share/ShareViewController.swift
+++ b/Sources/Extensions/Share/ShareViewController.swift
@@ -6,11 +6,6 @@ import UIKit
 
 @objc(HAShareViewController)
 class ShareViewController: SLComposeServiceViewController {
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     enum EventError: LocalizedError {
         case invalidExtensionContext
     }


### PR DESCRIPTION
I can't figure out when this started crashing, maybe a recent Xcode release, but it crashes due to the `init(nibName:bundle:)` initializer not being generated when the `init(coder:)` initializer is marked as unavailable. Strange. It crashes not just on the latest iOS 14 but also in iOS 13, so it's almost certainly a generated code and not runtime issue.