### PR TITLE
End-to-end encrypted notifications

### DIFF
--- a/Sources/Extensions/NotificationService/NotificationService.swift
+++ b/Sources/Extensions/NotificationService/NotificationService.swift
@@ -3,19 +3,45 @@ import Shared
 import UserNotifications
 
 final class NotificationService: UNNotificationServiceExtension {
+    class Pending {
+        internal init(content: UNNotificationContent, handler: @escaping (UNNotificationContent) -> Void) {
+            self.content = content
+            self.handler = handler
+        }
+
+        var content: UNNotificationContent
+        var handler: (UNNotificationContent) -> Void
+    }
+
+    private var pending: Pending?
+
     override func didReceive(
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
         Current.Log.info("didReceive \(request), user info \(request.content.userInfo)")
 
-        Current.api.then(on: nil) { api in
-            Current.notificationAttachmentManager.content(from: request.content, api: api)
+        let pending = Pending(content: request.content, handler: contentHandler)
+        self.pending = pending
+
+        firstly {
+            Current.notificationAttachmentManager.decryptContent(fromUserInfo: request.content.userInfo)
         }.recover { error in
-            Current.Log.error("failed to get content, giving default: \(error)")
+            Current.Log.error("failed to decrypt content, giving default: \(error)")
             return .value(request.content)
-        }.done {
-            contentHandler($0)
+        }.get {
+            pending.content = $0
+        }.then { withoutAttachment in
+            Current.api.then(on: nil) { api in
+                Current.notificationAttachmentManager.content(from: withoutAttachment, api: api)
+            }.recover { error in
+                Current.Log.error("failed to get content, giving default: \(error)")
+                return .value(withoutAttachment)
+            }
+        }.done { [weak self] content in
+            Current.Log.info("providing body \(content.body)")
+            contentHandler(content)
+            self?.pending = nil
         }
     }
 
@@ -23,6 +49,13 @@ final class NotificationService: UNNotificationServiceExtension {
         // Called just before the extension will be terminated by the system.
         // Use this as an opportunity to deliver your "best attempt" at modified content,
         // otherwise the original push payload will be used.
-        Current.Log.warning("serviceExtensionTimeWillExpire")
+        if let pending = pending {
+            Current.Log.info("sending content")
+            pending.handler(pending.content)
+        } else {
+            Current.Log.error("missing content at expiration time")
+        }
+
+        pending = nil
     }
 }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -436,6 +436,14 @@ public class HomeAssistantAPI {
                     "push_url": "https://mobile-apps.home-assistant.io/api/sendPushNotification",
                     "push_token": pushID,
                 ]
+                $0.PushConfig = [
+                    [
+                        "platform": Current.device.systemName(),
+                        "push_token": pushID,
+                        "push_url": "http://localhost:5000/home-assistant-mobile-apps/us-central1/encryptedV1",
+                        "supports_encryption": true,
+                    ],
+                ]
             }
 
             $0.AppIdentifier = Constants.BundleID
@@ -456,6 +464,7 @@ public class HomeAssistantAPI {
 
         let ident = with(MobileAppUpdateRegistrationRequest()) {
             $0.AppData = registerRequest.AppData
+            $0.PushConfig = registerRequest.PushConfig
             $0.AppVersion = registerRequest.AppVersion
             $0.DeviceName = registerRequest.DeviceName
             $0.Manufacturer = registerRequest.Manufacturer

--- a/Sources/Shared/API/Requests/MobileAppRegistrationRequest.swift
+++ b/Sources/Shared/API/Requests/MobileAppRegistrationRequest.swift
@@ -3,6 +3,7 @@ import ObjectMapper
 
 class MobileAppRegistrationRequest: Mappable {
     var AppData: [String: Any]?
+    var PushConfig: [[String: Any]]?
     var AppIdentifier: String?
     var AppName: String?
     var AppVersion: String?
@@ -21,6 +22,7 @@ class MobileAppRegistrationRequest: Mappable {
 
     func mapping(map: Map) {
         AppData <- map["app_data"]
+        PushConfig <- map["push_config"]
         AppIdentifier <- map["app_id"]
         AppName <- map["app_name"]
         AppVersion <- map["app_version"]

--- a/Sources/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
+++ b/Sources/Shared/API/Requests/MobileAppUpdateRegistrationRequest.swift
@@ -3,6 +3,7 @@ import ObjectMapper
 
 class MobileAppUpdateRegistrationRequest: Mappable {
     var AppData: [String: Any]?
+    var PushConfig: [[String: Any]]?
     var AppVersion: String?
     var DeviceName: String?
     var Manufacturer: String?
@@ -20,5 +21,6 @@ class MobileAppUpdateRegistrationRequest: Mappable {
         Manufacturer <- map["manufacturer"]
         Model <- map["model"]
         OSVersion <- map["os_version"]
+        PushConfig <- map["push_config"]
     }
 }


### PR DESCRIPTION
Fixes #70. Requires https://github.com/home-assistant/core/pull/52048.

- [ ] Pass cleartext commands through, need to wire up the command manager to the register calls. Also still need to make the fcm repo handle them, or make core send them through the legacy path.
- [ ] Avoid erroring the update registration webhook, which doesn't like extra params and so the push_config is going to start erroring for.
- [ ] Tests.
- [ ] Get dependent core PR merged.

## Summary
Allows decrypting notifications in the service extension.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
This relies on changes in core, specifically [my branch](https://github.com/home-assistant/core/compare/dev...zacwest:feat/mobile-app-notify-e2e) of [@robbiet480's branch](https://github.com/home-assistant/core/compare/dev...robbiet480:feat/mobile-app-notify-e2e) which encrypts using the same webhook secret that we already decrypt webhook contents for.

Since we were denied the `com.apple.developer.usernotifications.filtering` entitlement, we need to do the cleartext commands passthrough for things like `clear_notification`.