### PR TITLE
Fix crash updating active sensor idle time setting

### DIFF
--- a/Sources/App/Settings/Sensors/SensorDetailViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorDetailViewController.swift
@@ -126,7 +126,10 @@ class SensorDetailViewController: HAFormViewController, SensorObserver {
                                     row.value = maximum
                                 }
 
-                                row.value = (value / step).rounded(.down) * step
+                                let updated = (value / step).rounded(.down) * step
+                                if abs(updated - value) > 0.05 {
+                                    row.value = updated
+                                }
                             }
 
                             setter(row.value ?? 0)

--- a/Sources/Shared/API/Webhook/Sensors/ActiveSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/ActiveSensor.swift
@@ -43,8 +43,8 @@ final class ActiveSensor: SensorProvider {
         sensor.Attributes = activeState.states.attributes
 
         let durationFormatter = with(DateComponentsFormatter()) {
-            $0.allowedUnits = [.minute]
-            $0.allowsFractionalUnits = false
+            $0.allowedUnits = [.minute, .second]
+            $0.allowsFractionalUnits = true
             $0.formattingContext = .standalone
             $0.unitsStyle = .short
         }
@@ -54,9 +54,9 @@ final class ActiveSensor: SensorProvider {
                 type: .stepper(
                     getter: { activeState.minimumIdleTime.converted(to: .minutes).value },
                     setter: { activeState.minimumIdleTime = .init(value: $0, unit: .minutes) },
-                    minimum: 1,
+                    minimum: 0.25,
                     maximum: .greatestFiniteMagnitude,
-                    step: 1.0,
+                    step: 0.25,
                     displayValueFor: { value in
                         let valueMeasurement = Measurement<UnitDuration>(value: value ?? 0, unit: .minutes)
                         return durationFormatter.string(from: valueMeasurement.converted(to: .seconds).value)


### PR DESCRIPTION
## Summary
Fixes a crash caused by infinitely recursing the value change.

## Any other notes
This also allows setting fractional minute values, every 15 seconds. The minimum timer which we check is 5 seconds, and that low means we won't detect changes if they occur in a 10 second period which feels too low.