### PR TITLE
Add app support for clear_notification command

### DIFF
--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -83,10 +83,14 @@ class NotificationManager: NSObject {
             case "clear_badge":
                 Current.Log.verbose("Setting badge to 0 as requested")
                 UIApplication.shared.applicationIconBadgeNumber = 0
+                completionHandler(.newData)
             case "clear_notification":
                 Current.Log.verbose("clearing notification for \(userInfo)")
                 let keys = ["tag", "collapseId"].compactMap { hadict[$0] as? String }
-                UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
+                if !keys.isEmpty {
+                    UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
+                }
+                completionHandler(.newData)
             default:
                 Current.Log.warning("Received unknown command via APNS! \(userInfo)")
                 completionHandler(.noData)

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -58,7 +58,7 @@ class NotificationManager: NSObject {
         Messaging.messaging().appDidReceiveMessage(userInfo)
 
         if let userInfoDict = userInfo as? [String: Any],
-           let hadict = userInfoDict["homeassistant"] as? [String: String], let command = hadict["command"] {
+           let hadict = userInfoDict["homeassistant"] as? [String: Any], let command = hadict["command"] as? String {
             switch command {
             case "request_location_update":
                 guard Current.settingsStore.locationSources.pushNotifications else {
@@ -83,6 +83,10 @@ class NotificationManager: NSObject {
             case "clear_badge":
                 Current.Log.verbose("Setting badge to 0 as requested")
                 UIApplication.shared.applicationIconBadgeNumber = 0
+            case "clear_notification":
+                Current.Log.verbose("clearing notification for \(userInfo)")
+                let keys = ["tag", "collapseId"].compactMap { hadict[$0] as? String }
+                UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
             default:
                 Current.Log.warning("Received unknown command via APNS! \(userInfo)")
                 completionHandler(.noData)


### PR DESCRIPTION
Fixes #258. Depends on home-assistant/mobile-apps-fcm-push#48 which adds support for the command.

## Summary
Adds `clear_notification` to remove notifications. This behaves like Android which can only clear based on the `tag`/`collapse-id`.

## Link to pull request in Documentation repository
- Documentation: home-assistant/companion.home-assistant#497

## Any other notes
This may be unreliable as it depends on the app launching in the background to do the actual clear.