### PR TITLE
Show an alert on macOS when opening web auth session

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -194,6 +194,8 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "off_label" = "Off";
 "ok_label" = "OK";
 "on_label" = "On";
+"onboarding.connect.mac_safari_warning.title" = "Launching Safari";
+"onboarding.connect.mac_safari_warning.message" = "Try restarting Safari if the login form does not open.";
 "onboarding.connect.title" = "Connecting to %@";
 "onboarding.connection_error.more_info_button" = "More Info";
 "onboarding.connection_error.title" = "Failed to Connect";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -701,6 +701,12 @@ public enum L10n {
       public static func title(_ p1: Any) -> String {
         return L10n.tr("Localizable", "onboarding.connect.title", String(describing: p1))
       }
+      public enum MacSafariWarning {
+        /// Try restarting Safari if the login form does not open.
+        public static var message: String { return L10n.tr("Localizable", "onboarding.connect.mac_safari_warning.message") }
+        /// Launching Safari
+        public static var title: String { return L10n.tr("Localizable", "onboarding.connect.mac_safari_warning.title") }
+      }
     }
     public enum ConnectionError {
       /// More Info

--- a/Tests/App/Auth/OnboardingAuthLoginImpl.test.swift
+++ b/Tests/App/Auth/OnboardingAuthLoginImpl.test.swift
@@ -1,10 +1,11 @@
 import AuthenticationServices
 @testable import HomeAssistant
 import PromiseKit
+import Shared
 import XCTest
 
 class OnboardingAuthLoginImplTests: XCTestCase {
-    private var sender: UIViewController!
+    private var sender: FakeUIViewController!
     private var login: OnboardingAuthLoginImpl!
     private var authDetails: OnboardingAuthDetails!
 
@@ -13,7 +14,7 @@ class OnboardingAuthLoginImplTests: XCTestCase {
 
         FakeASWebAuthenticationSession.lastCreated = nil
 
-        sender = UIViewController()
+        sender = FakeUIViewController()
         login = OnboardingAuthLoginImpl()
         login.authenticationSessionClass = FakeASWebAuthenticationSession.self
 
@@ -60,6 +61,117 @@ class OnboardingAuthLoginImplTests: XCTestCase {
         session.completionHandler(try XCTUnwrap(URL(string: "homeassistant://auth-callback?code=code_123")), nil)
         XCTAssertEqual(try hang(result), "code_123")
     }
+
+    func testAlertOnMacCancelled() throws {
+        Current.isCatalyst = true
+
+        let result = login.open(authDetails: authDetails, sender: sender)
+        let session = try XCTUnwrap(FakeASWebAuthenticationSession.lastCreated)
+        assertConfigured(session)
+
+        let timer = try XCTUnwrap(login.macPresentTimer)
+        timer.fire()
+        let alert = try XCTUnwrap(sender.presentedViewController as? UIAlertController)
+        let cancel = try XCTUnwrap(alert.actions.first(where: { $0.style == .cancel }))
+        cancel.ha_handler(cancel)
+        XCTAssertTrue(session.isCancelled)
+        XCTAssertThrowsError(try hang(result)) { error in
+            if case PMKError.cancelled = error {
+                // pass
+            } else {
+                XCTFail("expected cancelled, got \(error)")
+            }
+        }
+    }
+
+    func testAlertOnMacCancelledBeforeTimer() throws {
+        Current.isCatalyst = true
+
+        let result = login.open(authDetails: authDetails, sender: sender)
+        let session = try XCTUnwrap(FakeASWebAuthenticationSession.lastCreated)
+        assertConfigured(session)
+
+        session.cancel()
+
+        let expectation = expectation(description: "one run loop")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 10.0)
+
+        let timer = try XCTUnwrap(login.macPresentTimer)
+        timer.fire()
+
+        XCTAssertNil(sender.presentedViewController)
+
+        XCTAssertThrowsError(try hang(result)) { error in
+            if case PMKError.cancelled = error {
+                // pass
+            } else {
+                XCTFail("expected cancelled, got \(error)")
+            }
+        }
+    }
+
+    func testAlertOnMacSuccessBeforeTimer() throws {
+        Current.isCatalyst = true
+
+        let result = login.open(authDetails: authDetails, sender: sender)
+        let session = try XCTUnwrap(FakeASWebAuthenticationSession.lastCreated)
+        let timer = try XCTUnwrap(login.macPresentTimer)
+
+        session.completionHandler(try XCTUnwrap(URL(string: "homeassistant://auth-callback?code=code_123")), nil)
+
+        XCTAssertEqual(try hang(result), "code_123")
+        timer.fire()
+
+        let expectation = expectation(description: "one run loop")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNil(sender.presentedViewController)
+    }
+
+    func testAlertOnMacSuccessAfterTimer() throws {
+        Current.isCatalyst = true
+
+        let result = login.open(authDetails: authDetails, sender: sender)
+        let session = try XCTUnwrap(FakeASWebAuthenticationSession.lastCreated)
+        let timer = try XCTUnwrap(login.macPresentTimer)
+
+        // we want it to show
+        timer.fire()
+
+        XCTAssertNotNil(sender.presentedViewController as? UIAlertController)
+
+        session.completionHandler(try XCTUnwrap(URL(string: "homeassistant://auth-callback?code=code_123")), nil)
+        XCTAssertEqual(try hang(result), "code_123")
+
+        let expectation = expectation(description: "one run loop")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNil(sender.presentedViewController)
+    }
+}
+
+private class FakeUIViewController: UIViewController {
+    private var backingPresentedViewController: UIViewController?
+    override var presentedViewController: UIViewController? {
+        backingPresentedViewController
+    }
+
+    override func present(
+        _ viewControllerToPresent: UIViewController,
+        animated flag: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        backingPresentedViewController = viewControllerToPresent
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        backingPresentedViewController = nil
+        super.dismiss(animated: flag, completion: completion)
+    }
 }
 
 private class FakeASWebAuthenticationSession: ASWebAuthenticationSession {
@@ -69,6 +181,7 @@ private class FakeASWebAuthenticationSession: ASWebAuthenticationSession {
     let scheme: String?
     let completionHandler: ASWebAuthenticationSession.CompletionHandler
     private(set) var started: Bool
+    private(set) var isCancelled: Bool
 
     override init(
         url: URL,
@@ -79,6 +192,7 @@ private class FakeASWebAuthenticationSession: ASWebAuthenticationSession {
         self.scheme = callbackURLScheme
         self.completionHandler = completionHandler
         self.started = false
+        self.isCancelled = false
         super.init(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
         Self.lastCreated = self
     }
@@ -89,5 +203,10 @@ private class FakeASWebAuthenticationSession: ASWebAuthenticationSession {
         }
         started = true
         return true
+    }
+
+    override func cancel() {
+        isCancelled = true
+        completionHandler(nil, ASWebAuthenticationSessionError(.canceledLogin))
     }
 }


### PR DESCRIPTION
Fixes #1951.

## Summary
Alert that we're opening Safari for login after a few seconds of waiting (so it's not distracting as Safari normally opens it). This alert dismisses on its own when cancelling or completing login, so 'cancel' is its only choice.

## Screenshots
| Scanning | Manual |
| -------- | ------ |
| <img width="712" alt="image" src="https://user-images.githubusercontent.com/74188/144169514-08690d60-873f-45f1-a4e9-7bc11914b411.png"> | <img width="712" alt="image" src="https://user-images.githubusercontent.com/74188/144169633-9b811ed6-48db-4ea1-949e-16fa3071254f.png"> |
