### PR TITLE
Enable Notification Content extension on macOS 11+

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -563,7 +563,7 @@
 		B627CB091D83C87B0057173E /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B627CB081D83C87B0057173E /* UserNotifications.framework */; };
 		B627CB0B1D83C87B0057173E /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B627CB0A1D83C87B0057173E /* UserNotificationsUI.framework */; };
 		B627CB0E1D83C87B0057173E /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B627CB0D1D83C87B0057173E /* NotificationViewController.swift */; };
-		B627CB151D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B627CB071D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B627CB151D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B627CB071D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B62817F0221D269B000BA86A /* RenderTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplate.swift */; };
 		B62817F2221D6CF4000BA86A /* Reachability+NetworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817F1221D6CF4000BA86A /* Reachability+NetworkType.swift */; };
 		B62CD2A5225B099D008DF3C5 /* WebhookSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62CD2A4225B099C008DF3C5 /* WebhookSensor.swift */; };
@@ -5591,7 +5591,6 @@
 		};
 		B627CB141D83C87B0057173E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
 			target = B627CB061D83C87B0057173E /* Extensions-NotificationContent */;
 			targetProxy = B627CB131D83C87B0057173E /* PBXContainerItemProxy */;
 		};
@@ -6090,13 +6089,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Configuration/Entitlements/Extension-ios.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Configuration/Entitlements/Extension-catalyst.entitlements";
 				INFOPLIST_FILE = Sources/Extensions/NotificationContent/Resources/Info.plist;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
 				PROVISIONING_SUFFIX = .NotificationContentExtension;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 			};
 			name = Debug;
 		};
@@ -6107,13 +6107,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Configuration/Entitlements/Extension-ios.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Configuration/Entitlements/Extension-catalyst.entitlements";
 				INFOPLIST_FILE = Sources/Extensions/NotificationContent/Resources/Info.plist;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
 				PROVISIONING_SUFFIX = .NotificationContentExtension;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 			};
 			name = Release;
 		};
@@ -6214,13 +6215,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Configuration/Entitlements/Extension-ios.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Configuration/Entitlements/Extension-catalyst.entitlements";
 				INFOPLIST_FILE = Sources/Extensions/NotificationContent/Resources/Info.plist;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
 				PROVISIONING_SUFFIX = .NotificationContentExtension;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 			};
 			name = Beta;
 		};

--- a/Sources/Extensions/NotificationContent/MapViewController.swift
+++ b/Sources/Extensions/NotificationContent/MapViewController.swift
@@ -70,7 +70,17 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
         mapView.delegate = self
         mapView.mapType = .standard
         mapView.showsUserLocation = (haDict["shows_user_location"] != nil)
-        mapView.showsPointsOfInterest = (haDict["shows_points_of_interest"] != nil)
+
+        if #available(iOS 13, *) {
+            if haDict["shows_points_of_interest"] != nil {
+                mapView.pointOfInterestFilter = .includingAll
+            } else {
+                mapView.pointOfInterestFilter = .excludingAll
+            }
+        } else {
+            mapView.showsPointsOfInterest = (haDict["shows_points_of_interest"] != nil)
+        }
+
         mapView.showsCompass = (haDict["shows_compass"] != nil)
         mapView.showsScale = (haDict["shows_scale"] != nil)
         mapView.showsTraffic = (haDict["shows_traffic"] != nil)

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -63,8 +63,17 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
         }
 
         // Try to grab the attachments, in case they failed or were lazy
+        let shouldDownload: Bool
 
-        if allowDownloads {
+        if Current.isCatalyst {
+            // catalyst doesn't have access to the system container for the builtin attachments
+            // however, it _also_ shows the system preview image in all cases, so we don't need to for that too
+            shouldDownload = attachmentURL == nil
+        } else {
+            shouldDownload = true
+        }
+
+        if allowDownloads, shouldDownload {
             return firstly {
                 Current.api
             }.then { api in

--- a/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
+++ b/Sources/Extensions/NotificationContent/VideoAudioAttachmentViewController.swift
@@ -20,6 +20,14 @@ class PlayerAttachmentViewController: UIViewController, NotificationCategory {
 
         self.needsEndSecurityScoped = attachmentURL.startAccessingSecurityScopedResource()
 
+        if Current.isCatalyst,
+           attachmentURL.isFileURL,
+           !FileManager.default.isReadableFile(atPath: attachmentURL.path) {
+            // if it's a file URL, on macOS we may not have access to the attachment on disk, so make sure
+            // FB9638431
+            throw PlayerAttachmentError.noAttachment
+        }
+
         self.attachmentURL = attachmentURL
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
Fixes #1592.

## Summary
Enables the Notification Content extension now that it works in Xcode 13.

## Any other notes
This is an entirely tooling enabling of this feature, as the extension works on macOS 11. There is a gotcha: the Notification Service Extension attachments are inaccessible. Additionally, macOS always displays the attached-by-us images/movies, which is a frustrating difference in behavior between macOS and iOS, but makes this particular deficiency less noticeable. Filed as FB9638431.