### PR TITLE
Store zones by server, allowing duplicate entity ids

### DIFF
--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -310,11 +310,11 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     Current.settingsStore.locationSources.pushNotifications = row.value ?? true
                 })
 
-            let zoneEntities = realm.objects(RLMZone.self).map { $0 }
+            let zoneEntities = realm.objects(RLMZone.self)
             for zone in zoneEntities {
                 form
                     +++ Section(header: zone.Name, footer: "") {
-                        $0.tag = zone.ID
+                        $0.tag = zone.identifier
                     }
                     <<< SwitchRow {
                         $0.title = L10n.SettingsDetails.Location.Zones.EnterExitTracked.title

--- a/Sources/App/ZoneManager/ZoneManagerCollector.swift
+++ b/Sources/App/ZoneManager/ZoneManagerCollector.swift
@@ -56,7 +56,8 @@ class ZoneManagerCollectorImpl: NSObject, ZoneManagerCollector {
         let zone = Current.realm()
             .objects(RLMZone.self)
             .first(where: {
-                $0.ID == region.identifier || $0.ID == region.identifier.components(separatedBy: "@").first
+                $0.identifier == region.identifier ||
+                    $0.identifier == region.identifier.components(separatedBy: "@").first
             })
 
         let event = ZoneManagerEvent(

--- a/Sources/App/ZoneManager/ZoneManagerEvent.swift
+++ b/Sources/App/ZoneManager/ZoneManagerEvent.swift
@@ -40,7 +40,7 @@ struct ZoneManagerEvent: Equatable, CustomStringConvertible {
 
     static func == (lhs: ZoneManagerEvent, rhs: ZoneManagerEvent) -> Bool {
         lhs.eventType == rhs.eventType &&
-            lhs.associatedZone?.ID == rhs.associatedZone?.ID
+            lhs.associatedZone?.identifier == rhs.associatedZone?.identifier
     }
 
     var description: String {
@@ -52,7 +52,7 @@ struct ZoneManagerEvent: Equatable, CustomStringConvertible {
             if zone.isInvalidated {
                 attributes.append("zone deleted")
             } else {
-                attributes.append(zone.ID)
+                attributes.append(zone.identifier)
             }
         }
 

--- a/Sources/App/ZoneManager/ZoneManagerRegionFilter.swift
+++ b/Sources/App/ZoneManager/ZoneManagerRegionFilter.swift
@@ -149,7 +149,7 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
                 "counts": counts.eventPayload,
                 "limits": limits.eventPayload,
                 "total_zones": allZones.count,
-                "stripped_zones": strippedZones.map(\.ID),
+                "stripped_zones": strippedZones.map(\.identifier),
                 "stripped_decision": decisionSource,
             ]
         )).cauterize()

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -611,7 +611,7 @@ public class HomeAssistantAPI {
         zone: RLMZone
     ) -> (eventType: String, eventData: [String: Any]) {
         var eventData: [String: Any] = sharedEventDeviceInfo
-        eventData["zone"] = zone.ID
+        eventData["zone"] = zone.entityId
         if region.identifier.contains("@"), let subId = region.identifier.split(separator: "@").last {
             eventData["multi_region_zone_id"] = String(subId)
         }

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -10,7 +10,6 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         case scene = 10000
     }
 
-    #warning("multiserver - primary key duplication")
     @objc public dynamic var ID: String = UUID().uuidString
     @objc public dynamic var Name: String = ""
     @objc public dynamic var Text: String = ""
@@ -23,6 +22,11 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
     @objc public dynamic var Scene: RLMScene?
     @objc public dynamic var isServerControlled: Bool = false
     @objc public dynamic var serverIdentifier: String = ""
+
+    static func primaryKey(sourceIdentifier: String, serverIdentifier: String) -> String {
+        #warning("multiserver - primary key duplication")
+        return sourceIdentifier
+    }
 
     override public static func primaryKey() -> String? {
         #keyPath(ID)

--- a/Sources/Shared/API/Models/NotificationCategory.swift
+++ b/Sources/Shared/API/Models/NotificationCategory.swift
@@ -9,7 +9,7 @@ public final class NotificationCategory: Object, UpdatableModel {
     @objc public dynamic var serverIdentifier: String = ""
 
     @objc public dynamic var Name: String = ""
-    #warning("multiserver - primary key duplication")
+
     @objc public dynamic var Identifier: String = ""
     @objc public dynamic var HiddenPreviewsBodyPlaceholder: String?
     // iOS 12+ only
@@ -24,6 +24,11 @@ public final class NotificationCategory: Object, UpdatableModel {
     // @objc dynamic var AllowInCarPlay: Bool = false
 
     public var Actions = List<NotificationAction>()
+
+    static func primaryKey(sourceIdentifier: String, serverIdentifier: String) -> String {
+        #warning("multiserver - primary key duplication")
+        return sourceIdentifier
+    }
 
     override public static func primaryKey() -> String? {
         #keyPath(Identifier)

--- a/Sources/Shared/API/Models/RealmPersistable.swift
+++ b/Sources/Shared/API/Models/RealmPersistable.swift
@@ -11,6 +11,8 @@ protocol UpdatableModel {
     static func primaryKey() -> String? // from realm, we use
     static func serverIdentifierKey() -> String
     static var updateEligiblePredicate: NSPredicate { get }
+
+    static func primaryKey(sourceIdentifier: String, serverIdentifier: String) -> String
     func update(with object: Source, server: Server, using realm: Realm) -> Bool
 }
 

--- a/Sources/Shared/API/Models/RealmScene.swift
+++ b/Sources/Shared/API/Models/RealmScene.swift
@@ -4,7 +4,6 @@ import ObjectMapper
 import RealmSwift
 
 public final class RLMScene: Object, UpdatableModel {
-    #warning("multiserver - primary key duplication")
     @objc public dynamic var identifier: String = ""
     @objc public dynamic var serverIdentifier: String = ""
 
@@ -40,6 +39,11 @@ public final class RLMScene: Object, UpdatableModel {
     @objc public dynamic var backgroundColor: String?
     @objc public dynamic var textColor: String?
     @objc public dynamic var iconColor: String?
+
+    public static func primaryKey(sourceIdentifier: String, serverIdentifier: String) -> String {
+        #warning("multiserver - primary key duplication")
+        return sourceIdentifier
+    }
 
     override public class func primaryKey() -> String? {
         #keyPath(identifier)

--- a/Tests/App/ZoneManager/ZoneManager.test.swift
+++ b/Tests/App/ZoneManager/ZoneManager.test.swift
@@ -80,7 +80,7 @@ class ZoneManagerTests: XCTestCase {
         var addedRegions = [CLRegion]()
         var zones = try addedZones([
             with(RLMZone()) {
-                $0.ID = "home"
+                $0.entityId = "home"
                 $0.serverIdentifier = apis[0].server.identifier.rawValue
                 $0.Latitude = 37.1234
                 $0.Longitude = -122.4567
@@ -91,7 +91,7 @@ class ZoneManagerTests: XCTestCase {
                 $0.BeaconMinor.value = 456
             },
             with(RLMZone()) {
-                $0.ID = "work"
+                $0.entityId = "work"
                 $0.serverIdentifier = apis[1].server.identifier.rawValue
                 $0.Latitude = 37.2345
                 $0.Longitude = -122.5678
@@ -164,18 +164,21 @@ class ZoneManagerTests: XCTestCase {
     }
 
     func testTrackingDisabledNotMonitored() throws {
+        let s1: String = apis[0].server.identifier.rawValue
+        let s2: String = apis[1].server.identifier.rawValue
+
         let zones = try addedZones([
             with(RLMZone()) {
-                $0.ID = "home"
-                $0.serverIdentifier = apis[0].server.identifier.rawValue
+                $0.entityId = "home"
+                $0.serverIdentifier = s1
                 $0.Latitude = 37.1234
                 $0.Longitude = -122.4567
                 $0.Radius = 100
                 $0.TrackingEnabled = false
             },
             with(RLMZone()) {
-                $0.ID = "work"
-                $0.serverIdentifier = apis[1].server.identifier.rawValue
+                $0.entityId = "work"
+                $0.serverIdentifier = s2
                 $0.Latitude = 37.2345
                 $0.Longitude = -122.5678
                 $0.Radius = 150
@@ -184,7 +187,7 @@ class ZoneManagerTests: XCTestCase {
         ])
 
         let manager = newZoneManager()
-        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["work"]))
+        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["\(s2)/work"]))
 
         try realm.write {
             zones[0].TrackingEnabled = true
@@ -192,7 +195,7 @@ class ZoneManagerTests: XCTestCase {
 
         realm.refresh()
 
-        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["work", "home"]))
+        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["\(s2)/work", "\(s1)/home"]))
 
         try realm.write {
             zones[1].TrackingEnabled = false
@@ -200,7 +203,7 @@ class ZoneManagerTests: XCTestCase {
 
         realm.refresh()
 
-        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["home"]))
+        XCTAssertEqual(Set(locationManager.monitoredRegions.map(\.identifier)), Set(["\(s1)/home"]))
 
         withExtendedLifetime(manager) { /* silences unused variable */ }
     }
@@ -208,7 +211,7 @@ class ZoneManagerTests: XCTestCase {
     func testFilterChangesOnLocationChange() throws {
         let zones = try addedZones([
             with(RLMZone()) {
-                $0.ID = "home"
+                $0.entityId = "home"
                 $0.serverIdentifier = apis[0].server.identifier.rawValue
                 $0.Latitude = 37.1234
                 $0.Longitude = -122.4567
@@ -219,7 +222,7 @@ class ZoneManagerTests: XCTestCase {
                 $0.BeaconMinor.value = 456
             },
             with(RLMZone()) {
-                $0.ID = "work"
+                $0.entityId = "work"
                 $0.serverIdentifier = apis[1].server.identifier.rawValue
                 $0.Latitude = 37.2345
                 $0.Longitude = -122.5678
@@ -280,7 +283,7 @@ class ZoneManagerTests: XCTestCase {
     func testLocationUpdateSource() throws {
         let zones = try addedZones([
             with(RLMZone()) {
-                $0.ID = "home"
+                $0.entityId = "home"
                 $0.serverIdentifier = apis[0].server.identifier.rawValue
                 $0.Latitude = 37.1234
                 $0.Longitude = -122.4567
@@ -291,7 +294,7 @@ class ZoneManagerTests: XCTestCase {
                 $0.BeaconMinor.value = 456
             },
             with(RLMZone()) {
-                $0.ID = "work"
+                $0.entityId = "work"
                 $0.serverIdentifier = apis[1].server.identifier.rawValue
                 $0.Latitude = 37.2345
                 $0.Longitude = -122.5678
@@ -330,7 +333,7 @@ class ZoneManagerTests: XCTestCase {
         )
         let zone = try addedZones([
             with(RLMZone()) {
-                $0.ID = "zone.zid"
+                $0.entityId = "zone.zid"
                 $0.serverIdentifier = api.server.identifier.rawValue
                 $0.Latitude = 42.2222
                 $0.Longitude = 43.3333
@@ -372,7 +375,7 @@ class ZoneManagerTests: XCTestCase {
         )
         let zone = try addedZones([
             with(RLMZone()) {
-                $0.ID = "zone.zid"
+                $0.entityId = "zone.zid"
                 $0.serverIdentifier = api.server.identifier.rawValue
                 $0.Latitude = 42.2222
                 $0.Longitude = 43.3333

--- a/Tests/App/ZoneManager/ZoneManagerCollector.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerCollector.test.swift
@@ -2,7 +2,7 @@ import CoreLocation
 import Foundation
 @testable import HomeAssistant
 import RealmSwift
-import Shared
+@testable import Shared
 import XCTest
 
 class ZoneManagerCollectorTests: XCTestCase {
@@ -98,13 +98,19 @@ class ZoneManagerCollectorTests: XCTestCase {
     }
 
     func testDidDetermineStateWithZoneInRealm() throws {
+        let server = Server.fake()
+
         let region = CLCircularRegion(
             center: .init(latitude: 1.23, longitude: 4.56),
             radius: 20,
-            identifier: "zone_identifier"
+            identifier: RLMZone.primaryKey(
+                sourceIdentifier: "zone_identifier",
+                serverIdentifier: server.identifier.rawValue
+            )
         )
         let realmZone = with(RLMZone()) {
-            $0.ID = "zone_identifier"
+            $0.entityId = "zone_identifier"
+            $0.serverIdentifier = server.identifier.rawValue
         }
 
         try realm.write {
@@ -123,13 +129,18 @@ class ZoneManagerCollectorTests: XCTestCase {
     }
 
     func testDidDetermineStateWithZoneInRealmForSmallRegionSplitIntoMultiple() throws {
+        let server = Server.fake()
         let region = CLCircularRegion(
             center: .init(latitude: 1.23, longitude: 4.56),
             radius: 20,
-            identifier: "zone_identifier@100"
+            identifier: RLMZone.primaryKey(
+                sourceIdentifier: "zone_identifier",
+                serverIdentifier: server.identifier.rawValue
+            ) + "@100"
         )
         let realmZone = with(RLMZone()) {
-            $0.ID = "zone_identifier"
+            $0.entityId = "zone_identifier"
+            $0.serverIdentifier = server.identifier.rawValue
         }
 
         try realm.write {

--- a/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerProcessor.test.swift
@@ -72,7 +72,7 @@ class ZoneManagerProcessorTests: XCTestCase {
     ) throws {
         try realm.write {
             circularRegionZone = with(RLMZone()) { zone in
-                zone.ID = circularRegion.identifier
+                zone.identifier = circularRegion.identifier
                 zone.Radius = circularRegion.radius
                 zone.Latitude = circularRegion.center.latitude
                 zone.Longitude = circularRegion.center.longitude
@@ -80,7 +80,7 @@ class ZoneManagerProcessorTests: XCTestCase {
             try circular(circularRegion, circularRegionZone!)
 
             beaconRegionZone = with(RLMZone()) { zone in
-                zone.ID = beaconRegion.identifier
+                zone.identifier = beaconRegion.identifier
             }
             try beacon(beaconRegion, beaconRegionZone!)
 
@@ -717,7 +717,7 @@ class ZoneManagerProcessorTests: XCTestCase {
             zone.inRegion = false
 
             outerZone = with(RLMZone()) {
-                $0.ID = region.identifier + "-outer"
+                $0.identifier = region.identifier + "-outer"
                 $0.Radius = region.radius * 2.0
                 $0.Latitude = region.center.latitude
                 $0.Longitude = region.center.longitude
@@ -799,7 +799,7 @@ class ZoneManagerProcessorTests: XCTestCase {
 
         try setUpZones(circular: { region, zone in
             outerZone = try with(RLMZone()) {
-                $0.ID = region.identifier + "-outer"
+                $0.identifier = region.identifier + "-outer"
                 $0.Radius = region.radius * 2.0
 
                 XCTAssert(zone.regionsForMonitoring.count > 1)

--- a/Tests/App/ZoneManager/ZoneManagerRegionFilter.test.swift
+++ b/Tests/App/ZoneManager/ZoneManagerRegionFilter.test.swift
@@ -29,28 +29,32 @@ class ZoneManagerRegionFilterTests: XCTestCase {
         // sorted by distance
         beaconZones = [
             with(RLMZone()) {
-                $0.ID = "zone.b_little_skillet"
+                $0.entityId = "zone.b_little_skillet"
+                $0.serverIdentifier = "server1"
                 $0.BeaconUUID = UUID().uuidString
                 $0.Latitude = 37.7796508
                 $0.Longitude = -122.3933569
                 $0.Radius = 1
             },
             with(RLMZone()) {
-                $0.ID = "zone.b_castro_theater"
+                $0.entityId = "zone.b_castro_theater"
+                $0.serverIdentifier = "server1"
                 $0.BeaconUUID = UUID().uuidString
                 $0.Latitude = 37.7622557
                 $0.Longitude = -122.4330972
                 $0.Radius = 2
             },
             with(RLMZone()) {
-                $0.ID = "zone.b_nopa"
+                $0.entityId = "zone.b_nopa"
+                $0.serverIdentifier = "server1"
                 $0.BeaconUUID = UUID().uuidString
                 $0.Latitude = 37.7727871
                 $0.Longitude = -122.4410906
                 $0.Radius = 3
             },
             with(RLMZone()) {
-                $0.ID = "zone.b_dmv"
+                $0.entityId = "zone.b_dmv"
+                $0.serverIdentifier = "server1"
                 $0.BeaconUUID = UUID().uuidString
                 $0.Latitude = 37.7739364
                 $0.Longitude = -122.4435184
@@ -61,25 +65,29 @@ class ZoneManagerRegionFilterTests: XCTestCase {
         // sorted by distance
         circularZones = [
             with(RLMZone()) {
-                $0.ID = "zone.home" // dropbox
+                $0.entityId = "zone.home" // dropbox
+                $0.serverIdentifier = "server1"
                 $0.Latitude = 37.7660435
                 $0.Longitude = -122.3952834
                 $0.Radius = 100
             },
             with(RLMZone()) {
-                $0.ID = "zone.oracle_park"
+                $0.entityId = "zone.oracle_park"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = 37.7806336
                 $0.Longitude = -122.3946727
                 $0.Radius = 140
             },
             with(RLMZone()) {
-                $0.ID = "zone.philz_coffee"
+                $0.entityId = "zone.philz_coffee"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = 37.7909037
                 $0.Longitude = -122.3973968
                 $0.Radius = 101
             },
             with(RLMZone()) {
-                $0.ID = "zone.ferrybuilding"
+                $0.entityId = "zone.ferrybuilding"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = 37.795571
                 $0.Longitude = -122.393572
                 $0.Radius = 120
@@ -157,7 +165,7 @@ class ZoneManagerRegionFilterTests: XCTestCase {
     }
 
     func testBothExceedWithoutHomeAndWithoutLocation() {
-        circularZones[0].ID = "zone.not_home_lol"
+        circularZones[0].entityId = "zone.not_home_lol"
 
         let zones = AnyCollection(beaconZones + circularZones)
         let regions = monitoredRegions(for: AnyCollection(beaconZones[0 ..< 3] + [

--- a/Tests/Shared/RealmZone.test.swift
+++ b/Tests/Shared/RealmZone.test.swift
@@ -10,9 +10,12 @@ class RealmZoneTests: XCTestCase {
         super.setUp()
 
         zone = RLMZone()
-        zone.ID = "monkeys"
+        zone.entityId = "monkeys"
+        zone.serverIdentifier = "fake1"
         zone.Latitude = 53.2225509
         zone.Longitude = -4.2212136
+
+        XCTAssertEqual(zone.identifier, "fake1/monkeys")
     }
 
     private func XCTAssertEqualRegions(
@@ -62,7 +65,7 @@ class RealmZoneTests: XCTestCase {
 
         XCTAssertFalse(zone.isBeaconRegion)
         XCTAssertEqualRegions(zone.regionsForMonitoring, [
-            CLCircularRegion(center: zone.center, radius: 100, identifier: zone.ID),
+            CLCircularRegion(center: zone.center, radius: 100, identifier: zone.identifier),
         ])
     }
 
@@ -82,7 +85,10 @@ class RealmZoneTests: XCTestCase {
                     direction: .init(value: angle, unit: .degrees)
                 )
                 XCTAssertTrue(zone.circularRegionsForMonitoring.allSatisfy { $0.contains(moved) })
-                XCTAssertTrue(zone.circularRegionsForMonitoring.allSatisfy { $0.identifier.starts(with: "monkeys@") })
+                XCTAssertTrue(
+                    zone.circularRegionsForMonitoring
+                        .allSatisfy { $0.identifier.starts(with: "fake1/monkeys@") }
+                )
             }
         }
     }

--- a/Tests/Shared/Sensors/GeocoderSensor.test.swift
+++ b/Tests/Shared/Sensors/GeocoderSensor.test.swift
@@ -13,6 +13,7 @@ private var permanent: [CLPlacemark] = []
 
 class GeocoderSensorTests: XCTestCase {
     private var realm: Realm!
+    private var server: Server!
 
     enum TestError: Error {
         case someError
@@ -20,6 +21,8 @@ class GeocoderSensorTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+
+        server = .fake()
 
         let executionIdentifier = UUID().uuidString
         let realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
@@ -180,7 +183,8 @@ class GeocoderSensorTests: XCTestCase {
 
         try realm.write {
             _ = with(RLMZone()) {
-                $0.ID = "zone.outside"
+                $0.entityId = "zone.outside"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 12.34
                 $0.Longitude = 1.337
                 realm.add($0, update: .all)
@@ -212,7 +216,8 @@ class GeocoderSensorTests: XCTestCase {
 
         try realm.write {
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_big"
+                $0.entityId = "zone.inside_big"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 1000
@@ -220,7 +225,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_small"
+                $0.entityId = "zone.inside_small"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 100
@@ -228,7 +234,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.outside"
+                $0.entityId = "zone.outside"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 12.34
                 $0.Longitude = 1.337
                 realm.add($0, update: .all)
@@ -261,7 +268,8 @@ class GeocoderSensorTests: XCTestCase {
 
         try realm.write {
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_tracking_disabled"
+                $0.entityId = "zone.inside_tracking_disabled"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 1000
@@ -270,7 +278,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_passive"
+                $0.entityId = "zone.inside_passive"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 100
@@ -279,7 +288,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.outside"
+                $0.entityId = "zone.outside"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 12.34
                 $0.Longitude = 1.337
                 realm.add($0, update: .all)
@@ -312,7 +322,8 @@ class GeocoderSensorTests: XCTestCase {
 
         try realm.write {
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_big"
+                $0.entityId = "zone.inside_big"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 1000
@@ -320,7 +331,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.inside_small"
+                $0.entityId = "zone.inside_small"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 37
                 $0.Longitude = -122
                 $0.Radius = 100
@@ -328,7 +340,8 @@ class GeocoderSensorTests: XCTestCase {
             }
 
             _ = with(RLMZone()) {
-                $0.ID = "zone.outside"
+                $0.entityId = "zone.outside"
+                $0.serverIdentifier = server.identifier.rawValue
                 $0.Latitude = 12.34
                 $0.Longitude = 1.337
                 realm.add($0, update: .all)

--- a/Tests/Shared/Webhook/WebhookUpdateLocation.test.swift
+++ b/Tests/Shared/Webhook/WebhookUpdateLocation.test.swift
@@ -18,7 +18,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionEnter,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -45,7 +46,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionEnter,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -75,7 +77,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionExit,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -105,7 +108,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionEnter,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.home"
+                $0.entityId = "zone.home"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -134,7 +138,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionExit,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -164,7 +169,8 @@ class WebhookUpdateLocationTests: XCTestCase {
             trigger: .BeaconRegionExit,
             location: CLLocation(latitude: 1.23, longitude: 4.56),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -208,7 +214,8 @@ class WebhookUpdateLocationTests: XCTestCase {
                 timestamp: now.addingTimeInterval(-110)
             ),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -250,7 +257,8 @@ class WebhookUpdateLocationTests: XCTestCase {
                 timestamp: now.addingTimeInterval(-110)
             ),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -292,7 +300,8 @@ class WebhookUpdateLocationTests: XCTestCase {
                 timestamp: now.addingTimeInterval(-110)
             ),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -334,7 +343,8 @@ class WebhookUpdateLocationTests: XCTestCase {
                 timestamp: now.addingTimeInterval(-110)
             ),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8
@@ -376,7 +386,8 @@ class WebhookUpdateLocationTests: XCTestCase {
                 timestamp: now.addingTimeInterval(-110)
             ),
             zone: with(RLMZone()) {
-                $0.ID = "zone.given_name"
+                $0.entityId = "zone.given_name"
+                $0.serverIdentifier = "server1"
                 $0.Latitude = -2.34
                 $0.Longitude = -5.67
                 $0.Radius = 88.8


### PR DESCRIPTION
## Summary
Stores a zone from s1 in Realm like `s1/zone.name` rather than `zone.name` so it's distinct from `s2/zone.name`. This is most apparent for `zone.home` which universally conflicts.

## Any other notes
This does not yet extend to the other synced models as we use their identifier in persisted locations that aren't programmatically changeable (e.g. action IDs are stored in intents). Zones don't pose such a problem, and are the most likely suspect to even have duplicates right now; scenes, actions, and deprecated notification categories can be done after an external beta.