### PR TITLE
Fix crash when migrating from 2021.11 to 2021.12

### DIFF
--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -176,7 +176,7 @@ public extension Realm {
 
                     migration.enumerateObjects(ofType: RLMZone.className()) { oldObject, newObject in
                         if let oldId = oldObject?["ID"] as? String,
-                           let serverId = oldObject?["serverIdentifier"] as? String {
+                           let serverId = newObject?["serverIdentifier"] as? String {
                             let newId = RLMZone.primaryKey(sourceIdentifier: oldId, serverIdentifier: serverId)
                             Current.Log.info("change \(oldId) + \(serverId) to \(newId)")
                             newObject?["identifier"] = newId


### PR DESCRIPTION
## Summary
Fixes a crash because the old version (2021.11) didn't have serverIdentifier, just a transitive Realm version I was using (which did) which doesn't promote it to oldObject values.

## Any other notes
😆 