### PR TITLE
Fix tests and Watch App execution in Xcode 12.5

### DIFF
--- a/Configuration/Scripts/fix_xcode_12.5_target_platform_issues.sh
+++ b/Configuration/Scripts/fix_xcode_12.5_target_platform_issues.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# when building for iOS, Xcode expects the Launcher.app to exist
+LAUNCHER_INFO_PLIST_PATH=$BUILD_DIR/Debug/Home\ Assistant\ Launcher.app/Contents/Info.plist
+if [ ! -f "$LAUNCHER_INFO_PLIST_PATH" ]; then
+	mkdir -p "$(dirname "$LAUNCHER_INFO_PLIST_PATH")"
+
+	cat >"$LAUNCHER_INFO_PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>io.robbie.HomeAssistant.dev.Launcher</string>
+</dict>
+</plist>
+EOF
+fi
+
+WATCHAPP_INFO_PLIST_PATH=$BUILD_DIR/Debug-watchos/HomeAssistant-WatchApp.app/Contents/Info.plist
+if [ ! -f "$WATCHAPP_INFO_PLIST_PATH" ]; then
+	mkdir -p "$(dirname "$WATCHAPP_INFO_PLIST_PATH")"
+
+	cat >"$WATCHAPP_INFO_PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>io.robbie.HomeAssistant.dev.watchkitapp</string>
+</dict>
+</plist>
+EOF
+fi

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -3587,6 +3587,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B657A9131CA646EB00121384 /* Build configuration list for PBXNativeTarget "Tests-App" */;
 			buildPhases = (
+				11FE64BC268D984D00AC4367 /* Fix Xcode 12.5+ Dependency Issues */,
 				6B47CD8F0AAF5C691F8256D7 /* [CP] Check Pods Manifest.lock */,
 				B657A8F81CA646EB00121384 /* Sources */,
 				B657A8F91CA646EB00121384 /* Frameworks */,
@@ -3701,6 +3702,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B6CC5DA52159D10F00833E5D /* Build configuration list for PBXNativeTarget "WatchApp" */;
 			buildPhases = (
+				11A67358268D9E7B00D1AFD4 /* Fix Xcode 12.5+ Dependency Issues */,
 				B6CC5D802159D10D00833E5D /* Resources */,
 				93C44648FF2FAE89B2ED8FC9 /* Frameworks */,
 				119A172824D74DA800D1B66D /* Embed App Extensions */,
@@ -4438,6 +4440,26 @@
 			shellPath = /bin/sh;
 			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    # swiftlint as of 2021-01-21 (0.42.0) can't handle spaces in paths\n    # for the config arg, so we rely on relative here\n    # https://github.com/realm/SwiftLint/issues/3471\n    \"${SRCROOT}/Pods/SwiftLint/swiftlint\" \\\n       --config \".swiftlint.yml\" \\\n       --quiet \\\n       \"${SRCROOT}\"\nfi\n";
 		};
+		11A67358268D9E7B00D1AFD4 /* Fix Xcode 12.5+ Dependency Issues */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Fix Xcode 12.5+ Dependency Issues";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "exec $PROJECT_DIR/Configuration/Scripts/fix_xcode_12.5_target_platform_issues.sh\n";
+			showEnvVarsInLog = 0;
+		};
 		11C03007267F22BC0095AD58 /* Enable Xcode 13-requiring intents */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4475,6 +4497,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ $IS_MACCATALYST ]]; then\n    rm -r \"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lokalise.framework\"    \nfi\n";
+		};
+		11FE64BC268D984D00AC4367 /* Fix Xcode 12.5+ Dependency Issues */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Fix Xcode 12.5+ Dependency Issues";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "exec $PROJECT_DIR/Configuration/Scripts/fix_xcode_12.5_target_platform_issues.sh\n";
+			showEnvVarsInLog = 0;
 		};
 		120054CCBDBFE9476AF3222E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary
Works around Xcode 12.5 / 13.0 (beta 1/2 at least) regressions in target launching.

## Any other notes
When running tests for iOS simulator, we get an error like:

> The bundle identifier for Home Assistant Launcher.app couldn’t be read. No such file or directory: “/Users/zac/Library/Developer/Xcode/DerivedData/HomeAssistant-ahjyjjgpphztaebycwnsuwmrdiho/Build/Products/Debug/Home Assistant Launcher.app”.

The Launcher.app target is set to macOS only, so it's not built for iOS simulator. Building it first then executing tests works, so clearly Xcode is incorrectly trying to analyze the target when it isn't used.

This also happens when building for Catalyst, where it can't find the watchOS app which isn't being compiled since it is iOS only:

> The bundle identifier for HomeAssistant-WatchApp.app couldn’t be read. No such file or directory: “/Users/zac/Library/Developer/Xcode/DerivedData/HomeAssistant-ahjyjjgpphztaebycwnsuwmrdiho/Build/Products/Debug-watchos/HomeAssistant-WatchApp.app”.

Filed this as FB9189357 as well.