### PR TITLE
Improve handling around refresh token errors

### DIFF
--- a/Sources/App/Onboarding/ConnectInstanceViewController.swift
+++ b/Sources/App/Onboarding/ConnectInstanceViewController.swift
@@ -165,6 +165,8 @@ class ConnectInstanceViewController: UIViewController {
             )
 
             self.setAnimationStatus(self.sensorsConfigured, state: .success)
+        }.get { _ in
+            Current.apiConnection.connect()
         }
     }
 }


### PR DESCRIPTION
Resolves #1542.

## Summary
Logs the error code we get when refreshing a token and log out if we encounter a 403 during token refresh.

## Any other notes
- Fixes an auth handling issue where the WebSocket connection doesn't connect initially.
- Logs out when we encounter a 403 during token refresh. Only a few auth providers do this; specifically, the `trusted_networks` one will reject token refreshes for auth tokens it vends when not on the trusted network. Otherwise, we'll keep retrying and end up getting banned (if enabled).
- Includes the error that we get into the event log so we can trace back the failure easily.