### PR TITLE
Show permissions onboarding if any are not determined

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -210,7 +210,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if #available(iOS 13, *) {
             return false
         } else {
-            if Current.onboardingObservation.requiresOnboarding {
+            if OnboardingNavigationViewController.requiredOnboardingStyle != nil {
                 Current.Log.info("disallowing state to be restored due to onboarding")
                 return false
             }

--- a/Sources/App/Onboarding/API/OnboardingAuthentication.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthentication.swift
@@ -6,7 +6,7 @@ import Shared
 
 class OnboardingAuthentication: NSObject {
     static func successController() -> UIViewController {
-        OnboardingPermissionWorkflowController().next()
+        OnboardingPermissionViewControllerFactory.next()
     }
 
     static func failureController(error: Error) -> UIViewController {

--- a/Sources/App/Onboarding/Container/OnboardingPermissionWorkflowController.swift
+++ b/Sources/App/Onboarding/Container/OnboardingPermissionWorkflowController.swift
@@ -1,10 +1,20 @@
 import Shared
 import UIKit
 
-class OnboardingPermissionWorkflowController {
-    private let permissions: [PermissionType]
+class OnboardingPermissionViewControllerFactory {
+    static var hasControllers: Bool {
+        !permissions.isEmpty
+    }
 
-    init() {
+    static func next() -> UIViewController {
+        if let permission = permissions.first {
+            return OnboardingPermissionViewController(permission: permission, factory: self)
+        } else {
+            return OnboardingTerminalViewController()
+        }
+    }
+
+    private static var permissions: [PermissionType] {
         var permissions: [PermissionType] = [
             .notification,
             .location,
@@ -18,14 +28,6 @@ class OnboardingPermissionWorkflowController {
             permissions.append(.focus)
         }
 
-        self.permissions = permissions
-    }
-
-    func next() -> UIViewController {
-        if let permission = permissions.first(where: { $0.status == .notDetermined }) {
-            return OnboardingPermissionViewController(permission: permission, workflowController: self)
-        } else {
-            return OnboardingTerminalViewController()
-        }
+        return permissions.filter { $0.status == .notDetermined }
     }
 }

--- a/Sources/App/Onboarding/Screens/OnboardingPermissionViewController.swift
+++ b/Sources/App/Onboarding/Screens/OnboardingPermissionViewController.swift
@@ -3,10 +3,10 @@ import UIKit
 
 class OnboardingPermissionViewController: UIViewController, OnboardingViewController {
     let permission: PermissionType
-    let workflowController: OnboardingPermissionWorkflowController
-    init(permission: PermissionType, workflowController: OnboardingPermissionWorkflowController) {
+    let factory: OnboardingPermissionViewControllerFactory.Type
+    init(permission: PermissionType, factory: OnboardingPermissionViewControllerFactory.Type) {
         self.permission = permission
-        self.workflowController = workflowController
+        self.factory = factory
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -113,7 +113,7 @@ class OnboardingPermissionViewController: UIViewController, OnboardingViewContro
             }
 
             sender.isUserInteractionEnabled = true
-            show(workflowController.next(), sender: self)
+            show(factory.next(), sender: self)
         }
     }
 

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -66,9 +66,9 @@ class WebViewWindowController {
     }
 
     func setup() {
-        if Current.onboardingObservation.requiresOnboarding {
-            Current.Log.info("showing onboarding")
-            updateRootViewController(to: OnboardingNavigationViewController(onboardingStyle: .initial))
+        if let style = OnboardingNavigationViewController.requiredOnboardingStyle {
+            Current.Log.info("showing onboarding \(style)")
+            updateRootViewController(to: OnboardingNavigationViewController(onboardingStyle: style))
         } else {
             if let rootController = window.rootViewController, !rootController.children.isEmpty {
                 Current.Log.info("state restoration loaded controller, not creating a new one")

--- a/Sources/Shared/Environment/OnboardingStateObservation.swift
+++ b/Sources/Shared/Environment/OnboardingStateObservation.swift
@@ -25,10 +25,6 @@ public protocol OnboardingStateObserver: AnyObject {
 public class OnboardingStateObservation {
     private var observers = NSHashTable<AnyObject>(options: .weakMemory)
 
-    public var requiresOnboarding: Bool {
-        Current.settingsStore.tokenInfo == nil || Current.settingsStore.connectionInfo == nil
-    }
-
     public func register(observer: OnboardingStateObserver) {
         observers.add(observer)
     }


### PR DESCRIPTION
## Summary
- For new permissions (like Focus) this means we'll actively prompt people to introduce it.
- For existing permissions, this brings normal app installations in line with the new onboarding, and also can help reinstalls where the keychain is still present, so people aren't confused about why the app isn't working.
