### PR TITLE
Permit more actions in widgets, support extra large on iPadOS 15

### DIFF
--- a/Sources/App/Resources/Base.lproj/Intents.intentdefinition
+++ b/Sources/App/Resources/Base.lproj/Intents.intentdefinition
@@ -9,7 +9,7 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>sI7YSe</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>21A5506j</string>
+	<string>21A5522h</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
 	<string>13A233</string>
 	<key>INIntentDefinitionToolsVersion</key>
@@ -1167,19 +1167,19 @@
 						</dict>
 						<dict>
 							<key>INIntentParameterArraySizeSize</key>
-							<integer>4</integer>
+							<integer>8</integer>
 							<key>INIntentParameterArraySizeSizeClass</key>
 							<string>Medium</string>
 						</dict>
 						<dict>
 							<key>INIntentParameterArraySizeSize</key>
-							<integer>8</integer>
+							<integer>16</integer>
 							<key>INIntentParameterArraySizeSizeClass</key>
 							<string>Large</string>
 						</dict>
 						<dict>
 							<key>INIntentParameterArraySizeSize</key>
-							<integer>12</integer>
+							<integer>24</integer>
 							<key>INIntentParameterArraySizeSizeClass</key>
 							<string>ExtraLarge</string>
 						</dict>

--- a/Sources/App/Resources/Base.lproj/Intents.intentdefinition
+++ b/Sources/App/Resources/Base.lproj/Intents.intentdefinition
@@ -1179,7 +1179,7 @@
 						</dict>
 						<dict>
 							<key>INIntentParameterArraySizeSize</key>
-							<integer>24</integer>
+							<integer>32</integer>
 							<key>INIntentParameterArraySizeSizeClass</key>
 							<string>ExtraLarge</string>
 						</dict>

--- a/Sources/Extensions/Widgets/Actions/WidgetActions.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActions.swift
@@ -13,6 +13,16 @@ struct WidgetActions: Widget {
         )
         .configurationDisplayName(L10n.Widgets.Actions.title)
         .description(L10n.Widgets.Actions.description)
-        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .supportedFamilies({
+            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+
+            #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
+            if #available(iOS 15, *) {
+                supportedFamilies.append(.systemExtraLarge)
+            }
+            #endif
+
+            return supportedFamilies
+        }())
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsActionView.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsActionView.swift
@@ -46,7 +46,7 @@ struct WidgetActionsActionView: View {
                         .lineLimit(1)
                     Spacer()
                 }
