### PR TITLE
Add hint about local network permission to internet offline error

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuthError.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthError.swift
@@ -70,7 +70,24 @@ struct OnboardingAuthError: LocalizedError {
                 + "\n\n" + underlying.localizedDescription
         case let .sslUntrusted(underlying),
              let .other(underlying):
-            return underlying.localizedDescription
+            let extraInfo: String?
+
+            if let urlError = underlying as? URLError {
+                switch urlError.code {
+                case .notConnectedToInternet:
+                    extraInfo = L10n.Onboarding.ConnectionTestResult.LocalNetworkPermission.description
+                default:
+                    extraInfo = nil
+                }
+            } else {
+                extraInfo = nil
+            }
+
+            if let extraInfo = extraInfo {
+                return extraInfo + "\n\n" + underlying.localizedDescription
+            } else {
+                return underlying.localizedDescription
+            }
         }
     }
 

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -203,6 +203,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "onboarding.connection_test_result.basic_auth.description" = "HTTP Basic Authentication is unsupported.";
 "onboarding.connection_test_result.client_certificate.description" = "Client Certificate Authentication is not supported.";
 "onboarding.connection_test_result.error_code" = "Error Code:";
+"onboarding.connection_test_result.local_network_permission.description" = "\"Local Network\" privacy permission may have been denied. You can change this in the system Settings app.";
 "onboarding.device_name_check.error.prompt" = "What device name should be used instead?";
 "onboarding.device_name_check.error.rename_action" = "Rename";
 "onboarding.device_name_check.error.title" = "A device already exists with the name '%1$@'";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -731,6 +731,10 @@ public enum L10n {
         /// Client Certificate Authentication is not supported.
         public static var description: String { return L10n.tr("Localizable", "onboarding.connection_test_result.client_certificate.description") }
       }
+      public enum LocalNetworkPermission {
+        /// "Local Network" privacy permission may have been denied. You can change this in the system Settings app.
+        public static var description: String { return L10n.tr("Localizable", "onboarding.connection_test_result.local_network_permission.description") }
+      }
     }
     public enum DeviceNameCheck {
       public enum Error {
@@ -879,7 +883,7 @@ public enum L10n {
     public enum ConnectionSection {
       /// Activate
       public static var activateServer: String { return L10n.tr("Localizable", "settings.connection_section.activate_server") }
-      /// Quickly activate using a two-finger swipe left or right when viewing a server.
+      /// Quickly activate using a three-finger swipe left or right when viewing a server.
       public static var activateSwipeHint: String { return L10n.tr("Localizable", "settings.connection_section.activate_swipe_hint") }
       /// Add Server
       public static var addServer: String { return L10n.tr("Localizable", "settings.connection_section.add_server") }


### PR DESCRIPTION
## Summary
Augments the internet offline error with a hint about the permission.

## Screenshots
<img width="300" src="https://user-images.githubusercontent.com/74188/144543200-3d6b9853-9cdf-43ab-8ceb-f7634b61bc6f.png">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
