### PR TITLE
fr: fix "envoie" syntax

### DIFF
--- a/Sources/App/Resources/fr.lproj/Localizable.strings
+++ b/Sources/App/Resources/fr.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "cl_error.description.ranging_unavailable" = "La portée est désactivée.";
 "cl_error.description.region_monitoring_denied" = "L'accès à la surveillance de région a été refusé par l'utilisateur.";
 "cl_error.description.region_monitoring_failure" = "Une région enregistrée ne peut pas être surveillée.";
-"cl_error.description.region_monitoring_response_delayed" = "Core Location assurera l'envoie des événements, mais ces derniers peuvent être retardés.";
+"cl_error.description.region_monitoring_response_delayed" = "Core Location assurera l'envoi des événements, mais ces derniers peuvent être retardés.";
 "cl_error.description.region_monitoring_setup_delayed" = "Core Location n'a pas pu initialiser immédiatement la fonction de surveillance de la région.";
 "cl_error.description.unknown" = "Erreur interne de localisation inconnue";
 "client_events.event_type.location_update" = "Mise à jour de l'emplacement";
@@ -99,7 +99,7 @@
 "ha_api.api_error.update_not_possible" = "L'opération n'a pas pu être effectuée.";
 "help_label" = "Aide";
 "location_change_notification.app_shortcut.body" = "Lieu mis à jour via l'App Shortcut";
-"location_change_notification.background_fetch.body" = "L'envoie de l'emplacement actuel a été déclenchée via l'actualisation en arrière-plan";
+"location_change_notification.background_fetch.body" = "L'envoi de l'emplacement actuel a été déclenché via l'actualisation en arrière-plan";
 "location_change_notification.beacon_region_enter.body" = "%@ entré via iBeacon";
 "location_change_notification.beacon_region_exit.body" = "%@ sorti via iBeacon";
 "location_change_notification.launch.body" = "Lieu mis à jour via le lancement de l'application";


### PR DESCRIPTION
"Envoi" (le nom) est masculin et ne prend pas de "e".

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixing french message on a specific noun: envoi, which does not end with a 'e' and is not feminine.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
