### PR TITLE
Reset badge to 0 automatically when opening the app

### DIFF
--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -20,9 +20,25 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
     var commandManager = NotificationCommandManager()
 
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
     func setupNotifications() {
         UNUserNotificationCenter.current().delegate = self
         _ = localPushManager
+    }
+
+    @objc private func didBecomeActive() {
+        if Current.settingsStore.clearBadgeAutomatically {
+            UIApplication.shared.applicationIconBadgeNumber = 0
+        }
     }
 
     func resetPushID() -> Promise<String> {

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -318,7 +318,10 @@ Your actions and local configuration will still be available after logging in.";
 "settings_details.location.zones.location.title" = "Location";
 "settings_details.location.zones.radius.label" = "%li m";
 "settings_details.location.zones.radius.title" = "Radius";
-"settings_details.notifications.badge_section.button.title" = "Reset badge to 0";
+"settings_details.notifications.badge_section.button.title" = "Reset Badge";
+/* under the 'Reset Badge' button, this is implied to be 'Reset Automatically' -- mostly dropped the Reset here because it looked a bit verbose. */
+"settings_details.notifications.badge_section.automatic_setting.title" = "Automatically";
+"settings_details.notifications.badge_section.automatic_setting.description" = "Resets the badge to 0 every time you launch the app.";
 "settings_details.notifications.badge_section.reset_alert.message" = "The badge has been reset to 0.";
 "settings_details.notifications.badge_section.reset_alert.title" = "Badge reset";
 "settings_details.notifications.categories_synced.empty" = "No Synced Categories";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1350,8 +1350,14 @@ public enum L10n {
       /// Notifications
       public static var title: String { return L10n.tr("Localizable", "settings_details.notifications.title") }
       public enum BadgeSection {
+        public enum AutomaticSetting {
+          /// Resets the badge to 0 every time you launch the app.
+          public static var description: String { return L10n.tr("Localizable", "settings_details.notifications.badge_section.automatic_setting.description") }
+          /// Automatically
+          public static var title: String { return L10n.tr("Localizable", "settings_details.notifications.badge_section.automatic_setting.title") }
+        }
         public enum Button {
-          /// Reset badge to 0
+          /// Reset Badge
           public static var title: String { return L10n.tr("Localizable", "settings_details.notifications.badge_section.button.title") }
         }
         public enum ResetAlert {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -451,6 +451,19 @@ public class SettingsStore {
         }
     }
 
+    public var clearBadgeAutomatically: Bool {
+        get {
+            if let value = prefs.object(forKey: "clearBadgeAutomatically") as? NSNumber {
+                return value.boolValue
+            } else {
+                return true
+            }
+        }
+        set {
+            prefs.set(newValue, forKey: "clearBadgeAutomatically")
+        }
+    }
+
     // MARK: - Private helpers
 
     private var defaultDeviceID: String {


### PR DESCRIPTION
## Summary
Adds a setting (defaulted on) to reset the badge to 0 when launching the app.

## Screenshots
| Light | Dark |
| -- | -- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 10 23 38](https://user-images.githubusercontent.com/74188/123462674-72f35c80-d59f-11eb-93d7-eaa021a021a2.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 10 23 40](https://user-images.githubusercontent.com/74188/123462699-7a1a6a80-d59f-11eb-9e23-238b7265e853.png) |

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#549

## Any other notes
This is the general behavior on most iOS apps, and should make micro-managing the badge a little easier.