### PR TITLE
Add live-updating to in-app display of focus sensor

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
@@ -1,5 +1,21 @@
 import Foundation
 import PromiseKit
+import HAKit
+
+final class FocusSensorUpdateSignaler: SensorProviderUpdateSignaler {
+    let cancellable: HACancellable
+    init(signal: @escaping () -> Void) {
+        self.cancellable = Current.focusStatus.trigger.observe { _ in
+            // this means that we will double-update the focus sensor if the app is running
+            // this feels less likely to happen, but allows us to keep the in-app visual state right
+            signal()
+        }
+    }
+
+    deinit {
+        cancellable.cancel()
+    }
+}
 
 final class FocusSensor: SensorProvider {
     public enum FocusError: Error, Equatable {
@@ -34,6 +50,9 @@ final class FocusSensor: SensorProvider {
                 $0.Type = "binary_sensor"
             })
         }
+
+        // Set up our observer
+        let _: FocusSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
 
         return .value(sensors)
     }

--- a/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
@@ -1,6 +1,6 @@
 import Foundation
-import PromiseKit
 import HAKit
+import PromiseKit
 
 final class FocusSensorUpdateSignaler: SensorProviderUpdateSignaler {
     let cancellable: HACancellable

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -8,7 +8,7 @@ public class FocusStateTrigger: UserDefaultsValueSync<Date> {
 }
 
 public class FocusStatusWrapper {
-    lazy private(set) var trigger = FocusStateTrigger()
+    private(set) lazy var trigger = FocusStateTrigger()
 
     public enum AuthorizationStatus: Equatable {
         case notDetermined

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -1,7 +1,15 @@
 import Intents
 import PromiseKit
 
+public class FocusStateTrigger: UserDefaultsValueSync<Date> {
+    init() {
+        super.init(settingsKey: "FocusStateTriggerKey")
+    }
+}
+
 public class FocusStatusWrapper {
+    lazy private(set) var trigger = FocusStateTrigger()
+
     public enum AuthorizationStatus: Equatable {
         case notDetermined
         case restricted
@@ -99,6 +107,7 @@ public class FocusStatusWrapper {
     public func update(fromReceived status: INFocusStatus?) {
         precondition(Current.isAppExtension)
         lastStatus = status.flatMap { Status(focusStatus: $0) }
+        trigger.value = Current.date()
     }
     #endif
 

--- a/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
+++ b/Sources/Shared/Notifications/LocalPush/UserDefaultsValueSync.swift
@@ -9,20 +9,16 @@ public class UserDefaultsValueSync<ValueType: Codable>: NSObject {
     public let settingsKey: String
     public let userDefaults: UserDefaults
 
-    public init(settingsKey: String, userDefaults: UserDefaults) {
+    public init(settingsKey: String, userDefaults: UserDefaults? = nil) {
         self.settingsKey = settingsKey
-        self.userDefaults = userDefaults
+        self.userDefaults = userDefaults ?? Current.settingsStore.prefs
         super.init()
-        userDefaults.addObserver(
+        self.userDefaults.addObserver(
             self,
             forKeyPath: settingsKey,
             options: [],
             context: nil
         )
-    }
-
-    public convenience init(settingsKey: String) {
-        self.init(settingsKey: settingsKey, userDefaults: Current.settingsStore.prefs)
     }
 
     deinit {


### PR DESCRIPTION
## Summary
Fires a sensor update pass if the app is running when the focus status changes.

## Any other notes
The focus sensor _always_ live-updates, but it does so in the Intents extension. This allows the Intents extension to inform the app that it did an update, which (unfortunately, for now) fires a sensor update pass in the app. So we're over-updating the sensors, but we're keeping the in-app sensor list updated. Worth the cost, I think, since the app running when focus changes happening feels rare unless the user's playing with the sensor.