### PR TITLE
Add Focus permission to onboarding

### DIFF
--- a/Sources/App/Onboarding/PermissionButton.swift
+++ b/Sources/App/Onboarding/PermissionButton.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Shared
 
 @IBDesignable class PermissionButton: UIButton {
     var style: Style = .default {
@@ -7,9 +8,6 @@ import UIKit
             setTitle(style.title, for: .normal)
 
             backgroundColor = style.backgroundColor
-            contentEdgeInsets = style.insets(titleLabel?.text?.count)
-
-            sizeToFit()
         }
     }
 
@@ -33,11 +31,21 @@ import UIKit
         sharedInit()
     }
 
-    func sharedInit() {
-        style = .default
-        titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .bold)
-        layer.masksToBounds = true
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
         layer.cornerRadius = frame.height / 2
+    }
+
+    func sharedInit() {
+        contentEdgeInsets = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+
+        style = .default
+        layer.masksToBounds = true
+
+        titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        titleLabel?.adjustsFontSizeToFitWidth = true
+        titleLabel?.baselineAdjustment = .alignCenters
     }
 
     override func setTitle(_ title: String?, for state: UIControl.State) {
@@ -71,19 +79,12 @@ import UIKit
             }
         }
 
-        func insets(_ characterCount: Int?) -> UIEdgeInsets {
-            if self == .default, characterCount ?? 5 < 4 {
-                return UIEdgeInsets(top: 6, left: 22, bottom: 6, right: 22)
-            }
-            return UIEdgeInsets(top: 6, left: 15, bottom: 6, right: 15)
-        }
-
         var title: String {
             switch self {
             case .default:
-                return "Allow"
+                return L10n.Onboarding.Permissions.allow
             case .allowed:
-                return "Allowed"
+                return L10n.Onboarding.Permissions.allowed
             }
         }
     }

