### PR TITLE
Fix cases of sending invalid sensor values on macOS

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -79,7 +79,6 @@
 		11169CEC262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */; };
 		1117FB4C250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
 		1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */; };
-		111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformAction.swift */; };
 		111858D624CB620500B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		111858D724CB620600B8CDDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = B63CCDCF2164714900123C50 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
 		111858DA24CB7F9900B8CDDC /* SiriIntents+ConvenienceInits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A5D9F4215233EC0013963F /* SiriIntents+ConvenienceInits.swift */; };
@@ -103,7 +102,6 @@
 		11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11267D0825BBA9FE00F28E5C /* Updater.test.swift */; };
 		1127381C2622B6F300F5E312 /* DebugSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1127381B2622B6F300F5E312 /* DebugSettingsViewController.swift */; };
 		1127383C2625512600F5E312 /* ButtonRowWithLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1127383B2625512600F5E312 /* ButtonRowWithLoading.swift */; };
-		112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensors.swift */; };
 		1130A5742751B29E00640E38 /* PerServerContainer.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130A5732751B29E00640E38 /* PerServerContainer.test.swift */; };
 		1130A5762751BA1800640E38 /* Server.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130A5752751BA1800640E38 /* Server.test.swift */; };
 		1130A5782751BDD900640E38 /* ServerManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130A5772751BDD900640E38 /* ServerManager.test.swift */; };
@@ -141,7 +139,6 @@
 		11521BD9254003B8009C5C72 /* SentryLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CC96D524B0097500CE53ED /* SentryLogDestination.swift */; };
 		115560E127010D8400A8F818 /* WidgetBasicContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */; };
 		115560E327010DAB00A8F818 /* WidgetBasicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E227010DAB00A8F818 /* WidgetBasicView.swift */; };
-		115560E6270116B400A8F818 /* OpenPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E4270116AF00A8F818 /* OpenPage.swift */; };
 		115560E827011E3300A8F818 /* HAPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E727011E3300A8F818 /* HAPanel.swift */; };
 		115560E927011E3300A8F818 /* HAPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E727011E3300A8F818 /* HAPanel.swift */; };
 		115560EE27012F7300A8F818 /* WidgetOpenPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560EB27012EE100A8F818 /* WidgetOpenPage.swift */; };
@@ -153,7 +150,6 @@
 		115AD72D267C57DA0090B243 /* FocusSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115AD72C267C57DA0090B243 /* FocusSensor.test.swift */; };
 		115BC8282676F44E00452430 /* FocusSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC8272676F44E00452430 /* FocusSensor.swift */; };
 		115BC8292676F44E00452430 /* FocusSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC8272676F44E00452430 /* FocusSensor.swift */; };
-		115BC82B267704E300452430 /* FocusStatusIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */; };
 		115BC82E2677093900452430 /* FocusStatusWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82C267708CA00452430 /* FocusStatusWrapper.swift */; };
 		115BC82F2677093A00452430 /* FocusStatusWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82C267708CA00452430 /* FocusStatusWrapper.swift */; };
 		115DA29324F464DC00C00BB1 /* MenuManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115DA28C24F4646500C00BB1 /* MenuManager.swift */; };
@@ -319,6 +315,30 @@
 		11AF4D30249DCA88006C74C0 /* ConnectivitySensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */; };
 		11B1FFC524CCD72F00F9BCB2 /* VoiceShortcutRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */; };
 		11B38EDF275BE29F00205C7B /* ConnectionInfo.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */; };
+		11B38EE3275C54A200205C7B /* OpenPageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */; };
+		11B38EE4275C54A200205C7B /* FireEventIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B22150892A004AB261 /* FireEventIntentHandler.swift */; };
+		11B38EE5275C54A200205C7B /* SendLocationIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B42150898A004AB261 /* SendLocationIntentHandler.swift */; };
+		11B38EE6275C54A200205C7B /* CallServiceIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B02150891B004AB261 /* CallServiceIntentHandler.swift */; };
+		11B38EE7275C54A200205C7B /* PerformActionIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformActionIntentHandler.swift */; };
+		11B38EE8275C54A200205C7B /* WidgetActionsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActionsIntentHandler.swift */; };
+		11B38EE9275C54A200205C7B /* GetCameraImageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */; };
+		11B38EEA275C54A200205C7B /* PickAServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2E7B227500DAD00CF144C /* PickAServerError.swift */; };
+		11B38EEB275C54A200205C7B /* UpdateSensorsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */; };
+		11B38EEC275C54A200205C7B /* RoutingIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */; };
+		11B38EED275C54A200205C7B /* RenderTemplateIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */; };
+		11B38EEE275C54A200205C7B /* FocusStatusIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */; };
+		11B38EEF275C54A300205C7B /* OpenPageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */; };
+		11B38EF0275C54A300205C7B /* FireEventIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B22150892A004AB261 /* FireEventIntentHandler.swift */; };
+		11B38EF1275C54A300205C7B /* SendLocationIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B42150898A004AB261 /* SendLocationIntentHandler.swift */; };
+		11B38EF2275C54A300205C7B /* CallServiceIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B02150891B004AB261 /* CallServiceIntentHandler.swift */; };
+		11B38EF3275C54A300205C7B /* PerformActionIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111858D324CB5B8900B8CDDC /* PerformActionIntentHandler.swift */; };
+		11B38EF4275C54A300205C7B /* WidgetActionsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActionsIntentHandler.swift */; };
+		11B38EF5275C54A300205C7B /* GetCameraImageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */; };
+		11B38EF6275C54A300205C7B /* PickAServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2E7B227500DAD00CF144C /* PickAServerError.swift */; };
+		11B38EF7275C54A300205C7B /* UpdateSensorsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */; };
+		11B38EF8275C54A300205C7B /* RoutingIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */; };
+		11B38EF9275C54A300205C7B /* RenderTemplateIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */; };
+		11B38EFA275C54A300205C7B /* FocusStatusIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */; };
 		11B62DBE24F2EDD800E5CB55 /* EurekaCondition+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */; };
 		11B62DC024F2F06100E5CB55 /* UIApplication+OpenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */; };
 		11B7DBFC266BE7550090BD3B /* LocalPushEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B7DBFB266BE7540090BD3B /* LocalPushEvent.swift */; };
@@ -340,7 +360,6 @@
 		11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */; };
 		11BD7B2D25B52E8D001826F0 /* MacBridgeStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */; };
 		11BD7B4D25B53D7F001826F0 /* AppMacBridgeStatusItemConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD7B3C25B53D37001826F0 /* AppMacBridgeStatusItemConfiguration.swift */; };
-		11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */; };
 		11C05F2D254919210031D038 /* AccountInitialsImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C05F2C254919210031D038 /* AccountInitialsImage.swift */; };
 		11C4627F24B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
 		11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */; };
@@ -424,7 +443,6 @@
 		11F20BC8274C60FF00DFB163 /* PushProviderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F20BC6274C60FF00DFB163 /* PushProviderConfiguration.swift */; };
 		11F20BFC274D5DA900DFB163 /* Server+Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F20BFB274D5DA900DFB163 /* Server+Fakes.swift */; };
 		11F20BFD274D5DA900DFB163 /* Server+Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F20BFB274D5DA900DFB163 /* Server+Fakes.swift */; };
-		11F2E7B327500DAD00CF144C /* PickAServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2E7B227500DAD00CF144C /* PickAServerError.swift */; };
 		11F2F1EC2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
 		11F2F1ED2586ED6100F61F7C /* NotificationAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F1EB2586ED6100F61F7C /* NotificationAttachmentManager.swift */; };
 		11F2F2092586FB0C00F61F7C /* NotificationAttachmentManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2F2082586FB0C00F61F7C /* NotificationAttachmentManager.test.swift */; };
@@ -626,7 +644,6 @@
 		B627CB0B1D83C87B0057173E /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B627CB0A1D83C87B0057173E /* UserNotificationsUI.framework */; };
 		B627CB0E1D83C87B0057173E /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B627CB0D1D83C87B0057173E /* NotificationViewController.swift */; };
 		B627CB151D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B627CB071D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		B62817F0221D269B000BA86A /* RenderTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplate.swift */; };
 		B62817F2221D6CF4000BA86A /* Reachability+NetworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817F1221D6CF4000BA86A /* Reachability+NetworkType.swift */; };
 		B62CD2A5225B099D008DF3C5 /* WebhookSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62CD2A4225B099C008DF3C5 /* WebhookSensor.swift */; };
 		B62CD2A6225B099D008DF3C5 /* WebhookSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62CD2A4225B099C008DF3C5 /* WebhookSensor.swift */; };
@@ -699,10 +716,7 @@
 		B661FC7E226C87BB00E541DD /* home.json in Resources */ = {isa = PBXBuildFile; fileRef = B661FC7D226C87BB00E541DD /* home.json */; };
 		B661FC88226D478300E541DD /* OnboardingScanningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B661FC87226D478300E541DD /* OnboardingScanningViewController.swift */; };
 		B66C58A8215086F0004AB261 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58A7215086F0004AB261 /* IntentHandler.swift */; };
