### PR TITLE
Only signal focus sensor updates in the foreground

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -77,12 +77,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Current.backgroundTask = ApplicationBackgroundTaskRunner()
 
-        Current.isBackgroundRequestsImmediate = {
+        Current.isBackgroundRequestsImmediate = { [lifecycleManager] in
             if Current.isCatalyst {
                 return false
             } else {
-                return application.applicationState != .background
+                return lifecycleManager.isActive
             }
+        }
+
+        Current.isForegroundApp = { [lifecycleManager] in
+            lifecycleManager.isActive
         }
 
         #if targetEnvironment(simulator)

--- a/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
@@ -8,7 +8,9 @@ final class FocusSensorUpdateSignaler: SensorProviderUpdateSignaler {
         self.cancellable = Current.focusStatus.trigger.observe { _ in
             // this means that we will double-update the focus sensor if the app is running
             // this feels less likely to happen, but allows us to keep the in-app visual state right
-            signal()
+            if Current.isForegroundApp() {
+                signal()
+            }
         }
     }
 

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -231,6 +231,7 @@ public class Environment {
     }
 
     public var isBackgroundRequestsImmediate = { true }
+    public var isForegroundApp = { false }
 
     public var appConfiguration: AppConfiguration {
         if isFastlaneSnapshot {

--- a/Tests/Shared/Sensors/FocusSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusSensor.test.swift
@@ -105,13 +105,17 @@ class FocusSensorTests: XCTestCase {
         _ = signaler
 
         let date = Date()
+        Current.isForegroundApp = { false }
         Current.focusStatus.trigger.value = date
+
+        Current.isForegroundApp = { true }
+        Current.focusStatus.trigger.value = date.addingTimeInterval(1.0)
 
         // so it sticks around, but we don't need to access it directly
         wait(for: [expectation], timeout: 10.0)
         signaler = nil
 
-        Current.focusStatus.trigger.value = date.addingTimeInterval(1.0)
+        Current.focusStatus.trigger.value = date.addingTimeInterval(2.0)
         // we expect this to not fire an expectation over-fulfill
     }
 }


### PR DESCRIPTION
## Summary
Fixes unnecessarily doing a sensor update pass when launching in the background, as well as an occasional crash talking to UIApplication's applicationState off the main thread.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
