### PR TITLE
Disable Bitcode to work around iOS 12 crash

### DIFF
--- a/Configuration/HomeAssistant.xcconfig
+++ b/Configuration/HomeAssistant.xcconfig
@@ -45,7 +45,7 @@ WATCHOS_DEPLOYMENT_TARGET = 5.0
 // Bitcode serves effectively no purpose (it was just for the 32_64 watch migration, and hasn't been used since)
 // but doubly so: starting in ~Xcode 13.2 times, Apple's backport of libConcurrency started crashing on startup
 // but only when they recompile it.
-ENABLE_BITCODE = NO
+ENABLE_BITCODE[sdk=iphoneos*] = NO
 
 CLANG_ENABLE_MODULES = YES
 CLANG_ENABLE_OBJC_ARC = YES

--- a/Configuration/HomeAssistant.xcconfig
+++ b/Configuration/HomeAssistant.xcconfig
@@ -42,6 +42,11 @@ IPHONEOS_DEPLOYMENT_TARGET = 12.0
 MACOSX_DEPLOYMENT_TARGET = 10.15
 WATCHOS_DEPLOYMENT_TARGET = 5.0
 
+// Bitcode serves effectively no purpose (it was just for the 32_64 watch migration, and hasn't been used since)
+// but doubly so: starting in ~Xcode 13.2 times, Apple's backport of libConcurrency started crashing on startup
+// but only when they recompile it.
+ENABLE_BITCODE = NO
+
 CLANG_ENABLE_MODULES = YES
 CLANG_ENABLE_OBJC_ARC = YES
 CLANG_ENABLE_OBJC_WEAK = YES


### PR DESCRIPTION
## Summary
Bitcode serves effectively no purpose (it was just for the 32_64 watch migration, and hasn't been used since) but doubly so: starting in ~Xcode 13.2 times, Apple's backport of libConcurrency started crashing on startup but only when they recompile it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
