### PR TITLE
Fix onboarding timeout when only internal URL is set and we lack SSID info

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		11AF4D2E249DA5AF006C74C0 /* GeocoderSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D2D249DA5AF006C74C0 /* GeocoderSensor.test.swift */; };
 		11AF4D30249DCA88006C74C0 /* ConnectivitySensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */; };
 		11B1FFC524CCD72F00F9BCB2 /* VoiceShortcutRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */; };
+		11B38EDF275BE29F00205C7B /* ConnectionInfo.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */; };
 		11B62DBE24F2EDD800E5CB55 /* EurekaCondition+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */; };
 		11B62DC024F2F06100E5CB55 /* UIApplication+OpenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */; };
 		11B7DBFC266BE7550090BD3B /* LocalPushEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7DBFB266BE7540090BD3B /* LocalPushEvent.swift */; };
@@ -1366,6 +1367,7 @@
 		11AF4D2D249DA5AF006C74C0 /* GeocoderSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeocoderSensor.test.swift; sourceTree = "<group>"; };
 		11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivitySensor.test.swift; sourceTree = "<group>"; };
 		11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcutRow.swift; sourceTree = "<group>"; };
+		11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionInfo.test.swift; sourceTree = "<group>"; };
 		11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EurekaCondition+Additions.swift"; sourceTree = "<group>"; };
 		11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenSettings.swift"; sourceTree = "<group>"; };
 		11B7DBFB266BE7540090BD3B /* LocalPushEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushEvent.swift; sourceTree = "<group>"; };
@@ -3476,6 +3478,7 @@
 				1130A5732751B29E00640E38 /* PerServerContainer.test.swift */,
 				1130A5752751BA1800640E38 /* Server.test.swift */,
 				1130A5772751BDD900640E38 /* ServerManager.test.swift */,
