### PR TITLE
Static image attachments in dynamic category

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		11169B7C262BDE80005EF90A /* DynamicNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B7B262BDE80005EF90A /* DynamicNotificationController.swift */; };
 		11169BC6262BE45F005EF90A /* UNNotificationContent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */; };
 		11169BC8262BE460005EF90A /* UNNotificationContent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */; };
+		11169CBB262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */; };
 		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformAction.swift */; };
@@ -1018,6 +1019,7 @@
 		11169B3E262BCEE6005EF90A /* dynamic_notification.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = dynamic_notification.apns; sourceTree = "<group>"; };
 		11169B7B262BDE80005EF90A /* DynamicNotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicNotificationController.swift; sourceTree = "<group>"; };
 		11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNNotificationContent+Additions.swift"; sourceTree = "<group>"; };
+		11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Additions.swift"; sourceTree = "<group>"; };
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
@@ -3104,6 +3106,7 @@
 				1104FC9025322C1800B8BE34 /* Dictionary+Additions.swift */,
 				1104FD04253292CD00B8BE34 /* Guarantee+Additions.swift */,
 				1164D9DD25FB1B9800515E8A /* UIBarButtonItem+Additions.swift */,
+				11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4621,6 +4624,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B63CCDCB216442C200123C50 /* MapViewController.swift in Sources */,
+				11169CBB262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift in Sources */,
 				110FB4532499DC28000865B4 /* NotificationErrorViewController.swift in Sources */,
 				B63CCDC9216442BB00123C50 /* CameraViewController.swift in Sources */,
 				110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		11169B7C262BDE80005EF90A /* DynamicNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B7B262BDE80005EF90A /* DynamicNotificationController.swift */; };
 		11169BC6262BE45F005EF90A /* UNNotificationContent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */; };
 		11169BC8262BE460005EF90A /* UNNotificationContent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */; };
+		11169CAA262FCE43005EF90A /* ImageAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */; };
 		11169CBB262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */; };
 		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
@@ -1019,6 +1020,7 @@
 		11169B3E262BCEE6005EF90A /* dynamic_notification.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = dynamic_notification.apns; sourceTree = "<group>"; };
 		11169B7B262BDE80005EF90A /* DynamicNotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicNotificationController.swift; sourceTree = "<group>"; };
 		11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNNotificationContent+Additions.swift"; sourceTree = "<group>"; };
+		11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentViewController.swift; sourceTree = "<group>"; };
 		11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Additions.swift"; sourceTree = "<group>"; };
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
@@ -2648,6 +2650,7 @@
 				110FB44D2499C1CF000865B4 /* CameraStreamHLSViewController.swift */,
 				110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */,
 				110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */,
+				11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */,
 			);
 			path = NotificationContent;
 			sourceTree = "<group>";
@@ -4625,6 +4628,7 @@
 			files = (
 				B63CCDCB216442C200123C50 /* MapViewController.swift in Sources */,
 				11169CBB262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift in Sources */,
+				11169CAA262FCE43005EF90A /* ImageAttachmentViewController.swift in Sources */,
 				110FB4532499DC28000865B4 /* NotificationErrorViewController.swift in Sources */,
 				B63CCDC9216442BB00123C50 /* CameraViewController.swift in Sources */,
 				110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */,

--- a/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
@@ -89,7 +89,7 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
     private var lastSize: CGSize? {
         didSet {
             if oldValue != lastSize, let size = lastSize {
-                aspectRatioConstraint = Self.aspectRatioConstraint(on: playerViewController.view, size: size)
+                aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: playerViewController.view, size: size)
             }
         }
     }

--- a/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
@@ -89,7 +89,10 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
     private var lastSize: CGSize? {
         didSet {
             if oldValue != lastSize, let size = lastSize {
-                aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: playerViewController.view, size: size)
+                aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(
+                    on: playerViewController.view,
+                    size: size
+                )
             }
         }
     }

--- a/Sources/Extensions/NotificationContent/CameraStreamHandler.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamHandler.swift
@@ -14,14 +14,3 @@ protocol CameraStreamHandler: AnyObject {
     func pause()
     func play()
 }
-
-extension CameraStreamHandler {
-    static func aspectRatioConstraint(on view: UIView, size: CGSize) -> NSLayoutConstraint? {
-        guard size.height > 0 else {
-            return nil
-        }
-
-        let ratio = size.width / size.height
-        return view.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: ratio)
-    }
-}

