### PR TITLE
Support attachments which aren't downloaded in advance

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		11EFCDDA24F5FE0600314D85 /* SceneActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDD924F5FE0600314D85 /* SceneActivity.swift */; };
 		11EFCDDC24F6065F00314D85 /* AboutSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */; };
 		11EFCDE024F60E5900314D85 /* BasicSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */; };
+		11F01A80263D050D002AC33B /* NotificationLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F01A7F263D050D002AC33B /* NotificationLoadingViewController.swift */; };
 		11F2F1EC2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
 		11F2F1ED2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
 		11F2F2092586FB0C00F61F7C /* NotificationAttachmentManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */; };
@@ -1223,6 +1224,7 @@
 		11EFCDD924F5FE0600314D85 /* SceneActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneActivity.swift; sourceTree = "<group>"; };
 		11EFCDDB24F6065F00314D85 /* AboutSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSceneDelegate.swift; sourceTree = "<group>"; };
 		11EFCDDF24F60E5900314D85 /* BasicSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicSceneDelegate.swift; sourceTree = "<group>"; };
+		11F01A7F263D050D002AC33B /* NotificationLoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLoadingViewController.swift; sourceTree = "<group>"; };
 		11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentManager.swift; sourceTree = "<group>"; };
 		11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentManager.test.swift; sourceTree = "<group>"; };
 		11F2F22525871C3100F61F7C /* NotificationAttachmentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAttachmentParser.swift; sourceTree = "<group>"; };
@@ -2663,6 +2665,7 @@
 				110FB4522499DC28000865B4 /* NotificationErrorViewController.swift */,
 				11169CA9262FCE43005EF90A /* ImageAttachmentViewController.swift */,
 				11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */,
+				11F01A7F263D050D002AC33B /* NotificationLoadingViewController.swift */,
 			);
 			path = NotificationContent;
 			sourceTree = "<group>";
@@ -4646,6 +4649,7 @@
 				B63CCDC9216442BB00123C50 /* CameraViewController.swift in Sources */,
 				110FB44E2499C1CF000865B4 /* CameraStreamHLSViewController.swift in Sources */,
 				B627CB0E1D83C87B0057173E /* NotificationViewController.swift in Sources */,
+				11F01A80263D050D002AC33B /* NotificationLoadingViewController.swift in Sources */,
 				11169CEC262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift in Sources */,
 				110FB44C2499C1A3000865B4 /* CameraStreamHandler.swift in Sources */,
 				110FB4502499CE34000865B4 /* CameraStreamMJPEGViewController.swift in Sources */,

--- a/Sources/Extensions/NotificationContent/CameraViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraViewController.swift
@@ -22,7 +22,7 @@ class CameraViewController: UIViewController, NotificationCategory {
             }
         }
     }
