### PR TITLE
Changeable local name for servers

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -275,7 +275,7 @@ public class HomeAssistantAPI {
             server.update { server in
                 server.connection.cloudhookURL = config.CloudhookURL
                 server.connection.set(address: config.RemoteUIURL, for: .remoteUI)
-                server.name = config.LocationName ?? ServerInfo.defaultName
+                server.remoteName = config.LocationName ?? ServerInfo.defaultName
 
                 if let version = try? Version(hassVersion: config.Version) {
                     server.version = version

--- a/Tests/Shared/Server.test.swift
+++ b/Tests/Shared/Server.test.swift
@@ -26,7 +26,7 @@ class ServerTests: XCTestCase {
                 identifier: "2",
                 getter: {
                     with(.fake()) {
-                        $0.name = "2"
+                        $0.remoteName = "2"
                         $0.sortOrder = 50
                     }
                 }, setter: {
@@ -37,7 +37,7 @@ class ServerTests: XCTestCase {
                 identifier: "3",
                 getter: {
                     with(.fake()) {
-                        $0.name = "1"
+                        $0.remoteName = "1"
                         $0.sortOrder = 50
                     }
                 }, setter: {
@@ -71,6 +71,24 @@ class ServerTests: XCTestCase {
         XCTAssertNotEqual(server_id1_1, server_id3)
         XCTAssertNotEqual(server_id1_2, server_id3)
         XCTAssertNotEqual(server_id2, server_id3)
+    }
+
+    func testLocalName() {
+        var serverInfo = ServerInfo.fake()
+        serverInfo.remoteName = "remote_name1"
+
+        let server = Server(identifier: "fake1", getter: { serverInfo }, setter: { serverInfo = $0 })
+
+        XCTAssertEqual(server.info.name, "remote_name1")
+
+        server.info.setSetting(value: "local_name1", for: .localName)
+        XCTAssertEqual(server.info.name, "local_name1")
+
+        server.info.setSetting(value: nil, for: .localName)
+        XCTAssertEqual(server.info.name, "remote_name1")
+
+        server.info.setSetting(value: "", for: .localName)
+        XCTAssertEqual(server.info.name, "remote_name1")
     }
 
     func testNotifyInfoChange() {


### PR DESCRIPTION
## Summary
Changes the server name row into an editable one, persists along with the server and uses it everywhere. Basically identical to 'device name' in functionality there.

Also hides the 'activate' button if there's only one server.

## Screenshots
| Light | Dark |
| ----- | ---- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-28 at 14 32 16](https://user-images.githubusercontent.com/74188/143788804-400475b0-44eb-4f73-a105-861f1a3cc9ae.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-28 at 14 31 57](https://user-images.githubusercontent.com/74188/143788806-7f586477-7e2f-41e2-bdb3-0b49c28a7895.png) |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-28 at 14 32 11](https://user-images.githubusercontent.com/74188/143788813-9fcf7bce-97e4-4def-98db-a52a415f31bc.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-28 at 14 32 01](https://user-images.githubusercontent.com/74188/143788817-d6ceedde-9a7e-4aa8-a8e7-3846d2095d6a.png) |
