### PR TITLE
Provide clearer error if mobile_app is not loaded during onboarding

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -362,7 +362,13 @@ public class HomeAssistantAPI {
             method: .post,
             parameters: buildMobileAppRegistration(),
             encoding: JSONEncoding.default
-        ).done { (resp: MobileAppRegistrationResponse) in
+        ).recover { error -> Promise<MobileAppRegistrationResponse> in
+            if case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) = error {
+                throw APIError.mobileAppComponentNotLoaded
+            }
+
+            throw error
+        }.done { (resp: MobileAppRegistrationResponse) in
             Current.Log.verbose("Registration response \(resp)")
 
             let connectionInfo = try self.connectionInfo()


### PR DESCRIPTION
## Summary
If the API call to `mobile_app/registrations` fails due to a 404, explain that the component needs to be loaded. This likely, in the old flow, was erroring a bit more randomly on the final screen, as the same order of checks was happening.

## Screenshots
| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/74188/141503139-e09bf4fb-fafb-4743-ad14-34cd9c1bc923.png) | ![image](https://user-images.githubusercontent.com/74188/141503061-7712615f-21fd-45b9-8a83-8ddc67bb6721.png) |

## Any other notes
This is the "Alamofire.AFError 9" error during onboarding _after_ logging in noted in [this forum post](https://community.home-assistant.io/t/ha-companion-app-alamofire-aferror-9/355504/11).

It is worth noting that this error message could be happening because the internal URL (or the URL connecting to) is incorrect, which would produce the same error message after entering the URL or tapping the discovered row, but before entering credentials.