### PR TITLE
Fix crash in push provider when stop/start

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		117318AB25199E1A0013E010 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AA25199E1A0013E010 /* AppKit.framework */; };
 		117318AD25199E220013E010 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 117318AC25199E220013E010 /* Foundation.framework */; };
 		11761E2925EC1415007A9D17 /* WebSocketStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11761E2825EC1415007A9D17 /* WebSocketStatusRow.swift */; };
+		11764A6C26817FC3007D47F3 /* UserDefaultsValueSync.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11764A6B26817FC3007D47F3 /* UserDefaultsValueSync.test.swift */; };
 		117675EF252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
 		117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */; };
 		1178AB00263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178AAFF263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift */; };
@@ -1147,6 +1148,7 @@
 		117318AA25199E1A0013E010 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = DEVELOPER_DIR; };
 		117318AC25199E220013E010 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		11761E2825EC1415007A9D17 /* WebSocketStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketStatusRow.swift; sourceTree = "<group>"; };
+		11764A6B26817FC3007D47F3 /* UserDefaultsValueSync.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsValueSync.test.swift; sourceTree = "<group>"; };
 		117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateComplications.swift; sourceTree = "<group>"; };
 		1178AAFF263E2DF7007BA9D0 /* WKInterfaceLabel+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKInterfaceLabel+Additions.swift"; sourceTree = "<group>"; };
 		1178C4E424D5CEB200FDEC3E /* ConnectionURLViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionURLViewController.swift; sourceTree = "<group>"; };
@@ -3255,6 +3257,7 @@
 				11AA9976266B0CEC00B829E1 /* NotificationParserLegacy.test.swift */,
 				11B7DC0D266C3EEB0090BD3B /* LocalPushEvent.test.swift */,
 				11B7DC1E266C5D3E0090BD3B /* LocalPushManager.test.swift */,
+				11764A6B26817FC3007D47F3 /* UserDefaultsValueSync.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -5477,6 +5480,7 @@
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */,
 				1133F5F625F1DBF000AD776F /* CLLocation+Sanitize.test.swift in Sources */,
+				11764A6C26817FC3007D47F3 /* UserDefaultsValueSync.test.swift in Sources */,
 				D0BE441221043B8100C74314 /* AuthorizationTests.swift in Sources */,
 				110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */,
 			);

--- a/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
+++ b/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
@@ -7,19 +7,26 @@ public class LocalPushStateSync: UserDefaultsValueSync<LocalPushManager.State> {
 
 public class UserDefaultsValueSync<ValueType: Codable>: NSObject {
     public let settingsKey: String
-    public init(settingsKey: String) {
+    public let userDefaults: UserDefaults
+
+    public init(settingsKey: String, userDefaults: UserDefaults) {
         self.settingsKey = settingsKey
+        self.userDefaults = userDefaults
         super.init()
-        Current.settingsStore.prefs.addObserver(
+        userDefaults.addObserver(
             self,
             forKeyPath: settingsKey,
-            options: [.initial],
+            options: [],
             context: nil
         )
     }
 
+    public convenience init(settingsKey: String) {
+        self.init(settingsKey: settingsKey, userDefaults: Current.settingsStore.prefs)
+    }
+
     deinit {
-        Current.settingsStore.prefs.removeObserver(self, forKeyPath: settingsKey)
+        userDefaults.removeObserver(self, forKeyPath: settingsKey)
     }
 
     public var value: ValueType? {
@@ -27,16 +34,16 @@ public class UserDefaultsValueSync<ValueType: Codable>: NSObject {
             do {
                 if let state = newValue {
                     let json = try JSONEncoder().encode(state)
-                    Current.settingsStore.prefs.set(json, forKey: settingsKey)
+                    userDefaults.set(json, forKey: settingsKey)
                 } else {
-                    Current.settingsStore.prefs.removeObject(forKey: settingsKey)
+                    userDefaults.removeObject(forKey: settingsKey)
                 }
             } catch {
                 Current.Log.error("failed to encode: \(error)")
             }
         }
         get {
-            guard let data = Current.settingsStore.prefs.data(forKey: settingsKey) else {
+            guard let data = userDefaults.data(forKey: settingsKey) else {
                 return nil
             }
 

--- a/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
+++ b/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
@@ -18,6 +18,10 @@ public class UserDefaultsValueSync<ValueType: Codable>: NSObject {
         )
     }
 
+    deinit {
+        Current.settingsStore.prefs.removeObserver(self, forKeyPath: settingsKey)
+    }
+
     public var value: ValueType? {
         set {
             do {

--- a/Tests/Shared/UserDefaultsValueSync.test.swift
+++ b/Tests/Shared/UserDefaultsValueSync.test.swift
@@ -1,0 +1,83 @@
+@testable import Shared
+import XCTest
+
+class UserDefaultsValueSyncTests: XCTestCase {
+    private var model: UserDefaultsValueSync<TestCodable>!
+    private var userDefaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+
+        userDefaults = UserDefaults()
+        model = UserDefaultsValueSync<TestCodable>(settingsKey: "basicSync", userDefaults: userDefaults)
+    }
+
+    func testReuseKey() {
+        var model2: UserDefaultsValueSync<TestCodable>? = UserDefaultsValueSync<TestCodable>(
+            settingsKey: model.settingsKey
+        )
+        weak var weakSync1 = model2
+        model2 = nil
+
+        XCTAssertNil(weakSync1)
+
+        // if KVO isn't set up correctly, this will crash
+        model.value = .init(value: "new")
+    }
+
+    func testNotify() {
+        var values = [TestCodable]()
+
+        let cancellable = model.observe { value in
+            values.append(value)
+        }
+
+        model.value = .init(value: "1")
+        model.value = .init(value: "2")
+        model.value = .init(value: "3")
+        model.value = .init(value: "4")
+        model.value = nil
+        cancellable.cancel()
+        model.value = .init(value: "5")
+
+        XCTAssertEqual(values.map(\.value), ["1", "2", "3", "4"])
+    }
+
+    func testFailedGet() {
+        userDefaults.set("moo".data(using: .utf8), forKey: model.settingsKey)
+        XCTAssertNil(model.value)
+    }
+
+    func testFailedSet() {
+        let failObject = TestCodable(value: "failed")
+        failObject.failEncode = true
+
+        model.value = .init(value: "base")
+        model.value = failObject
+
+        XCTAssertEqual(model.value?.value, "base")
+    }
+}
+
+private class TestCodable: Codable {
+    var value: String?
+    var failEncode: Bool = false
+
+    enum FailEncodeError: Error {
+        case fail
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if failEncode {
+            throw FailEncodeError.fail
+        } else {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(value, forKey: .value)
+            try container.encode(failEncode, forKey: .failEncode)
+        }
+    }
+
+    init(value: String?) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
## Summary
Old-style KVO requires manually removing observations, of course, otherwise it'll hit random memory and crash.
