### PR TITLE
Stop using background sessions in extensions by default on iOS

### DIFF
--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -229,7 +229,14 @@ public class AppEnvironment {
         NSClassFromString("XCTest") != nil
     }
 
-    public var isBackgroundRequestsImmediate = { true }
+    public var isBackgroundRequestsImmediate = {
+        #if os(watchOS)
+        true
+        #else
+        false
+        #endif
+    }
+
     public var isForegroundApp = { false }
 
     public var appConfiguration: AppConfiguration {


### PR DESCRIPTION
## Summary
In iOS/macOS extensions, prefer using the immediate webhook session rather than the background session as XPC in extensions to urlsessiond is a bit spotty.

## Any other notes
This may fix errors like "Could not communicate with background transfer service" in Shortcuts.