### PR TITLE
Fix server seeming to be editable for scene actions & color when disabled

### DIFF
--- a/Sources/App/Settings/Eureka/ServerSelectRow.swift
+++ b/Sources/App/Settings/Eureka/ServerSelectRow.swift
@@ -32,10 +32,21 @@ final class ServerSelectRow: _PushRow<PushSelectorCell<AccountRowValue>>, RowTyp
             to.enableDeselection = false
         }
         cellUpdate { cell, row in
+            // matching the colors of _FieldCell which this row is often near
             if row.isDisabled {
                 cell.accessoryType = .none
+                if #available(iOS 13, *) {
+                    cell.detailTextLabel?.textColor = .tertiaryLabel
+                } else {
+                    cell.detailTextLabel?.textColor = .gray
+                }
             } else {
                 cell.accessoryType = .disclosureIndicator
+                if #available(iOS 13, *) {
+                    cell.detailTextLabel?.textColor = .secondaryLabel
+                } else {
+                    cell.detailTextLabel?.textColor = .darkGray
+                }
             }
         }
         initializer(self)

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -67,7 +67,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
              \Action.Text:
             return Scene == nil
         case \Action.serverIdentifier:
-            return !isServerControlled
+            return Scene == nil
         default:
             return true
         }


### PR DESCRIPTION
## Summary
Fixes bad logic in the "can server identifier be edited?" check, and colors the detail label of the server select row like a field row in other Eureka contexts.

## Screenshots
| Thing   | Light | Dark |
| ------- | ----- | ---- |
| Scene   | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 58](https://user-images.githubusercontent.com/74188/143978645-efa59759-a08b-4a85-b3e9-ac418a952f54.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 56](https://user-images.githubusercontent.com/74188/143978665-b1c176b4-ef83-48b6-8fbb-e23573e1bf78.png) |
| Synced  | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 50](https://user-images.githubusercontent.com/74188/143978853-3688885b-d849-4914-99fe-b3d7506b3f77.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 52](https://user-images.githubusercontent.com/74188/143978860-2132b44b-9291-4961-8967-945bab2cfb8c.png) |
| Regular | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 44](https://user-images.githubusercontent.com/74188/143978866-2a3b434f-cbb6-4026-acd1-4a9f45159940.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 19 04 38](https://user-images.githubusercontent.com/74188/143978878-1a31b223-7420-4607-8ddc-ee4b583594e9.png) |