### PR TITLE
Fix keyboard and scroll handling in template editing

### DIFF
--- a/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationEditViewController.swift
@@ -494,7 +494,7 @@ class ComplicationEditViewController: HAFormViewController, TypedRowControllerTy
                 $0.tag = key + "_text"
                 $0.title = location.label
                 $0.add(rule: RuleRequired())
-                $0.placeholder = "{{ states(\"weather.current_temperature\") }}"
+                $0.placeholder = "{{ states(\"weather.temperature\") }}"
                 if let value = dataDict["text"] as? String {
                     $0.value = value
                 }

--- a/Sources/App/Settings/Eureka/HAFormViewController.swift
+++ b/Sources/App/Settings/Eureka/HAFormViewController.swift
@@ -15,4 +15,14 @@ class HAFormViewController: FormViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.keyboardDismissMode = .interactive
+    }
+
+    override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        // don't end editing automatically
+    }
 }

--- a/Sources/App/Settings/Eureka/TemplateSection.swift
+++ b/Sources/App/Settings/Eureka/TemplateSection.swift
@@ -47,6 +47,7 @@ public final class TemplateSection: Section {
     }
 
     let inputRow = TextAreaRow {
+        $0.textAreaHeight = .dynamic(initialTextViewHeight: 100.0)
         $0.cellSetup { cell, _ in
             cell.textView.configureCodeFont()
             cell.textView.keyboardType = .asciiCapable


### PR DESCRIPTION
## Summary
Prevents the keyboard from immediately dismissing on scroll, allows scrolling on the text view.

## Any other notes
This is potentially a bug in the future if drag-start triggers some side effect in Eureka, but eh…seems unlikely.