### PR TITLE
Fix crash in background in push provider from update_location call

### DIFF
--- a/Sources/Shared/Common/Extensions/XCGLogger+UNNotification.swift
+++ b/Sources/Shared/Common/Extensions/XCGLogger+UNNotification.swift
@@ -17,7 +17,7 @@ public extension XCGLogger {
         }
 
         if let level = logLevel {
-            logln(closure, level: level, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+            logln(closure(), level: level, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
         }
 
         guard Current.settingsStore.prefs.bool(forKey: Self.shouldNotifyUserDefaultsKey) else {

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -191,6 +191,7 @@ public class Environment {
 
     // Use of 'appConfiguration' is preferred, but sometimes Beta builds are done as releases.
     public var isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    public var isAppExtension = Constants.BundleID != Bundle.main.bundleIdentifier
     public var isAppStore: Bool = {
         do {
             // https://developer.apple.com/library/archive/technotes/tn2259/_index.html suggested method

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -183,7 +183,7 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
 
         super.init()
 
-        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.allowsBackgroundLocationUpdates = !Current.isAppExtension
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
         locationManager.delegate = self
 


### PR DESCRIPTION
Looks like iOS 15 (and maybe earlier) will crash if we try and ask for background updates in the extension.
