### PR TITLE
Add two-finger swipe to go forward/back, change server to three-finger

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -617,6 +617,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }
 
         let hud = MBProgressHUD.showAdded(to: view, animated: true)
+        hud.isUserInteractionEnabled = false
         hud.customView = with(IconImageView(frame: CGRect(x: 0, y: 0, width: 37, height: 37))) {
             $0.iconDrawable = icon
         }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -4,6 +4,7 @@ import AVKit
 import CoreLocation
 import HAKit
 import KeychainAccess
+import MBProgressHUD
 import PromiseKit
 import Shared
 import SwiftMessages
@@ -147,6 +148,13 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         webView = WKWebView(frame: view!.frame, configuration: config)
         webView.isOpaque = false
         view!.addSubview(webView)
+
+        for direction: UISwipeGestureRecognizer.Direction in [.left, .right] {
+            webView.addGestureRecognizer(with(UISwipeGestureRecognizer(target: self, action: #selector(swipe(_:)))) {
+                $0.numberOfTouchesRequired = 2
+                $0.direction = direction
+            })
+        }
 
         urlObserver = webView.observe(\.url) { [weak self] webView, _ in
             guard let self = self else { return }
@@ -592,6 +600,28 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
                 webView.load(URLRequest(url: webviewURL))
             }
         }
+    }
+
+    @objc private func swipe(_ gesture: UISwipeGestureRecognizer) {
+        let icon: MaterialDesignIcons
+
+        if gesture.direction == .left, webView.canGoForward {
+            _ = webView.goForward()
+            icon = .arrowRightIcon
+        } else if gesture.direction == .right, webView.canGoBack {
+            _ = webView.goBack()
+            icon = .arrowLeftIcon
+        } else {
+            // the returned WKNavigation doesn't appear to be nil/non-nil based on whether forward/back occurred
+            return
+        }
+
+        let hud = MBProgressHUD.showAdded(to: view, animated: true)
+        hud.customView = with(IconImageView(frame: CGRect(x: 0, y: 0, width: 37, height: 37))) {
+            $0.iconDrawable = icon
+        }
+        hud.mode = .customView
+        hud.hide(animated: true, afterDelay: 1.0)
     }
 
     @objc private func updateSensors() {

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -270,7 +270,7 @@ class WebViewWindowController {
     private lazy var serverChangeGestures: [UIGestureRecognizer] = {
         [.left, .right].map { (direction: UISwipeGestureRecognizer.Direction) in
             with(UISwipeGestureRecognizer()) {
-                $0.numberOfTouchesRequired = 2
+                $0.numberOfTouchesRequired = 3
                 $0.direction = direction
                 $0.addTarget(self, action: #selector(serverChangeGestureDidChange(_:)))
             }

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -311,6 +311,7 @@ class WebViewWindowController {
 
         open(server: server).done { controller in
             let hud = MBProgressHUD.showAdded(to: controller.view, animated: true)
+            hud.isUserInteractionEnabled = false
             hud.mode = .text
             hud.label.text = server.info.name
             hud.hide(animated: true, afterDelay: 1.0)


### PR DESCRIPTION
## Summary
- Changes the swipe gesture to switch between servers to require 3 fingers.
- Adds forward/back gestures when using 2 fingers.
- Allows swiping when the swipe HUD is shown, so you can spam it fast.