### PR TITLE
Fix cloud not enabling by default in onboarding

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -203,6 +203,9 @@ private extension ConnectionInfo {
             isLocalPushEnabled: true
         )
 
+        // default cloud to on
+        useCloud = true
+
         // if we have internal+external, we're on the internal network doing discovery
         // but we don't yet have location permission to know we're on an internal ssid
         if internalSSIDs == [] || internalSSIDs == nil,

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -186,11 +186,7 @@ public struct ConnectionInfo: Codable, Equatable {
     }
 
     public mutating func webhookURL() -> URL {
-        if useCloud, let cloudURL = cloudhookURL {
-            return cloudURL
-        }
-
-        return activeURL().appendingPathComponent(webhookPath, isDirectory: false)
+        activeURL().appendingPathComponent(webhookPath, isDirectory: false)
     }
 
     public var webhookPath: String {

--- a/Tests/App/Auth/OnboardingAuth.test.swift
+++ b/Tests/App/Auth/OnboardingAuth.test.swift
@@ -160,6 +160,7 @@ class OnboardingAuthTests: XCTestCase {
         XCTAssertNil(connectionInfo.address(for: .internal))
         XCTAssertEqual(connectionInfo.address(for: .external), instance.externalURL)
         XCTAssertNil(connectionInfo.overrideActiveURLType)
+        XCTAssertTrue(connectionInfo.useCloud)
 
         XCTAssertEqual(Current.servers.server(for: server.identifier)?.info, server.info)
     }
@@ -180,6 +181,7 @@ class OnboardingAuthTests: XCTestCase {
         XCTAssertNil(connectionInfo.address(for: .internal))
         XCTAssertEqual(connectionInfo.address(for: .external), instance.externalURL)
         XCTAssertNil(connectionInfo.overrideActiveURLType)
+        XCTAssertTrue(connectionInfo.useCloud)
 
         XCTAssertEqual(Current.servers.server(for: server.identifier)?.info, server.info)
     }


### PR DESCRIPTION
## Summary
Regressed in new onboarding; old onboarding did this during the final checklist screen, which no longer exists.