### PR TITLE
Decline opening a WebView for AirPlay to mirror instead

### DIFF
--- a/Sources/App/Scenes/WebViewSceneDelegate.swift
+++ b/Sources/App/Scenes/WebViewSceneDelegate.swift
@@ -15,6 +15,8 @@ final class WebViewSceneDelegate: NSObject, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         guard let scene = scene as? UIWindowScene else { return }
+        // if it tries to connect for an external display, decline -- it'll mirror instead
+        guard session.role != .windowExternalDisplay else { return }
 
         ScaleFactorMutator.record(sceneIdentifier: session.persistentIdentifier)
 


### PR DESCRIPTION
The default behavior here is to open a second scene for the external display, but since you can't interact with it, it's not super useful.

We could maybe do something like:
- Offer to track the current page in the phone
- Add a setting to control which page to show, e.g. mirror or display

The upside of the second WebView scene is that it's at the full resolution of the device (e.g. at 1080p landscape, not whatever the phone is showing).