### PR TITLE
Preload WebView during Onboarding

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -210,7 +210,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if #available(iOS 13, *) {
             return false
         } else {
-            if sceneManager.compatibility.windowController?.requiresOnboarding == true {
+            if Current.onboardingObservation.requiresOnboarding {
                 Current.Log.info("disallowing state to be restored due to onboarding")
                 return false
             }

--- a/Sources/App/Onboarding/API/OnboardingAuthentication.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthentication.swift
@@ -178,6 +178,8 @@ class OnboardingAuthentication: NSObject {
                 userInfo: nil
             )
             Current.apiConnection.connect()
+
+            Current.onboardingObservation.didConnect()
         }
     }
 

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -241,7 +241,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         userActivity?.resignCurrent()
     }
 
-    init(restorationActivity: NSUserActivity?) {
+    init(restorationActivity: NSUserActivity?, shouldLoadImmediately: Bool = false) {
         super.init(nibName: nil, bundle: nil)
 
         userActivity = with(NSUserActivity(activityType: "\(Constants.BundleID).frontend")) {
@@ -250,6 +250,11 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
         if let url = restorationActivity?.userInfo?[RestorableStateKey.lastURL.rawValue] as? URL {
             self.initialURL = url
+        }
+
+        if shouldLoadImmediately {
+            loadViewIfNeeded()
+            loadActiveURLIfNeeded()
         }
     }
 

--- a/Sources/Shared/Environment/OnboardingStateObservation.swift
+++ b/Sources/Shared/Environment/OnboardingStateObservation.swift
@@ -14,6 +14,7 @@ public enum NeededType {
 
 public enum OnboardingState {
     case complete
+    case didConnect
     case needed(NeededType)
 }
 
@@ -23,6 +24,10 @@ public protocol OnboardingStateObserver: AnyObject {
 
 public class OnboardingStateObservation {
     private var observers = NSHashTable<AnyObject>(options: .weakMemory)
+
+    public var requiresOnboarding: Bool {
+        Current.settingsStore.tokenInfo == nil || Current.settingsStore.connectionInfo == nil
+    }
 
     public func register(observer: OnboardingStateObserver) {
         observers.add(observer)
@@ -45,5 +50,9 @@ public class OnboardingStateObservation {
 
     public func needed(_ type: NeededType) {
         notify(for: .needed(type))
+    }
+
+    public func didConnect() {
+        notify(for: .didConnect)
     }
 }


### PR DESCRIPTION
## Summary
- Creates and loads the WebView when onboarding finishes connecting to a server, but before permissions are finished.

## Screenshots
https://user-images.githubusercontent.com/74188/137650341-16884602-300d-491f-a853-642aad08ee3c.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
