### PR TITLE
Fix onboarding error 404 when URL has a trailing `/`

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuthDetails.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthDetails.swift
@@ -6,7 +6,7 @@ struct OnboardingAuthDetails: Equatable {
     var scheme: String
 
     init(baseURL: URL) throws {
-        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+        guard var components = URLComponents(url: baseURL.sanitized(), resolvingAgainstBaseURL: false) else {
             throw OnboardingAuthError(kind: .invalidURL)
         }
 

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -232,21 +232,6 @@ public class ConnectionInfo: Codable {
         }
     }
 
-    private func sanitize(_ url: URL) -> URL {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return url
-        }
-
-        if components.path.hasSuffix("/") {
-            while components.path.hasSuffix("/") {
-                components.path.removeLast()
-            }
-            return components.url ?? url
-        } else {
-            return url
-        }
-    }
-
     /// Returns the url that should be used at this moment to access the Home Assistant instance.
     public var activeURL: URL {
         if let overrideActiveURLType = overrideActiveURLType {
@@ -262,7 +247,7 @@ public class ConnectionInfo: Codable {
             }
 
             if let overrideURL = overrideURL {
-                return sanitize(overrideURL)
+                return overrideURL.sanitized()
             }
         }
 
@@ -281,7 +266,7 @@ public class ConnectionInfo: Codable {
             url = URL(string: "http://homeassistant.local:8123")!
         }
 
-        return sanitize(url)
+        return url.sanitized()
     }
 
     /// Returns the activeURL with /api appended.

--- a/Sources/Shared/Common/Extensions/URL+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/URL+Extensions.swift
@@ -23,6 +23,19 @@ extension URL {
         }
     }
 
+    public func sanitized() -> URL {
+        guard path.hasSuffix("/"),
+              var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+
+        while components.path.hasSuffix("/") {
+            components.path.removeLast()
+        }
+
+        return components.url ?? self
+    }
+
     func adapting(url: URL) -> URL {
         guard
             let components = URLComponents(url: self, resolvingAgainstBaseURL: false),


### PR DESCRIPTION
## Summary
Fixes receiving "Alamofire.AFError 9" with a response status code of 404 during onboarding when a URL like `http://192.168.1.3:8123/` (with trailing slash) is provided.

## Any other notes
The real crux of this issue is that ConnectionInfo strips it, but the connectivity check in onboarding does not, giving us a URL like `http://92.168.1.3:8123//auth/authorize` which errors with a status code of 404.