### PR TITLE
Retry uploads to Apple a few times if they fail

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -456,12 +456,24 @@ private_lane :upload_archive_to_sentry do
 end
 
 private_lane :upload_binary_to_apple do |options|
-  sh(
-    'xcrun', 'altool', '--upload-app', '--type', options[:type],
-    '--file', options[:path],
-    '--username', ENV['DELIVER_USERNAME'],
-    '--password', '@env:FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
-  )
+  attempts = 0
+
+  begin
+    sh(
+      'xcrun', 'altool', '--upload-app', '--type', options[:type],
+      '--file', options[:path],
+      '--username', ENV['DELIVER_USERNAME'],
+      '--password', '@env:FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
+    )
+  rescue StandardError => e
+    puts "Failed with #{e}; retrying upload..."
+
+    # retry a few times, then give up
+    attempts += 1
+
+    retry if attempts <= 3
+    raise e
+  end
 end
 
 platform :ios do


### PR DESCRIPTION
## Summary
This has been timing out recently, which is a huge waste of compile time to have to manually run the action again