### PR TITLE
Remove 'loading actions' from DYNAMIC on Catalyst

### DIFF
--- a/Sources/App/Settings/Observation/NotificationCategory+Observation.swift
+++ b/Sources/App/Settings/Observation/NotificationCategory+Observation.swift
@@ -24,20 +24,32 @@ extension NotificationCategory {
                 }))
             }
 
-            let builtin = Promise<Set<UNNotificationCategory>>.value([
-                UNNotificationCategory(
-                    identifier: "DYNAMIC",
-                    actions: [
+            let builtin = Promise<Set<UNNotificationCategory>> { seal in
+                var categories = Set<UNNotificationCategory>()
+
+                let dynamicActions: [UNNotificationAction]
+
+                if Current.isCatalyst {
+                    dynamicActions = []
+                } else {
+                    dynamicActions = [
                         UNNotificationAction(
                             identifier: "LOADING",
                             title: L10n.NotificationService.loadingDynamicActions,
                             options: []
                         ),
-                    ],
+                    ]
+                }
+
+                categories.insert(UNNotificationCategory(
+                    identifier: "DYNAMIC",
+                    actions: dynamicActions,
                     intentIdentifiers: [],
                     options: []
-                ),
-            ])
+                ))
+
+                seal.fulfill(categories)
+            }
 
             let persisted = Promise<Set<UNNotificationCategory>> { seal in
                 seal.fulfill(Set(collection.flatMap(\.categories)))


### PR DESCRIPTION
## Summary
Until the notification content extension is loadable on Mac, this is a misleading button.

## Screenshots
<img width="370" alt="image" src="https://user-images.githubusercontent.com/74188/117529548-f5db3c00-af8c-11eb-9a13-578585ab4055.png">

## Any other notes
Even with a working content extension, you have to click the well-hidden chevron to expose the actions for it to actually load the possible actions, making the notification banner completely useless and this loading action even moreso.
