### PR TITLE
Always allow media capture in frontend

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -486,6 +486,19 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }
     }
 
+    #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
+    @available(iOS 15, *)
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.grant)
+    }
+    #endif
+
     @objc private func connectionInfoDidChange() {
         DispatchQueue.main.async { [self] in
             loadActiveURLIfNeeded()


### PR DESCRIPTION
Fixes #1671.

## Summary
Always allows access to to the camera and microphone via `navigator.mediaDevices.getUserMedia`.

## Any other notes
Since this is gated on the app-level system permission for Camera and Microphone, it feels silly to require the user to allow access to them during the normal app runtime - this is exclusively a weird WebView behavior-ism. Also doesn't feel worth making this a preference - if users don't want the frontend to access it, it seems to me like the app-level permission is enough.

Tested this by using e.g. [the WebRTC samples](https://webrtc.github.io/samples/): going to a video or audio or both test page, after granting app permission, successfully starts right away.