### PR TITLE
Check location services enabled status in onboarding permissions

### DIFF
--- a/Sources/App/Utilities/Permissions.swift
+++ b/Sources/App/Utilities/Permissions.swift
@@ -177,6 +177,7 @@ public enum PermissionType {
     var status: PermissionStatus {
         switch self {
         case .location:
+            guard CLLocationManager.locationServicesEnabled() else { return .restricted }
             return CLLocationManager.authorizationStatus().genericStatus
         case .motion:
             return CMMotionActivityManager.authorizationStatus().genericStatus


### PR DESCRIPTION
Refs #1919 (and may fix it).

## Summary
Checks whether Location Services are enabled before checking the authorization status.

## Any other notes
Best as I can tell, whenever it's disabled globally, we get 'denied' as the status back. It's possible some environments on Mac (likely which are patching/overriding location services or something) do not keep this constraint.