### PR TITLE
Fix watch notifications not handling multi-line

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		11761E2925EC1415007A9D17 /* WebSocketStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11761E2825EC1415007A9D17 /* WebSocketStatusRow.swift */; };
 		117675EF252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
 		117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
+		1178AB00263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178AAFF263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift */; };
 		1178C4E524D5CEB200FDEC3E /* ConnectionURLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */; };
 		1179E42D24F9FAA100D4E307 /* SensorProviderDependencies.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */; };
 		117D8A0824A9347F00580913 /* UIColor+CSSRGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */; };
@@ -1086,6 +1087,7 @@
 		117318AC25199E220013E010 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		11761E2825EC1415007A9D17 /* WebSocketStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketStatusRow.swift; sourceTree = "<group>"; };
 		117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateComplications.swift; sourceTree = "<group>"; };
+		1178AAFF263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKInterfaceLabel+Additions.swift"; sourceTree = "<group>"; };
 		1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionURLViewController.swift; sourceTree = "<group>"; };
 		1179E42C24F9FAA100D4E307 /* SensorProviderDependencies.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorProviderDependencies.test.swift; sourceTree = "<group>"; };
 		117D8A0724A9347F00580913 /* UIColor+CSSRGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CSSRGB.swift"; sourceTree = "<group>"; };
@@ -2884,6 +2886,7 @@
 			children = (
 				B69769832162430300FFFAD6 /* WKInterfaceDevice+Size.swift */,
 				B672AB572216B5E000175465 /* Date+ComplicationDivination.swift */,
+				1178AAFF263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -4966,6 +4969,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1178AB00263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift in Sources */,
 				B6CC5D962159D10E00833E5D /* ExtensionDelegate.swift in Sources */,
 				B672AB582216B5E000175465 /* Date+ComplicationDivination.swift in Sources */,
 				B6B2E6A0216A940700D39A26 /* ActionRow.swift in Sources */,

