### PR TITLE
Bump HAKit for re-subscription delay

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -3587,8 +3587,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B657A9131CA646EB00121384 /* Build configuration list for PBXNativeTarget "Tests-App" */;
 			buildPhases = (
-				11FE64BC268D984D00AC4367 /* Fix Xcode 12.5+ Dependency Issues */,
 				6B47CD8F0AAF5C691F8256D7 /* [CP] Check Pods Manifest.lock */,
+				11FE64BC268D984D00AC4367 /* Fix Xcode 12.5+ Dependency Issues */,
 				B657A8F81CA646EB00121384 /* Sources */,
 				B657A8F91CA646EB00121384 /* Frameworks */,
 				B657A8FA1CA646EB00121384 /* Resources */,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -184,7 +184,7 @@ CHECKOUT OPTIONS:
     :commit: ff5b4ccf9bb424cb454e76ee91e32165d2d9c12c
     :git: https://github.com/hirokimu/EMTLoadingIndicator
   HAKit:
-    :commit: 9e87261d849d743e59ac496a1ae6502169af41e8
+    :commit: 19e6267dff11426da2c090d5e7943953606ac334
     :git: https://github.com/home-assistant/HAKit.git
   NotificationTestCases:
     :commit: f01bf06e0a3088d9eee1281df3fb08355093bc51


### PR DESCRIPTION
## Summary
Fixes flooding the logs with "Received invalid command: mobile_app/push_notification_channel" when HA is restarting.