### PR TITLE
Fix complications not updating in 2021.12

### DIFF
--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -94,6 +94,7 @@ public class WatchComplication: Object, ImmutableMappable {
         self.identifier = try map.value("identifier")
         self.name = try map.value("name")
         self.IsPublic = try map.value("IsPublic")
+        self.serverIdentifier = try map.value("serverIdentifier")
     }
 
     public func mapping(map: ObjectMapper.Map) {
@@ -104,6 +105,7 @@ public class WatchComplication: Object, ImmutableMappable {
         identifier >>> map["identifier"]
         name >>> map["name"]
         IsPublic >>> map["IsPublic"]
+        serverIdentifier >>> map["serverIdentifier"]
     }
 
     enum RenderedValueType: Hashable {


### PR DESCRIPTION
Fixes #1955.

## Summary
We were not updating any complications watch-side, so any updates exclusively came from the iOS app's updating them.

## Any other notes
Complications weren't syncing over to the watch with their serverIdentifier value set, so when we went to update none of the API instances thought their server had any complications needing updating.
