### PR TITLE
Bump notification category deprecation to iOS-2022.4

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -443,7 +443,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         let userDefaults = UserDefaults.standard
-        let seenKey = "category-deprecation-2-" + Current.clientVersion().description
+        let seenKey = "category-deprecation-3-" + Current.clientVersion().description
 
         guard !userDefaults.bool(forKey: seenKey) else {
             return
@@ -457,7 +457,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             let alert = UIAlertController(
                 title: L10n.Alerts.Deprecations.NotificationCategory.title,
-                message: L10n.Alerts.Deprecations.NotificationCategory.message("iOS-2021.2"),
+                message: L10n.Alerts.Deprecations.NotificationCategory.message("iOS-2022.4"),
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: L10n.Nfc.List.learnMore, style: .default, handler: { _ in


### PR DESCRIPTION
## Summary
Turns out 2021.2 already happened, and I want to push it out a bit more.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
