### PR TITLE
Fix playback of animated GIFs in notification content extension

### DIFF
--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -4,14 +4,27 @@ import Shared
 import UIKit
 import UserNotifications
 import UserNotificationsUI
+import WebKit
 
 class ImageAttachmentViewController: UIViewController, NotificationCategory {
     let attachmentURL: URL
     let needsEndSecurityScoped: Bool
     let image: UIImage
-    let imageView = with(UIImageView()) {
-        $0.contentMode = .scaleAspectFit
+    let imageData: Data
+    let imageUTI: CFString
+
+    enum ImageViewType {
+        case imageView(UIImageView)
+        case webView(WKWebView)
+
+        var view: UIView {
+            switch self {
+            case let .imageView(imageView): return imageView
+            case let .webView(webView): return webView
+            }
+        }
     }
+    let visibleView: ImageViewType
 
     required init(notification: UNNotification, attachmentURL: URL?) throws {
         guard let attachmentURL = attachmentURL else {
@@ -25,12 +38,55 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
         // has the full list of what is advertised - at time of writing (iOS 14.5) it's jpeg, gif and png
         // but iOS 14 also supports webp, so who knows if it'll be added silently or not
 
-        guard let image = UIImage(contentsOfFile: attachmentURL.path) else {
+        do {
+            let data = try Data(contentsOf: attachmentURL, options: .alwaysMapped)
+            guard let image = UIImage(data: data) else {
+                throw ImageAttachmentError.imageDecodeFailure
+            }
+            self.image = image
+            self.imageData = data
+
+            if let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+               let uti = CGImageSourceGetType(imageSource) {
+                self.imageUTI = uti
+            } else {
+                // can't figure out, just assume JPEG
+                self.imageUTI = kUTTypeJPEG
+            }
+
+            if UTTypeConformsTo(imageUTI, kUTTypeGIF) {
+                // use a WebView for gif so we can animate without pulling in a third party library
+                let config = with(WKWebViewConfiguration()) {
+                    $0.userContentController = with(WKUserContentController()) {
+                        // we can't use `loadHTMLString` with `<img>` inside to do styling because the webview can't get
+                        // the security scoped file if loaded by the service extension so we need to load data directly
+                        $0.addUserScript(WKUserScript(source: """
+                            var style = document.createElement('style');
+                            style.innerHTML = `
+                                img { width: 100%; height: 100%; }
+                            `;
+                            document.head.appendChild(style);
+                        """, injectionTime: .atDocumentEnd, forMainFrameOnly: true))
+                    }
+                }
+
+                visibleView = .webView(with(WKWebView(frame: .zero, configuration: config)) {
+                    $0.scrollView.isScrollEnabled = false
+                    $0.isOpaque = false
+                    $0.backgroundColor = .clear
+                    $0.scrollView.backgroundColor = .clear
+                })
+            } else {
+                visibleView = .imageView(with(UIImageView()) {
+                    $0.contentMode = .scaleAspectFit
+                })
+            }
+
+        } catch {
             attachmentURL.stopAccessingSecurityScopedResource()
-            throw ImageAttachmentError.imageDecodeFailure
+            throw error
         }
 
-        self.image = image
         self.attachmentURL = attachmentURL
         super.init(nibName: nil, bundle: nil)
     }
@@ -68,9 +124,22 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
     }
 
     func start() -> Promise<Void> {
-        imageView.image = image
         lastAttachmentURL = attachmentURL
-        aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: imageView, size: image.size)
+
+        switch visibleView {
+        case let .webView(webView):
+            let mime = UTTypeCopyPreferredTagWithClass(imageUTI, kUTTagClassMIMEType)?.takeRetainedValue() as String?
+            webView.load(
+                imageData,
+                mimeType: mime ?? "image/gif",
+                characterEncodingName: "UTF-8",
+                baseURL: attachmentURL
+            )
+        case let .imageView(imageView):
+            imageView.image = image
+        }
+
+        aspectRatioConstraint = NSLayoutConstraint.aspectRatioConstraint(on: visibleView.view, size: image.size)
 
         return .value(())
     }
@@ -92,13 +161,14 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.addSubview(imageView)
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        let subview = visibleView.view
+        view.addSubview(subview)
+        subview.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: view.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            subview.topAnchor.constraint(equalTo: view.topAnchor),
+            subview.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            subview.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
 

--- a/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/ImageAttachmentViewController.swift
@@ -24,6 +24,7 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
             }
         }
     }
+
     let visibleView: ImageViewType
 
     required init(notification: UNNotification, attachmentURL: URL?) throws {
@@ -77,7 +78,7 @@ class ImageAttachmentViewController: UIViewController, NotificationCategory {
                     $0.scrollView.backgroundColor = .clear
                 })
             } else {
-                visibleView = .imageView(with(UIImageView()) {
+                self.visibleView = .imageView(with(UIImageView()) {
                     $0.contentMode = .scaleAspectFit
                 })
             }


### PR DESCRIPTION
Fixes #1709.

## Summary
Loads a webview to play back gif attachments, since they may be animated and UIImageView doesn't handle that for us.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Due to sandboxing and security scoping, getting this to display reliably is a little convoluted - we need to load by Data and inject a CSS style to get the image to scale as we want, since we size the webview to fit based on aspect fit rules.