--- a/Sources/Extensions/NotificationContent/CameraStreamMJPEGViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamMJPEGViewController.swift
@@ -97,7 +97,7 @@ class CameraStreamMJPEGViewController: UIViewController, CameraStreamHandler {
     private var lastSize: CGSize? {
         didSet {
             if oldValue != lastSize, let size = lastSize {
-                aspectRatioConstraint = Self.aspectRatioConstraint(on: imageView, size: size)
+                aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: imageView, size: size)
             }
         }
     }

--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -1,9 +1,9 @@
+import MobileCoreServices
 import PromiseKit
 import Shared
 import UIKit
 import UserNotifications
 import UserNotificationsUI
-import MobileCoreServices
 
 class ImageAttachmentViewController: UIViewController, NotificationCategory {
     let imageView = with(UIImageView()) {

--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -1,0 +1,99 @@
+import PromiseKit
+import Shared
+import UIKit
+import UserNotifications
+import UserNotificationsUI
+import MobileCoreServices
+
+class ImageAttachmentViewController: UIViewController, NotificationCategory {
+    let imageView = with(UIImageView()) {
+        $0.contentMode = .scaleAspectFit
+    }
+
+    enum ImageAttachmentError: Error {
+        case noAttachment
+        case notImage
+        case securityFailure
+        case imageDecodeFailure
+    }
+
+    private var aspectRatioConstraint: NSLayoutConstraint? {
+        willSet {
+            aspectRatioConstraint?.isActive = false
+        }
+        didSet {
+            aspectRatioConstraint?.isActive = true
+        }
+    }
+
+    private var lastAttachmentURL: URL? {
+        didSet {
+            oldValue?.stopAccessingSecurityScopedResource()
+        }
+    }
+
+    deinit {
+        lastAttachmentURL?.stopAccessingSecurityScopedResource()
+    }
+
+    func didReceive(
+        notification: UNNotification,
+        extensionContext: NSExtensionContext?
+    ) throws -> Promise<Void> {
+        guard let attachment = notification.request.content.attachments.first else {
+            throw ImageAttachmentError.noAttachment
+        }
+
+        guard attachment.url.startAccessingSecurityScopedResource() else {
+            throw ImageAttachmentError.securityFailure
+        }
+
+        // rather than hard-coding an acceptable list of UTTypes it's probably easier to just try decoding
+        // https://developer.apple.com/documentation/usernotifications/unnotificationattachment
+        // has the full list of what is advertised - at time of writing (iOS 14.5) it's jpeg, gif and png
+        // but iOS 14 also supports webp, so who knows if it'll be added silently or not
+
+        guard let image = UIImage(contentsOfFile: attachment.url.path) else {
+            attachment.url.stopAccessingSecurityScopedResource()
+            throw ImageAttachmentError.imageDecodeFailure
+        }
+
+        imageView.image = image
+        lastAttachmentURL = attachment.url
+        aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: imageView, size: image.size)
+
+        return .value(())
+    }
+
+    override func loadView() {
+        class UnanimatingView: UIView {
+            override func layoutSubviews() {
+                // avoids the image view sizing up from nothing when initially displaying
+                // since we don't control our own view's expansion, we need to disable animation at our level
+                UIView.performWithoutAnimation {
+                    super.layoutSubviews()
+                }
+            }
+        }
+
+        view = UnanimatingView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(imageView)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: view.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    var mediaPlayPauseButtonType: UNNotificationContentExtensionMediaPlayPauseButtonType { .none }
+    var mediaPlayPauseButtonFrame: CGRect?
+    func mediaPlay() {}
+    func mediaPause() {}
+}

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -39,6 +39,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
     private static var possibleControllers: [(UIViewController & NotificationCategory).Type] { [
         CameraViewController.self,
         MapViewController.self,
+        ImageAttachmentViewController.self,
     ] }
 
     private func viewController(

--- a/Sources/Shared/Common/Extensions/NSLayoutConstraint+Additions.swift
+++ b/Sources/Shared/Common/Extensions/NSLayoutConstraint+Additions.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+public extension NSLayoutConstraint {
+    static func aspectRatioConstraint(on view: UIView, size: CGSize) -> NSLayoutConstraint? {
+        guard size.height > 0 else {
+            return nil
+        }
+
+        let ratio = size.width / size.height
+        return view.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: ratio)
+    }
+}


### PR DESCRIPTION
Refs #1591.

## Summary
Adds support for using image notification attachments in the content extension.

## Screenshots
<img width="350" src="https://user-images.githubusercontent.com/74188/115494743-18462900-a21b-11eb-83d5-3e6c112d99df.png">

## Any other notes
Dynamic actions require the 'DYNAMIC' category but our content extension causes attachments to not appear and we want every possible feature to work with just this category.