-    
+
     let entityId: String
 
     required init(notification: UNNotification, attachmentURL: URL?) throws {
@@ -35,6 +35,7 @@ class CameraViewController: UIViewController, NotificationCategory {
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -64,7 +65,7 @@ class CameraViewController: UIViewController, NotificationCategory {
     }
 
     func start() -> Promise<Void> {
-        return Current.api.then(on: nil) { [entityId] api -> Promise<(HomeAssistantAPI, StreamCameraResponse)> in
+        Current.api.then(on: nil) { [entityId] api -> Promise<(HomeAssistantAPI, StreamCameraResponse)> in
             firstly {
                 api.StreamCamera(entityId: entityId)
             }.recover { error -> Promise<StreamCameraResponse> in

--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -6,14 +6,48 @@ import UserNotifications
 import UserNotificationsUI
 
 class ImageAttachmentViewController: UIViewController, NotificationCategory {
+    let attachmentURL: URL
+    let needsEndSecurityScoped: Bool
+    let image: UIImage
     let imageView = with(UIImageView()) {
         $0.contentMode = .scaleAspectFit
+    }
+
+    required init(notification: UNNotification, attachmentURL: URL?) throws {
+        guard let attachmentURL = attachmentURL else {
+            throw ImageAttachmentError.noAttachment
+        }
+
+        self.needsEndSecurityScoped = attachmentURL.startAccessingSecurityScopedResource()
+
+        // rather than hard-coding an acceptable list of UTTypes it's probably easier to just try decoding
+        // https://developer.apple.com/documentation/usernotifications/unnotificationattachment
+        // has the full list of what is advertised - at time of writing (iOS 14.5) it's jpeg, gif and png
+        // but iOS 14 also supports webp, so who knows if it'll be added silently or not
+
+        guard let image = UIImage(contentsOfFile: attachmentURL.path) else {
+            attachmentURL.stopAccessingSecurityScopedResource()
+            throw ImageAttachmentError.imageDecodeFailure
+        }
+
+        self.image = image
+        self.attachmentURL = attachmentURL
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if needsEndSecurityScoped {
+            attachmentURL.stopAccessingSecurityScopedResource()
+        }
     }
 
     enum ImageAttachmentError: Error {
         case noAttachment
         case notImage
-        case securityFailure
         case imageDecodeFailure
     }
 
@@ -32,34 +66,9 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
         }
     }
 
-    deinit {
-        lastAttachmentURL?.stopAccessingSecurityScopedResource()
-    }
-
-    func didReceive(
-        notification: UNNotification,
-        extensionContext: NSExtensionContext?
-    ) throws -> Promise<Void> {
-        guard let attachment = notification.request.content.attachments.first else {
-            throw ImageAttachmentError.noAttachment
-        }
-
-        guard attachment.url.startAccessingSecurityScopedResource() else {
-            throw ImageAttachmentError.securityFailure
-        }
-
-        // rather than hard-coding an acceptable list of UTTypes it's probably easier to just try decoding
-        // https://developer.apple.com/documentation/usernotifications/unnotificationattachment
-        // has the full list of what is advertised - at time of writing (iOS 14.5) it's jpeg, gif and png
-        // but iOS 14 also supports webp, so who knows if it'll be added silently or not
-
-        guard let image = UIImage(contentsOfFile: attachment.url.path) else {
-            attachment.url.stopAccessingSecurityScopedResource()
-            throw ImageAttachmentError.imageDecodeFailure
-        }
-
+    func start() -> Promise<Void> {
         imageView.image = image
-        lastAttachmentURL = attachment.url
+        lastAttachmentURL = attachmentURL
         aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: imageView, size: image.size)
 
         return .value(())

--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -35,6 +35,7 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/Extensions/NotificationContent/MapViewController.swift
+++ b/Sources/Extensions/NotificationContent/MapViewController.swift
@@ -25,6 +25,7 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/Extensions/NotificationContent/MapViewController.swift
+++ b/Sources/Extensions/NotificationContent/MapViewController.swift
@@ -6,7 +6,28 @@ import UserNotifications
 import UserNotificationsUI
 
 class MapViewController: UIViewController, NotificationCategory, MKMapViewDelegate {
-    private var mapView: MKMapView!
+    let location: CLLocationCoordinate2D
+    let haDict: [String: Any]
+
+    required init(notification: UNNotification, attachmentURL: URL?) throws {
+        guard let haDict = notification.request.content.userInfo["homeassistant"] as? [String: Any] else {
+            throw MapError.missingPayload
+        }
+        guard let latitude = CLLocationDegrees(templateValue: haDict["latitude"]) else {
+            throw MapError.missingLatitude
+        }
+        guard let longitude = CLLocationDegrees(templateValue: haDict["longitude"]) else {
+            throw MapError.missingLongitude
+        }
+
+        self.haDict = haDict
+        self.location = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     enum MapError: LocalizedError {
         case missingPayload
@@ -33,25 +54,20 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         ])
     }
 
-    func didReceive(notification: UNNotification, extensionContext: NSExtensionContext?) throws -> Promise<Void> {
-        let userInfo = notification.request.content.userInfo
+    func start() -> Promise<Void> {
+        let mapView = MKMapView()
+        view.addSubview(mapView)
 
-        guard let haDict = userInfo["homeassistant"] as? [String: Any] else {
-            throw MapError.missingPayload
-        }
-        guard let latitude = CLLocationDegrees(templateValue: haDict["latitude"]) else {
-            throw MapError.missingLatitude
-        }
-        guard let longitude = CLLocationDegrees(templateValue: haDict["longitude"]) else {
-            throw MapError.missingLongitude
-        }
-        let location = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
-        mapView = MKMapView()
+        mapView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            mapView.topAnchor.constraint(equalTo: view.topAnchor),
+            mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
 
         mapView.delegate = self
         mapView.mapType = .standard
-        mapView.frame = view.frame
-
         mapView.showsUserLocation = (haDict["shows_user_location"] != nil)
         mapView.showsPointsOfInterest = (haDict["shows_points_of_interest"] != nil)
         mapView.showsCompass = (haDict["shows_compass"] != nil)
@@ -63,7 +79,6 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         let span = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
         let region = MKCoordinateRegion(center: location, span: span)
         mapView.setRegion(region, animated: true)
-        view.addSubview(mapView)
 
         let dropPin = MKPointAnnotation()
         dropPin.coordinate = location

--- a/Sources/Extensions/NotificationContent/NotificationLoadingViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationLoadingViewController.swift
@@ -3,16 +3,13 @@ import PromiseKit
 import UIKit
 import UserNotificationsUI
 
-class NotificationErrorViewController: UIViewController, NotificationCategory {
-    let label = UILabel()
-
+class NotificationLoadingViewController: UIViewController, NotificationCategory {
     required init(notification: UNNotification, attachmentURL: URL?) throws {
-        fatalError("not meant to be used in the list of potentials, just directly set")
+        super.init(nibName: nil, bundle: nil)
     }
 
-    init(error: Error) {
+    init() {
         super.init(nibName: nil, bundle: nil)
-        label.text = error.localizedDescription
     }
 
     @available(*, unavailable)
@@ -23,23 +20,24 @@ class NotificationErrorViewController: UIViewController, NotificationCategory {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        label.numberOfLines = 0
-        label.textAlignment = .center
+        let activityIndicator: UIActivityIndicatorView
 
         if #available(iOS 13, *) {
-            label.textColor = .systemRed
+            activityIndicator = UIActivityIndicatorView(style: .medium)
         } else {
-            label.textColor = .red
+            activityIndicator = UIActivityIndicatorView(style: .gray)
         }
 
-        view.addSubview(label)
-        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: view.topAnchor),
-            label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            label.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            activityIndicator.topAnchor.constraint(equalTo: view.topAnchor),
+            activityIndicator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            activityIndicator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            activityIndicator.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+
+        activityIndicator.startAnimating()
     }
 
     func start() -> Promise<Void> {

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -74,7 +74,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
             }.then { [self] url in
                 viewController(for: notification, attachmentURL: url, allowDownloads: false)
             }.recover { _ in
-                return .value(nil)
+                .value(nil)
             }
         } else {
             return .value(nil)

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -44,19 +44,41 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
     ] }
 
     private func viewController(
-        for notification: UNNotification
-    ) -> (UIViewController & NotificationCategory, Promise<Void>)? {
+        for notification: UNNotification,
+        attachmentURL: URL?,
+        allowDownloads: Bool = true
+    ) -> Guarantee<(UIViewController & NotificationCategory)?> {
+        // Try based on current info (e.g. entity_id or attached via service extension)
+
         for controllerType in Self.possibleControllers {
             do {
-                let controller = controllerType.init()
-                let promise = try controller.didReceive(notification: notification, extensionContext: extensionContext)
-                return (controller, promise)
+                let controller = try controllerType.init(
+                    notification: notification,
+                    attachmentURL: attachmentURL
+                )
+                return .value(controller)
             } catch {
                 // not valid
             }
         }
 
-        return nil
+        // Try to grab the attachments, in case they failed or were lazy
+
+        if allowDownloads {
+            return firstly {
+                Current.api
+            }.then { api in
+                // potential future optimization: feed the url into e.g. the AVPlayer instance.
+                // not super straightforward because authentication headers may be needed.
+                NotificationAttachmentManager().downloadAttachment(from: notification.request.content, api: api)
+            }.then { [self] url in
+                viewController(for: notification, attachmentURL: url, allowDownloads: false)
+            }.recover { _ in
+                return .value(nil)
+            }
+        } else {
+            return .value(nil)
+        }
     }
 
     func didReceive(_ notification: UNNotification) {
@@ -68,25 +90,31 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
             extensionContext?.notificationActions = notification.request.content.userInfoActions
         }
 
-        guard let (controller, promise) = viewController(for: notification) else {
-            activeViewController = nil
-            return
-        }
+        activeViewController = NotificationLoadingViewController()
 
-        activeViewController = controller
+        var hud: MBProgressHUD?
 
-        let hud: MBProgressHUD? = {
-            guard controller.mediaPlayPauseButtonType == .none else {
-                // don't show the HUD for a screen that has pause/play because it already acts like a loading indicator
-                return nil
+        viewController(
+            for: notification,
+            attachmentURL: notification.request.content.attachments.first?.url
+        ).then { [weak self] controller -> Promise<Void> in
+            self?.activeViewController = controller
+
+            guard let controller = controller else {
+                return .value(())
             }
 
-            let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
-            hud.offset = CGPoint(x: 0, y: -MBProgressMaxOffset + 50)
-            return hud
-        }()
+            if controller.mediaPlayPauseButtonType == .none, let view = self?.view {
+                // don't show the HUD for a screen that has pause/play because it already acts like a loading indicator
+                hud = {
+                    let hud = MBProgressHUD.showAdded(to: view, animated: true)
+                    hud.offset = CGPoint(x: 0, y: -MBProgressMaxOffset + 50)
+                    return hud
+                }()
+            }
 
-        promise.ensure {
+            return controller.start()
+        }.ensure {
             hud?.hide(animated: true)
         }.catch { [weak self] error in
             Current.Log.error("finally failed: \(error)")
@@ -117,14 +145,8 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
 }
 
 protocol NotificationCategory: NSObjectProtocol {
-    // This will be called to send the notification to be displayed by
-    // the extension. If the extension is being displayed and more related
-    // notifications arrive (eg. more messages for the same conversation)
-    // the same method will be called for each new notification.
-    func didReceive(
-        notification: UNNotification,
-        extensionContext: NSExtensionContext?
-    ) throws -> Promise<Void>
+    init(notification: UNNotification, attachmentURL: URL?) throws
+    func start() -> Promise<Void>
 
     // Implementing this method and returning a button type other that "None" will
     // make the notification attempt to draw a play/pause button correctly styled

--- a/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
@@ -8,7 +8,30 @@ import UserNotificationsUI
 class PlayerAttachmentViewController: UIViewController, NotificationCategory {
     enum PlayerAttachmentError: Error {
         case noAttachment
-        case securityFailure
+    }
+
+    let attachmentURL: URL
+    let needsEndSecurityScoped: Bool
+
+    required init(notification: UNNotification, attachmentURL: URL?) throws {
+        guard let attachmentURL = attachmentURL else {
+            throw PlayerAttachmentError.noAttachment
+        }
+
+        needsEndSecurityScoped = attachmentURL.startAccessingSecurityScopedResource()
+
+        self.attachmentURL = attachmentURL
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if needsEndSecurityScoped {
+            videoViewController?.url.stopAccessingSecurityScopedResource()
+        }
     }
 
     var videoViewController: CameraStreamHLSViewController? {
@@ -36,22 +59,10 @@ class PlayerAttachmentViewController: UIViewController, NotificationCategory {
         }
     }
 
-    deinit {
-        videoViewController?.url.stopAccessingSecurityScopedResource()
-    }
-
-    func didReceive(notification: UNNotification, extensionContext: NSExtensionContext?) throws -> Promise<Void> {
-        guard let attachment = notification.request.content.attachments.first else {
-            throw PlayerAttachmentError.noAttachment
-        }
-
-        guard attachment.url.startAccessingSecurityScopedResource() else {
-            throw PlayerAttachmentError.securityFailure
-        }
-
-        let controller = with(CameraStreamHLSViewController(url: attachment.url)) {
+    func start() -> Promise<Void> {
+        let controller = with(CameraStreamHLSViewController(url: attachmentURL)) {
             var lastState: CameraStreamHandlerState?
-            $0.didUpdateState = { state in
+            $0.didUpdateState = { [extensionContext] state in
                 guard lastState != state else {
                     return
                 }

--- a/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
@@ -18,12 +18,13 @@ class PlayerAttachmentViewController: UIViewController, NotificationCategory {
             throw PlayerAttachmentError.noAttachment
         }
 
-        needsEndSecurityScoped = attachmentURL.startAccessingSecurityScopedResource()
+        self.needsEndSecurityScoped = attachmentURL.startAccessingSecurityScopedResource()
 
         self.attachmentURL = attachmentURL
         super.init(nibName: nil, bundle: nil)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
@@ -32,6 +32,9 @@ public class NotificationAttachmentManager {
 
             if case ServiceError.noAttachment = error {
                 throw error
+            } else if error is URLError {
+                // we'll try loading in the content extension, no need to decorate the thumbnail
+                throw error
             } else {
                 #if os(iOS)
                 return .value(try self.attachment(for: error, api: api))

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
@@ -1,3 +1,4 @@
+import Alamofire
 import Foundation
 import MobileCoreServices
 import PromiseKit
@@ -32,7 +33,7 @@ public class NotificationAttachmentManager {
 
             if case ServiceError.noAttachment = error {
                 throw error
-            } else if error is URLError {
+            } else if error is URLError || error.asAFError?.isSessionTaskError == true {
                 // we'll try loading in the content extension, no need to decorate the thumbnail
                 throw error
             } else {

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentManager.swift
@@ -87,7 +87,11 @@ public class NotificationAttachmentManager {
         from attachmentInfo: NotificationAttachmentInfo,
         api: HomeAssistantAPI
     ) -> Promise<UNNotificationAttachment> {
-        firstly {
+        guard !attachmentInfo.lazy else {
+            return .init(error: ServiceError.noAttachment)
+        }
+
+        return firstly {
             api.DownloadDataAt(url: attachmentInfo.url, needsAuth: attachmentInfo.needsAuth)
         }.map { url -> UNNotificationAttachment in
             try UNNotificationAttachment(

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParser.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParser.swift
@@ -47,6 +47,7 @@ internal struct NotificationAttachmentInfo: Equatable {
     var needsAuth: Bool
     var typeHint: CFString?
     var hideThumbnail: Bool?
+    var lazy: Bool
 
     var attachmentOptions: [String: Any] {
         var options = [String: Any]()

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserCamera.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserCamera.swift
@@ -24,12 +24,14 @@ final class NotificationAttachmentParserCamera: NotificationAttachmentParser {
         }
 
         let hideThumbnail = (content.userInfo["attachment"] as? [String: Any])?["hide-thumbnail"] as? Bool
+        let lazy = (content.userInfo["attachment"] as? [String: Any])?["lazy"] as? Bool == true
 
         return .value(.fulfilled(.init(
             url: proxyURL,
             needsAuth: true,
             typeHint: kUTTypeJPEG,
-            hideThumbnail: hideThumbnail
+            hideThumbnail: hideThumbnail,
+            lazy: lazy
         )))
     }
 }

--- a/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserURL.swift
+++ b/Sources/Shared/Notifications/NotificationAttachments/NotificationAttachmentParserURL.swift
@@ -31,12 +31,14 @@ final class NotificationAttachmentParserURL: NotificationAttachmentParser {
         let needsAuth: Bool = urlString.hasPrefix("/")
         let contentType = (attachment["content-type"] as? String).flatMap(NotificationAttachmentInfo.contentType(for:))
         let hideThumbnail = attachment["hide-thumbnail"] as? Bool
+        let lazy = attachment["lazy"] as? Bool == true
 
         return .value(.fulfilled(.init(
             url: url,
             needsAuth: needsAuth,
             typeHint: contentType,
-            hideThumbnail: hideThumbnail
+            hideThumbnail: hideThumbnail,
+            lazy: lazy
         )))
     }
 }

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
@@ -63,6 +63,15 @@ class NotificationAttachmentManagerTests: XCTestCase {
         }
     }
 
+    private func assertDownloadedAttachment(for content: UNNotificationContent, api: HomeAssistantAPI) throws {
+        let promise = manager.downloadAttachment(from: content, api: api)
+        let url = try hang(Promise(promise))
+        if UIImage(contentsOfFile: url.path) == nil {
+            enum NoImageError: Error { case noImage }
+            throw NoImageError.noImage
+        }
+    }
+
     func testDefaultParsers() {
         let parsers = NotificationAttachmentManager().parsers
         XCTAssertFalse(parsers.isEmpty)
@@ -76,6 +85,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let content = UNNotificationContent()
         let promise = manager.content(from: content, api: api)
         XCTAssertEqual(try hang(Promise(promise)), content)
+        XCTAssertThrowsError(try hang(Promise(manager.downloadAttachment(from: content, api: api))))
     }
 
     func testOneContentUnauth() throws {
@@ -83,6 +93,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
 
         let attachment = try firstAttachment(for: .init())
         XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testOneContentAuth() throws {
@@ -90,6 +101,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
 
         let attachment = try firstAttachment(for: .init())
         XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testTwoContentUnauth() throws {
@@ -98,6 +110,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
 
         let attachment = try firstAttachment(for: .init())
         XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testTwoContentAuth() throws {
@@ -106,6 +119,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
 
         let attachment = try firstAttachment(for: .init())
         XCTAssertEqual(try Data(contentsOf: attachment.url), image1.data)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testContentTimesOut() throws {
@@ -115,6 +129,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let attachment = try firstAttachment(for: .init())
         XCTAssertNotEqual(try Data(contentsOf: attachment.url), image1.data)
         XCTAssertTrue(attachment.accessibilityLabel?.contains(error.localizedDescription) == true)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testContentNotFound() throws {
@@ -123,6 +138,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let attachment = try firstAttachment(for: .init())
         XCTAssertNotEqual(try Data(contentsOf: attachment.url), image1.data)
         XCTAssertTrue(attachment.accessibilityLabel?.contains("404") == true)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testContentType() throws {
@@ -134,6 +150,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
 
         let attachment = try firstAttachment(for: .init())
         XCTAssertEqual(attachment.type, kUTTypeGIF as String)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testHideThumbnailDefault() throws {
@@ -146,6 +163,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let attachment = try firstAttachment(for: .init())
         // fragile? yes. lazy? yes. effective? ask me in an iOS release
         XCTAssertTrue(attachment.debugDescription.contains("displayLocation: default"))
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testHideThumbnailTrue() throws {
@@ -158,6 +176,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let attachment = try firstAttachment(for: .init())
         // fragile? yes. lazy? yes. effective? ask me in an iOS release
         XCTAssertTrue(attachment.debugDescription.contains("displayLocation: long-look"))
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testHideThumbnailFalse() throws {
@@ -170,6 +189,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let attachment = try firstAttachment(for: .init())
         // fragile? yes. lazy? yes. effective? ask me in an iOS release
         XCTAssertTrue(attachment.debugDescription.contains("displayLocation: default"))
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 
     func testLazy() throws {
@@ -183,6 +203,7 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let content = UNNotificationContent()
         let promise = manager.content(from: content, api: api)
         XCTAssertEqual(try hang(Promise(promise)), content)
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 }
 

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
@@ -202,7 +202,8 @@ private class Image {
     func successParserResult(
         needsAuth: Bool = false,
         typeHint: CFString? = nil,
-        hideThumbnail: Bool? = nil
+        hideThumbnail: Bool? = nil,
+        lazy: Bool = false
     ) -> NotificationAttachmentParserResult {
         let url = Self.newURL()
 
@@ -226,7 +227,8 @@ private class Image {
             url: url,
             needsAuth: needsAuth,
             typeHint: typeHint,
-            hideThumbnail: hideThumbnail
+            hideThumbnail: hideThumbnail,
+            lazy: lazy
         ))
     }
 
@@ -254,7 +256,8 @@ private class Image {
             url: url,
             needsAuth: needsAuth,
             typeHint: nil,
-            hideThumbnail: nil
+            hideThumbnail: nil,
+            lazy: false
         ))
     }
 }

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
@@ -171,6 +171,19 @@ class NotificationAttachmentManagerTests: XCTestCase {
         // fragile? yes. lazy? yes. effective? ask me in an iOS release
         XCTAssertTrue(attachment.debugDescription.contains("displayLocation: default"))
     }
+
+    func testLazy() throws {
+        parser1.result = image1.successParserResult(
+            needsAuth: false,
+            typeHint: nil,
+            hideThumbnail: nil,
+            lazy: true
+        )
+
+        let content = UNNotificationContent()
+        let promise = manager.content(from: content, api: api)
+        XCTAssertEqual(try hang(Promise(promise)), content)
+    }
 }
 
 private class Image {

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentManager.test.swift
@@ -1,3 +1,4 @@
+import Alamofire
 import CoreServices
 import Foundation
 import OHHTTPStubs
@@ -126,9 +127,19 @@ class NotificationAttachmentManagerTests: XCTestCase {
         let error = URLError(.timedOut)
         parser1.result = image1.failureParserResult(failure: .error(error))
 
-        let attachment = try firstAttachment(for: .init())
-        XCTAssertNotEqual(try Data(contentsOf: attachment.url), image1.data)
-        XCTAssertTrue(attachment.accessibilityLabel?.contains(error.localizedDescription) == true)
+        // no attachment to notification
+        XCTAssertThrowsError(try firstAttachment(for: .init()))
+        // but error image when downloading
+        XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
+    }
+
+    func testContentDownloadErrors() throws {
+        let error = AFError.sessionTaskFailed(error: URLError(.timedOut))
+        parser1.result = image1.failureParserResult(failure: .error(error))
+
+        // no attachment to notification
+        XCTAssertThrowsError(try firstAttachment(for: .init()))
+        // but error image when downloading
         XCTAssertNoThrow(try assertDownloadedAttachment(for: .init(), api: api))
     }
 

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentParserCamera.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentParserCamera.test.swift
@@ -54,6 +54,26 @@ class NotificationAttachmentParserCameraTests: XCTestCase {
         XCTAssertEqual(result.hideThumbnail, true)
     }
 
+    func testAttachmentLazy() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["entity_id"] = "camera.any"
+        content.userInfo["attachment"] = [
+            "lazy": true,
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/api/camera_proxy/camera.any"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, kUTTypeJPEG)
+        XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, true)
+    }
+
     func testAttachmentNotHidden() {
         let content = UNMutableNotificationContent()
         content.userInfo["entity_id"] = "camera.any"

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
@@ -138,7 +138,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         let content = UNMutableNotificationContent()
         content.userInfo["attachment"] = [
             "url": "/media/local/file.png",
-            "lazy": true
+            "lazy": true,
         ]
         let promise = parser.attachmentInfo(from: content)
 
@@ -158,7 +158,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         let content = UNMutableNotificationContent()
         content.userInfo["attachment"] = [
             "url": "/media/local/file.png",
-            "lazy": false
+            "lazy": false,
         ]
         let promise = parser.attachmentInfo(from: content)
 

--- a/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
+++ b/Tests/Shared/NotificationAttachment/NotificationAttachmentParserURL.test.swift
@@ -52,6 +52,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         XCTAssertEqual(result.needsAuth, true)
         XCTAssertEqual(result.typeHint, nil)
         XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, false)
     }
 
     func testAbsoluteAttachmentURL() {
@@ -70,6 +71,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         XCTAssertEqual(result.needsAuth, false)
         XCTAssertEqual(result.typeHint, nil)
         XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, false)
     }
 
     func testContentType() {
@@ -89,6 +91,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         XCTAssertEqual(result.needsAuth, true)
         XCTAssertEqual(result.typeHint, kUTTypePNG)
         XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, false)
     }
 
     func testAttachmentHidden() {
@@ -108,6 +111,7 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         XCTAssertEqual(result.needsAuth, true)
         XCTAssertEqual(result.typeHint, nil)
         XCTAssertEqual(result.hideThumbnail, true)
+        XCTAssertEqual(result.lazy, false)
     }
 
     func testAttachmentNotHidden() {
@@ -127,5 +131,46 @@ class NotificationAttachmentParserURLTests: XCTestCase {
         XCTAssertEqual(result.needsAuth, true)
         XCTAssertEqual(result.typeHint, nil)
         XCTAssertEqual(result.hideThumbnail, false)
+        XCTAssertEqual(result.lazy, false)
+    }
+
+    func testLazyTrue() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png",
+            "lazy": true
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, true)
+    }
+
+    func testLazyFalse() {
+        let content = UNMutableNotificationContent()
+        content.userInfo["attachment"] = [
+            "url": "/media/local/file.png",
+            "lazy": false
+        ]
+        let promise = parser.attachmentInfo(from: content)
+
+        guard let result = promise.wait().attachmentInfo else {
+            XCTFail("not an attachment")
+            return
+        }
+
+        XCTAssertEqual(result.url, URL(string: "/media/local/file.png"))
+        XCTAssertEqual(result.needsAuth, true)
+        XCTAssertEqual(result.typeHint, nil)
+        XCTAssertEqual(result.hideThumbnail, nil)
+        XCTAssertEqual(result.lazy, false)
     }
 }


### PR DESCRIPTION
## Summary
Allows attachments to be loaded on-the-fly in the content extension if they are not present.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#510

## Any other notes
- Adds `lazy` as an option to the `attachment` dictionary. When true, this prevents the attachment from being downloaded except when displayed in the content extension.  
  
This is similar, but not identical, to hide-thumbnail. Hiding the thumbnail still uses the internal storage of the notifications which are limited to e.g. 50mb. However, we'd still want to pre-load those attachments even if the thumbnail is hidden.
- Retries non-lazy attachments which failed due to a network error when the content extension opens.