### PR TITLE
Handle invalidly close to 0.0 latitude/longitude as invalid too

### DIFF
--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -86,8 +86,14 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
             return
         }
 
-        if location.coordinate.latitude == 0 || location.coordinate.longitude == 0 {
+        func isBadCoordinateValue(_ value: Double) -> Bool {
+            // this is within 110µm of 0.0 latitude/longitude and is very unlikely to really happen
+            (value >= 0 && value <= 0.000000001) || (value >= -0.000000001 && value <= 0)
+        }
+
+        if isBadCoordinateValue(location.coordinate.latitude) || isBadCoordinateValue(location.coordinate.longitude) {
             // iOS 13.5? seems to occasionally report 0 lat/long, so ignore these locations
+            // iOS 15? seems to occasionally report ``9.368162246e-315 (or similar small values), so ignore these too
             Current.Log.error("Location \(location.coordinate) was super duper invalid")
             self.quality = .invalid
         } else {

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -115,7 +115,7 @@ internal struct PotentialLocation: Comparable, CustomStringConvertible {
     }
 
     var description: String {
-        "accuracy \(accuracy) from \(timestamp) quality \(quality)"
+        "coordinate \(location.coordinate) accuracy \(accuracy) from \(timestamp) quality \(quality)"
     }
 
     var accuracy: CLLocationAccuracy {
@@ -267,7 +267,7 @@ internal final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
         let updatedPotentialLocations = locations.map {
             PotentialLocation(location: $0, accuracyAuthorization: authorization)
         }
-        Current.Log.verbose("got potential locations: \(updatedPotentialLocations)")
+        Current.Log.verbose("got raw locations \(locations) and turned into potential: \(updatedPotentialLocations)")
         potentialLocations.append(contentsOf: updatedPotentialLocations)
         checkPotentialLocations(outOfTime: false)
     }

--- a/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
+++ b/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
@@ -448,6 +448,34 @@ class OneShotLocationTests: XCTestCase {
             verticalAccuracy: 0,
             timestamp: now.addingTimeInterval(0)
         )
+        let location5 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: Double.leastNonzeroMagnitude),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(0)
+        )
+        let location6 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: Double.leastNonzeroMagnitude, longitude: 123),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(0)
+        )
+        let location7 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 123, longitude: -Double.leastNonzeroMagnitude),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(0)
+        )
+        let location8 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -Double.leastNonzeroMagnitude, longitude: 123),
+            altitude: 0,
+            horizontalAccuracy: 200,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(0)
+        )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
             timeout: timeoutPromise
@@ -455,6 +483,7 @@ class OneShotLocationTests: XCTestCase {
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
             location1, location2, location3, location4,
+            location5, location6, location7, location8,
         ])
         timeoutSeal(())
 


### PR DESCRIPTION
Refs [a forum post](https://community.home-assistant.io/t/ios-15-location-issues/323498).

## Summary
iOS 15 appears to give us extremely small values for longitude like `9.368162246e-315`, which we should throw away as invalid.

## Any other notes
I reduced the logging we do for longitude/latitude, but we don't send it anywhere anymore (since only errors go up to Sentry on crash), so I'm adding it back in so I can see in future logs what's happening. Some of the logs from the user show the invalid value happening _multiple_ times and I just can't tell if we're butchering it from the raw, or if the raw coming in is bad. This should help.