### PR TITLE
Two-finger swipe to switch servers

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -251,6 +251,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "sensors.active.setting.time_until_idle" = "Time Until Idle";
 "sensors.geocoded_location.setting.use_zones" = "Use Zone Name";
 "settings.connection_section.activate_server" = "Activate";
+"settings.connection_section.activate_swipe_hint" = "Quickly activate using a two-finger swipe left or right when viewing a server.";
 "settings.connection_section.add_server" = "Add Server";
 "settings.connection_section.all_servers" = "All Servers";
 "settings.connection_section.cloud_overrides_external" = "When connecting via Cloud, the External URL will not be used. You do not need to configure one unless you want to disable Cloud.";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -37,8 +37,8 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
         let connection = Current.api(for: server).connection
 
         if Current.servers.all.count > 1 {
-            form +++ Section { _ in
-
+            form +++ Section(footer: L10n.Settings.ConnectionSection.activateSwipeHint) {
+                _ in
             } <<< ButtonRow {
                 $0.title = L10n.Settings.ConnectionSection.activateServer
                 $0.onCellSelection { [server] _, _ in

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -1,8 +1,8 @@
 import Foundation
+import MBProgressHUD
 import PromiseKit
 import Shared
 import UIKit
-import MBProgressHUD
 
 @available(iOS, deprecated: 13.0)
 enum StateRestorationKey: String {
@@ -293,7 +293,7 @@ class WebViewWindowController {
         guard servers.count > 1,
               let current = webViewControllerPromise.value?.server,
               let startIndex = servers.firstIndex(of: current) else {
-              return
+            return
         }
 
         // swiping "right" visually goes left, which is down in index

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -2,6 +2,7 @@ import Foundation
 import PromiseKit
 import Shared
 import UIKit
+import MBProgressHUD
 
 @available(iOS, deprecated: 13.0)
 enum StateRestorationKey: String {
@@ -14,6 +15,8 @@ class WebViewWindowController {
     var restorationActivity: NSUserActivity?
 
     var webViewControllerPromise: Guarantee<WebViewController>
+
+    private var cachedWebViewControllers = [Identifier<Server>: WebViewController]()
 
     private var webViewControllerSeal: (WebViewController) -> Void
     private var onboardingPreloadWebViewController: WebViewController?
@@ -44,6 +47,8 @@ class WebViewWindowController {
             } else {
                 webViewControllerSeal(newWebViewController)
             }
+
+            update(webViewController: newWebViewController)
         } else if webViewControllerPromise.isFulfilled {
             // replacing one, so set up a new promise if necessary
             (webViewControllerPromise, webViewControllerSeal) = Guarantee<WebViewController>.pending()
@@ -130,10 +135,12 @@ class WebViewWindowController {
                 return .value(controller)
             }
 
+            cachedWebViewControllers[controller.server.identifier] = controller
+
             let (promise, resolver) = Guarantee<WebViewController>.pending()
 
             let perform = {
-                let newController = WebViewController(server: server)
+                let newController = cachedWebViewControllers[server.identifier] ?? WebViewController(server: server)
                 updateRootViewController(to: webViewNavigationController(rootViewController: newController))
                 resolver(newController)
             }
@@ -259,6 +266,56 @@ class WebViewWindowController {
             triggerOpen()
         }
     }
+
+    private lazy var serverChangeGestures: [UIGestureRecognizer] = {
+        [.left, .right].map { (direction: UISwipeGestureRecognizer.Direction) in
+            with(UISwipeGestureRecognizer()) {
+                $0.numberOfTouchesRequired = 2
+                $0.direction = direction
+                $0.addTarget(self, action: #selector(serverChangeGestureDidChange(_:)))
+            }
+        }
+    }()
+
+    private func update(webViewController: WebViewController) {
+        for gesture in serverChangeGestures {
+            webViewController.view.addGestureRecognizer(gesture)
+        }
+    }
+
+    @objc private func serverChangeGestureDidChange(_ gesture: UISwipeGestureRecognizer) {
+        guard gesture.state == .ended else {
+            return
+        }
+
+        let servers = Current.servers.all
+
+        guard servers.count > 1,
+              let current = webViewControllerPromise.value?.server,
+              let startIndex = servers.firstIndex(of: current) else {
+              return
+        }
+
+        // swiping "right" visually goes left, which is down in index
+        let nextIndex = gesture.direction == .right ? startIndex - 1 : startIndex + 1
+
+        let server: Server
+
+        if nextIndex < servers.startIndex {
+            server = servers[servers.endIndex - 1]
+        } else if nextIndex >= servers.endIndex {
+            server = servers[servers.startIndex]
+        } else {
+            server = servers[nextIndex]
+        }
+
+        open(server: server).done { controller in
+            let hud = MBProgressHUD.showAdded(to: controller.view, animated: true)
+            hud.mode = .text
+            hud.label.text = server.info.name
+            hud.hide(animated: true, afterDelay: 1.0)
+        }
+    }
 }
 
 extension WebViewWindowController: OnboardingStateObserver {
@@ -268,6 +325,8 @@ extension WebViewWindowController: OnboardingStateObserver {
             guard !(window.rootViewController is OnboardingNavigationViewController) else {
                 return
             }
+
+            cachedWebViewControllers.removeAll()
 
             if Current.servers.all.isEmpty {
                 let controller = OnboardingNavigationViewController(onboardingStyle: .initial)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -873,6 +873,8 @@ public enum L10n {
     public enum ConnectionSection {
       /// Activate
       public static var activateServer: String { return L10n.tr("Localizable", "settings.connection_section.activate_server") }
+      /// Quickly activate using a two-finger swipe left or right when viewing a server.
+      public static var activateSwipeHint: String { return L10n.tr("Localizable", "settings.connection_section.activate_swipe_hint") }
       /// Add Server
       public static var addServer: String { return L10n.tr("Localizable", "settings.connection_section.add_server") }
       /// All Servers


### PR DESCRIPTION
## Summary
Adds a two-finger left/right swipe gesture to go left/right between servers. Caches the WebView when switching, which makes swiping back and forth significantly faster. Shows the name of the server as it switches.

## Screenshots
| Thing | Light | Dark |
| ----- | ----- | ---- |
| Settings | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 20 57 27](https://user-images.githubusercontent.com/74188/143988210-06ba5d9f-8a3b-4c02-afcd-90df3a39b01b.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 20 57 28](https://user-images.githubusercontent.com/74188/143988218-b7245caa-d9a9-4aff-ba7c-2a494c21474d.png) |
| Switching | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 20 58 36](https://user-images.githubusercontent.com/74188/143988298-75844447-a7f5-446a-bfd4-44cc8a7f6300.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-29 at 20 58 41](https://user-images.githubusercontent.com/74188/143988304-9a8a339f-d12a-4edf-ac65-32c0f9669713.png) |

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
