### PR TITLE
Fix menu bar template when deleting server it was set to

### DIFF
--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -278,10 +278,11 @@ public class SettingsStore {
         get {
             let server: Server?
 
-            if let serverIdentifier = prefs.string(forKey: "menuItemTemplate-server") {
-                server = Current.servers.server(forServerIdentifier: serverIdentifier)
+            if let serverIdentifier = prefs.string(forKey: "menuItemTemplate-server"),
+               let configured = Current.servers.server(forServerIdentifier: serverIdentifier) {
+                server = configured
             } else {
-                // backwards compatibility to before servers
+                // backwards compatibility to before servers, or if the server was deleted
                 server = Current.servers.all.first
             }
 


### PR DESCRIPTION
## Summary
Need to fall back to any server if the server's gone. Other alternative is to reset the template to empty and pick a new server, but that felt a little bit more like losing the template unexpectedly.

## Any other notes
This can also be temporarily fixed by editing `~/Library/Group Containers/group.io.robbie.homeassistant/Library/Preferences/group.io.robbie.homeassistant.plist` and removing the `menuItemTemplate-server` key.