-		B66C58AC215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66C58A5215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		B66C58B12150891B004AB261 /* CallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B02150891B004AB261 /* CallService.swift */; };
-		B66C58B32150892A004AB261 /* FireEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B22150892A004AB261 /* FireEvent.swift */; };
-		B66C58B52150898A004AB261 /* SendLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58B42150898A004AB261 /* SendLocation.swift */; };
+		B66C58AC215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66C58A5215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B66F9F24216B1E61000CAA0F /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B66F9F23216B1E61000CAA0F /* NotificationCenter.framework */; };
 		B66F9F27216B1E61000CAA0F /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66F9F26216B1E61000CAA0F /* TodayViewController.swift */; };
 		B66F9F2E216B1E61000CAA0F /* HomeAssistant-Extensions-Today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66F9F22216B1E61000CAA0F /* HomeAssistant-Extensions-Today.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -793,7 +807,6 @@
 		B6DA3C7122690B1F00DE811C /* NotificationSoundsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA3C7022690B1F00DE811C /* NotificationSoundsViewController.swift */; };
 		B6DA3C7322691A5000DE811C /* AKConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA3C7222691A5000DE811C /* AKConverter.swift */; };
 		B6DD5E6A24940F6F003A0154 /* OpenInFirefoxControllerSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DD5E6924940F6F003A0154 /* OpenInFirefoxControllerSwift.swift */; };
-		B6DF8BC4221D047400370A59 /* GetCameraImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC3221D047400370A59 /* GetCameraImage.swift */; };
 		B6E2D4D52270706300446DFA /* ha-loading.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4D42270706200446DFA /* ha-loading.json */; };
 		B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
 		B9820AF29664869FD0B25CDF /* Pods_iOS_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD90A8F251D0671EFAC931ED /* Pods_iOS_App.framework */; };
@@ -1154,7 +1167,7 @@
 		11169CBA262FD6E1005EF90A /* NSLayoutConstraint+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Additions.swift"; sourceTree = "<group>"; };
 		11169CEB262FE3A2005EF90A /* VideoAudioAttachmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioAttachmentViewController.swift; sourceTree = "<group>"; };
 		1117FB4B250C5F7C00895C13 /* DeviceBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBattery.swift; sourceTree = "<group>"; };
-		111858D324CB5B8900B8CDDC /* PerformAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
+		111858D324CB5B8900B8CDDC /* PerformActionIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformActionIntentHandler.swift; sourceTree = "<group>"; };
 		11195F6A267EFB1F003DF674 /* NotificationManagerLocalPushInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerLocalPushInterface.swift; sourceTree = "<group>"; };
 		11195F6C267EFC15003DF674 /* HACancellable+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HACancellable+App.swift"; sourceTree = "<group>"; };
 		11195F6E267EFC8E003DF674 /* NotificationManagerLocalPushInterfaceDirect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerLocalPushInterfaceDirect.swift; sourceTree = "<group>"; };
@@ -1167,7 +1180,7 @@
 		11267D0825BBA9FE00F28E5C /* Updater.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updater.test.swift; sourceTree = "<group>"; };
 		1127381B2622B6F300F5E312 /* DebugSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSettingsViewController.swift; sourceTree = "<group>"; };
 		1127383B2625512600F5E312 /* ButtonRowWithLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonRowWithLoading.swift; sourceTree = "<group>"; };
-		112B705A2526B1C500FEAA76 /* UpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensors.swift; sourceTree = "<group>"; };
+		112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSensorsIntentHandler.swift; sourceTree = "<group>"; };
 		1130A5732751B29E00640E38 /* PerServerContainer.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerServerContainer.test.swift; sourceTree = "<group>"; };
 		1130A5752751BA1800640E38 /* Server.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Server.test.swift; sourceTree = "<group>"; };
 		1130A5772751BDD900640E38 /* ServerManager.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManager.test.swift; sourceTree = "<group>"; };
@@ -1192,7 +1205,7 @@
 		11521BBB25400284009C5C72 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBasicContainerView.swift; sourceTree = "<group>"; };
 		115560E227010DAB00A8F818 /* WidgetBasicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBasicView.swift; sourceTree = "<group>"; };
-		115560E4270116AF00A8F818 /* OpenPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPage.swift; sourceTree = "<group>"; };
+		115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPageIntentHandler.swift; sourceTree = "<group>"; };
 		115560E727011E3300A8F818 /* HAPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAPanel.swift; sourceTree = "<group>"; };
 		115560EB27012EE100A8F818 /* WidgetOpenPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetOpenPage.swift; sourceTree = "<group>"; };
 		115560EF27012F8100A8F818 /* WidgetOpenPageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetOpenPageProvider.swift; sourceTree = "<group>"; };
@@ -1368,6 +1381,7 @@
 		11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivitySensor.test.swift; sourceTree = "<group>"; };
 		11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcutRow.swift; sourceTree = "<group>"; };
 		11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionInfo.test.swift; sourceTree = "<group>"; };
+		11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingIntentHandler.swift; sourceTree = "<group>"; };
 		11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EurekaCondition+Additions.swift"; sourceTree = "<group>"; };
 		11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenSettings.swift"; sourceTree = "<group>"; };
 		11B7DBFB266BE7540090BD3B /* LocalPushEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushEvent.swift; sourceTree = "<group>"; };
@@ -1386,7 +1400,7 @@
 		11BC9E5624FDC1C900B9FBF7 /* ActiveSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSensor.test.swift; sourceTree = "<group>"; };
 		11BD7B2C25B52E8D001826F0 /* MacBridgeStatusItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridgeStatusItem.swift; sourceTree = "<group>"; };
 		11BD7B3C25B53D37001826F0 /* AppMacBridgeStatusItemConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMacBridgeStatusItemConfiguration.swift; sourceTree = "<group>"; };
-		11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActions.swift; sourceTree = "<group>"; };
+		11BD8BBC24E76BAD004B9A54 /* WidgetActionsIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsIntentHandler.swift; sourceTree = "<group>"; };
 		11C05F2C254919210031D038 /* AccountInitialsImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInitialsImage.swift; sourceTree = "<group>"; };
 		11C4627E24B04CB800031902 /* Promise+RetryNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+RetryNetworking.swift"; sourceTree = "<group>"; };
 		11C4628124B053A800031902 /* WebhookResponseUpdateSensors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookResponseUpdateSensors.swift; sourceTree = "<group>"; };
@@ -1679,7 +1693,7 @@
 		B627CB0A1D83C87B0057173E /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
 		B627CB0D1D83C87B0057173E /* NotificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
 		B627CB121D83C87B0057173E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B62817EF221D269B000BA86A /* RenderTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderTemplate.swift; sourceTree = "<group>"; };
+		B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderTemplateIntentHandler.swift; sourceTree = "<group>"; };
 		B62817F1221D6CF4000BA86A /* Reachability+NetworkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reachability+NetworkType.swift"; sourceTree = "<group>"; };
 		B62CD2A4225B099C008DF3C5 /* WebhookSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebhookSensor.swift; sourceTree = "<group>"; };
 		B630F295238C9A1200C6E4BE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Intents.strings; sourceTree = "<group>"; };
@@ -1794,9 +1808,9 @@
 		B66C58A5215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "HomeAssistant-Extensions-Intents.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66C58A7215086F0004AB261 /* IntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
 		B66C58A9215086F0004AB261 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B66C58B02150891B004AB261 /* CallService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallService.swift; sourceTree = "<group>"; };
-		B66C58B22150892A004AB261 /* FireEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEvent.swift; sourceTree = "<group>"; };
-		B66C58B42150898A004AB261 /* SendLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendLocation.swift; sourceTree = "<group>"; };
+		B66C58B02150891B004AB261 /* CallServiceIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallServiceIntentHandler.swift; sourceTree = "<group>"; };
+		B66C58B22150892A004AB261 /* FireEventIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEventIntentHandler.swift; sourceTree = "<group>"; };
+		B66C58B42150898A004AB261 /* SendLocationIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendLocationIntentHandler.swift; sourceTree = "<group>"; };
 		B66D6B1F2227A2EA009D8B90 /* WatchHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHelpers.swift; sourceTree = "<group>"; };
 		B66F9F22216B1E61000CAA0F /* HomeAssistant-Extensions-Today.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "HomeAssistant-Extensions-Today.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66F9F23216B1E61000CAA0F /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
@@ -1863,7 +1877,7 @@
 		B6DAC736215F06B100727D2A /* NotificationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAction.swift; sourceTree = "<group>"; };
 		B6DD5E6924940F6F003A0154 /* OpenInFirefoxControllerSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInFirefoxControllerSwift.swift; sourceTree = "<group>"; };
 		B6DF8BC0221C890600370A59 /* UIImageView+UIActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+UIActivityIndicator.swift"; sourceTree = "<group>"; };
-		B6DF8BC3221D047400370A59 /* GetCameraImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCameraImage.swift; sourceTree = "<group>"; };
+		B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCameraImageIntentHandler.swift; sourceTree = "<group>"; };
 		B6E2D4D42270706200446DFA /* ha-loading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ha-loading.json"; sourceTree = "<group>"; };
 		B6E857A11CB1CCCC00F96925 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		B6EE36A120CF593E001494E3 /* RealmZone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmZone.swift; sourceTree = "<group>"; };
@@ -2634,6 +2648,25 @@
 			path = Sensors;
 			sourceTree = "<group>";
 		};
+		11B38EE0275C545C00205C7B /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				B66C58B02150891B004AB261 /* CallServiceIntentHandler.swift */,
+				B66C58B22150892A004AB261 /* FireEventIntentHandler.swift */,
+				B66C58B42150898A004AB261 /* SendLocationIntentHandler.swift */,
+				B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */,
+				B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */,
+				111858D324CB5B8900B8CDDC /* PerformActionIntentHandler.swift */,
+				11BD8BBC24E76BAD004B9A54 /* WidgetActionsIntentHandler.swift */,
+				112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */,
+				115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */,
+				115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */,
+				11F2E7B227500DAD00CF144C /* PickAServerError.swift */,
+				11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */,
+			);
+			path = Intents;
+			sourceTree = "<group>";
+		};
 		11B7ECD9274DA521009AD634 /* Servers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3150,17 +3183,6 @@
 			children = (
 				11AD2E7C2528FF7A00FBC437 /* Resources */,
 				B66C58A7215086F0004AB261 /* IntentHandler.swift */,
