### PR TITLE
Fix server identifier of non-synced actions & complications for deleted servers

### DIFF
--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -109,7 +109,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         }
     }
 
-    static func willDelete(objects: [Action], server: Server, realm: Realm) {}
+    static func willDelete(objects: [Action], server: Server?, realm: Realm) {}
 
     static var updateEligiblePredicate: NSPredicate {
         .init(format: "isServerControlled == YES")

--- a/Sources/Shared/API/Models/NotificationCategory.swift
+++ b/Sources/Shared/API/Models/NotificationCategory.swift
@@ -100,7 +100,7 @@ public final class NotificationCategory: Object, UpdatableModel {
 
     static func didUpdate(objects: [NotificationCategory], server: Server, realm: Realm) {}
 
-    static func willDelete(objects: [NotificationCategory], server: Server, realm: Realm) {}
+    static func willDelete(objects: [NotificationCategory], server: Server?, realm: Realm) {}
 
     static var updateEligiblePredicate: NSPredicate {
         .init(format: "isServerControlled == YES")

--- a/Sources/Shared/API/Models/RealmPersistable.swift
+++ b/Sources/Shared/API/Models/RealmPersistable.swift
@@ -6,7 +6,7 @@ protocol UpdatableModel {
     associatedtype Source: UpdatableModelSource
 
     static func didUpdate(objects: [Self], server: Server, realm: Realm)
-    static func willDelete(objects: [Self], server: Server, realm: Realm)
+    static func willDelete(objects: [Self], server: Server?, realm: Realm)
 
     static func primaryKey() -> String? // from realm, we use
     static func serverIdentifierKey() -> String

--- a/Sources/Shared/API/Models/RealmScene.swift
+++ b/Sources/Shared/API/Models/RealmScene.swift
@@ -65,7 +65,7 @@ public final class RLMScene: Object, UpdatableModel {
         }
     }
 
-    static func willDelete(objects: [RLMScene], server: Server, realm: Realm) {
+    static func willDelete(objects: [RLMScene], server: Server?, realm: Realm) {
         // also delete our paired actions if they exist
         let actions = realm.objects(Action.self).filter("ID in %@", objects.map(\.identifier))
         Current.Log.info("deleting actions \(Array(actions.map(\.ID)))")

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -58,7 +58,7 @@ public final class RLMZone: Object, UpdatableModel {
 
     static func didUpdate(objects: [RLMZone], server: Server, realm: Realm) {}
 
-    static func willDelete(objects: [RLMZone], server: Server, realm: Realm) {}
+    static func willDelete(objects: [RLMZone], server: Server?, realm: Realm) {}
 
     func update(with zone: HAEntity, server: Server, using: Realm) -> Bool {
         guard let zoneAttributes = zone.attributes.zone else {


### PR DESCRIPTION
## Summary
When a server is deleted, we now update the identifiers of any locally-defined actions or complications to point to the first server. We want to avoid ever having a server identifier pointing to a deleted server so we can trust the identifiers more.

## Any other notes
Deleting in this case would be bad as it's an unexpected data loss. I can imagine someone deletes and re-adds the server (potentially the last one, too), or other maintenance tasks.