### PR TITLE
Fixes zone enter with multiple overlapping zones where core ignores accuracy

### DIFF
--- a/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
+++ b/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
@@ -86,14 +86,13 @@ struct ZoneManagerAccuracyFuzzerMultiZone: ZoneManagerAccuracyFuzzer {
             return nil
         }
 
-        let containedZones = Set(Current.realm()
+        let containedZones = Current.realm()
             .objects(RLMZone.self)
             .filter {
                 // ignoring accuracy because that is not what matters for this case
                 // allowing the zone we're entering since we know we're not in it but we should be
                 $0.circularRegion.contains(coordinate) || $0 == zone
             }
-        )
 
         guard containedZones.count > 1 else {
             // no overlapping zones for this location, no change is necessary

--- a/Sources/App/ZoneManager/ZoneManagerProcessor.swift
+++ b/Sources/App/ZoneManager/ZoneManagerProcessor.swift
@@ -31,6 +31,7 @@ class ZoneManagerProcessorImpl: ZoneManagerProcessor {
     weak var delegate: ZoneManagerProcessorDelegate?
 
     var accuracyFuzzers: [ZoneManagerAccuracyFuzzer] = [
+        ZoneManagerAccuracyFuzzerMultiZone(),
         ZoneManagerAccuracyFuzzerRegionEnter(),
         ZoneManagerAccuracyFuzzerMultiRegionOverlap(),
     ]

--- a/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/CLLocation+Extensions.swift
@@ -1,9 +1,37 @@
 import CoreLocation
 import Foundation
 
-extension CLLocationCoordinate2D {
+public extension CLLocationCoordinate2D {
     func toArray() -> [Double] {
         [latitude, longitude]
+    }
+
+    func bearing(to destination: CLLocationCoordinate2D) -> Measurement<UnitAngle> {
+        let sourceLatitude: Measurement<UnitAngle> = .init(value: latitude, unit: .degrees)
+        let sourceLongitude: Measurement<UnitAngle> = .init(value: longitude, unit: .degrees)
+        let destinationLatitude: Measurement<UnitAngle> = .init(value: destination.latitude, unit: .degrees)
+        let destinationLongitude: Measurement<UnitAngle> = .init(value: destination.longitude, unit: .degrees)
+
+        // tanθ = sinΔλ⋅cosφ2 / cosφ1⋅sinφ2 − sinφ1⋅cosφ2⋅cosΔλ
+        // see mathforum.org/library/drmath/view/55417.html for derivation
+        // https://www.movable-type.co.uk/scripts/latlong.html
+
+        let φ1 = sourceLatitude.converted(to: .radians).value
+        let φ2 = destinationLatitude.converted(to: .radians).value
+        let Δλ = (destinationLongitude - sourceLongitude).converted(to: .radians).value
+
+        // everything in here is now in radians
+
+        let x = cos(φ1) * sin(φ2) - sin(φ1) * cos(φ2) * cos(Δλ)
+        let y = sin(Δλ) * cos(φ2)
+        var θ = atan2(y, x)
+
+        while θ < 0 {
+            // normalize to positive -- doesn't change the math, but makes logging/tests easier
+            θ += 2.0 * Double.pi
+        }
+
+        return .init(value: θ, unit: .radians)
     }
 
     func moving(
@@ -92,6 +120,32 @@ public extension CLLocation {
                 coordinate: coordinate,
                 altitude: altitude,
                 horizontalAccuracy: horizontalAccuracy + amount + 1,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                speed: speed,
+                timestamp: timestamp
+            )
+        }
+    }
+
+    func changingCoordinate(to fuzzedCoordinate: CLLocationCoordinate2D) -> CLLocation {
+        if #available(iOS 13.4, watchOS 6.2, *) {
+            return CLLocation(
+                coordinate: fuzzedCoordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy,
+                verticalAccuracy: verticalAccuracy,
+                course: course,
+                courseAccuracy: courseAccuracy,
+                speed: speed,
+                speedAccuracy: speedAccuracy,
+                timestamp: timestamp
+            )
+        } else {
+            return CLLocation(
+                coordinate: fuzzedCoordinate,
+                altitude: altitude,
+                horizontalAccuracy: horizontalAccuracy,
                 verticalAccuracy: verticalAccuracy,
                 course: course,
                 speed: speed,

--- a/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
@@ -775,7 +775,6 @@ class ZoneManagerProcessorTests: XCTestCase {
         } else {
             XCTFail("no state but one was expected")
         }
-
     }
 
     func testNotOneShot() throws {

--- a/Tests/Shared/CLLocation+Extensions.test.swift
+++ b/Tests/Shared/CLLocation+Extensions.test.swift
@@ -135,8 +135,6 @@ class CLLocationExtensionsTests: XCTestCase {
                 longitude: recomputedCoordinate.longitude
             )
 
-            print("\(name) bearing \(bearing.converted(to: .degrees)) distance \(distance)")
-
             // the locations i picked aren't exactly cardinal directions, so there's a small fuzz, but they are close
             XCTAssertEqual(bearing.converted(to: .degrees).value, roughBearing, accuracy: 4, name)
             // it should be good enough to get us back to very close accuracy-wise to the location

--- a/Tests/Shared/CLLocation+Extensions.test.swift
+++ b/Tests/Shared/CLLocation+Extensions.test.swift
@@ -104,4 +104,43 @@ class CLLocationExtensionsTests: XCTestCase {
         XCTAssertFalse(region.containsWithAccuracy(locationNoAccuracy))
         XCTAssertTrue(region.containsWithAccuracy(locationWithAccuracy))
     }
+
+    func testBearing() {
+        // old mint is our starting point
+        let start = CLLocation(latitude: 37.78319463773435, longitude: -122.40664036682519)
+
+        XCTAssertEqual(start.coordinate.bearing(to: start.coordinate).value, 0)
+
+        for (name, destination, roughBearing) in [
+            // basically north
+            ("mister jius", CLLocation(latitude: 37.793855824513756, longitude: -122.40657738553836), 0.0),
+            // basically east
+            ("21st amendment", CLLocation(latitude: 37.783090295994604, longitude: -122.39266797412634), 90.0),
+            // basically south
+            ("deli board", CLLocation(latitude: 37.77781029169787, longitude: -122.4070094340342), 180.0),
+            // basically west
+            ("brendas", CLLocation(latitude: 37.78313519107828, longitude: -122.41904411931317), 270.0),
+            // hotel right nearby
+            ("hotel zetta", CLLocation(latitude: 37.78345931149641, longitude: -122.4070579074126), 309),
+        ] {
+            let bearing = start.coordinate.bearing(to: destination.coordinate)
+            let distance = start.distance(from: destination)
+
+            let recomputedCoordinate = start.coordinate.moving(
+                distance: .init(value: distance, unit: .meters),
+                direction: bearing
+            )
+            let recomputedLocation = CLLocation(
+                latitude: recomputedCoordinate.latitude,
+                longitude: recomputedCoordinate.longitude
+            )
+
+            print("\(name) bearing \(bearing.converted(to: .degrees)) distance \(distance)")
+
+            // the locations i picked aren't exactly cardinal directions, so there's a small fuzz, but they are close
+            XCTAssertEqual(bearing.converted(to: .degrees).value, roughBearing, accuracy: 4, name)
+            // it should be good enough to get us back to very close accuracy-wise to the location
+            XCTAssertEqual(recomputedLocation.distance(from: destination), 0, accuracy: 0.005 * distance, name)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1627.

## Summary
When a GPS coordinate is outside the zone, even if accuracy places it inside, the logic in core will prefer a zone which contains the exact coordinates, regardless of accuracy. This moves the coordinate over to be inside the zone.

## Any other notes
- Allows fuzzers to change coordinate, even though we really do not want to do this. This is effectively fudging the real location data, which is something I've avoided as much as possible to this point.
- Adds a helper method to determine bearing to another location so that we know how to adjust the position towards the center of the zone.