### PR TITLE
Static video/audio attachments in dynamic category

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		11169BC8262BE460005EF90A /* UNNotificationContent+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */; };
 		11169CAA262FCE43005EF90A /* ImageAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */; };
 		11169CBB262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */; };
+		11169CEC262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */; };
 		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformAction.swift */; };
@@ -1022,6 +1023,7 @@
 		11169B9A262BE3E1005EF90A /* UNNotificationContent+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNNotificationContent+Additions.swift"; sourceTree = "<group>"; };
 		11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentViewController.swift; sourceTree = "<group>"; };
 		11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Additions.swift"; sourceTree = "<group>"; };
+		11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioAttachmentViewController.swift; sourceTree = "<group>"; };
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
 		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
 		111D295424F30D2C00C8A7D1 /* Updater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.swift; sourceTree = "<group>"; };
@@ -2651,6 +2653,7 @@
 				110FB44F2499CE34000865B4 /* CameraStreamMJPEGViewController.swift */,
 				110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */,
 				11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */,
+				11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */,
 			);
 			path = NotificationContent;
 			sourceTree = "<group>";
@@ -4633,6 +4636,7 @@
 				B63CCDC9216442BB00123C50 /* CameraViewController.swift in Sources */,
 				110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */,
 				B627CB0E1D83C87B0057173E /* NotificationViewController.swift in Sources */,
+				11169CEC262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift in Sources */,
 				110FB44C2499C1A3000865B4 /* CameraStreamHandler.swift in Sources */,
 				110FB4502499CE34000865B4 /* CameraStreamMJPEGViewController.swift in Sources */,
 			);

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Extensions-NotificationContent.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Extensions-NotificationContent.xcscheme
@@ -47,8 +47,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
@@ -101,11 +101,11 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
         guard let path = response.hlsPath else {
             fatalError("we checked for a non-nil path on init, this should not be possible")
         }
+        try? AVAudioSession.sharedInstance().setCategory(.playback)
 
         let url = connectionInfo.activeURL.appendingPathComponent(path)
         let videoPlayer = AVPlayer(url: url)
         playerViewController.player = videoPlayer
-        videoPlayer.isMuted = true
 
         // assume 16:9
         lastSize = CGSize(width: 16, height: 9)

--- a/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamHLSViewController.swift
@@ -5,9 +5,7 @@ import Shared
 import UIKit
 
 class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
-    let api: HomeAssistantAPI
-    let connectionInfo: ConnectionInfo
-    let response: StreamCameraResponse
+    let url: URL
     let playerViewController: AVPlayerViewController
     let promise: Promise<Void>
     var didUpdateState: (CameraStreamHandlerState) -> Void = { _ in }
@@ -28,14 +26,19 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
         }
     }
 
-    required init(api: HomeAssistantAPI, response: StreamCameraResponse) throws {
-        guard response.hlsPath != nil else {
+    required convenience init(api: HomeAssistantAPI, response: StreamCameraResponse) throws {
+        guard let path = response.hlsPath else {
             throw HLSError.noPath
         }
 
-        self.api = api
-        self.connectionInfo = try api.connectionInfo()
-        self.response = response
+        let connectionInfo = try api.connectionInfo()
+        let url = connectionInfo.activeURL.appendingPathComponent(path)
+
+        self.init(url: url)
+    }
+
+    init(url: URL) {
+        self.url = url
         self.playerViewController = AVPlayerViewController()
         (self.promise, self.seal) = Promise<Void>.pending()
         super.init(nibName: nil, bundle: nil)
@@ -98,12 +101,8 @@ class CameraStreamHLSViewController: UIViewController, CameraStreamHandler {
     }
 
     private func setupVideo() {
-        guard let path = response.hlsPath else {
-            fatalError("we checked for a non-nil path on init, this should not be possible")
-        }
         try? AVAudioSession.sharedInstance().setCategory(.playback)
 
-        let url = connectionInfo.activeURL.appendingPathComponent(path)
         let videoPlayer = AVPlayer(url: url)
         playerViewController.player = videoPlayer
 

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -40,6 +40,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
         CameraViewController.self,
         MapViewController.self,
         ImageAttachmentViewController.self,
+        PlayerAttachmentViewController.self,
     ] }
 
     private func viewController(

--- a/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
@@ -30,7 +30,7 @@ class PlayerAttachmentViewController: UIViewController, NotificationCategory {
                     videoViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                     videoViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
                 ])
-                
+
                 videoViewController.didMove(toParent: self)
             }
         }

--- a/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
@@ -1,0 +1,90 @@
+import MobileCoreServices
+import PromiseKit
+import Shared
+import UIKit
+import UserNotifications
+import UserNotificationsUI
+
+class PlayerAttachmentViewController: UIViewController, NotificationCategory {
+    enum PlayerAttachmentError: Error {
+        case noAttachment
+        case securityFailure
+    }
+
+    var videoViewController: CameraStreamHLSViewController? {
+        willSet {
+            videoViewController?.url.stopAccessingSecurityScopedResource()
+            videoViewController?.willMove(toParent: nil)
+            newValue.flatMap { addChild($0) }
+        }
+        didSet {
+            oldValue?.view.removeFromSuperview()
+            oldValue?.removeFromParent()
+
+            if let videoViewController = videoViewController {
+                view.addSubview(videoViewController.view)
+                videoViewController.view.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    videoViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+                    videoViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                    videoViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                    videoViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                ])
+                
+                videoViewController.didMove(toParent: self)
+            }
+        }
+    }
+
+    deinit {
+        videoViewController?.url.stopAccessingSecurityScopedResource()
+    }
+
+    func didReceive(notification: UNNotification, extensionContext: NSExtensionContext?) throws -> Promise<Void> {
+        guard let attachment = notification.request.content.attachments.first else {
+            throw PlayerAttachmentError.noAttachment
+        }
+
+        guard attachment.url.startAccessingSecurityScopedResource() else {
+            throw PlayerAttachmentError.securityFailure
+        }
+
+        let controller = with(CameraStreamHLSViewController(url: attachment.url)) {
+            var lastState: CameraStreamHandlerState?
+            $0.didUpdateState = { state in
+                guard lastState != state else {
+                    return
+                }
+
+                switch state {
+                case .playing:
+                    // if this happens too fast (which happens for local files) the extension context ignores it
+                    // so trigger a short delay as well
+                    extensionContext?.mediaPlayingStarted()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                        if lastState == .playing {
+                            extensionContext?.mediaPlayingStarted()
+                        }
+                    }
+                case .paused:
+                    extensionContext?.mediaPlayingPaused()
+                }
+
+                lastState = state
+            }
+        }
+        videoViewController = controller
+        return controller.promise
+    }
+
+    var mediaPlayPauseButtonType: UNNotificationContentExtensionMediaPlayPauseButtonType { .overlay }
+    var mediaPlayPauseButtonFrame: CGRect? { nil }
+
+    func mediaPlay() {
+        videoViewController?.play()
+    }
+
+    func mediaPause() {
+        videoViewController?.pause()
+    }
+}


### PR DESCRIPTION
Fixes #1591.

## Summary
Adds support for using video and audio notification attachments in the content extension, including audio playback for both.

## Screenshots
https://user-images.githubusercontent.com/74188/115503572-7c70e900-a22b-11eb-970b-b4e9c2225986.mov

## Any other notes
Dynamic actions require the 'DYNAMIC' category but our content extension causes attachments to not appear and we want every possible feature to work with just this category.