-				B66C58B02150891B004AB261 /* CallService.swift */,
-				B66C58B22150892A004AB261 /* FireEvent.swift */,
-				B66C58B42150898A004AB261 /* SendLocation.swift */,
-				B6DF8BC3221D047400370A59 /* GetCameraImage.swift */,
-				B62817EF221D269B000BA86A /* RenderTemplate.swift */,
-				111858D324CB5B8900B8CDDC /* PerformAction.swift */,
-				11BD8BBC24E76BAD004B9A54 /* WidgetActions.swift */,
-				112B705A2526B1C500FEAA76 /* UpdateSensors.swift */,
-				115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */,
-				115560E4270116AF00A8F818 /* OpenPage.swift */,
-				11F2E7B227500DAD00CF144C /* PickAServerError.swift */,
 			);
 			path = Intents;
 			sourceTree = "<group>";
@@ -3421,6 +3443,7 @@
 		D03D891820E0A85300D4F28D /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				11B38EE0275C545C00205C7B /* Intents */,
 				D014EEAA212928EC008EA6F5 /* API */,
 				D0FF79C920D7787F0034574D /* ClientEvents */,
 				D00302BC20D4BEC0004C2CA9 /* Environment */,
@@ -3856,7 +3879,6 @@
 				B66C58A1215086F0004AB261 /* Sources */,
 				B66C58A2215086F0004AB261 /* Frameworks */,
 				B66C58A3215086F0004AB261 /* Resources */,
-				11C03007267F22BC0095AD58 /* Enable Xcode 13-requiring intents */,
 			);
 			buildRules = (
 			);
@@ -4681,25 +4703,6 @@
 			shellScript = "exec $PROJECT_DIR/Configuration/Scripts/fix_xcode_12.5_target_platform_issues.sh\n";
 			showEnvVarsInLog = 0;
 		};
-		11C03007267F22BC0095AD58 /* Enable Xcode 13-requiring intents */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Enable Xcode 13-requiring intents";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ $XCODE_VERSION_MAJOR != \"1200\" ]]; then\n    /usr/libexec/PlistBuddy -c \"add NSExtension:NSExtensionAttributes:IntentsSupported:0 string 'INShareFocusStatusIntent'\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		11FE64BC268D984D00AC4367 /* Fix Xcode 12.5+ Dependency Issues */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -5343,19 +5346,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B66C58B52150898A004AB261 /* SendLocation.swift in Sources */,
-				B6DF8BC4221D047400370A59 /* GetCameraImage.swift in Sources */,
-				B62817F0221D269B000BA86A /* RenderTemplate.swift in Sources */,
 				B66C58A8215086F0004AB261 /* IntentHandler.swift in Sources */,
-				B66C58B32150892A004AB261 /* FireEvent.swift in Sources */,
-				11BD8BBD24E76BAD004B9A54 /* WidgetActions.swift in Sources */,
-				B66C58B12150891B004AB261 /* CallService.swift in Sources */,
 				11DC6BAB24E23780002D9FDA /* Intents.intentdefinition in Sources */,
-				11F2E7B327500DAD00CF144C /* PickAServerError.swift in Sources */,
-				115BC82B267704E300452430 /* FocusStatusIntentHandler.swift in Sources */,
-				112B705B2526B1C500FEAA76 /* UpdateSensors.swift in Sources */,
-				111858D524CB5D4700B8CDDC /* PerformAction.swift in Sources */,
-				115560E6270116B400A8F818 /* OpenPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5384,6 +5376,7 @@
 				117675F0252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift in Sources */,
 				B67CE8AE22200F220034C1D0 /* TokenManager.swift in Sources */,
 				11BA5ECA2759AC0300FC40E8 /* XCGLogger+Export.swift in Sources */,
+				11B38EF0275C54A300205C7B /* FireEventIntentHandler.swift in Sources */,
 				1120C5852749C6350046C38B /* ServerProviding.swift in Sources */,
 				11C4628024B04CB800031902 /* Promise+RetryNetworking.swift in Sources */,
 				1104FCC02532755400B8BE34 /* WatchBackgroundRefreshScheduler.swift in Sources */,
@@ -5391,10 +5384,12 @@
 				B672333F225DB68B0031D629 /* WebSocketMessage.swift in Sources */,
 				11AF4D1A249C8253006C74C0 /* PedometerSensor.swift in Sources */,
 				1117FB4D250C5F7C00895C13 /* DeviceBattery.swift in Sources */,
+				11B38EF9275C54A300205C7B /* RenderTemplateIntentHandler.swift in Sources */,
 				11F855DB24DF6C7A0018013E /* IconDrawable.swift in Sources */,
 				11F2F25F25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */,
 				11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */,
 				B6A258462232485300ADD202 /* Alamofire+EncryptedResponses.swift in Sources */,
+				11B38EF8275C54A300205C7B /* RoutingIntentHandler.swift in Sources */,
 				11AF4D23249C924B006C74C0 /* GeocoderSensor.swift in Sources */,
 				11C4629224B14E6B00031902 /* XCGLogger+UNNotification.swift in Sources */,
 				1182620224F9C3F7000795C6 /* HACoreBlahObject.swift in Sources */,
@@ -5404,6 +5399,7 @@
 				110ED59025A6743900489AF7 /* ConnectivityWrapper.swift in Sources */,
 				1110836924AFEFA60027A67A /* Promise+WebhookJson.swift in Sources */,
 				1164D9DF25FB1B9800515E8A /* UIBarButtonItem+Additions.swift in Sources */,
+				11B38EF6275C54A300205C7B /* PickAServerError.swift in Sources */,
 				B67CE8AF22200F220034C1D0 /* ObjectMapperTransformers.swift in Sources */,
 				11AF4D13249C7E08006C74C0 /* ActivitySensor.swift in Sources */,
 				11E5CF8224BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */,
@@ -5419,6 +5415,7 @@
 				B67CE8B522200F220034C1D0 /* String+HA.swift in Sources */,
 				11169BC6262BE45F005EF90A /* UNNotificationContent+Additions.swift in Sources */,
 				B672334B225DDF410031D629 /* Event.swift in Sources */,
+				11B38EF5275C54A300205C7B /* GetCameraImageIntentHandler.swift in Sources */,
 				11521BBD25400284009C5C72 /* CrashReporter.swift in Sources */,
 				B6872E642226841400C475D1 /* MobileAppRegistrationRequest.swift in Sources */,
 				B613936A24F728F8002B8C5D /* InputDeviceSensor.swift in Sources */,
@@ -5443,11 +5440,13 @@
 				11195F73267F01E4003DF674 /* HACancellable+App.swift in Sources */,
 				B6B74CBE228399AC00D58A68 /* Action.swift in Sources */,
 				11358AF024FCA8BE0074C4E2 /* ActiveStateManager.swift in Sources */,
+				11B38EF1275C54A300205C7B /* SendLocationIntentHandler.swift in Sources */,
 				1120C580274638330046C38B /* PerServerContainer.swift in Sources */,
 				110ED56425A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				1168BF312718070400DD4D15 /* NSMutableAttributedString+Additions.swift in Sources */,
 				B67CE8B922200F220034C1D0 /* Environment.swift in Sources */,
 				11B7DBFD266BE7550090BD3B /* LocalPushEvent.swift in Sources */,
+				11B38EEF275C54A300205C7B /* OpenPageIntentHandler.swift in Sources */,
 				B6723342225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				11ADF941267D34B20040A7E3 /* NotificationsCommandManager.swift in Sources */,
 				B67CE8B122200F220034C1D0 /* CLError+DebugDescription.swift in Sources */,
@@ -5459,6 +5458,7 @@
 				113D29DF24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */,
 				11CFD78227364F450082D557 /* Identifier.swift in Sources */,
 				11AF4D17249C8083006C74C0 /* With.swift in Sources */,
+				11B38EF7275C54A300205C7B /* UpdateSensorsIntentHandler.swift in Sources */,
 				1141182B24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */,
 				119385A5249E8E360097F497 /* StorageSensor.swift in Sources */,
 				B67CE8AD22200F220034C1D0 /* AuthenticationAPI.swift in Sources */,
@@ -5470,7 +5470,9 @@
 				11E1639B250B1B760076D612 /* OnboardingStateObservation.swift in Sources */,
 				115BC8292676F44E00452430 /* FocusSensor.swift in Sources */,
 				B6221F6522266F9F00502A30 /* WebhookRequest.swift in Sources */,
+				11B38EF4275C54A300205C7B /* WidgetActionsIntentHandler.swift in Sources */,
 				11F3847C24FB27FC00CB0D74 /* DeviceWrapperBatteryObserver.swift in Sources */,
