### PR TITLE
Fix incorrectly entering a <100m zone whose regions intersect a nearby zone

### DIFF
--- a/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
+++ b/Sources/App/ZoneManager/ZoneManagerAccuracyFuzzer.swift
@@ -56,7 +56,7 @@ struct ZoneManagerAccuracyFuzzerMultiRegionOverlap: ZoneManagerAccuracyFuzzer {
 
         let zoneRegion = zone.circularRegion
 
-        guard zone.circularRegionsForMonitoring.allSatisfy({ $0.containsWithAccuracy(location) }) else {
+        guard zone.containsInRegions(location) else {
             // all of the regions think we're in the zone
             return nil
         }
@@ -76,6 +76,12 @@ struct ZoneManagerAccuracyFuzzerMultiRegionOverlap: ZoneManagerAccuracyFuzzer {
 struct ZoneManagerAccuracyFuzzerMultiZone: ZoneManagerAccuracyFuzzer {
     func fuzz(for location: CLLocation, for event: ZoneManagerEvent) -> ZoneManagerAccuracyFuzzerChange? {
         guard let zone = event.associatedZone, case .region(_, .inside) = event.eventType else {
+            return nil
+        }
+
+        guard zone.containsInRegions(location) else {
+            // the zone needs to believe this location _should_ belong inside it, otherwise moving the coordinate is
+            // an incorrect change. this can happen for e.g. entering one of the circular regions for <100m zone.
             return nil
         }
 

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -175,6 +175,10 @@ public final class RLMZone: Object, UpdatableModel {
     }
     #endif
 
+    public func containsInRegions(_ location: CLLocation) -> Bool {
+        circularRegionsForMonitoring.allSatisfy { $0.containsWithAccuracy(location) }
+    }
+
     public var circularRegionsForMonitoring: [CLCircularRegion] {
         if Radius >= 100 {
             // zone is big enough to not have false-enters


### PR DESCRIPTION
Fixes #1693.

## Summary
When we fuzz the coordinate to deal with zone overlap issues in core, we need to also take into account whether we're actually in the zone we'd be fuzzing coordinate to. For zones >=100m, this is the region, but for smaller zones we need to make sure all of the monitored regions agree before changing coordinate.