-                .padding([.leading, .trailing])
+                .padding([.leading])
             } else {
                 VStack(alignment: .leading) {
                     Text(verbatim: MaterialDesignIcons(named: action.IconName).unicode)

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsActionView.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsActionView.swift
@@ -9,13 +9,13 @@ struct WidgetActionsActionView: View {
 
     enum SizeStyle {
         case single
-        case multiple(expanded: Bool)
+        case multiple(expanded: Bool, condensed: Bool)
 
         var font: Font {
             switch self {
             case .single:
                 return .subheadline
-            case let .multiple(expanded: expanded):
+            case let .multiple(expanded: expanded, _):
                 return expanded ? .subheadline : .footnote
             }
         }
@@ -30,19 +30,34 @@ struct WidgetActionsActionView: View {
     var body: some View {
         ZStack(alignment: .leading) {
             Color(hex: action.BackgroundColor)
-            VStack(alignment: .leading) {
-                Text(verbatim: MaterialDesignIcons(named: action.IconName).unicode)
-                    .font(.custom(MaterialDesignIcons.familyName, size: 38.0))
-                    .minimumScaleFactor(0.2)
-                    .foregroundColor(.init(hex: action.IconColor))
-                Spacer()
-                Text(verbatim: action.Text)
-                    .font(sizeStyle.font)
-                    .fontWeight(.bold)
-                    .multilineTextAlignment(.leading)
-                    .foregroundColor(.init(hex: action.TextColor))
+
+            let text = Text(verbatim: action.Text)
+                .font(sizeStyle.font)
+                .fontWeight(.bold)
+                .multilineTextAlignment(.leading)
+                .foregroundColor(.init(hex: action.TextColor))
+
+            if case .multiple(_, condensed: true) = sizeStyle {
+                HStack(alignment: .center) {
+                    Text(verbatim: MaterialDesignIcons(named: action.IconName).unicode)
+                        .font(.custom(MaterialDesignIcons.familyName, size: 16.0))
+                        .foregroundColor(.init(hex: action.IconColor))
+                    text
+                        .lineLimit(1)
+                    Spacer()
+                }
+                .padding([.leading, .trailing])
+            } else {
+                VStack(alignment: .leading) {
+                    Text(verbatim: MaterialDesignIcons(named: action.IconName).unicode)
+                        .font(.custom(MaterialDesignIcons.familyName, size: 38.0))
+                        .minimumScaleFactor(0.2)
+                        .foregroundColor(.init(hex: action.IconColor))
+                    Spacer()
+                    text
+                }
+                .padding()
             }
-            .padding()
         }
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsContainerView.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsContainerView.swift
@@ -5,6 +5,7 @@ import WidgetKit
 struct WidgetActionsContainerView: View {
     var entry: WidgetActionsEntry
     @SwiftUI.Environment(\.widgetFamily) var family: WidgetFamily
+    @SwiftUI.Environment(\.pixelLength) var pixelLength: CGFloat
 
     init(entry: WidgetActionsEntry) {
         self.entry = entry
@@ -29,14 +30,18 @@ struct WidgetActionsContainerView: View {
 
     @ViewBuilder
     func multiView(for actions: [Action]) -> some View {
-        let columnCount = Self.columnCount(family: family, actionCount: actions.count)
+        let actionCount = actions.count
+        let columnCount = Self.columnCount(family: family, actionCount: actionCount)
         let rows = Array(columnify(count: columnCount, actions: actions))
         let maximumRowCount = Self.maximumCount(family: family) / columnCount
-        let sizeStyle: WidgetActionsActionView.SizeStyle = .multiple(expanded: rows.count < maximumRowCount)
+        let sizeStyle: WidgetActionsActionView.SizeStyle = .multiple(
+            expanded: rows.count < maximumRowCount,
+            condensed: Self.compactSizeBreakpoint(for: family) < actionCount
+        )
 
-        VStack(alignment: .leading, spacing: 1) {
+        VStack(alignment: .leading, spacing: pixelLength) {
             ForEach(rows, id: \.self) { column in
-                HStack(spacing: 1) {
+                HStack(spacing: pixelLength) {
                     ForEach(column, id: \.ID) { action in
                         Link(destination: action.widgetLinkURL) {
                             WidgetActionsActionView(action: action, sizeStyle: sizeStyle)
@@ -68,16 +73,40 @@ struct WidgetActionsContainerView: View {
             } else {
                 return 2
             }
+        #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
+        case .systemExtraLarge:
+            if actionCount <= 3 {
+                return 1
+            } else {
+                return 3
+            }
+        #endif
         @unknown default: return 2
+        }
+    }
+
+    /// more than this number: show compact (icon left, text right) version
+    static func compactSizeBreakpoint(for family: WidgetFamily) -> Int {
+        switch family {
+        case .systemSmall: return 1
+        case .systemMedium: return 4
+        case .systemLarge: return 8
+        #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
+        case .systemExtraLarge: return 12
+        #endif
+        @unknown default: return 8
         }
     }
 
     static func maximumCount(family: WidgetFamily) -> Int {
         switch family {
         case .systemSmall: return 1
-        case .systemMedium: return 4
-        case .systemLarge: return 8
-        @unknown default: return 8
+        case .systemMedium: return 8
+        case .systemLarge: return 16
+        #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
+        case .systemExtraLarge: return 24
+        #endif
+        @unknown default: return 16
         }
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsContainerView.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsContainerView.swift
@@ -75,10 +75,13 @@ struct WidgetActionsContainerView: View {
             }
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
         case .systemExtraLarge:
-            if actionCount <= 3 {
+            if actionCount <= 4 {
                 return 1
-            } else {
+            } else if actionCount <= 15 {
+                // note this is 15 and not 16 - divisibility by 3 here
                 return 3
+            } else {
+                return 4
             }
         #endif
         @unknown default: return 2
@@ -92,7 +95,7 @@ struct WidgetActionsContainerView: View {
         case .systemMedium: return 4
         case .systemLarge: return 8
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
-        case .systemExtraLarge: return 12
+        case .systemExtraLarge: return 16
         #endif
         @unknown default: return 8
         }
@@ -104,9 +107,9 @@ struct WidgetActionsContainerView: View {
         case .systemMedium: return 8
         case .systemLarge: return 16
         #if compiler(>=5.5) && !targetEnvironment(macCatalyst)
-        case .systemExtraLarge: return 24
+        case .systemExtraLarge: return 32
         #endif
-        @unknown default: return 16
+        @unknown default: return 8
         }
     }
 }


### PR DESCRIPTION
## Summary
This updates our maximum action count per size, adding extra large:

| Family | Old Maximum | New Maximum Count |
| -- | -- | -- |
| Small | 1 | 1 |
| Medium | 4 | 8 |
| Large | 8 | 16 |
| Extra Large (new) | n/a | 32 |

Extra Large is approximately 2 'Large' stacked horizontally, so we extend this into 3 (for ≤15 items) or 4 columns, depending on item count.

## Screenshots
| Kind | Image |
| -- | -- |
| Maximum | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-09-25 at 20 17 55](https://user-images.githubusercontent.com/74188/134792223-a83bbee7-7a6c-407f-864f-3c87cd3caee3.png) |
| Old Maximum | ![simulator_screenshot_6AD05BE4-7D54-4B83-8FD1-A1C110EAD0B6](https://user-images.githubusercontent.com/74188/134792289-37200bce-220d-4938-82b1-d4b6545ff3e8.png) |

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