+				11B38EFA275C54A300205C7B /* FocusStatusIntentHandler.swift in Sources */,
 				11A48D7E24CA7E4E0021BDD9 /* NotificationCategory.swift in Sources */,
 				1121CD4D271295AD0071C2AA /* Style.swift in Sources */,
 				116570782702B0F6003906A7 /* DiskCache.swift in Sources */,
@@ -5483,6 +5485,7 @@
 				B6723345225DBACF0031D629 /* AuthRequestMessage.swift in Sources */,
 				11F2F26F25871D8200F61F7C /* NotificationAttachmentParserURL.swift in Sources */,
 				11F2F24225871CB000F61F7C /* NotificationAttachmentParser.swift in Sources */,
+				11B38EF3275C54A300205C7B /* PerformActionIntentHandler.swift in Sources */,
 				B67CE8AC22200F220034C1D0 /* AuthenticationRoutes.swift in Sources */,
 				119EC3C824D5119300617D51 /* MobileAppConfig.swift in Sources */,
 				115BC82F2677093A00452430 /* FocusStatusWrapper.swift in Sources */,
@@ -5494,6 +5497,7 @@
 				B67CE8A822200F220034C1D0 /* MJPEGStreamer.swift in Sources */,
 				B67CE89522200F220034C1D0 /* LocationHistory.swift in Sources */,
 				491E990025D543560077BBE3 /* LogbookEntry.swift in Sources */,
+				11B38EF2275C54A300205C7B /* CallServiceIntentHandler.swift in Sources */,
 				11521BD8254003B7009C5C72 /* SentryLogDestination.swift in Sources */,
 				B67CE8A722200F220034C1D0 /* HAAPI+RequestHelpers.swift in Sources */,
 				11C4628924B109C100031902 /* WebhookResponseLocation.swift in Sources */,
@@ -5565,6 +5569,7 @@
 				B6723344225DBACF0031D629 /* AuthRequestMessage.swift in Sources */,
 				D0DD2CEE213BCA8900C3D9F7 /* URL+Extensions.swift in Sources */,
 				11BA5EC92759AC0300FC40E8 /* XCGLogger+Export.swift in Sources */,
+				11B38EE4275C54A200205C7B /* FireEventIntentHandler.swift in Sources */,
 				1120C5842749C6350046C38B /* ServerProviding.swift in Sources */,
 				B6872E6022267EE800C475D1 /* HAAPI.swift in Sources */,
 				B62817F2221D6CF4000BA86A /* Reachability+NetworkType.swift in Sources */,
@@ -5572,10 +5577,12 @@
 				11F855DA24DF6C7A0018013E /* IconDrawable.swift in Sources */,
 				D0EEF335214EB77100D1D360 /* CLLocation+Extensions.swift in Sources */,
 				11AF4D1F249C8AF1006C74C0 /* ConnectivitySensor.swift in Sources */,
+				11B38EED275C54A200205C7B /* RenderTemplateIntentHandler.swift in Sources */,
 				B6723341225DB82E0031D629 /* KeyedDecodingContainer+JSON.swift in Sources */,
 				11C4629124B14E6B00031902 /* XCGLogger+UNNotification.swift in Sources */,
 				110ED56325A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				11AF4D16249C8083006C74C0 /* With.swift in Sources */,
+				11B38EEC275C54A200205C7B /* RoutingIntentHandler.swift in Sources */,
 				1182620124F9C3F7000795C6 /* HACoreBlahObject.swift in Sources */,
 				B672333E225DB68B0031D629 /* WebSocketMessage.swift in Sources */,
 				11482AD62505CB6E00C48C58 /* HACoreAudioObjectDevice.swift in Sources */,
@@ -5585,6 +5592,7 @@
 				D0BE440E210437F900C74314 /* AuthenticationRoutes.swift in Sources */,
 				11E5CF8124BBCE1B009AC30F /* ProcessInfo+BackgroundTask.swift in Sources */,
 				1164D9DE25FB1B9800515E8A /* UIBarButtonItem+Additions.swift in Sources */,
+				11B38EEA275C54A200205C7B /* PickAServerError.swift in Sources */,
 				B6B74CBD228399AB00D58A68 /* Action.swift in Sources */,
 				11CB98CA249E62E700B05222 /* Version+HA.swift in Sources */,
 				11EE9B4924C5116F00404AF8 /* ModelManager.swift in Sources */,
@@ -5600,6 +5608,7 @@
 				D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */,
 				11169BC8262BE460005EF90A /* UNNotificationContent+Additions.swift in Sources */,
 				11AF4D14249C7E09006C74C0 /* ActivitySensor.swift in Sources */,
+				11B38EE9275C54A200205C7B /* GetCameraImageIntentHandler.swift in Sources */,
 				D0EEF306214DD3CF00D1D360 /* ObjectMapperTransformers.swift in Sources */,
 				11AF4D22249C924B006C74C0 /* GeocoderSensor.swift in Sources */,
 				11A48D7B24CA7D7F0021BDD9 /* NotificationAction.swift in Sources */,
@@ -5624,11 +5633,13 @@
 				11195F72267F01E4003DF674 /* HACancellable+App.swift in Sources */,
 				113E73102518457C004006D8 /* LocalizedManager.swift in Sources */,
 				111D295624F30E2400C8A7D1 /* Updater.swift in Sources */,
+				11B38EE5275C54A200205C7B /* SendLocationIntentHandler.swift in Sources */,
 				1120C57F274638330046C38B /* PerServerContainer.swift in Sources */,
 				B672334D225DE1490031D629 /* SubscribeEvents.swift in Sources */,
 				1168BF302718070400DD4D15 /* NSMutableAttributedString+Additions.swift in Sources */,
 				1104FC9125322C1800B8BE34 /* Dictionary+Additions.swift in Sources */,
 				11B7DBFC266BE7550090BD3B /* LocalPushEvent.swift in Sources */,
+				11B38EE3275C54A200205C7B /* OpenPageIntentHandler.swift in Sources */,
 				113D29DE24946EDA0014067C /* CLLocationManager+OneShotLocation.swift in Sources */,
 				11ADF940267D34B10040A7E3 /* NotificationsCommandManager.swift in Sources */,
 				11C4627F24B04CB800031902 /* Promise+RetryNetworking.swift in Sources */,
@@ -5640,6 +5651,7 @@
 				1182620424F9C453000795C6 /* HACoreMediaObjectSystem.swift in Sources */,
 				11CFD78127364F450082D557 /* Identifier.swift in Sources */,
 				D0EEF2FF214D8D4C00D1D360 /* CLError+DebugDescription.swift in Sources */,
+				11B38EEB275C54A200205C7B /* UpdateSensorsIntentHandler.swift in Sources */,
 				B62CD2A5225B099D008DF3C5 /* WebhookSensor.swift in Sources */,
 				11E1639A250B1B760076D612 /* OnboardingStateObservation.swift in Sources */,
 				11C4628224B053A800031902 /* WebhookResponseUpdateSensors.swift in Sources */,
@@ -5651,7 +5663,9 @@
 				D03D893820E0AF8A00D4F28D /* ClientEventStore.swift in Sources */,
 				115BC8282676F44E00452430 /* FocusSensor.swift in Sources */,
 				1104FCBF2532755400B8BE34 /* WatchBackgroundRefreshScheduler.swift in Sources */,
+				11B38EE8275C54A200205C7B /* WidgetActionsIntentHandler.swift in Sources */,
 				B6D3B4ED225B26900082BB4F /* SensorContainer.swift in Sources */,
+				11B38EEE275C54A200205C7B /* FocusStatusIntentHandler.swift in Sources */,
 				11C4628E24B128EF00031902 /* WebhookResponseUnhandled.swift in Sources */,
 				1121CD4C271295AD0071C2AA /* Style.swift in Sources */,
 				116570772702B0F6003906A7 /* DiskCache.swift in Sources */,
@@ -5664,6 +5678,7 @@
 				1182620724F9C492000795C6 /* HACoreMediaObjectCamera.swift in Sources */,
 				B6221F6622266FA000502A30 /* WebhookRequest.swift in Sources */,
 				1104FD05253292CD00B8BE34 /* Guarantee+Additions.swift in Sources */,
+				11B38EE7275C54A200205C7B /* PerformActionIntentHandler.swift in Sources */,
 				11FA53F2251071D2008D9506 /* NSItemProvider+Additions.swift in Sources */,
 				D0C8847A2122A65800CCB501 /* SettingsStore.swift in Sources */,
 				115BC82E2677093900452430 /* FocusStatusWrapper.swift in Sources */,
@@ -5675,6 +5690,7 @@
 				11C4628B24B1230E00031902 /* WebhookResponseServiceCall.swift in Sources */,
 				D0EEF30A214DD64C00D1D360 /* UIImage+Icons.swift in Sources */,
 				D0EEF303214D8F0300D1D360 /* String+HA.swift in Sources */,
+				11B38EE6275C54A200205C7B /* CallServiceIntentHandler.swift in Sources */,
 				491E98FF25D543560077BBE3 /* LogbookEntry.swift in Sources */,
 				11358AEC24FC9F300074C4E2 /* ActiveSensor.swift in Sources */,
 				11EE9B4E24C6089800404AF8 /* RealmPersistable.swift in Sources */,
@@ -5845,6 +5861,7 @@
 		};
 		B66C58AB215086F0004AB261 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilter = ios;
 			target = B66C58A4215086F0004AB261 /* Extensions-Intents */;
 			targetProxy = B66C58AA215086F0004AB261 /* PBXContainerItemProxy */;
 		};

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 		11B38EE9275C54A200205C7B /* GetCameraImageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */; };
 		11B38EEA275C54A200205C7B /* PickAServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2E7B227500DAD00CF144C /* PickAServerError.swift */; };
 		11B38EEB275C54A200205C7B /* UpdateSensorsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */; };