+				11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -5704,6 +5707,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11B38EDF275BE29F00205C7B /* ConnectionInfo.test.swift in Sources */,
 				11883CC524C12C8A0036A6C6 /* CLLocation+Extensions.test.swift in Sources */,
 				11AA9977266B0CEC00B829E1 /* NotificationParserLegacy.test.swift in Sources */,
 				1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */,

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -214,9 +214,6 @@ public struct ConnectionInfo: Codable, Equatable {
 
     /// Returns true if current SSID is SSID marked for internal URL use.
     public var isOnInternalNetwork: Bool {
-        #if targetEnvironment(simulator)
-        return true
-        #else
         if let current = Current.connectivity.currentWiFiSSID(),
            internalSSIDs?.contains(current) == true {
             return true
@@ -228,7 +225,6 @@ public struct ConnectionInfo: Codable, Equatable {
         }
 
         return false
-        #endif
     }
 }
 

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -173,8 +173,17 @@ public struct ConnectionInfo: Codable, Equatable {
             activeURLType = .external
             url = externalURL
         } else {
-            activeURLType = .internal
-            url = URL(string: "http://homeassistant.local:8123")!
+            // we're missing a url, so try and fall back to one that _could_ work
+            if let remoteUIURL = remoteUIURL {
+                activeURLType = .remoteUI
+                url = remoteUIURL
+            } else if let internalURL = internalURL {
+                activeURLType = .internal
+                url = internalURL
+            } else {
+                activeURLType = .internal
+                url = URL(string: "http://homeassistant.local:8123")!
+            }
         }
 
         return url.sanitized()

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -56,6 +56,10 @@ public class ConnectivityWrapper {
         }
         self.hasWiFi = { true }
         self.currentWiFiSSID = {
+            #if targetEnvironment(simulator)
+            return "Simulator"
+            #endif
+
             guard let interfaces = CNCopySupportedInterfaces() as? [String] else { return nil }
             for interface in interfaces {
                 guard let interfaceInfo = CNCopyCurrentNetworkInfo(interface as CFString) as NSDictionary? else {

--- a/Tests/App/Auth/OnboardingAuth.test.swift
+++ b/Tests/App/Auth/OnboardingAuth.test.swift
@@ -128,7 +128,9 @@ class OnboardingAuthTests: XCTestCase {
         XCTAssertTrue(Current.servers.all.isEmpty)
     }
 
-    func testSuccessfulWithInternalAndExternalAndInternalSucceeds() throws {
+    func testSuccessfulWithInternalAndExternalAndInternalSucceedsWithoutSSID() throws {
+        Current.connectivity.currentWiFiSSID = { nil }
+
         let result = auth()
         let server = try hang(result)
         // test api state
@@ -142,6 +144,28 @@ class OnboardingAuthTests: XCTestCase {
         XCTAssertEqual(connectionInfo.address(for: .internal), instance.internalURL)
         XCTAssertEqual(connectionInfo.address(for: .external), instance.externalURL)
         XCTAssertEqual(connectionInfo.overrideActiveURLType, .internal)
+
+        XCTAssertEqual(Current.servers.server(for: server.identifier)?.info, server.info)
+    }
+
+    func testSuccessfulWithInternalAndExternalAndInternalSucceedsWithSSID() throws {
+        Current.connectivity.currentWiFiSSID = { "unit_test" }
+        Current.connectivity.currentNetworkHardwareAddress = { "unit_test_addr" }
+
+        let result = auth()
+        let server = try hang(result)
+        // test api state
+        // add tests above to test negated api state
+
+        let tokenInfo = server.info.token
+        XCTAssertEqual(tokenInfo.accessToken, "access_token1")
+        XCTAssertEqual(tokenInfo.refreshToken, "refresh_token1")
+
+        let connectionInfo = server.info.connection
+        XCTAssertEqual(connectionInfo.address(for: .internal), instance.internalURL)
+        XCTAssertEqual(connectionInfo.address(for: .external), instance.externalURL)
+        XCTAssertEqual(connectionInfo.internalSSIDs, ["unit_test"])
+        XCTAssertEqual(connectionInfo.internalHardwareAddresses, ["unit_test_addr"])
 
         XCTAssertEqual(Current.servers.server(for: server.identifier)?.info, server.info)
     }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -1,0 +1,276 @@
+@testable import Shared
+import XCTest
+
+class ConnectionInfoTests: XCTestCase {
+    func testInternalOnlyURL() {
+        let url = URL(string: "http://example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: url,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        Current.connectivity.currentWiFiSSID = { nil }
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        info.internalSSIDs = ["unit_tests"]
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .internal)
+    }
+
+    func testRemoteOnlyURL() {
+        let url = URL(string: "http://example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: url,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        info.useCloud = false
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+
+        info.useCloud = true
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+    }
+
+    func testExternalOnlyURL() {
+        let url = URL(string: "http://example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: url,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.internalSSIDs = ["unit_tests"]
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.internalSSIDs = nil
+        info.internalHardwareAddresses = ["unit_tests"]
+        Current.connectivity.currentNetworkHardwareAddress = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .external)
+    }
+
+    func testInternalExternalURL() {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.internalSSIDs = ["unit_tests"]
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        info.internalSSIDs = nil
+        info.internalHardwareAddresses = ["unit_tests"]
+        Current.connectivity.currentNetworkHardwareAddress = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+    }
+
+    func testExternalRemoteURL() {
+        let externalURL = URL(string: "http://external.example.com:8123")
+        let remoteURL = URL(string: "http://remote.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: remoteURL,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.useCloud = true
+
+        XCTAssertEqual(info.activeURL(), remoteURL)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+    }
+
+    func testInternalRemoteURL() {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let remoteURL = URL(string: "http://remote.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: remoteURL,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), remoteURL)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+
+        info.useCloud = true
+
+        XCTAssertEqual(info.activeURL(), remoteURL)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+
+        info.internalSSIDs = ["unit_tests"]
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        info.internalSSIDs = nil
+        info.internalHardwareAddresses = ["unit_tests"]
+        Current.connectivity.currentNetworkHardwareAddress = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+    }
+
+    func testInternalExternalRemoteURL() {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+        let remoteURL = URL(string: "http://remote.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: remoteURL,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.useCloud = true
+
+        XCTAssertEqual(info.activeURL(), remoteURL)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+
+        info.internalSSIDs = ["unit_tests"]
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        info.internalSSIDs = nil
+        info.internalHardwareAddresses = ["unit_tests"]
+        Current.connectivity.currentNetworkHardwareAddress = { "unit_tests" }
+
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        info.internalHardwareAddresses = nil
+    }
+
+    func testOverrideURL() {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+        let remoteURL = URL(string: "http://remote.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: remoteURL,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        // valid override states
+
+        info.overrideActiveURLType = .remoteUI
+        XCTAssertEqual(info.activeURL(), remoteURL)
+        XCTAssertEqual(info.activeURLType, .remoteUI)
+
+        info.overrideActiveURLType = .external
+        XCTAssertEqual(info.activeURL(), externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.overrideActiveURLType = .internal
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+
+        // invalid override states
+
+        info.set(address: nil, for: .remoteUI)
+        info.overrideActiveURLType = .remoteUI
+        XCTAssertEqual(info.activeURL(), externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+
+        info.set(address: nil, for: .external)
+        info.overrideActiveURLType = .external
+        XCTAssertEqual(info.activeURL(), internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+    }
+
+    func testFallbackURL() {
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false
+        )
+
+        XCTAssertEqual(info.activeURL(), URL(string: "http://homeassistant.local:8123"))
+    }
+}


### PR DESCRIPTION
Fixes #1918.

## Summary
During initial onboarding (or even after the fact), we don't have permission to read SSID values due to Location permission occurring later. When only an internal URL was set, we were falling back to homeassistant.local.:8123 which is possibly not valid, rather than using the one we slurped from discovery info.

## Any other notes
Manually entering a URL worked here because it sets the value as 'external URL' which didn't have this issue.