### PR TITLE
Fix crash adding new server with scene actions

### DIFF
--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -67,7 +67,7 @@ public struct ServerInfo: Codable, Equatable {
         version: Version
     ) {
         self.name = name
-        self.sortOrder = .max
+        self.sortOrder = Self.defaultSortOrder
         self.connection = connection
         self.token = token
         self.version = version
@@ -77,6 +77,8 @@ public struct ServerInfo: Codable, Equatable {
     public static var defaultName: String {
         L10n.Settings.StatusSection.LocationNameRow.placeholder
     }
+
+    public static var defaultSortOrder: Int { -1 }
 
     public mutating func setSetting<T>(value: T?, for key: ServerSettingKey<T>) {
         settings[key.rawValue] = value

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -184,7 +184,7 @@ internal final class ServerManagerImpl: ServerManager {
     @discardableResult
     public func add(identifier: Identifier<Server>, serverInfo: ServerInfo) -> Server {
         let setValue = with(serverInfo) {
-            if $0.sortOrder == .max {
+            if $0.sortOrder == ServerInfo.defaultSortOrder {
                 $0.sortOrder = all.map(\.info.sortOrder).max().map { $0 + 1000 } ?? 0
             }
         }


### PR DESCRIPTION
Fixes regression from #1941.

## Summary
The default value of `.max` isn't adjusted to a real one until after onboarding is finished, but we do a model fetch _during_ onboarding to test that it works.