### PR TITLE
Possibly fix phantom local push subscription not alerting

### DIFF
--- a/Sources/Extensions/PushProvider/PushProvider.swift
+++ b/Sources/Extensions/PushProvider/PushProvider.swift
@@ -102,6 +102,7 @@ import UserNotifications
 
     override func stop(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         Current.Log.notify("stopping with reason \(reason)", log: .error)
+        localPushManager?.invalidate()
         localPushManager = nil
         Current.apiConnection.disconnect()
     }

--- a/Tests/Shared/LocalPushManager.test.swift
+++ b/Tests/Shared/LocalPushManager.test.swift
@@ -39,6 +39,10 @@ class LocalPushManagerTests: XCTestCase {
         weak var weakManager = manager
         manager = nil
         XCTAssertNil(weakManager)
+
+        for sub in apiConnection.pendingSubscriptions {
+            XCTAssertTrue(sub.cancellable.wasCancelled)
+        }
     }
 
     private func setUpManager(webhookID: String?) {
@@ -158,6 +162,13 @@ class LocalPushManagerTests: XCTestCase {
         fireConnectionChange()
 
         XCTAssertTrue(sub2.cancellable.wasCancelled)
+    }
+
+    func testInvalidate() throws {
+        setUpManager(webhookID: "webhook1")
+        let sub = try XCTUnwrap(apiConnection.pendingSubscriptions.first)
+        manager.invalidate()
+        XCTAssertTrue(sub.cancellable.wasCancelled)
     }
 
     func testNoSubscriptionAtStart() throws {


### PR DESCRIPTION
Refs #1799.

## Summary
I can't see too many cases where we'd drop a subscription, but this is one of them - basically, multiple connection info change notifications fire at once, and the invoked method isn't threadsafe.

## Any other notes
Also adds some more logging and discrete subscription cancelling when stopping to hopefully help debug this in the future if it continues.