### PR TITLE
Update local push parsing for recent fcm changes

### DIFF
--- a/Configuration/Podspecs/NotificationTestCases.podspec.json
+++ b/Configuration/Podspecs/NotificationTestCases.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "NotificationTestCases",
-  "version": "0.2",
+  "version": "0.3",
   "summary": "NotificationTestCases",
   "description": "Test cases from the Home Assistant FCM functions.",
   "homepage": "https://github.com/home-assistant/mobile-apps-fcm-push",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,7 +24,7 @@ PODS:
   - Lokalise (0.10.2)
   - lottie-ios (3.2.3)
   - MBProgressHUD (1.2.0)
-  - NotificationTestCases (0.2)
+  - NotificationTestCases (0.3)
   - ObjcExceptionBridging (1.0.1):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 1.0.1)
   - ObjcExceptionBridging/ObjcExceptionBridging (1.0.1)
@@ -62,9 +62,9 @@ PODS:
   - SwiftFormat/CLI (0.48.6)
   - SwiftGen (6.4.0)
   - SwiftLint (0.43.1)
-  - SwiftMessages (9.0.2):
-    - SwiftMessages/App (= 9.0.2)
-  - SwiftMessages/App (9.0.2)
+  - SwiftMessages (9.0.3):
+    - SwiftMessages/App (= 9.0.3)
+  - SwiftMessages/App (9.0.3)
   - UIColor_Hex_Swift (5.1.0)
   - Version (0.8.0)
   - ViewRow (0.8):
@@ -187,7 +187,7 @@ CHECKOUT OPTIONS:
     :commit: 19e6267dff11426da2c090d5e7943953606ac334
     :git: https://github.com/home-assistant/HAKit.git
   NotificationTestCases:
-    :commit: f01bf06e0a3088d9eee1281df3fb08355093bc51
+    :commit: bb5906878530973b74eed54f1751f580afa87260
     :git: https://github.com/home-assistant/mobile-apps-fcm-push.git
   ObjectMapper:
     :commit: a593b4d647a970b3d184d046f8f52b945083ccf9
@@ -216,7 +216,7 @@ SPEC CHECKSUMS:
   Lokalise: 252c397887dfd9983331abffa90ab60cdb004e19
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
-  NotificationTestCases: d93e754ce3a45afee1067319f067b6276468ebed
+  NotificationTestCases: 569f617780b296399015f8c40052ebac36887662
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
   ObjectMapper: 5a6c9f063ef67e7fc0d7eb8958919e3121396a96
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
@@ -230,7 +230,7 @@ SPEC CHECKSUMS:
   SwiftFormat: 835d432cbffc8916d3def6e37a01a10c516d8e24
   SwiftGen: 67860cc7c3cfc2ed25b9b74cfd55495fc89f9108
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  SwiftMessages: 77b847d1405f99046ffbd0d856bc7d73e6892686
+  SwiftMessages: 077f19126c24033fe24042237ecc20261adb46e4
   UIColor_Hex_Swift: 8be7432edacb7fa91c78aa05ef3c30b66e4f9415
   Version: de5907f2c5d0f3cf21708db7801d1d5401139486
   ViewRow: 8da541e9c019f3be63f4e28f311a62cac2045ecf


### PR DESCRIPTION
Refs home-assistant/mobile-apps-fcm-push#58, refs home-assistant/mobile-apps-fcm-push#57.

## Summary
Updates the test dependency and makes the new cases pass: badge with commands, clear_badge not using a command (this one doesn't matter for local push, however).