### PR TITLE
Fix focus sensor updating in iOS 15 RC

### DIFF
--- a/Sources/Extensions/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Extensions/Intents/FocusStatusIntentHandler.swift
@@ -7,7 +7,9 @@ import Shared
 @available(iOS 15, *)
 class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
     func handle(intent: INShareFocusStatusIntent, completion: @escaping (INShareFocusStatusIntentResponse) -> Void) {
-        Current.Log.info("starting")
+        let currentState = intent.focusStatus
+        Current.focusStatus.update(fromReceived: currentState)
+        Current.Log.info("starting, status from intent is \(String(describing: currentState)) from \(intent)")
 
         Current.api.then(on: nil) {
             $0.UpdateSensors(trigger: .Siri)

--- a/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
@@ -4,6 +4,7 @@ import PromiseKit
 final class FocusSensor: SensorProvider {
     public enum FocusError: Error, Equatable {
         case unauthorized
+        case unavailable
     }
 
     let request: SensorProviderRequest
@@ -12,6 +13,10 @@ final class FocusSensor: SensorProvider {
     }
 
     func sensors() -> Promise<[WebhookSensor]> {
+        guard Current.focusStatus.isAvailable() else {
+            return .init(error: FocusError.unavailable)
+        }
+
         guard Current.focusStatus.authorizationStatus() == .authorized else {
             return .init(error: FocusError.unauthorized)
         }

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -1,7 +1,7 @@
 import Intents
 import PromiseKit
 
-public struct FocusStatusWrapper {
+public class FocusStatusWrapper {
     public enum AuthorizationStatus: Equatable {
         case notDetermined
         case restricted
@@ -27,10 +27,16 @@ public struct FocusStatusWrapper {
         #endif
     }
 
-    public var isAvailable: () -> Bool = {
+    public var lastStatus: Status?
+
+    public lazy var isAvailable: () -> Bool = { [weak self] in
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
         if #available(iOS 15, watchOS 8, *) {
-            return true
+            if Current.isAppExtension {
+                return self?.lastStatus != nil
+            } else {
+                return true
+            }
         } else {
             return false
         }
@@ -84,10 +90,20 @@ public struct FocusStatusWrapper {
         }
     }
 
-    public var status: () -> Status = {
+    @available(iOS 15, watchOS 8, *)
+    public func update(fromReceived status: INFocusStatus?) {
+        precondition(Current.isAppExtension)
+        lastStatus = status.flatMap { Status(focusStatus: $0) }
+    }
+
+    public lazy var status: () -> Status = { [weak self] in
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
         if #available(iOS 15, watchOS 8, *) {
-            return .init(focusStatus: INFocusStatusCenter.default.focusStatus)
+            if Current.isAppExtension, let lastStatus = self?.lastStatus {
+                return lastStatus
+            } else {
+                return .init(focusStatus: INFocusStatusCenter.default.focusStatus)
+            }
         }
         #endif
         return .init(isFocused: nil)

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -27,7 +27,11 @@ public class FocusStatusWrapper {
         #endif
     }
 
-    public var lastStatus: Status?
+    private var lastStatus: Status? {
+        willSet {
+            precondition(Current.isAppExtension)
+        }
+    }
 
     public lazy var isAvailable: () -> Bool = { [weak self] in
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)

--- a/Tests/Shared/Sensors/FocusSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusSensor.test.swift
@@ -24,6 +24,15 @@ class FocusSensorTests: XCTestCase {
         Current.focusStatus.status = { status }
     }
 
+    func testNotAvailable() throws {
+        setUp(isAvailable: false)
+
+        let promise = FocusSensor(request: request).sensors()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? FocusSensor.FocusError, .unavailable)
+        }
+    }
+
     func testNotAuthorized() throws {
         for state: FocusStatusWrapper.AuthorizationStatus in [
             .restricted, .denied, .notDetermined,


### PR DESCRIPTION
## Summary
Fixes the insta-updating of the focus sensor on iOS 15.

## Any other notes
`INFocusStatusCenter.default.focusStatus` always returns isFocused=false in the extension, but the intent provides the correct focus status for each update -- so we need to cache this value in the extension, and not trust the focus center state.