### PR TITLE
Minor fixes for open page widget

### DIFF
--- a/Sources/Extensions/Widgets/Actions/WidgetActions.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActions.swift
@@ -19,7 +19,7 @@ struct WidgetActions: Widget {
                             id: action.ID,
                             title: action.Text,
                             widgetURL: action.widgetLinkURL,
-                            icon: action.IconName,
+                            icon: MaterialDesignIcons(serversideValueNamed: action.IconName),
                             textColor: .init(hex: action.TextColor),
                             iconColor: .init(hex: action.IconColor),
                             backgroundColor: .init(hex: action.BackgroundColor)

--- a/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
@@ -7,7 +7,7 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
         id: String,
         title: String,
         widgetURL: URL,
-        icon: String,
+        icon: MaterialDesignIcons,
         textColor: Color = Color.black,
         iconColor: Color = Color.black,
         backgroundColor: Color = Color.white
@@ -26,7 +26,7 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
     var title: String
     var widgetURL: URL
 
-    var icon: String
+    var icon: MaterialDesignIcons
 
     var backgroundColor: Color
     var textColor: Color
@@ -72,7 +72,7 @@ struct WidgetBasicView: View {
             switch sizeStyle {
             case .condensed:
                 HStack(alignment: .center) {
-                    Text(verbatim: MaterialDesignIcons(named: model.icon).unicode)
+                    Text(verbatim: model.icon.unicode)
                         .font(.custom(MaterialDesignIcons.familyName, size: 16.0))
                         .foregroundColor(model.iconColor)
                     text
@@ -81,7 +81,7 @@ struct WidgetBasicView: View {
                 .padding([.leading])
             case .regular, .expanded, .single:
                 VStack(alignment: .leading) {
-                    Text(verbatim: MaterialDesignIcons(named: model.icon).unicode)
+                    Text(verbatim: model.icon.unicode)
                         .font(.custom(MaterialDesignIcons.familyName, size: 38.0))
                         .minimumScaleFactor(0.2)
                         .foregroundColor(model.iconColor)

--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
@@ -19,7 +19,7 @@ struct WidgetOpenPage: Widget {
                             id: panel.identifier!,
                             title: panel.displayString,
                             widgetURL: panel.widgetURL,
-                            icon: panel.icon ?? MaterialDesignIcons.abTestingIcon.name,
+                            icon: panel.materialDesignIcon,
                             textColor: Color(Constants.tintColor),
                             iconColor: Color(Constants.tintColor),
                             backgroundColor: Color(UIColor.systemBackground)

--- a/Sources/Shared/API/WebSocket/HAPanel.swift
+++ b/Sources/Shared/API/WebSocket/HAPanel.swift
@@ -8,10 +8,12 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
     public var icon: String?
     public var title: String
     public var path: String
+    public var component: String
     public var showInSidebar: Bool
 
     public init(data: HAData) throws {
         let component: String = try data.decode("component_name")
+        self.component = component
         let fallbackIcon: String? = { () -> String? in
             switch component {
             case "profile": return "mdi:account"
@@ -44,7 +46,37 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
     public init(panelsByPath: [String: HAPanel]) {
         self.panelsByPath = panelsByPath
         self.allPanels = panelsByPath.values.sorted(by: {
-            $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+            let sortedByTitle = $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+
+            switch ($0.component, $1.component) {
+            case ("lovelace", "lovelace"):
+                return sortedByTitle
+            case ("lovelace", _):
+                return true
+            case (_, "lovelace"):
+                return false
+            default:
+                // from the frontend as of 9a928259549b255ae79fbdb412538109e31d62d2 2021-07-28
+                // https://github.com/home-assistant/frontend/blob/b26c44b2/src/components/ha-sidebar.ts#L55-L63
+                let pathSortValue = [
+                    "energy": 1,
+                    "map": 2,
+                    "logbook": 3,
+                    "history": 4,
+                    "developer-tools": 9,
+                    "hassio": 10,
+                    "config": 11,
+                ]
+
+                let sort0 = pathSortValue[$0.path, default: -1]
+                let sort1 = pathSortValue[$1.path, default: -1]
+
+                if sort0 == sort1 {
+                    return sortedByTitle
+                } else {
+                    return sort0 < sort1
+                }
+            }
         })
     }
 

--- a/Sources/Shared/API/WebSocket/HAPanel.swift
+++ b/Sources/Shared/API/WebSocket/HAPanel.swift
@@ -8,6 +8,7 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
     public var icon: String?
     public var title: String
     public var path: String
+    public var showInSidebar: Bool
 
     public init(data: HAData) throws {
         let component: String = try data.decode("component_name")
@@ -19,6 +20,7 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
             }
         }()
 
+        self.showInSidebar = data.decode("show_in_sidebar", fallback: true)
         self.icon = data.decode("icon", fallback: fallbackIcon)
         self.path = try data.decode("url_path")
 
@@ -63,6 +65,8 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
                 .mapValues {
                     try HAPanel(data: .init(value: $0))
                 }
+                // non-show_in_sidebar dashboards have badly-named titles
+                .filter(\.value.showInSidebar)
         )
     }
 }

--- a/Sources/Shared/Common/Extensions/UIImage+Icons.swift
+++ b/Sources/Shared/Common/Extensions/UIImage+Icons.swift
@@ -18,8 +18,12 @@ public extension UIImage {
 }
 
 public extension MaterialDesignIcons {
-    convenience init(serversideValueNamed value: String) {
-        self.init(named: value.normalizingIconString)
+    convenience init(serversideValueNamed value: String, fallback: MaterialDesignIcons? = nil) {
+        if let fallback = fallback {
+            self.init(named: value.normalizingIconString, fallback: fallback)
+        } else {
+            self.init(named: value.normalizingIconString)
+        }
     }
 }
 

--- a/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
+++ b/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
@@ -173,7 +173,6 @@ public extension IntentPanel {
         MaterialDesignIcons(serversideValueNamed: name ?? "", fallback: .cogOutlineIcon)
     }
 
-
     var materialDesignIcon: MaterialDesignIcons {
         Self.materialDesignIcon(for: icon)
     }

--- a/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
+++ b/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
@@ -131,10 +131,12 @@ public extension IntentPanel {
     convenience init(panel: HAPanel) {
         let image: INImage?
 
+        let icon = panel.icon?.normalizingIconString
+
         #if os(iOS)
         image = panel.icon.flatMap {
             INImage(
-                icon: MaterialDesignIcons(named: $0.normalizingIconString),
+                icon: Self.materialDesignIcon(for: icon),
                 foreground: Constants.tintColor.resolvedColor(with: .init(userInterfaceStyle: .light)),
                 background: .white
             )
@@ -156,7 +158,7 @@ public extension IntentPanel {
                 display: panel.title
             )
         }
-        self.icon = panel.icon?.normalizingIconString
+        self.icon = icon
     }
 
     var widgetURL: URL {
@@ -165,6 +167,15 @@ public extension IntentPanel {
         components.host = "navigate"
         components.path = "/" + (identifier ?? "lovelace")
         return components.url!
+    }
+
+    private static func materialDesignIcon(for name: String?) -> MaterialDesignIcons {
+        MaterialDesignIcons(serversideValueNamed: name ?? "", fallback: .cogOutlineIcon)
+    }
+
+
+    var materialDesignIcon: MaterialDesignIcons {
+        Self.materialDesignIcon(for: icon)
     }
 }
 

--- a/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
+++ b/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
@@ -134,7 +134,7 @@ public extension IntentPanel {
         let icon = panel.icon?.normalizingIconString
 
         #if os(iOS)
-        image = panel.icon.flatMap {
+        image = icon.flatMap { icon in
             INImage(
                 icon: Self.materialDesignIcon(for: icon),
                 foreground: Constants.tintColor.resolvedColor(with: .init(userInterfaceStyle: .light)),

--- a/Sources/Shared/Iconic/MaterialDesignIcons.swift
+++ b/Sources/Shared/Iconic/MaterialDesignIcons.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public final class MaterialDesignIcons: CaseIterable, Equatable, CustomStringConvertible, IconDrawable {
+public final class MaterialDesignIcons: CaseIterable, Hashable, Equatable, CustomStringConvertible, IconDrawable {
     public static let familyName: String = "MaterialDesignIcons"
     public static let count: Int = 6195
     public let name: String
@@ -17,12 +17,16 @@ public final class MaterialDesignIcons: CaseIterable, Equatable, CustomStringCon
     }
 
     public convenience init(named iconName: String) {
+        self.init(named: iconName, fallback: Self.allCases.first!)
+    }
+
+    public convenience init(named iconName: String, fallback: MaterialDesignIcons) {
         let existing: MaterialDesignIcons
 
         if let found = Self.allCases.first(where: { $0.name == iconName.lowercased() }) {
             existing = found
         } else {
-            existing = Self.allCases.first!
+            existing = fallback
         }
 
         self.init(name: existing.name, unicode: existing.unicode)
@@ -34,7 +38,11 @@ public final class MaterialDesignIcons: CaseIterable, Equatable, CustomStringCon
     }
 
     public static func == (lhs: MaterialDesignIcons, rhs: MaterialDesignIcons) -> Bool {
-        lhs.name == rhs.name && lhs.unicode == rhs.unicode
+        lhs.unicode == rhs.unicode
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(unicode)
     }
 
     public static let abTestingIcon = MaterialDesignIcons(name: "ab_testing", unicode: "\u{F01C9}")

--- a/Tools/icons.stencil
+++ b/Tools/icons.stencil
@@ -14,7 +14,7 @@ import Foundation
 {% for file in files %}
 {% set icons file.document.data %}
 {% set typeName %}{{param.typeName|default:file.name}}{% endset %}
-{{ accessModifier }} final class {{ typeName }}: CaseIterable, Equatable, CustomStringConvertible, IconDrawable {
+{{ accessModifier }} final class {{ typeName }}: CaseIterable, Hashable, Equatable, CustomStringConvertible, IconDrawable {
     {{ accessModifier }} static let familyName: String = "{{ typeName }}"
     {{ accessModifier }} static let count: Int = {{ icons.count }}
     {{ accessModifier }} let name: String
@@ -24,13 +24,17 @@ import Foundation
         "<MaterialDesignIcons: \(name)>"
     }
 
-    {{ accessModifier }} convenience init(named iconName: String) {
+    public convenience init(named iconName: String) {
+        self.init(named: iconName, fallback: Self.allCases.first!)
+    }
+
+    public convenience init(named iconName: String, fallback: MaterialDesignIcons) {
         let existing: {{ typeName }}
 
         if let found = Self.allCases.first(where: { $0.name == iconName.lowercased() }) {
             existing = found
         } else {
-            existing = Self.allCases.first!
+            existing = fallback
         }
 
         self.init(name: existing.name, unicode: existing.unicode)
@@ -42,7 +46,11 @@ import Foundation
     }
 
     {{ accessModifier }} static func == (lhs: {{ typeName }}, rhs: {{ typeName }}) -> Bool {
-        lhs.name == rhs.name && lhs.unicode == rhs.unicode
+        lhs.unicode == rhs.unicode
+    }
+
+    {{ accessModifier }} func hash(into hasher: inout Hasher) {
+        hasher.combine(unicode)
     }
 
     {% for icon in icons %}


### PR DESCRIPTION
## Summary
- Fixes e.g. HACS (which is `hacs:hacs`) icons showing the A/B icon. We now fall back to the outline cog.
- Hide panels without the "show in sidebar" option. We get them in the response, but e.g. the title is incorrect.
- Changes sort order in the automatic version to more closely align with the frontend.
- Fixes a case where chosen panels in the past would fail to be updated due to being at the tail end of the array in the API response, due to truncating to widget size _before_ updating.

## Screenshots
![image](https://user-images.githubusercontent.com/74188/135203919-d2951c9a-0bfe-4eb4-8285-a74f9c546882.png)