-		11B38EEC275C54A200205C7B /* RoutingIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */; };
+		11B38EEC275C54A200205C7B /* IntentHandlerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* IntentHandlerFactory.swift */; };
 		11B38EED275C54A200205C7B /* RenderTemplateIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */; };
 		11B38EEE275C54A200205C7B /* FocusStatusIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */; };
 		11B38EEF275C54A300205C7B /* OpenPageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */; };
@@ -336,7 +336,7 @@
 		11B38EF5275C54A300205C7B /* GetCameraImageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DF8BC3221D047400370A59 /* GetCameraImageIntentHandler.swift */; };
 		11B38EF6275C54A300205C7B /* PickAServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2E7B227500DAD00CF144C /* PickAServerError.swift */; };
 		11B38EF7275C54A300205C7B /* UpdateSensorsIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B705A2526B1C500FEAA76 /* UpdateSensorsIntentHandler.swift */; };
-		11B38EF8275C54A300205C7B /* RoutingIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */; };
+		11B38EF8275C54A300205C7B /* IntentHandlerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B38EE1275C547A00205C7B /* IntentHandlerFactory.swift */; };
 		11B38EF9275C54A300205C7B /* RenderTemplateIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62817EF221D269B000BA86A /* RenderTemplateIntentHandler.swift */; };
 		11B38EFA275C54A300205C7B /* FocusStatusIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */; };
 		11B62DBE24F2EDD800E5CB55 /* EurekaCondition+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */; };
@@ -1381,7 +1381,7 @@
 		11AF4D2F249DCA87006C74C0 /* ConnectivitySensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivitySensor.test.swift; sourceTree = "<group>"; };
 		11B1FFC424CCD72F00F9BCB2 /* VoiceShortcutRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcutRow.swift; sourceTree = "<group>"; };
 		11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionInfo.test.swift; sourceTree = "<group>"; };
-		11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingIntentHandler.swift; sourceTree = "<group>"; };
+		11B38EE1275C547A00205C7B /* IntentHandlerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentHandlerFactory.swift; sourceTree = "<group>"; };
 		11B62DBD24F2EDD800E5CB55 /* EurekaCondition+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EurekaCondition+Additions.swift"; sourceTree = "<group>"; };
 		11B62DBF24F2F06100E5CB55 /* UIApplication+OpenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenSettings.swift"; sourceTree = "<group>"; };
 		11B7DBFB266BE7540090BD3B /* LocalPushEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushEvent.swift; sourceTree = "<group>"; };
@@ -2662,7 +2662,7 @@
 				115BC82A267704E300452430 /* FocusStatusIntentHandler.swift */,
 				115560E4270116AF00A8F818 /* OpenPageIntentHandler.swift */,
 				11F2E7B227500DAD00CF144C /* PickAServerError.swift */,
-				11B38EE1275C547A00205C7B /* RoutingIntentHandler.swift */,
+				11B38EE1275C547A00205C7B /* IntentHandlerFactory.swift */,
 			);
 			path = Intents;
 			sourceTree = "<group>";
@@ -5389,7 +5389,7 @@
 				11F2F25F25871D6000F61F7C /* NotificationAttachmentParserCamera.swift in Sources */,
 				11B7FD752493225200E60ED9 /* BackgroundTask.swift in Sources */,
 				B6A258462232485300ADD202 /* Alamofire+EncryptedResponses.swift in Sources */,
-				11B38EF8275C54A300205C7B /* RoutingIntentHandler.swift in Sources */,
+				11B38EF8275C54A300205C7B /* IntentHandlerFactory.swift in Sources */,
 				11AF4D23249C924B006C74C0 /* GeocoderSensor.swift in Sources */,
 				11C4629224B14E6B00031902 /* XCGLogger+UNNotification.swift in Sources */,
 				1182620224F9C3F7000795C6 /* HACoreBlahObject.swift in Sources */,
@@ -5582,7 +5582,7 @@
 				11C4629124B14E6B00031902 /* XCGLogger+UNNotification.swift in Sources */,
 				110ED56325A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				11AF4D16249C8083006C74C0 /* With.swift in Sources */,
-				11B38EEC275C54A200205C7B /* RoutingIntentHandler.swift in Sources */,
+				11B38EEC275C54A200205C7B /* IntentHandlerFactory.swift in Sources */,
 				1182620124F9C3F7000795C6 /* HACoreBlahObject.swift in Sources */,
 				B672333E225DB68B0031D629 /* WebSocketMessage.swift in Sources */,
 				11482AD62505CB6E00C48C58 /* HACoreAudioObjectDevice.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -716,7 +716,7 @@
 		B661FC7E226C87BB00E541DD /* home.json in Resources */ = {isa = PBXBuildFile; fileRef = B661FC7D226C87BB00E541DD /* home.json */; };
 		B661FC88226D478300E541DD /* OnboardingScanningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B661FC87226D478300E541DD /* OnboardingScanningViewController.swift */; };
 		B66C58A8215086F0004AB261 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C58A7215086F0004AB261 /* IntentHandler.swift */; };
-		B66C58AC215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66C58A5215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B66C58AC215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66C58A5215086F0004AB261 /* HomeAssistant-Extensions-Intents.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B66F9F24216B1E61000CAA0F /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B66F9F23216B1E61000CAA0F /* NotificationCenter.framework */; };
 		B66F9F27216B1E61000CAA0F /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66F9F26216B1E61000CAA0F /* TodayViewController.swift */; };
 		B66F9F2E216B1E61000CAA0F /* HomeAssistant-Extensions-Today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B66F9F22216B1E61000CAA0F /* HomeAssistant-Extensions-Today.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -5861,7 +5861,6 @@
 		};
 		B66C58AB215086F0004AB261 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
 			target = B66C58A4215086F0004AB261 /* Extensions-Intents */;
 			targetProxy = B66C58AA215086F0004AB261 /* PBXContainerItemProxy */;
 		};

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -12,6 +12,7 @@ import SafariServices
 import Shared
 import UIKit
 import XCGLogger
+import Intents
 
 let keychain = Constants.Keychain
 
@@ -369,6 +370,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Current.Log.error("couldn't find appropriate session for for \(identifier)")
             completionHandler()
         }
+    }
+
+    func application(_ application: UIApplication, handlerFor intent: INIntent) -> Any? {
+        RoutingIntentHandler.handler(for: intent)
     }
 
     // MARK: - Private helpers

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -3,6 +3,7 @@ import CallbackURLKit
 import Communicator
 import FirebaseCore
 import FirebaseMessaging
+import Intents
 import KeychainAccess
 import MBProgressHUD
 import ObjectMapper
@@ -12,7 +13,6 @@ import SafariServices
 import Shared
 import UIKit
 import XCGLogger
-import Intents
 
 let keychain = Constants.Keychain
 

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -374,7 +374,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, handlerFor intent: INIntent) -> Any? {
         if #available(iOS 13, *) {
-            return RoutingIntentHandler.handler(for: intent)
+            return IntentHandlerFactory.handler(for: intent)
         } else {
             return nil
         }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -373,7 +373,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, handlerFor intent: INIntent) -> Any? {
-        RoutingIntentHandler.handler(for: intent)
+        if #available(iOS 13, *) {
+            return RoutingIntentHandler.handler(for: intent)
+        } else {
+            return nil
+        }
     }
 
     // MARK: - Private helpers

--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -554,6 +554,20 @@
 	<false/>
 	<key>FirebaseMessagingAutoInitEnabled</key>
 	<false/>
+	<key>INIntentsSupported</key>
+	<array>
+		<string>CallServiceIntent</string>
+		<string>FireEventIntent</string>
+		<string>GetCameraImageIntent</string>
+		<string>OpenPageIntent</string>
+		<string>PerformActionIntent</string>
+		<string>RenderTemplateIntent</string>
+		<string>SendLocationIntent</string>
+		<string>UpdateSensorsIntent</string>
+		<string>WidgetActionsIntent</string>
+		<string>WidgetOpenPageIntent</string>
+		<string>INShareFocusStatusIntent</string>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -566,7 +566,6 @@
 		<string>UpdateSensorsIntent</string>
 		<string>WidgetActionsIntent</string>
 		<string>WidgetOpenPageIntent</string>
-		<string>INShareFocusStatusIntent</string>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/Sources/Extensions/Intents/IntentHandler.swift
+++ b/Sources/Extensions/Intents/IntentHandler.swift
@@ -3,41 +3,6 @@ import Shared
 
 class IntentHandler: INExtension {
     override func handler(for intent: INIntent) -> Any {
-        let handler: Any = {
-            if intent is FireEventIntent {
-                return FireEventIntentHandler()
-            }
-            if intent is CallServiceIntent {
-                return CallServiceIntentHandler()
-            }
-            if intent is SendLocationIntent {
-                return SendLocationIntentHandler()
-            }
-            if intent is GetCameraImageIntent {
-                return GetCameraImageIntentHandler()
-            }
-            if intent is RenderTemplateIntent {
-                return RenderTemplateIntentHandler()
-            }
-            if intent is PerformActionIntent {
-                return PerformActionIntentHandler()
-            }
-            if intent is UpdateSensorsIntent {
-                return UpdateSensorsIntentHandler()
-            }
-            if intent is OpenPageIntent || intent is WidgetOpenPageIntent {
-                return OpenPageIntentHandler()
-            }
-            if #available(iOS 15, *), intent is INShareFocusStatusIntent {
-                return FocusStatusIntentHandler()
-            }
-            if #available(iOS 14, *), intent is WidgetActionsIntent {
-                return WidgetActionsIntentHandler()
-            }
-            return self
-        }()
-
-        Current.Log.info("for \(intent) found handler \(handler)")
-        return handler
+        RoutingIntentHandler.handler(for: intent)
     }
 }

