### PR TITLE
Add icons to dynamic notification actions

### DIFF
--- a/Sources/Shared/API/Models/NotificationAction.swift
+++ b/Sources/Shared/API/Models/NotificationAction.swift
@@ -8,6 +8,7 @@ public class NotificationAction: Object {
     @objc public dynamic var Title: String = ""
     @objc public dynamic var TextInput: Bool = false
     @objc public dynamic var isServerControlled: Bool = false
+    @objc public dynamic var icon: String?
 
     // Options
     @objc public dynamic var Foreground: Bool = false
@@ -31,6 +32,7 @@ public class NotificationAction: Object {
         self.Foreground = (action.activationMode.lowercased() == "foreground")
         self.Destructive = action.destructive
         self.TextInput = (action.behavior.lowercased() == "textinput")
+        self.icon = action.icon
         if let title = action.textInputButtonTitle {
             self.TextInputButtonTitle = title
         } else {
@@ -59,17 +61,53 @@ public class NotificationAction: Object {
     }
 
     public var action: UNNotificationAction {
-        if TextInput {
-            return UNTextInputNotificationAction(
-                identifier: Identifier,
-                title: Title,
-                options: options,
-                textInputButtonTitle: TextInputButtonTitle,
-                textInputPlaceholder: TextInputPlaceholder
-            )
+        let action: UNNotificationAction
+
+        if #available(iOS 15, watchOS 8, *) {
+            let actionIcon: UNNotificationActionIcon?
+
+            if let icon = icon, icon.hasPrefix("sfsymbols:") {
+                actionIcon = .init(systemImageName: icon.replacingOccurrences(of: "sfsymbols:", with: ""))
+            } else {
+                actionIcon = nil
+            }
+
+            if TextInput {
+                action = UNTextInputNotificationAction(
+                    identifier: Identifier,
+                    title: Title,
+                    options: options,
+                    icon: actionIcon,
+                    textInputButtonTitle: TextInputButtonTitle,
+                    textInputPlaceholder: TextInputPlaceholder
+                )
+            } else {
+                action = UNNotificationAction(
+                    identifier: Identifier,
+                    title: Title,
+                    options: options,
+                    icon: actionIcon
+                )
+            }
+        } else {
+            if TextInput {
+                action = UNTextInputNotificationAction(
+                    identifier: Identifier,
+                    title: Title,
+                    options: options,
+                    textInputButtonTitle: TextInputButtonTitle,
+                    textInputPlaceholder: TextInputPlaceholder
+                )
+            } else {
+                action = UNNotificationAction(
+                    identifier: Identifier,
+                    title: Title,
+                    options: options
+                )
+            }
         }
 
-        return UNNotificationAction(identifier: Identifier, title: Title, options: options)
+        return action
     }
 
     public class func exampleTrigger(

--- a/Sources/Shared/API/Responses/MobileAppConfig.swift
+++ b/Sources/Shared/API/Responses/MobileAppConfig.swift
@@ -32,6 +32,7 @@ public struct MobileAppConfigPushCategory: ImmutableMappable, UpdatableModelSour
         public var textInputButtonTitle: String?
         public var textInputPlaceholder: String?
         public var url: String?
+        public var icon: String?
 
         public init(map: Map) throws {
             self.title = try map.value("title", default: "Missing title")
@@ -43,6 +44,7 @@ public struct MobileAppConfigPushCategory: ImmutableMappable, UpdatableModelSour
             self.destructive = try map.value("destructive", default: false)
             self.textInputButtonTitle = try? map.value("textInputButtonTitle")
             self.textInputPlaceholder = try? map.value("textInputPlaceholder")
+            self.icon = try? map.value("icon")
             for urlKey in ["url", "uri"] {
                 if let value: String = try? map.value(urlKey) {
                     // a url is set, which means this is likely coming from an actionable notification

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -74,7 +74,8 @@ public extension Realm {
         // 14 - 2020-10-29 v2020.8 (complication privacy)
         // 15 - 2021-03-21 v2021.4 (scene properties)
         // 16 - 2021-04-12 v2021.5 (accuracy authorization on location history entries)
-        let schemaVersion: UInt64 = 16
+        // 17 - 2021-09-20 v2021.10 (added notification action key icon)
+        let schemaVersion: UInt64 = 17
         let mdiVersion = UInt64(MDIMigration.migrationNumber)
 
         let config = Realm.Configuration(
@@ -142,6 +143,10 @@ public extension Realm {
                 }
 
                 if oldVersion < 16 {
+                    // nothing, it added an optional
+                }
+
+                if oldVersion < 17 {
                     // nothing, it added an optional
                 }
 


### PR DESCRIPTION
Fixes #1657.

## Summary
Adds the `icon` key to actionable notifications' actions, which must be `sfsymbols:`-prefixed strings of SFSymbols names.

## Screenshots
With a payload that looks like…

```js
{
  /* … */
  "actions": [
    {
      "action": "SOUND_ALARM",
      "title": "Sound Alarm",
      "icon": "sfsymbols:bell",
    },
    {
      "action": "SILENCE_ALARM",
      "title": "Silence Alarm",
      "icon": "sfsymbols:bell.slash",
    }
  ]
}
```

| Dark | Light |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/74188/134095088-554f48e9-fe65-417f-9aa5-59c408299da9.png) | ![image](https://user-images.githubusercontent.com/74188/134095094-debd4625-b60c-4dda-ac92-8ac0f5b44c5e.png) |



## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#577

## Any other notes
Apple requires that these icons either be pre-baked asset catalog assets, or part of the SFSymbols library (FB9149810), so these are prefixed with `sfsymbols:` to future-proof it.