### PR TITLE
Fix location change overriding recent region changes

### DIFF
--- a/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
+++ b/Sources/App/ClientEvents/LocationHistoryDetailViewController.swift
@@ -115,6 +115,7 @@ final class LocationHistoryDetailViewController: UIViewController, TypedRowContr
             ```
 
             ## Location
+            - Trigger: \(entry.Trigger ?? "(unknown)")
             - Center: (\(latLongString(entry.Latitude)), \(latLongString(entry.Longitude)))
             - Accuracy: \(distanceString(entry.Accuracy))\(accuracyNote)
             - Accuracy Authorization: \(accuracyAuthorization)

--- a/Sources/App/ZoneManager/ZoneManagerIgnoreReason.swift
+++ b/Sources/App/ZoneManager/ZoneManagerIgnoreReason.swift
@@ -10,6 +10,7 @@ enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
     case ignoredSSID(String)
     case zoneUpdateFailed(NSError) // NSError so Equatable for laziness
     case beaconExitIgnored
+    case recentlyUpdated
 
     var errorDescription: String? {
         switch self {
@@ -31,6 +32,8 @@ enum ZoneManagerIgnoreReason: LocalizedError, Equatable {
             return "failed to update realm: \(error.localizedDescription)"
         case .beaconExitIgnored:
             return "beacon exit ignored"
+        case .recentlyUpdated:
+            return "recent location update already occurred"
         }
     }
 }


### PR DESCRIPTION
Fixes #1620.

## Summary
Prevents doing a location update just after a region event -- within 30 seconds. Region events may have accuracy fuzzing which the significant location change wouldn't know about, so it would override the fuzz. Region events are never prevented.

## Any other notes
This also makes processor events queue up rather than all executing simultaneously, both so we can make sure we don't do this error case and so we don't have other weird state transitions that I can't think of.
