### PR TITLE
Handle multiple dynamic actions with the same identifier

### DIFF
--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -228,7 +228,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         }
         let userInfo = response.notification.request.content.userInfo
 
-        Current.Log.verbose("User info in incoming notification \(userInfo)")
+        Current.Log.verbose("User info in incoming notification \(userInfo) with response \(response)")
 
         if let shortcutDict = userInfo["shortcut"] as? [String: String],
            let shortcutName = shortcutDict["name"] {
@@ -246,7 +246,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             Current.backgroundTask(withName: "handle-push-action") { _ in
                 Current.api.then(on: nil) { api in
                     api.handlePushAction(
-                        identifier: response.actionIdentifier,
+                        identifier: UNNotificationContent.uncombinedAction(from: response.actionIdentifier),
                         category: response.notification.request.content.categoryIdentifier,
                         userInfo: userInfo,
                         userInput: userText

--- a/Sources/Shared/Notifications/UNNotificationContent+Additions.swift
+++ b/Sources/Shared/Notifications/UNNotificationContent+Additions.swift
@@ -2,10 +2,36 @@ import ObjectMapper
 import UserNotifications
 
 public extension UNNotificationContent {
+    private static var separator: String = "@duplicate_identifier-"
+
+    static func uncombinedAction(from identifier: String) -> String {
+        if identifier.contains(separator), let substring = identifier.components(separatedBy: separator).first {
+            return substring
+        } else {
+            return identifier
+        }
+    }
+
+    static func combinedAction(base: String, appended: String) -> String {
+        [base, appended].joined(separator: String(Self.separator))
+    }
+
     var userInfoActionConfigs: [MobileAppConfigPushCategory.Action] {
         let actions = userInfo["actions"] as? [[String: Any]] ?? []
+
         do {
-            return try Mapper<MobileAppConfigPushCategory.Action>().mapArray(JSONArray: actions)
+            return try Mapper<MobileAppConfigPushCategory.Action>()
+                .mapArray(JSONArray: actions)
+                .reduce(into: []) { result, original in
+                    var trailing = (2...).lazy.map(String.init(describing:)).makeIterator()
+                    var action = original
+
+                    while result.contains(where: { $0.identifier == action.identifier }) {
+                        action.identifier = Self.combinedAction(base: original.identifier, appended: trailing.next()!)
+                    }
+
+                    result.append(action)
+                }
         } catch {
             return []
         }


### PR DESCRIPTION
Fixes #1593.

## Summary
Suffixes the given identifiers with a consistent string, split when sending anywhere.

## Any other notes
Since Android requires an action identifier of 'URI' to open URLs, users may enter more than 1 in the actions array; this fixes using just the first matching identifier.
