### PR TITLE
Fix Mac compilation in Xcode 13 RC

### DIFF
--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -94,11 +94,13 @@ public class FocusStatusWrapper {
         }
     }
 
+    #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
     @available(iOS 15, watchOS 8, *)
     public func update(fromReceived status: INFocusStatus?) {
         precondition(Current.isAppExtension)
         lastStatus = status.flatMap { Status(focusStatus: $0) }
     }
+    #endif
 
     public lazy var status: () -> Status = { [weak self] in
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)


### PR DESCRIPTION
## Summary
Fixes `INFocusStatus` not being available in Xcode 13 for Catalyst.

## Any other notes
This whole "you can only develop for Monterey using Xcode 13's earlier betas" schtick is just frustrating.