### PR TITLE
Add deprecation alert for notification categories

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -33,6 +33,9 @@
 "alerts.auth_required.title" = "You must sign in to continue";
 "alerts.confirm.cancel" = "Cancel";
 "alerts.confirm.ok" = "OK";
+/* value filled in will be like iOS-2021.2 */
+"alerts.deprecations.notification_category.message" = "You must migrate to actions defined in the notification itself before %1$@.";
+"alerts.deprecations.notification_category.title" = "Notification Categories are deprecated";
 "alerts.open_url_from_deep_link.message" = "Open URL (%@) from deep link?";
 "alerts.open_url_from_notification.message" = "Open URL (%@) found in notification?";
 "alerts.open_url_from_notification.title" = "Open URL?";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -180,6 +180,16 @@ public enum L10n {
       /// OK
       public static var ok: String { return L10n.tr("Localizable", "alerts.confirm.ok") }
     }
+    public enum Deprecations {
+      public enum NotificationCategory {
+        /// You must migrate to actions defined in the notification itself before %1$@.
+        public static func message(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "alerts.deprecations.notification_category.message", String(describing: p1))
+        }
+        /// Notification Categories are deprecated
+        public static var title: String { return L10n.tr("Localizable", "alerts.deprecations.notification_category.title") }
+      }
+    }
     public enum OpenUrlFromDeepLink {
       /// Open URL (%@) from deep link?
       public static func message(_ p1: Any) -> String {


### PR DESCRIPTION
## Summary
Alerts if there are any notification categories (local or synced) if the user is an admin on any of their servers.

The configuration is marked as deprecated in home-assistant/core#61078 and will produce warnings until it's removed from there as well.

## Screenshots
| Light | Dark |
| ----- | ---- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-05 at 22 32 20](https://user-images.githubusercontent.com/74188/144798997-e105d578-535b-45fd-a7aa-3679ba0b5949.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-05 at 22 32 21](https://user-images.githubusercontent.com/74188/144799004-6139960c-e07c-4613-b992-8a4282aa6b4b.png) |

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