--- a/Sources/Extensions/Intents/IntentHandler.swift
+++ b/Sources/Extensions/Intents/IntentHandler.swift
@@ -3,6 +3,6 @@ import Shared
 
 class IntentHandler: INExtension {
     override func handler(for intent: INIntent) -> Any {
-        RoutingIntentHandler.handler(for: intent)
+        IntentHandlerFactory.handler(for: intent)
     }
 }

--- a/Sources/Extensions/Intents/Resources/Info.plist
+++ b/Sources/Extensions/Intents/Resources/Info.plist
@@ -45,6 +45,7 @@
 				<string>UpdateSensorsIntent</string>
 				<string>WidgetActionsIntent</string>
 				<string>WidgetOpenPageIntent</string>
+				<string>INShareFocusStatusIntent</string>
 			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -760,7 +760,7 @@ public class HomeAssistantAPI {
                 shouldIncludeNilValues: false
             )
             return (sensorResponse, mapper.toJSONArray(sensorResponse.sensors))
-        }.then { [server] sensorResponse, payload -> Promise<Void> in
+        }.then { [server] _, payload -> Promise<Void> in
             if payload.isEmpty {
                 Current.Log.info("skipping network request for unchanged sensor update")
                 return .value(())

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -738,9 +738,18 @@ public class HomeAssistantAPI {
         trigger: LocationUpdateTrigger,
         location: CLLocation? = nil
     ) -> Promise<Void> {
+        UpdateSensors(trigger: trigger, limitedTo: nil, location: location)
+    }
+
+    internal func UpdateSensors(
+        trigger: LocationUpdateTrigger,
+        limitedTo: [SensorProvider.Type]?,
+        location: CLLocation? = nil
+    ) -> Promise<Void> {
         firstly {
             Current.sensors.sensors(
                 reason: .trigger(trigger.rawValue),
+                limitedTo: limitedTo,
                 location: location,
                 serverVersion: server.info.version
             )

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -761,19 +761,15 @@ public class HomeAssistantAPI {
             )
             return (sensorResponse, mapper.toJSONArray(sensorResponse.sensors))
         }.then { [server] sensorResponse, payload -> Promise<Void> in
-            firstly { () -> Promise<Void> in
-                if payload.isEmpty {
-                    Current.Log.info("skipping network request for unchanged sensor update")
-                    return .value(())
-                } else {
-                    return Current.webhooks.send(
-                        identifier: .updateSensors,
-                        server: server,
-                        request: .init(type: "update_sensor_states", data: payload)
-                    )
-                }
-            }.done {
-                sensorResponse.didPersist()
+            if payload.isEmpty {
+                Current.Log.info("skipping network request for unchanged sensor update")
+                return .value(())
+            } else {
+                return Current.webhooks.send(
+                    identifier: .updateSensors,
+                    server: server,
+                    request: .init(type: "update_sensor_states", data: payload)
+                )
             }
         }
     }

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -194,6 +194,7 @@ public class SensorContainer {
 
     internal func sensors(
         reason: SensorProviderRequest.Reason,
+        limitedTo: [SensorProvider.Type]? = nil,
         location: CLLocation? = nil,
         serverVersion: Version
     ) -> Guarantee<SensorResponse> {
@@ -206,6 +207,13 @@ public class SensorContainer {
 
         let generatedSensors = firstly {
             let promises = providers
+                .filter { providerType in
+                    if let limitedTo = limitedTo {
+                        return limitedTo.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(providerType) })
+                    } else {
+                        return true
+                    }
+                }
                 .map { providerType in providerType.init(request: request) }
                 .map { provider in provider.sensors().map { ($0, provider) } }
 

--- a/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
+++ b/Sources/Shared/Common/SiriIntents+ConvenienceInits.swift
@@ -126,7 +126,7 @@ public extension WidgetActionsIntent {
     static let widgetKind = "WidgetActions"
 }
 
-@available(iOS 13, watchOS 7, *)
+@available(iOS 13, watchOS 6, *)
 public extension IntentPanel {
     convenience init(panel: HAPanel, server: Server) {
         let image: INImage?
@@ -145,7 +145,7 @@ public extension IntentPanel {
         image = nil
         #endif
 
-        if #available(iOS 14, *) {
+        if #available(iOS 14, watchOS 7, *) {
             self.init(
                 identifier: panel.path,
                 display: panel.title,

--- a/Sources/Shared/Intents/CallServiceIntentHandler.swift
+++ b/Sources/Shared/Intents/CallServiceIntentHandler.swift
@@ -4,6 +4,7 @@ import Intents
 import PromiseKit
 import UIKit
 
+@available(iOS 13, watchOS 6, *)
 class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
     typealias Intent = CallServiceIntent
 
@@ -62,7 +63,7 @@ class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
         .catch { completion(nil, $0) }
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     func provideServiceOptionsCollection(
         for intent: Intent,
         with completion: @escaping (INObjectCollection<NSString>?, Error?) -> Void

--- a/Sources/Shared/Intents/CallServiceIntentHandler.swift
+++ b/Sources/Shared/Intents/CallServiceIntentHandler.swift
@@ -2,7 +2,6 @@ import Foundation
 import HAKit
 import Intents
 import PromiseKit
-import Shared
 import UIKit
 
 class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {

--- a/Sources/Shared/Intents/FireEventIntentHandler.swift
+++ b/Sources/Shared/Intents/FireEventIntentHandler.swift
@@ -3,6 +3,7 @@ import Intents
 import PromiseKit
 import UIKit
 
+@available(iOS 13, watchOS 6, *)
 class FireEventIntentHandler: NSObject, FireEventIntentHandling {
     typealias Intent = FireEventIntent
 

--- a/Sources/Shared/Intents/FireEventIntentHandler.swift
+++ b/Sources/Shared/Intents/FireEventIntentHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 import UIKit
 
 class FireEventIntentHandler: NSObject, FireEventIntentHandling {

--- a/Sources/Shared/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Shared/Intents/FocusStatusIntentHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 
 @available(iOS 15, *)
 class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {

--- a/Sources/Shared/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Shared/Intents/FocusStatusIntentHandler.swift
@@ -9,8 +9,16 @@ class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
         Current.focusStatus.update(fromReceived: currentState)
         Current.Log.info("starting, status from intent is \(String(describing: currentState)) from \(intent)")
 
+        let limitedTo: [SensorProvider.Type]?
+
+        if Current.isCatalyst {
+            limitedTo = [FocusSensor.self]
+        } else {
+            limitedTo = nil
+        }
+
         when(fulfilled: Current.apis.map {
-            $0.UpdateSensors(trigger: .Siri)
+            $0.UpdateSensors(trigger: .Siri, limitedTo: limitedTo)
         }).done {
             Current.Log.info("finished successfully")
             completion(.init(code: .success, userActivity: nil))

--- a/Sources/Shared/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Shared/Intents/FocusStatusIntentHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 import Intents
 import PromiseKit
 
-@available(iOS 15, *)
+@available(iOS 15, watchOS 8, *)
 class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
     func handle(intent: INShareFocusStatusIntent, completion: @escaping (INShareFocusStatusIntentResponse) -> Void) {
         let currentState = intent.focusStatus

--- a/Sources/Shared/Intents/GetCameraImageIntentHandler.swift
+++ b/Sources/Shared/Intents/GetCameraImageIntentHandler.swift
@@ -4,6 +4,7 @@ import MobileCoreServices
 import PromiseKit
 import UIKit
 
+@available(iOS 13, watchOS 6, *)
 class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
     typealias Intent = GetCameraImageIntent
 
@@ -57,7 +58,7 @@ class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {
             .catch { completion(nil, $0) }
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     func provideCameraIDOptionsCollection(
         for intent: Intent,
         with completion: @escaping (INObjectCollection<NSString>?, Error?) -> Void

--- a/Sources/Shared/Intents/GetCameraImageIntentHandler.swift
+++ b/Sources/Shared/Intents/GetCameraImageIntentHandler.swift
@@ -2,7 +2,6 @@ import Foundation
 import Intents
 import MobileCoreServices
 import PromiseKit
-import Shared
 import UIKit
 
 class GetCameraImageIntentHandler: NSObject, GetCameraImageIntentHandling {

--- a/Sources/Shared/Intents/IntentHandlerFactory.swift
+++ b/Sources/Shared/Intents/IntentHandlerFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import Intents
 
 @available(iOS 13, watchOS 6, *)
-public class IntentHandlerFactory {
+public enum IntentHandlerFactory {
     public static func handler(for intent: INIntent) -> Any {
         let handler: Any = {
             if intent is FireEventIntent {

--- a/Sources/Shared/Intents/IntentHandlerFactory.swift
+++ b/Sources/Shared/Intents/IntentHandlerFactory.swift
@@ -2,7 +2,7 @@ import Foundation
 import Intents
 
 @available(iOS 13, watchOS 6, *)
-public class RoutingIntentHandler {
+public class IntentHandlerFactory {
     public static func handler(for intent: INIntent) -> Any {
         let handler: Any = {
             if intent is FireEventIntent {

--- a/Sources/Shared/Intents/OpenPageIntentHandler.swift
+++ b/Sources/Shared/Intents/OpenPageIntentHandler.swift
@@ -1,6 +1,5 @@
 import Intents
 import PromiseKit
-import Shared
 
 class OpenPageIntentHandler: NSObject, OpenPageIntentHandling, WidgetOpenPageIntentHandling {
     private func panelsByServer() -> Promise<[(Server, [IntentPanel])]> {

--- a/Sources/Shared/Intents/OpenPageIntentHandler.swift
+++ b/Sources/Shared/Intents/OpenPageIntentHandler.swift
@@ -1,6 +1,7 @@
 import Intents
 import PromiseKit
 
+@available(iOS 13, watchOS 6, *)
 class OpenPageIntentHandler: NSObject, OpenPageIntentHandling, WidgetOpenPageIntentHandling {
     private func panelsByServer() -> Promise<[(Server, [IntentPanel])]> {
         when(resolved: Current.apis.map { api in
@@ -15,7 +16,7 @@ class OpenPageIntentHandler: NSObject, OpenPageIntentHandling, WidgetOpenPageInt
         }
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     private func panelsIntentCollection() -> Promise<INObjectCollection<IntentPanel>> {
         panelsByServer().map { panelsByServer in
             .init(sections: panelsByServer.map { server, panels in
@@ -30,7 +31,7 @@ class OpenPageIntentHandler: NSObject, OpenPageIntentHandling, WidgetOpenPageInt
         }
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     func providePagesOptionsCollection(
         for intent: WidgetOpenPageIntent,
         with completion: @escaping (INObjectCollection<IntentPanel>?, Error?) -> Void
@@ -38,7 +39,7 @@ class OpenPageIntentHandler: NSObject, OpenPageIntentHandling, WidgetOpenPageInt
         panelsIntentCollection().done { completion($0, nil) }.catch { completion(nil, $0) }
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     func providePageOptionsCollection(
         for intent: OpenPageIntent,
         with completion: @escaping (INObjectCollection<IntentPanel>?, Error?) -> Void

--- a/Sources/Shared/Intents/PerformActionIntentHandler.swift
+++ b/Sources/Shared/Intents/PerformActionIntentHandler.swift
@@ -2,6 +2,7 @@ import Foundation
 import Intents
 import PromiseKit
 
+@available(iOS 13, watchOS 6, *)
 class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
     func handle(
         intent: PerformActionIntent,
@@ -53,7 +54,7 @@ class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
         completion(Array(performActions), nil)
     }
 
-    @available(iOS 14, *)
+    @available(iOS 14, watchOS 7, *)
     func provideActionOptionsCollection(
         for intent: PerformActionIntent,
         with completion: @escaping (INObjectCollection<IntentAction>?, Error?) -> Void

--- a/Sources/Shared/Intents/PerformActionIntentHandler.swift
+++ b/Sources/Shared/Intents/PerformActionIntentHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 
 class PerformActionIntentHandler: NSObject, PerformActionIntentHandling {
     func handle(

--- a/Sources/Shared/Intents/PickAServerError.swift
+++ b/Sources/Shared/Intents/PickAServerError.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Shared
 
 enum PickAServerError {
     // NSError because LocalizedError doesn't send messages through

--- a/Sources/Shared/Intents/RenderTemplateIntentHandler.swift
+++ b/Sources/Shared/Intents/RenderTemplateIntentHandler.swift
@@ -3,6 +3,7 @@ import Intents
 import PromiseKit
 import UIKit
 
+@available(iOS 13, watchOS 6, *)
 class RenderTemplateIntentHandler: NSObject, RenderTemplateIntentHandling {
     typealias Intent = RenderTemplateIntent
 

--- a/Sources/Shared/Intents/RenderTemplateIntentHandler.swift
+++ b/Sources/Shared/Intents/RenderTemplateIntentHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 import UIKit
 
 class RenderTemplateIntentHandler: NSObject, RenderTemplateIntentHandling {

--- a/Sources/Shared/Intents/RoutingIntentHandler.swift
+++ b/Sources/Shared/Intents/RoutingIntentHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Intents
 
+@available(iOS 13, watchOS 6, *)
 public class RoutingIntentHandler {
     public static func handler(for intent: INIntent) -> Any {
         let handler: Any = {

--- a/Sources/Shared/Intents/RoutingIntentHandler.swift
+++ b/Sources/Shared/Intents/RoutingIntentHandler.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Intents
+
+public class RoutingIntentHandler {
+    public static func handler(for intent: INIntent) -> Any {
+        let handler: Any = {
+            if intent is FireEventIntent {
+                return FireEventIntentHandler()
+            }
+            if intent is CallServiceIntent {
+                return CallServiceIntentHandler()
+            }
+            if intent is SendLocationIntent {
+                return SendLocationIntentHandler()
+            }
+            if intent is GetCameraImageIntent {
+                return GetCameraImageIntentHandler()
+            }
+            if intent is RenderTemplateIntent {
+                return RenderTemplateIntentHandler()
+            }
+            if intent is PerformActionIntent {
+                return PerformActionIntentHandler()
+            }
+            if intent is UpdateSensorsIntent {
+                return UpdateSensorsIntentHandler()
+            }
+            if intent is OpenPageIntent || intent is WidgetOpenPageIntent {
+                return OpenPageIntentHandler()
+            }
+            if #available(iOS 15, watchOS 8, *), intent is INShareFocusStatusIntent {
+                return FocusStatusIntentHandler()
+            }
+            if #available(iOS 14, watchOS 7, *), intent is WidgetActionsIntent {
+                return WidgetActionsIntentHandler()
+            }
+            return self
+        }()
+
+        Current.Log.info("for \(intent) found handler \(handler)")
+        return handler
+    }
+}

--- a/Sources/Shared/Intents/SendLocationIntentHandler.swift
+++ b/Sources/Shared/Intents/SendLocationIntentHandler.swift
@@ -2,7 +2,6 @@ import CoreLocation
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 import UIKit
 
 class SendLocationIntentHandler: NSObject, SendLocationIntentHandling {

--- a/Sources/Shared/Intents/SendLocationIntentHandler.swift
+++ b/Sources/Shared/Intents/SendLocationIntentHandler.swift
@@ -4,6 +4,7 @@ import Intents
 import PromiseKit
 import UIKit
 
+@available(iOS 13, watchOS 6, *)
 class SendLocationIntentHandler: NSObject, SendLocationIntentHandling {
     func resolveLocation(
         for intent: SendLocationIntent,

--- a/Sources/Shared/Intents/UpdateSensorsIntentHandler.swift
+++ b/Sources/Shared/Intents/UpdateSensorsIntentHandler.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PromiseKit
-import Shared
 
 class UpdateSensorsIntentHandler: NSObject, UpdateSensorsIntentHandling {
     func handle(intent: UpdateSensorsIntent, completion: @escaping (UpdateSensorsIntentResponse) -> Void) {

--- a/Sources/Shared/Intents/UpdateSensorsIntentHandler.swift
+++ b/Sources/Shared/Intents/UpdateSensorsIntentHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PromiseKit
 
+@available(iOS 13, watchOS 6, *)
 class UpdateSensorsIntentHandler: NSObject, UpdateSensorsIntentHandling {
     func handle(intent: UpdateSensorsIntent, completion: @escaping (UpdateSensorsIntentResponse) -> Void) {
         Current.Log.info("starting")

--- a/Sources/Shared/Intents/WidgetActionsIntentHandler.swift
+++ b/Sources/Shared/Intents/WidgetActionsIntentHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 import Intents
 import PromiseKit
 
-@available(iOS 14, *)
+@available(iOS 14, watchOS 7, *)
 class WidgetActionsIntentHandler: NSObject, WidgetActionsIntentHandling {
     func provideActionsOptionsCollection(
         for intent: WidgetActionsIntent,

--- a/Sources/Shared/Intents/WidgetActionsIntentHandler.swift
+++ b/Sources/Shared/Intents/WidgetActionsIntentHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Intents
 import PromiseKit
-import Shared
 
 @available(iOS 14, *)
 class WidgetActionsIntentHandler: NSObject, WidgetActionsIntentHandling {

--- a/Tests/Shared/Sensors/SensorContainer.test.swift
+++ b/Tests/Shared/Sensors/SensorContainer.test.swift
@@ -106,8 +106,6 @@ class SensorContainerTests: XCTestCase {
             "test1a", "test1b",
         ]))
 
-        result1.didPersist()
-
         container.register(observer: observer)
         XCTAssertEqual(observer.updates.count, 1)
         if let update = observer.updates.first {
@@ -257,7 +255,6 @@ class SensorContainerTests: XCTestCase {
             "test1a", "test1b", "test2a", "test2b",
         ]))
 
-        // don't notify about the persisting, it should stay the same
         MockSensorProvider.returnedPromises = initialValues
         promise = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
         result = try hang(Promise(promise))
@@ -265,14 +262,7 @@ class SensorContainerTests: XCTestCase {
             "test1a", "test1b", "test2a", "test2b",
         ]))
 
-        // notify, try the same values, nothing should come through
-        result.didPersist()
-        MockSensorProvider.returnedPromises = initialValues
-        promise = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        result = try hang(Promise(promise))
-        XCTAssertTrue(result.sensors.isEmpty)
-
-        // now try a couple changed things, only those should come through
+        // now try a couple changed things
         MockSensorProvider.returnedPromises = [
             .value([
                 WebhookSensor(name: "test1a", uniqueID: "test1a"),
@@ -288,11 +278,8 @@ class SensorContainerTests: XCTestCase {
         promise = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
         result = try hang(Promise(promise))
         XCTAssertEqual(Set(result.sensors.map(\.UniqueID)), Set([
-            "test1b", "test2c",
+            "test1a", "test1b", "test2a", "test2b", "test2c",
         ]))
-
-        // persist again and try again
-        result.didPersist()
 
         // now return nothing, should get nothing
         MockSensorProvider.returnedPromises = [.value([]), .value([])]
@@ -311,195 +298,6 @@ class SensorContainerTests: XCTestCase {
                 "test1a", "test1b", "test2a", "test2b", "test2c",
             ]))
         }
-    }
-
-    func testOutOfOrderCachingValues() throws {
-        container.register(provider: MockSensorProvider.self)
-        container.register(provider: MockSensorProvider.self)
-
-        MockSensorProvider.returnedPromises = [
-            .value([
-                WebhookSensor(name: "test1a", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b", uniqueID: "test1b"),
-                WebhookSensor(name: "test1c", uniqueID: "test1c"), // only in first and last one
-            ]),
-            .value([
-                WebhookSensor(name: "test2a", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b", uniqueID: "test2b"),
-            ]),
-        ]
-
-        let promise1 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result1 = try hang(Promise(promise1))
-        XCTAssertEqual(Set(result1.sensors.map(\.Name)), Set([
-            "test1a", "test1b", "test1c", "test2a", "test2b",
-        ]))
-
-        let updatedValues: [Promise<[WebhookSensor]>] = [
-            .value([
-                WebhookSensor(name: "test1a_mod", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b_mod", uniqueID: "test1b"),
-            ]),
-            .value([
-                WebhookSensor(name: "test2a_mod", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b_mod", uniqueID: "test2b"),
-            ]),
-        ]
-
-        MockSensorProvider.returnedPromises = updatedValues
-
-        let promise2 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result2 = try hang(Promise(promise2))
-        XCTAssertEqual(Set(result2.sensors.map(\.Name)), Set([
-            "test1a_mod", "test1b_mod", "test2a_mod", "test2b_mod",
-        ]))
-
-        // complete the later one first
-        result2.didPersist()
-        // this should _not_ override the 'last persisted' from the newer one
-        result1.didPersist()
-
-        MockSensorProvider.returnedPromises = updatedValues
-
-        let promise3 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result3 = try hang(Promise(promise3))
-        // we have to assume result1 cleared away what we sent up, so the new values should be the same
-        XCTAssertEqual(Set(result3.sensors.map(\.Name)), Set([
-            "test1a_mod", "test1b_mod", "test2a_mod", "test2b_mod",
-        ]))
-
-        container.register(observer: observer)
-        XCTAssertFalse(observer.updates.isEmpty)
-
-        if let last = observer.updates.last?.sensors {
-            let observerResult = try hang(Promise(last))
-            XCTAssertEqual(Set(observerResult.map(\.Name)), Set([
-                "test1a_mod", "test1b_mod", "test1c", "test2a_mod", "test2b_mod",
-            ]))
-        }
-
-        result3.didPersist()
-
-        MockSensorProvider.returnedPromises = [
-            .value([
-                WebhookSensor(name: "test1a_mod", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b_mod", uniqueID: "test1b"),
-                WebhookSensor(name: "test1c", uniqueID: "test1c"), // only in first and last one
-            ]),
-            .value([
-                WebhookSensor(name: "test2a_mod", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b_mod", uniqueID: "test2b"),
-            ]),
-        ]
-
-        let promise4 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result4 = try hang(Promise(promise4))
-        // this time we expect nothing new to go up, including the unique one from result1
-        XCTAssertTrue(result4.sensors.isEmpty)
-    }
-
-    func testChangedFailsButSilentlySucceeded() throws {
-        container.register(provider: MockSensorProvider.self)
-        container.register(provider: MockSensorProvider.self)
-
-        MockSensorProvider.returnedPromises = [
-            .value([
-                WebhookSensor(name: "test1a", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b", uniqueID: "test1b"),
-            ]),
-            .value([
-                WebhookSensor(name: "test2a", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b", uniqueID: "test2b"),
-            ]),
-        ]
-
-        let promise1 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result1 = try hang(Promise(promise1))
-        XCTAssertEqual(Set(result1.sensors.map(\.Name)), Set([
-            "test1a", "test1b", "test2a", "test2b",
-        ]))
-
-        result1.didPersist()
-
-        MockSensorProvider.returnedPromises = [
-            .value([
-                WebhookSensor(name: "test1a_mod", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b", uniqueID: "test1b"),
-            ]),
-            .value([
-                WebhookSensor(name: "test2a", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b", uniqueID: "test2b"),
-            ]),
-        ]
-
-        let promise2 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result2 = try hang(Promise(promise2))
-        XCTAssertEqual(Set(result2.sensors.map(\.Name)), Set([
-            "test1a_mod",
-        ]))
-
-        // not persisting -- this is e.g. an error case, but the error was silently successful
-        // the act of trying to mutate a sensor is going to cause it to need to be re-sent
-
-        MockSensorProvider.returnedPromises = [
-            .value([
-                WebhookSensor(name: "test1a", uniqueID: "test1a"),
-                WebhookSensor(name: "test1b", uniqueID: "test1b"),
-            ]),
-            .value([
-                WebhookSensor(name: "test2a", uniqueID: "test2a"),
-                WebhookSensor(name: "test2b", uniqueID: "test2b"),
-            ]),
-        ]
-
-        let promise3 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result3 = try hang(Promise(promise3))
-        XCTAssertEqual(Set(result3.sensors.map(\.Name)), Set([
-            "test1a",
-        ]))
-    }
-
-    func testTransientSensorExposedToObservers() throws {
-        container.register(provider: MockSensorProvider.self)
-
-        MockSensorProvider.returnedPromises = [.value([
-            WebhookSensor(name: "available", uniqueID: "available"),
-            WebhookSensor(name: "transient", uniqueID: "transient"),
-        ])]
-        let promise1 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result1 = try hang(Promise(promise1))
-        XCTAssertEqual(Set(result1.sensors.map(\.Name)), Set([
-            "available", "transient",
-        ]))
-
-        result1.didPersist()
-
-        MockSensorProvider.returnedPromises = [.value([
-            WebhookSensor(name: "available", uniqueID: "available"),
-            WebhookSensor(name: "transient_changed", uniqueID: "transient"),
-        ])]
-        let promise2 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result2 = try hang(Promise(promise2))
-        XCTAssertEqual(Set(result2.sensors.map(\.Name)), Set([
-            "transient_changed",
-        ]))
-
-        // not persisting 2 here
-
-        MockSensorProvider.returnedPromises = [.value([
-            WebhookSensor(name: "available", uniqueID: "available"),
-        ])]
-        let promise3 = container.sensors(reason: .trigger("unit-test"), serverVersion: Version())
-        let result3 = try hang(Promise(promise3))
-        XCTAssertEqual(Set(result3.sensors.map(\.Name)), Set([]))
-
-        container.register(observer: observer)
-        XCTAssertEqual(observer.updates.count, 1)
-        let observerSensors = try hang(Promise(XCTUnwrap(observer.updates.last).sensors))
-        XCTAssertEqual(observerSensors.map(\.Name), [
-            // 'transient' being missing here means that we lost some previous state that was known to be valid
-            "available", "transient",
-        ])
     }
 
     func testDisabledSensorRedacted() throws {
@@ -533,6 +331,25 @@ class SensorContainerTests: XCTestCase {
         let result2 = try hang(Promise(promise2))
         let result2sensor = try XCTUnwrap(result2.sensors.first)
         XCTAssertEqual(result2sensor, underlying)
+    }
+
+    func testSensorsLimitedTo() throws {
+        container.register(provider: MockSensorProvider.self)
+        container.register(provider: MockSensorProviderLimitedTo.self)
+
+        let expected = WebhookSensor(name: "included", uniqueID: "included")
+        let promises: [Promise<[WebhookSensor]>] = [.value([expected])]
+
+        MockSensorProvider.returnedPromises = promises
+
+        let promise = container.sensors(
+            reason: .registration,
+            limitedTo: [MockSensorProvider.self],
+            location: nil,
+            serverVersion: Version()
+        )
+        let result = try hang(Promise(promise))
+        XCTAssertEqual(Set(result.sensors.map(\.UniqueID)), Set(["included"]))
     }
 }
 
@@ -576,6 +393,17 @@ private class MockSensorProvider: SensorProvider {
 
     func sensors() -> Promise<[WebhookSensor]> {
         returnedPromise
+    }
+}
+
+private class MockSensorProviderLimitedTo: SensorProvider {
+    required init(request: SensorProviderRequest) {
+        //
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        XCTFail("expected to not be called")
+        return .value([])
     }
 }
 


### PR DESCRIPTION
- Stops caching of sensor values and now sends them to the server regardless if we think they have changed. Fixes #1473. The sensor container was (a) prone to issues (as it could not fully capture network semantics) and (b) not updated for multi-server support.
- Moves all intent handling that I can into the app for iOS 14+ / macOS 11+. The only intent that must be in the extension is the focus intent, which now strictly updates just the focus sensor on macOS, since it did not have access to all sensor values. Fixes #1921.