--- a/Sources/Extensions/NotificationContent/Resources/TestNotifications/dynamic_notification.apns
+++ b/Sources/Extensions/NotificationContent/Resources/TestNotifications/dynamic_notification.apns
@@ -1,8 +1,8 @@
 {
   "aps": {
     "alert": {
-      "title": "title here",
-      "body": "body here"
+      "title": "Massa placerat duis ultricies lacus",
+      "body": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. In nulla posuere sollicitudin aliquam."
     },
     "sound": "default",
     "category": "DYNAMIC"
@@ -10,11 +10,11 @@
   "actions": [
     {
       "identifier": "id1",
-      "title": "id1 title"
+      "title": "Lectus Magna",
     },
     {
       "action": "id2",
-      "title": "id2 title"
+      "title": "Bibendum Est",
     }
   ]
 }

--- a/Sources/Extensions/Watch/CameraNotificationController.swift
+++ b/Sources/Extensions/Watch/CameraNotificationController.swift
@@ -55,9 +55,9 @@ class CameraNotificationController: WKUserNotificationInterfaceController {
     }
 
     override func didReceive(_ notification: UNNotification) {
-        notificationTitleLabel.setText(notification.request.content.title)
-        notificationSubtitleLabel.setText(notification.request.content.subtitle)
-        notificationAlertLabel!.setText(notification.request.content.body)
+        notificationTitleLabel.setTextAndHideIfEmpty(notification.request.content.title)
+        notificationSubtitleLabel.setTextAndHideIfEmpty(notification.request.content.subtitle)
+        notificationAlertLabel.setTextAndHideIfEmpty(notification.request.content.body)
 
         if notificationActions.isEmpty {
             notificationActions = notification.request.content.userInfoActions

--- a/Sources/Extensions/Watch/DynamicNotificationController.swift
+++ b/Sources/Extensions/Watch/DynamicNotificationController.swift
@@ -11,9 +11,9 @@ class DynamicNotificationController: WKUserNotificationInterfaceController {
     override func didReceive(_ notification: UNNotification) {
         super.didReceive(notification)
 
-        notificationTitleLabel.setText(notification.request.content.title)
-        notificationSubtitleLabel.setText(notification.request.content.subtitle)
-        notificationAlertLabel!.setText(notification.request.content.body)
+        notificationTitleLabel.setTextAndHideIfEmpty(notification.request.content.title)
+        notificationSubtitleLabel.setTextAndHideIfEmpty(notification.request.content.subtitle)
+        notificationAlertLabel.setTextAndHideIfEmpty(notification.request.content.body)
 
         notificationActions = notification.request.content.userInfoActions
     }

--- a/Sources/Extensions/Watch/MapNotificationController.swift
+++ b/Sources/Extensions/Watch/MapNotificationController.swift
@@ -14,9 +14,9 @@ class MapNotificationController: WKUserNotificationInterfaceController {
     // MARK: - WKUserNotificationInterfaceController
 
     override func didReceive(_ notification: UNNotification) {
-        notificationTitleLabel.setText(notification.request.content.title)
-        notificationSubtitleLabel.setText(notification.request.content.subtitle)
-        notificationAlertLabel!.setText(notification.request.content.body)
+        notificationTitleLabel.setTextAndHideIfEmpty(notification.request.content.title)
+        notificationSubtitleLabel.setTextAndHideIfEmpty(notification.request.content.subtitle)
+        notificationAlertLabel.setTextAndHideIfEmpty(notification.request.content.body)
 
         if notificationActions.isEmpty {
             notificationActions = notification.request.content.userInfoActions

--- a/Sources/Extensions/Watch/Utilities/WKInterfaceLabel+Additions.swift
+++ b/Sources/Extensions/Watch/Utilities/WKInterfaceLabel+Additions.swift
@@ -1,0 +1,8 @@
+import WatchKit
+
+extension WKInterfaceLabel {
+    func setTextAndHideIfEmpty(_ text: String) {
+        setText(text)
+        setHidden(text.isEmpty)
+    }
+}

--- a/Sources/WatchApp/Base.lproj/Interface.storyboard
+++ b/Sources/WatchApp/Base.lproj/Interface.storyboard
@@ -44,13 +44,13 @@
             <objects>
                 <notificationController id="h4f-Hf-ll2" userLabel="Map Static Notification Interface Controller">
                     <items>
-                        <label alignment="left" text="Title" id="p2M-Qe-cqH">
+                        <label alignment="left" text="Title" numberOfLines="0" id="p2M-Qe-cqH">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="R0j-pC-RXg">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="R0j-pC-RXg">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="zei-SN-eTI"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="zei-SN-eTI"/>
                     </items>
                     <notificationCategory key="notificationCategory" identifier="MAP" id="PaD-pF-3Yk"/>
                     <connections>
@@ -68,13 +68,13 @@
             <objects>
                 <controller id="LrQ-kJ-7bY" customClass="MapNotificationController" customModule="WatchApp" customModuleProvider="target">
                     <items>
-                        <label alignment="left" text="Title" id="p2V-Pw-SrF">
+                        <label alignment="left" text="Title" numberOfLines="0" id="p2V-Pw-SrF">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="Luv-KR-F0P">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="Luv-KR-F0P">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="FCu-iE-uLc"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="FCu-iE-uLc"/>
                         <map height="150" alignment="left" id="Nsd-Pz-t9E"/>
                     </items>
                     <connections>
@@ -92,13 +92,13 @@
             <objects>
                 <notificationController id="JOO-yq-9Md" userLabel="Camera Static Notification Interface Controller">
                     <items>
-                        <label alignment="left" text="Title" id="jQa-FU-AW7">
+                        <label alignment="left" text="Title" numberOfLines="0" id="jQa-FU-AW7">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="xYG-S0-atc">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="xYG-S0-atc">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="yBa-4u-GxD"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="yBa-4u-GxD"/>
                     </items>
                     <notificationCategory key="notificationCategory" identifier="CAMERA" id="reZ-Qf-LhH"/>
                     <connections>
@@ -116,13 +116,13 @@
             <objects>
                 <controller id="R7r-up-oD1" customClass="CameraNotificationController" customModule="WatchApp" customModuleProvider="target">
                     <items>
-                        <label alignment="left" text="Title" id="LvM-IN-iYf">
+                        <label alignment="left" text="Title" numberOfLines="0" id="LvM-IN-iYf">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="MDv-3I-PbQ">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="MDv-3I-PbQ">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="sYZ-if-ad8"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="sYZ-if-ad8"/>
                         <imageView alignment="center" id="abh-Pc-dOV"/>
                     </items>
                     <connections>
@@ -140,13 +140,13 @@
             <objects>
                 <notificationController id="QI5-5x-CEK">
                     <items>
-                        <label alignment="left" text="Title" id="E7h-tN-FpM">
+                        <label alignment="left" text="Title" numberOfLines="0" id="E7h-tN-FpM">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="RcO-zr-Q0h">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="RcO-zr-Q0h">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="qhB-ey-Ock"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="qhB-ey-Ock"/>
                     </items>
                     <notificationCategory key="notificationCategory" identifier="DYNAMIC" id="8b7-DD-rBi"/>
                     <connections>
@@ -164,13 +164,13 @@
             <objects>
                 <controller id="CnG-yJ-6kl" customClass="DynamicNotificationController" customModule="WatchExtension_Watch">
                     <items>
-                        <label alignment="left" text="Title" id="vEF-dD-raf">
+                        <label alignment="left" text="Title" numberOfLines="0" id="vEF-dD-raf">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Subtitle" id="d7N-vP-Xvn">
+                        <label alignment="left" text="Subtitle" numberOfLines="0" id="d7N-vP-Xvn">
                             <fontDescription key="font" style="UICTFontTextStyleHeadline"/>
                         </label>
-                        <label alignment="left" text="Body" id="nz5-h3-92S"/>
+                        <label alignment="left" text="Body" numberOfLines="0" id="nz5-h3-92S"/>
                     </items>
                     <connections>
                         <outlet property="notificationAlertLabel" destination="nz5-h3-92S" id="mTD-G5-uoJ"/>


### PR DESCRIPTION
Fixes #1612.

## Summary
Sets the number of lines to 0, and to make the group prettier also hides the labels when empty.

## Screenshots
![Simulator Screen Shot - Apple Watch Series 6 - 40mm - 2021-05-01 17 48 37](https://user-images.githubusercontent.com/74188/116798602-2a8b5700-aaa6-11eb-884f-d8a4b29accad.png)
