### PR TITLE
Fix avatar showing a black line on some edges

### DIFF
--- a/Sources/App/Settings/Eureka/AccountInitialsImage.swift
+++ b/Sources/App/Settings/Eureka/AccountInitialsImage.swift
@@ -18,7 +18,7 @@ enum AccountInitialsImage {
     }
 
     static var defaultSize: CGSize {
-        let height = min(64, UIFont.preferredFont(forTextStyle: .body).lineHeight * 2.0)
+        let height = ceil(min(64, UIFont.preferredFont(forTextStyle: .body).lineHeight * 2.0))
         return CGSize(width: height, height: height)
     }
 


### PR DESCRIPTION
## Summary
The images were being draw at something like `40.53x40.53` which, unsurprisingly, can cause some aliasing issues.

## Screenshots
| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-05 at 15 02 27](https://user-images.githubusercontent.com/74188/144767927-d5812c04-f380-4ffe-8f35-bc675d5868c9.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-05 at 15 01 59](https://user-images.githubusercontent.com/74188/144767925-7d58be25-9d85-4354-aa78-fda2413e5455.png) |

## Any other notes
This depends on the image contents or dynamic type font setting whether this reproduces.