### PR TITLE
Handle individual server deletion & logout

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -196,6 +196,7 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                                 }.ensure {
                                     hud.hide(animated: true)
                                 }.done {
+                                    Current.onboardingObservation.needed(.logout)
                                     navigationController?.popViewController(animated: true)
                                 }.cauterize()
                             }


### PR DESCRIPTION
## Summary
Shows onboarding when necessary, or switches to another server otherwise.

## Any other notes
When deleting a server, resetting the app, logging out in the WebView, or being logged out due to token invalidation, we now either:
1. Change to another server in the WebView, if one is available, or
2. Show onboarding, like we did before when the only server was invalidated