--- a/Sources/App/Onboarding/PermissionButton.swift
+++ b/Sources/App/Onboarding/PermissionButton.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Shared
+import UIKit
 
 @IBDesignable class PermissionButton: UIButton {
     var style: Style = .default {

--- a/Sources/App/Onboarding/PermissionLineItemView.swift
+++ b/Sources/App/Onboarding/PermissionLineItemView.swift
@@ -57,7 +57,7 @@ protocol PermissionViewChangeDelegate: AnyObject {
         animationView.backgroundColor = .white
     }
 
-    func updateContents() {
+    @objc private func updateContents() {
         titleLabel.text = permission.title
         descriptionLabel.text = permission.description
         animationView.animation = permission.animation
@@ -109,6 +109,13 @@ protocol PermissionViewChangeDelegate: AnyObject {
     }
 
     private func commonInit() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateContents),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
         animationView.contentMode = .scaleAspectFill
         animationView.loopMode = .loop
         animationView.backgroundBehavior = .pauseAndRestore

--- a/Sources/App/Onboarding/PermissionLineItemView.swift
+++ b/Sources/App/Onboarding/PermissionLineItemView.swift
@@ -63,10 +63,6 @@ protocol PermissionViewChangeDelegate: AnyObject {
         animationView.animation = permission.animation
         button.style = permission.isAuthorized ? .allowed : .default
         animationView.play()
-
-        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [button] _ in
-            button.style = Int.random(in: 0...1) == 0 ? .allowed : .default
-        }
     }
 
     @objc func buttonTapped(_ sender: PermissionButton) {

--- a/Sources/App/Onboarding/PermissionLineItemView.swift
+++ b/Sources/App/Onboarding/PermissionLineItemView.swift
@@ -8,12 +8,19 @@ protocol PermissionViewChangeDelegate: AnyObject {
 
 @IBDesignable class PermissionLineItemView: UIView {
     let titleLabel = UILabel()
+    let descriptionWrapper = UIView()
     let descriptionLabel = UILabel()
-    var animationView = AnimationView()
-    var button = PermissionButton()
-    // var separatorView = UIView()
+    let animationView = AnimationView()
+    let button = PermissionButton()
+    let titleStackView = UIStackView()
 
-    var permission = PermissionType.location
+    var descriptionHeightConstraint: NSLayoutConstraint?
+
+    var permission = PermissionType.location {
+        didSet {
+            updateContents()
+        }
+    }
 
     weak var delegate: PermissionViewChangeDelegate?
 
@@ -24,18 +31,13 @@ protocol PermissionViewChangeDelegate: AnyObject {
             }
 
             self.permission = permission
-            titleLabel.text = permission.title
-            descriptionLabel.text = permission.description
-            animationView.animation = permission.animation
-            commonInit()
         }
     }
 
-    init(permission: PermissionType) {
+    convenience init(permission: PermissionType) {
+        self.init(frame: .zero)
         self.permission = permission
-        super.init(frame: .zero)
-
-        commonInit()
+        updateContents()
     }
 
     override required init(frame: CGRect) {
@@ -45,11 +47,26 @@ protocol PermissionViewChangeDelegate: AnyObject {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        commonInit()
     }
 
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
-        commonInit()
+
+        // for visual alignment
+        animationView.backgroundColor = .white
+    }
+
+    func updateContents() {
+        titleLabel.text = permission.title
+        descriptionLabel.text = permission.description
+        animationView.animation = permission.animation
+        button.style = permission.isAuthorized ? .allowed : .default
+        animationView.play()
+
+        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [button] _ in
+            button.style = Int.random(in: 0...1) == 0 ? .allowed : .default
+        }
     }
 
     @objc func buttonTapped(_ sender: PermissionButton) {
@@ -62,72 +79,100 @@ protocol PermissionViewChangeDelegate: AnyObject {
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setNeedsUpdateConstraints()
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+
+        let descConstraint: NSLayoutConstraint
+
+        if let descriptionHeightConstraint = descriptionHeightConstraint {
+            descConstraint = descriptionHeightConstraint
+        } else {
+            descConstraint = descriptionWrapper.heightAnchor.constraint(greaterThanOrEqualToConstant: 0)
+            descriptionHeightConstraint = descConstraint
+        }
+
+        let lines: Int
+
+        if traitCollection.verticalSizeClass == .compact {
+            lines = 1
+        } else {
+            lines = 3
+        }
+
+        let desired = ceil(descriptionLabel.font.lineHeight * CGFloat(lines))
+
+        if descConstraint.constant != desired {
+            descConstraint.constant = desired
+            descConstraint.isActive = true
+        }
+    }
+
     private func commonInit() {
         animationView.contentMode = .scaleAspectFill
         animationView.loopMode = .loop
         animationView.backgroundBehavior = .pauseAndRestore
-        animationView.play()
 
         backgroundColor = .clear
 
-        addSubview(animationView)
+        titleStackView.axis = .vertical
+        titleStackView.alignment = .leading
 
-        titleLabel.numberOfLines = 1
+        titleLabel.numberOfLines = 0
         titleLabel.textColor = .white
-        titleLabel.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        addSubview(titleLabel)
+        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleStackView.addArrangedSubview(titleLabel)
 
-        descriptionLabel.numberOfLines = 3
+        descriptionLabel.numberOfLines = 0
         descriptionLabel.textColor = .white
-        descriptionLabel.font = UIFont.systemFont(ofSize: 13, weight: .regular)
-        addSubview(descriptionLabel)
+        descriptionLabel.font = .systemFont(ofSize: 13, weight: .regular)
+
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionWrapper.addSubview(descriptionLabel)
+        NSLayoutConstraint.activate([
+            descriptionLabel.topAnchor.constraint(equalTo: descriptionWrapper.topAnchor),
+            descriptionLabel.bottomAnchor.constraint(lessThanOrEqualTo: descriptionWrapper.bottomAnchor),
+            descriptionLabel.leadingAnchor.constraint(equalTo: descriptionWrapper.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: descriptionWrapper.trailingAnchor),
+        ])
+
+        titleStackView.addArrangedSubview(descriptionWrapper)
 
         button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
 
-        button.style = permission.isAuthorized ? .allowed : .default
+        animationView.translatesAutoresizingMaskIntoConstraints = false
+        titleStackView.translatesAutoresizingMaskIntoConstraints = false
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(animationView)
+        addSubview(titleStackView)
         addSubview(button)
 
-        // self.separatorView.backgroundColor = .white
-        // self.addSubview(self.separatorView)
-    }
+        let margins = layoutMarginsGuide
+        directionalLayoutMargins = .init(top: 8, leading: 0, bottom: 8, trailing: 0)
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
+        NSLayoutConstraint.activate([
+            animationView.widthAnchor.constraint(equalToConstant: 75.0),
+            button.widthAnchor.constraint(equalToConstant: 75.0),
 
-        frame = CGRect(origin: frame.origin, size: CGSize(width: frame.width, height: 120))
+            animationView.topAnchor.constraint(greaterThanOrEqualTo: margins.topAnchor),
+            animationView.centerYAnchor.constraint(equalTo: margins.centerYAnchor),
+            animationView.widthAnchor.constraint(equalTo: animationView.heightAnchor),
+            animationView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            animationView.bottomAnchor.constraint(lessThanOrEqualTo: margins.bottomAnchor),
 
-        animationView.frame = CGRect(x: 0, y: 0, width: 75, height: 75)
-        animationView.center.y = frame.height / 2
+            titleStackView.topAnchor.constraint(greaterThanOrEqualTo: margins.topAnchor),
+            titleStackView.leadingAnchor.constraint(equalTo: animationView.trailingAnchor),
+            titleStackView.centerYAnchor.constraint(equalTo: margins.centerYAnchor),
+            titleStackView.bottomAnchor.constraint(lessThanOrEqualTo: margins.bottomAnchor),
 
-        button.sizeToFit()
-        button.frame.origin.x = frame.width - button.frame.width
-        button.center.y = frame.height / 2
-
-        let titleInset: CGFloat = 15
-        let titlesWidth: CGFloat = button.frame.origin
-            .x - (animationView.frame.origin.x + animationView.frame.width) - titleInset * 2
-
-        titleLabel.frame = CGRect(x: 0, y: 8, width: titlesWidth, height: 0)
-        titleLabel.sizeToFit()
-        titleLabel.frame = CGRect(
-            origin: titleLabel.frame.origin,
-            size: CGSize(width: titlesWidth, height: titleLabel.frame.height)
-        )
-        titleLabel.frame.origin.x = (animationView.frame.origin.x + animationView.frame.width) + titleInset
-
-        descriptionLabel.frame = CGRect(x: titleLabel.frame.origin.x + titleInset, y: 0, width: titlesWidth, height: 0)
-        descriptionLabel.sizeToFit()
-        descriptionLabel.frame = CGRect(
-            origin: descriptionLabel.frame.origin,
-            size: CGSize(width: titlesWidth, height: descriptionLabel.frame.height)
-        )
-        descriptionLabel.frame.origin.x = animationView.frame.origin.x + animationView.frame.width + titleInset
-
-        let allHeight = titleLabel.frame.height + 2 + descriptionLabel.frame.height
-        titleLabel.frame.origin.y = (frame.height - allHeight) / 2
-        descriptionLabel.frame.origin.y = titleLabel.frame.origin.y + titleLabel.frame.height + 2
-
-        // self.separatorView.frame = CGRect(x: self.descriptionLabel.frame.origin.x, y: self.frame.height - 0.7, width: self.button.frame.origin.x + self.button.frame.width - self.descriptionLabel.frame.origin.x, height: 0.7)
-        // self.separatorView.layer.cornerRadius = self.separatorView.frame.height / 2
+            button.leadingAnchor.constraint(greaterThanOrEqualTo: titleStackView.trailingAnchor, constant: 8),
+            button.centerYAnchor.constraint(equalTo: margins.centerYAnchor),
+            button.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+        ])
     }
 }

--- a/Sources/App/Onboarding/PermissionsViewController.swift
+++ b/Sources/App/Onboarding/PermissionsViewController.swift
@@ -9,6 +9,8 @@ class PermissionsViewController: UIViewController, PermissionViewChangeDelegate 
     @IBOutlet var locationPermissionView: PermissionLineItemView!
     @IBOutlet var motionPermissionView: PermissionLineItemView!
     @IBOutlet var notificationsPermissionView: PermissionLineItemView!
+    @IBOutlet var focusPermissionView: PermissionLineItemView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -25,6 +27,10 @@ class PermissionsViewController: UIViewController, PermissionViewChangeDelegate 
 
         notificationsPermissionView.delegate = self
         notificationsPermissionView.permission.updateInitial()
+
+        focusPermissionView.delegate = self
+        focusPermissionView.isHidden = !Current.focusStatus.isAvailable()
+        focusPermissionView.permission.updateInitial()
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Sources/App/Resources/Base.lproj/Onboarding.storyboard
+++ b/Sources/App/Resources/Base.lproj/Onboarding.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="k1J-B5-uSb">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="k1J-B5-uSb">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to Home Assistant Companion!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mse-YA-DiV">
-                                <rect key="frame" x="83.5" y="8" width="208.5" height="54.5"/>
+                                <rect key="frame" x="95.5" y="8" width="184.5" height="47"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -35,7 +35,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N4h-WC-wIw">
-                                <rect key="frame" x="154.5" y="595" width="66" height="32"/>
+                                <rect key="frame" x="160" y="599" width="55" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Continue"/>
                                 <connections>
@@ -43,7 +43,7 @@
                                 </connections>
                             </button>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To continue with automatic setup, please connect to your home Wi-Fi network" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="djx-xj-AwF" userLabel="Wifi Disconnected">
-                                <rect key="frame" x="8" y="70.5" width="375" height="82.5"/>
+                                <rect key="frame" x="8" y="63" width="375" height="47"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -88,26 +88,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" sectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sOg-Tl-IGk">
-                                <rect key="frame" x="0.0" y="100" width="375" height="475"/>
+                                <rect key="frame" x="0.0" y="100" width="375" height="479"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="gray" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="discoveredInstanceCell" textLabel="LVW-4r-7hW" detailTextLabel="bLi-Ty-QLQ" style="IBUITableViewCellStyleSubtitle" id="WW3-6V-g8b">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="60.5"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="50.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WW3-6V-g8b" id="7SZ-ee-IAN">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="60.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="50.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="My Home Assistant" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="LVW-4r-7hW">
-                                                    <rect key="frame" x="16" y="8" width="154" height="20.5"/>
+                                                    <rect key="frame" x="16" y="7.5" width="130" height="17"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="http://homeassistant.local:8123" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="bLi-Ty-QLQ">
-                                                    <rect key="frame" x="16" y="31.5" width="215" height="18"/>
+                                                    <rect key="frame" x="16" y="27" width="178" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
@@ -135,7 +135,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqx-lo-wDB">
-                                <rect key="frame" x="102" y="595" width="171" height="32"/>
+                                <rect key="frame" x="116" y="599" width="143" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Enter Address Manually">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -206,13 +206,13 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual Configuration" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7iT-bd-cdY">
-                                <rect key="frame" x="16" y="0.0" width="343" height="33.5"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="30"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PIW-dY-j0P" userLabel="Instructions">
-                                <rect key="frame" x="16" y="41.5" width="343" height="103.5"/>
+                                <rect key="frame" x="16" y="38" width="343" height="70"/>
                                 <string key="text">Please enter your Home Assistant URL to continue. It must be a fully formed URL of the format "http://homeassistant.local:8123" (that is, containing a scheme/protocol, hostname and port).</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -274,14 +274,14 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="10" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UKm-Ju-0Yr" userLabel="Error Description">
-                                <rect key="frame" x="16" y="315" width="343" height="222.5"/>
+                                <rect key="frame" x="16" y="315" width="343" height="167"/>
                                 <string key="text">We encountered an error while connecting to your instance. Your SSL certificate is invalid. Due to iOS limitations, you will not be able to continue with setup until a valid SSL certificate is installed. We recommend Lets Encrypt or Nabu Casa Remote UI.</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tqw-iY-A2S">
-                                <rect key="frame" x="153" y="535" width="69" height="32"/>
+                                <rect key="frame" x="158.5" y="539" width="58" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="More Info"/>
                                 <connections>
@@ -289,7 +289,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="suf-pJ-Nle">
-                                <rect key="frame" x="150" y="595" width="75" height="32"/>
+                                <rect key="frame" x="156" y="599" width="63" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Start Over"/>
                                 <connections>
@@ -337,20 +337,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authentication" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lM3-aA-jqO">
-                                <rect key="frame" x="99" y="0.0" width="177" height="33.5"/>
+                                <rect key="frame" x="109" y="0.0" width="157" height="30"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wsC-f5-jbO">
-                                <rect key="frame" x="16" y="193" width="343" height="86.5"/>
+                                <rect key="frame" x="16" y="205.5" width="343" height="74"/>
                                 <string key="text">We are now ready to connect to your Home Assistant and do the initial authentication. Tapping the Connect button below will cause a browser to open for you to log in to. </string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f1j-Ol-pW5">
-                                <rect key="frame" x="156.5" y="299.5" width="62" height="48"/>
+                                <rect key="frame" x="161.5" y="299.5" width="52" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="FXM-qV-KcU"/>
                                 </constraints>
@@ -361,7 +361,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RSW-l5-eRA">
-                                <rect key="frame" x="150" y="595" width="75" height="32"/>
+                                <rect key="frame" x="156" y="599" width="63" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Start Over"/>
                                 <connections>
@@ -434,7 +434,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connected" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XyQ-gy-yHY" userLabel="Connected">
-                                                <rect key="frame" x="0.0" y="0.0" width="80" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="66.5" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -453,7 +453,7 @@
                                         <rect key="frame" x="0.0" y="32" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Authenticated" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJr-sw-A9l" userLabel="Authenticated">
-                                                <rect key="frame" x="0.0" y="0.0" width="102" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="85" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -473,7 +473,7 @@
                                         <rect key="frame" x="0.0" y="64" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Integration Created" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bP1-C8-fgs" userLabel="Integration Created">
-                                                <rect key="frame" x="0.0" y="0.0" width="140.5" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="117.5" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -492,7 +492,7 @@
                                         <rect key="frame" x="0.0" y="96" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nabu Casa Cloud Detected" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O7a-0s-trd" userLabel="Nabu Casa Cloud Detected">
-                                                <rect key="frame" x="0.0" y="0.0" width="197" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -511,7 +511,7 @@
                                         <rect key="frame" x="0.0" y="128" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Encrypted Communications Established" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d97-7H-RBe" userLabel="Remote UI Detected">
-                                                <rect key="frame" x="0.0" y="0.0" width="288" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="240.5" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -530,7 +530,7 @@
                                         <rect key="frame" x="0.0" y="160" width="343" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sensors Configured" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rle-jZ-AWa" userLabel="Sensors Configured">
-                                                <rect key="frame" x="0.0" y="0.0" width="144" height="32"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="120" height="32"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -596,17 +596,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jTp-eG-rL8">
-                                <rect key="frame" x="20" y="120" width="335" height="483"/>
+                                <rect key="frame" x="20" y="120" width="335" height="487"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="YlM-SI-sh2">
-                                        <rect key="frame" x="0.0" y="0.0" width="335" height="360"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="335" height="480"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tox-sk-7fZ" userLabel="Location Permission Line Item View" customClass="PermissionLineItemView" customModule="HomeAssistant" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="120"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="120" id="iUj-9u-5IR"/>
-                                                </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="permissionInt">
                                                         <integer key="value" value="0"/>
@@ -616,9 +613,6 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kJc-Fh-WIp" userLabel="Motion Permission Line Item View" customClass="PermissionLineItemView" customModule="HomeAssistant" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="120" width="335" height="120"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="120" id="p10-IE-97q"/>
-                                                </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="permissionInt">
                                                         <integer key="value" value="1"/>
@@ -628,12 +622,18 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YDH-nq-m24" userLabel="Notifications Permission Line Item View" customClass="PermissionLineItemView" customModule="HomeAssistant" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="240" width="335" height="120"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="120" id="Ao6-a2-zsK"/>
-                                                </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="permissionInt">
                                                         <integer key="value" value="2"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oLK-58-zAw" userLabel="Notifications Permission Line Item View" customClass="PermissionLineItemView" customModule="HomeAssistant" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="360" width="335" height="120"/>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="permissionInt">
+                                                        <integer key="value" value="3"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
@@ -649,7 +649,7 @@
                                 </constraints>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jrL-9x-fFX" userLabel="Continue Button">
-                                <rect key="frame" x="154.5" y="603" width="66" height="32"/>
+                                <rect key="frame" x="160" y="607" width="55" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Continue"/>
                                 <connections>
@@ -675,6 +675,7 @@
                     <navigationItem key="navigationItem" id="JEo-gj-M70"/>
                     <connections>
                         <outlet property="continueButton" destination="jrL-9x-fFX" id="0JI-v4-BDo"/>
+                        <outlet property="focusPermissionView" destination="oLK-58-zAw" id="xXG-pI-omd"/>
                         <outlet property="locationPermissionView" destination="tox-sk-7fZ" id="2uD-iO-QNd"/>
                         <outlet property="motionPermissionView" destination="kJc-Fh-WIp" id="kIX-eD-8rx"/>
                         <outlet property="notificationsPermissionView" destination="YDH-nq-m24" id="2cO-w9-gXu"/>

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -216,6 +216,18 @@ Your actions and local configuration will still be available after logging in.";
 "onboarding.manual_setup.couldnt_make_url.title" = "Could not create a URL";
 "onboarding.manual_setup.no_scheme.message" = "Should we try connecting using http:// or https://?";
 "onboarding.manual_setup.no_scheme.title" = "URL entered without scheme";
+"onboarding.permissions.focus.description" = "Allow Focus status to be sent to Home Assistant";
+"onboarding.permissions.focus.title" = "Focus";
+"onboarding.permissions.location.description" = "Enable location services to allow presence detection automations.";
+"onboarding.permissions.location.title" = "Location";
+"onboarding.permissions.motion.description" = "Allow motion activity and pedometer data to be sent to Home Assistant";
+"onboarding.permissions.motion.title" = "Motion & Pedometer";
+"onboarding.permissions.notification.description" = "Allow push notifications to be sent from your Home Assistant";
+"onboarding.permissions.notification.title" = "Notifications";
+/* verb, grant permission button */
+"onboarding.permissions.allow" = "Allow";
+/* try to keep this terse. shorter than 'Allow' if you can. past tense, after allow is done successfully */
+"onboarding.permissions.allowed" = "Done";
 "open_label" = "Open";
 "preview_output" = "Preview Output";
 "retry_label" = "Retry";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -216,7 +216,7 @@ Your actions and local configuration will still be available after logging in.";
 "onboarding.manual_setup.couldnt_make_url.title" = "Could not create a URL";
 "onboarding.manual_setup.no_scheme.message" = "Should we try connecting using http:// or https://?";
 "onboarding.manual_setup.no_scheme.title" = "URL entered without scheme";
-"onboarding.permissions.focus.description" = "Allow Focus status to be sent to Home Assistant";
+"onboarding.permissions.focus.description" = "Allow whether you are in focus mode to be sent to Home Assistant";
 "onboarding.permissions.focus.title" = "Focus";
 "onboarding.permissions.location.description" = "Enable location services to allow presence detection automations.";
 "onboarding.permissions.location.title" = "Location";

--- a/Sources/App/Settings/Sensors/SensorListViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorListViewController.swift
@@ -148,7 +148,7 @@ class SensorListViewController: HAFormViewController, SensorObserver {
 
             row.onCellSelection { _, row in
                 if Current.focusStatus.authorizationStatus() == .notDetermined {
-                    Current.focusStatus.requestAuthorization().done {
+                    Current.focusStatus.requestAuthorization().done { _ in
                         update(isInitial: false)
                     }
                 } else {

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -319,7 +319,13 @@ public class Environment {
             return CMMotionActivityManager.authorizationStatus() == .authorized
         }
 
-        public var isActivityAvailable: () -> Bool = CMMotionActivityManager.isActivityAvailable
+        public var isActivityAvailable: () -> Bool = {
+            #if os(iOS) && targetEnvironment(simulator)
+            { true }
+            #else
+            CMMotionActivityManager.isActivityAvailable
+            #endif
+        }()
         public lazy var queryStartEndOnQueueHandler: (
             Date, Date, OperationQueue, @escaping CMMotionActivityQueryHandler
         ) -> Void = { [underlyingManager] start, end, queue, handler in

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -321,11 +321,12 @@ public class Environment {
 
         public var isActivityAvailable: () -> Bool = {
             #if os(iOS) && targetEnvironment(simulator)
-            { true }
+            return { true }
             #else
-            CMMotionActivityManager.isActivityAvailable
+            return CMMotionActivityManager.isActivityAvailable
             #endif
         }()
+
         public lazy var queryStartEndOnQueueHandler: (
             Date, Date, OperationQueue, @escaping CMMotionActivityQueryHandler
         ) -> Void = { [underlyingManager] start, end, queue, handler in

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -67,16 +67,16 @@ public class FocusStatusWrapper {
         return .restricted
     }
 
-    public var requestAuthorization: () -> Guarantee<Void> = {
-        let (promise, seal) = Guarantee<Void>.pending()
+    public var requestAuthorization: () -> Guarantee<AuthorizationStatus> = {
+        let (promise, seal) = Guarantee<AuthorizationStatus>.pending()
 
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
         if #available(iOS 15, watchOS 8, *) {
-            INFocusStatusCenter.default.requestAuthorization { _ in
-                seal(())
+            INFocusStatusCenter.default.requestAuthorization { result in
+                seal(.init(authorizationStatus: result))
             }
         } else {
-            seal(())
+            seal(.restricted)
         }
         #else
         seal(())

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -781,6 +781,36 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "onboarding.manual_setup.no_scheme.title") }
       }
     }
+    public enum Permissions {
+      /// Allow
+      public static var allow: String { return L10n.tr("Localizable", "onboarding.permissions.allow") }
+      /// Done
+      public static var allowed: String { return L10n.tr("Localizable", "onboarding.permissions.allowed") }
+      public enum Focus {
+        /// Allow Focus status to be sent to Home Assistant
+        public static var description: String { return L10n.tr("Localizable", "onboarding.permissions.focus.description") }
+        /// Focus
+        public static var title: String { return L10n.tr("Localizable", "onboarding.permissions.focus.title") }
+      }
+      public enum Location {
+        /// Enable location services to allow presence detection automations.
+        public static var description: String { return L10n.tr("Localizable", "onboarding.permissions.location.description") }
+        /// Location
+        public static var title: String { return L10n.tr("Localizable", "onboarding.permissions.location.title") }
+      }
+      public enum Motion {
+        /// Allow motion activity and pedometer data to be sent to Home Assistant
+        public static var description: String { return L10n.tr("Localizable", "onboarding.permissions.motion.description") }
+        /// Motion & Pedometer
+        public static var title: String { return L10n.tr("Localizable", "onboarding.permissions.motion.title") }
+      }
+      public enum Notification {
+        /// Allow push notifications to be sent from your Home Assistant
+        public static var description: String { return L10n.tr("Localizable", "onboarding.permissions.notification.description") }
+        /// Notifications
+        public static var title: String { return L10n.tr("Localizable", "onboarding.permissions.notification.title") }
+      }
+    }
   }
 
   public enum Sensors {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -787,7 +787,7 @@ public enum L10n {
       /// Done
       public static var allowed: String { return L10n.tr("Localizable", "onboarding.permissions.allowed") }
       public enum Focus {
-        /// Allow Focus status to be sent to Home Assistant
+        /// Allow whether you are in focus mode to be sent to Home Assistant
         public static var description: String { return L10n.tr("Localizable", "onboarding.permissions.focus.description") }
         /// Focus
         public static var title: String { return L10n.tr("Localizable", "onboarding.permissions.focus.title") }


### PR DESCRIPTION
Refs #945.

## Summary
Adds the Focus permission to the onboarding permission screen and cleans up some of the views there.

## Screenshots
https://user-images.githubusercontent.com/74188/134089206-2786d6f0-9cba-43bc-abcb-1e3267f53b61.mov

## Any other notes
- Makes a lot of the strings here localizable which were not before.
- Doesn't yet have a unique Lottie animation for the focus permission.
- Fixes tapping a denied permission, now opens Settings app.
- Fixes some of the text getting truncated or hidden because of the number-of-lines requirements.