### PR TITLE
Reconnect if the WebView WebSocket connection is likely disconnected

### DIFF
--- a/Sources/Shared/API/WebSocket/WebSocketMessage.swift
+++ b/Sources/Shared/API/WebSocket/WebSocketMessage.swift
@@ -8,6 +8,7 @@ public class WebSocketMessage: Codable {
     public var Result: [String: Any]?
     public var Message: String?
     public var HAVersion: String?
+    public var command: String?
 
     private enum CodingKeys: String, CodingKey {
         case MessageType = "type"
@@ -17,6 +18,7 @@ public class WebSocketMessage: Codable {
         case Result = "result"
         case Message = "message"
         case HAVersion = "ha_version"
+        case command = "command"
     }
 
     public required init(from decoder: Decoder) throws {
@@ -28,6 +30,7 @@ public class WebSocketMessage: Codable {
         self.Result = try? values.decode([String: Any].self, forKey: .Result)
         self.Message = try? values.decode(String.self, forKey: .Message)
         self.HAVersion = try? values.decode(String.self, forKey: .HAVersion)
+        self.command = try values.decodeIfPresent(String.self, forKey: .command)
     }
 
     public init?(_ dictionary: [String: Any]) {
@@ -39,6 +42,7 @@ public class WebSocketMessage: Codable {
         self.Payload = dictionary["payload"] as? [String: Any]
         self.Result = dictionary["result"] as? [String: Any]
         self.Success = dictionary["success"] as? Bool
+        self.command = dictionary["command"] as? String
     }
 
     public init(_ incomingMessage: WebSocketMessage, _ result: [String: Any]) {
@@ -46,6 +50,7 @@ public class WebSocketMessage: Codable {
         self.MessageType = "result"
         self.Result = result
         self.Success = true
+        self.command = nil
     }
 
     public init(id: Int, type: String, result: [String: Any], success: Bool = true) {
@@ -53,6 +58,13 @@ public class WebSocketMessage: Codable {
         self.MessageType = type
         self.Result = result
         self.Success = success
+        self.command = nil
+    }
+
+    public init(command: String) {
+        self.ID = -1
+        self.MessageType = "command"
+        self.command = command
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -70,6 +82,7 @@ public class WebSocketMessage: Codable {
         if let Result = Result {
             try container.encode(Result, forKey: .Result)
         }
+        try container.encodeIfPresent(command, forKey: .command)
     }
 
     init(_ messageType: String) {

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -144,4 +144,5 @@ public extension Version {
     static var tagPlatformTrigger: Version = .init(minor: 115, prerelease: "any0")
     static var actionSyncing: Version = .init(minor: 115, prerelease: "any0")
     static var localPushConfirm: Version = .init(major: 2021, minor: 10, prerelease: "any0")
+    static var externalBusCommandRestart: Version = .init(major: 2021, minor: 12, prerelease: "b6")
 }


### PR DESCRIPTION
Fixes #1801 by working around the Apple bug.
Refs home-assistant/frontend#10819.
Requires core-2021.12.0b6 or newer.

## Summary
When the app has been in the background for a while without executing, reset the WebSocket connection in the WebView when execution begins again.

Also implements the new `theme-update` external bus command since it will log as an unhandled message. This likely means we're over-updating theme colors, but that is relatively cheap to do and doesn't cause harm.

## Any other notes
This works around a bug in NSURLSession's WebSocket implementation -- which WKWebView moved to in iOS 15 -- where it cannot reliably detect network connectivity failures due to extended backgrounding. Eventually it'll get a "connection reset by peer" or other error, but in the meantime it reports itself as still connected, thus leaving our WebView thinking it's connected but anything sent isn't sent and nothing is received.