### PR TITLE
Fix events not firing from watch dynamic notification actions

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -8,6 +8,7 @@ import Lokalise
 #endif
 import FirebaseCore
 import MBProgressHUD
+import ObjectMapper
 import PromiseKit
 import RealmSwift
 import SafariServices
@@ -453,6 +454,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         InteractiveImmediateMessage.observations.store[.init(queue: .main)] = { message in
             Current.Log.verbose("Received message: \(message.identifier)")
 
+            // TODO: move all these to something more strongly typed
+
             if message.identifier == "ActionRowPressed" {
                 Current.Log.verbose("Received ActionRowPressed \(message) \(message.content)")
                 let responseIdentifier = "ActionRowPressedResponse"
@@ -470,6 +473,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }.catch { err -> Void in
                     Current.Log.error("Error during action event fire: \(err)")
                     message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+                }
+            } else if message.identifier == "PushAction" {
+                Current.Log.verbose("Received PushAction \(message) \(message.content)")
+                let responseIdentifier = "PushActionResponse"
+
+                if let infoJSON = message.content["PushActionInfo"] as? [String: Any],
+                   let info = Mapper<HomeAssistantAPI.PushActionInfo>().map(JSON: infoJSON) {
+                    Current.backgroundTask(withName: "watch-push-action") { _ in
+                        Current.api.then(on: nil) { api in
+                            api.handlePushAction(for: info)
+                        }.ensure {
+                            message.reply(.init(identifier: responseIdentifier))
+                        }
+                    }.catch { error in
+                        Current.Log.error("error handling push action: \(error)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #1604.

## Summary
Dynamic actions -- unlike category-based -- appear to never forward their action handling to the iOS app, despite what the documentation says. Adds tooling to do call it manually.

## Any other notes
Not setting the notification delegate doesn't resolve this, either -- it doesn't appear we're doing anything unexpected, this is just an undocumented/rarely-used area, I guess.
