### PR TITLE
Change crash reporting & analytics to opt-in

### DIFF
--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -443,6 +443,13 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     Current.settingsStore.privacy.messaging = row.value ?? true
                     Messaging.messaging().isAutoInitEnabled = Current.settingsStore.privacy.messaging
                 }
+                +++ Section(header: nil, footer: L10n.SettingsDetails.Privacy.Alerts.description)
+                <<< SwitchRow {
+                    $0.title = L10n.SettingsDetails.Privacy.Alerts.title
+                    $0.value = Current.settingsStore.privacy.alerts
+                }.onChange { row in
+                    Current.settingsStore.privacy.alerts = row.value ?? true
+                }
                 +++ Section(
                     header: nil,
                     footer: L10n.SettingsDetails.Privacy.CrashReporting.description
@@ -460,13 +467,6 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     $0.value = Current.settingsStore.privacy.analytics
                 }.onChange { row in
                     Current.settingsStore.privacy.analytics = row.value ?? true
-                }
-                +++ Section(header: nil, footer: L10n.SettingsDetails.Privacy.Alerts.description)
-                <<< SwitchRow {
-                    $0.title = L10n.SettingsDetails.Privacy.Alerts.title
-                    $0.value = Current.settingsStore.privacy.alerts
-                }.onChange { row in
-                    Current.settingsStore.privacy.alerts = row.value ?? true
                 }
 
         default:

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -313,6 +313,18 @@ public class SettingsStore {
             default: return ""
             }
         }
+
+        internal static func `default`(for keyPath: KeyPath<Privacy, Bool>) -> Bool {
+            switch keyPath {
+            case \.messaging: return true
+            case \.crashes: return false
+            case \.analytics: return false
+            case \.alerts: return true
+            case \.updates: return true
+            case \.updatesIncludeBetas: return true
+            default: return false
+            }
+        }
     }
 
     public var privacy: Privacy {
@@ -320,8 +332,8 @@ public class SettingsStore {
             func boolValue(for keyPath: KeyPath<Privacy, Bool>) -> Bool {
                 let key = Privacy.key(for: keyPath)
                 if prefs.object(forKey: key) == nil {
-                    // default to enabled for privacy settings
-                    return true
+                    // value never set, use the default for this one
+                    return Privacy.default(for: keyPath)
                 }
                 return prefs.bool(forKey: key)
             }


### PR DESCRIPTION
## Summary
Disables crash reporting and analytics by default.

## Screenshots

| Light | Dark |
| -- | -- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 15 50 53](https://user-images.githubusercontent.com/74188/120721844-82d9be00-c483-11eb-960e-bd3a3b915211.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 15 50 55](https://user-images.githubusercontent.com/74188/120721846-866d4500-c483-11eb-83ab-675212011995.png) |

## Any other notes
- Users who have changed _any_ privacy setting have all of the values persisted, but users who have never done so will now find crash reporting and analytics disabled.
- Crash reporting being disabled explicitly prevents any communication with Sentry.
- Analytics doesn't actually do anything other than control whether error/warning logs are sent to Sentry if a crash occurs, so this doesn't really change much.
- Moves "Alerts" to under "Firebase" since it is prettier flow for them to be in that order.
- Done in response to Apple reject us (how many years since Robbie added these?!) but it's better with our ethos anyway.