### PR TITLE
Fix active URL check failing if port was specified as 80/443

### DIFF
--- a/Sources/Shared/Common/Extensions/URL+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/URL+Extensions.swift
@@ -4,10 +4,23 @@ extension URL {
     /// Return true if receiver's host and scheme is equal to `otherURL`
     public func baseIsEqual(to otherURL: URL) -> Bool {
         host == otherURL.host
-            && port == otherURL.port
+            && portWithFallback == otherURL.portWithFallback
             && scheme == otherURL.scheme
             && user == otherURL.user
             && password == otherURL.password
+    }
+
+    // port will be removed if 80 or 443 by WKWebView, so we provide defaults for comparison
+    var portWithFallback: Int? {
+        if let port = port {
+            return port
+        }
+
+        switch scheme?.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return nil
+        }
     }
 
     func adapting(url: URL) -> URL {


### PR DESCRIPTION
## Summary
If a URL is specified like `http://localhost:80` then WKWebView will eat the port, and we'll assume the URL being displayed is always one that needs to be mutated due to settings or internal/external change when the app enters foreground.