### PR TITLE
Immediately disconnect in PushProvider when asked to stop

### DIFF
--- a/Sources/Extensions/PushProvider/PushProvider.swift
+++ b/Sources/Extensions/PushProvider/PushProvider.swift
@@ -103,6 +103,7 @@ import UserNotifications
     override func stop(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         Current.Log.notify("stopping with reason \(reason)", log: .error)
         localPushManager = nil
+        Current.apiConnection.disconnect()
     }
 
     override func handleTimerEvent() {


### PR DESCRIPTION
This may make turning off Wi-Fi a little bit more reliable. Or not, it doesn't seem to get called. Maybe in the future.