### PR TITLE
Fix scaling issue with page zoom < 100% and pinch-to-zoom disabled

### DIFF
--- a/Sources/App/Resources/WebSocketBridge.js
+++ b/Sources/App/Resources/WebSocketBridge.js
@@ -56,7 +56,7 @@ const setOverrideZoomEnabled = (shouldZoom) => {
     }
 
     const ignoredBits = ['user-scalable', 'minimum-scale', 'maximum-scale'];
-    const elements = element['content']
+    let elements = element['content']
         .split(',')
         .filter(contentItem => {
             return ignoredBits.every(ignoredBit => !contentItem.includes(ignoredBit));
@@ -65,8 +65,9 @@ const setOverrideZoomEnabled = (shouldZoom) => {
     if (shouldZoom) {
         elements.push('user-scalable=yes');
     } else {
-        // setting minimum/maximum scale resets existing zoom if there is one
-        elements.push('user-scalable=no', 'minimum-scale=1.0', 'maximum-scale=1.0');
+        // setting minimum/maximum scale resets existing zoom if there is one, but it doesn't play nice with
+        // the overall 'page zoom' scaling that we add. users can generally unpinch 
+        elements.push('user-scalable=no');
     }
 
     element['content'] = elements.join(',');


### PR DESCRIPTION
Fixes #1493.

## Summary
When page zoom is smaller than 100%, setting the minimum/maximum scale to 1.0 causes the layout to break.

## Screenshots
| Before | After |
| -- | -- |
| <img width="350" src="https://user-images.githubusercontent.com/74188/116007536-0e2e7c80-a5c5-11eb-85bb-bdb4a0da6092.png"> | <img width="350" src="https://user-images.githubusercontent.com/74188/116007539-15558a80-a5c5-11eb-8b80-e10425937267.png"> |

## Any other notes
If the user transitions from pinch-to-zoom to not pinch-to-zoom, this will no longer reset any pre-existing pinched zoom. At least on iOS 13 and 14, you can un-pinch-to-zoom and it'll lock in at the regular scale afterwards, but only if you do not do it with the sidebar open; that will then require a refresh.