### PR TITLE
Setting for types of locations sent to a server

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -745,3 +745,9 @@ Home Assistant is free and open source home automation software with a focus on 
 "widgets.open_page.not_configured" = "No Pages Available";
 "widgets.open_page.title" = "Open Page";
 "yes_label" = "Yes";
+"settings.connection_section.location_send_type.title" = "Location Sent";
+"settings.connection_section.location_send_type.setting.exact" = "Exact";
+"settings.connection_section.location_send_type.setting.zone_only" = "Zone Name Only";
+"settings.connection_section.location_send_type.setting.never" = "Never";
+/* e.g. value here is e.g. core-2021.12 or frontend-2021.12 */
+"requires_version" = "Requires %@ or later.";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -153,11 +153,14 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                     to.enableDeselection = false
                     if server.info.version <= .updateLocationGPSOptional {
                         to.sectionKeyForValue = { _ in
-                            // so we get asked for footer title
+                            // so we get asked for section titles
                             return "section"
                         }
                         to.selectableRowSetup = { row in
                             row.disabled = true
+                        }
+                        to.sectionHeaderTitleForKey = { _ in
+                            nil
                         }
                         to.sectionFooterTitleForKey = { _ in
                             Version.updateLocationGPSOptional.coreRequiredString

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -143,35 +143,6 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 }
             }
 
-            <<< PushRow<ServerLocationType> {
-                $0.title = L10n.Settings.ConnectionSection.LocationSendType.title
-                $0.selectorTitle = $0.title
-                $0.value = server.info.setting(for: .locationType) ?? .default
-                $0.options = ServerLocationType.allCases
-                $0.displayValueFor = { $0?.localizedDescription }
-                $0.onPresent { [server] _, to in
-                    to.enableDeselection = false
-                    if server.info.version <= .updateLocationGPSOptional {
-                        to.sectionKeyForValue = { _ in
-                            // so we get asked for section titles
-                            "section"
-                        }
-                        to.selectableRowSetup = { row in
-                            row.disabled = true
-                        }
-                        to.sectionHeaderTitleForKey = { _ in
-                            nil
-                        }
-                        to.sectionFooterTitleForKey = { _ in
-                            Version.updateLocationGPSOptional.coreRequiredString
-                        }
-                    }
-                }
-                $0.onChange { [server] row in
-                    server.info.setSetting(value: row.value, for: .locationType)
-                }
-            }
-
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
                 row.cellStyle = .value1
                 row.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
@@ -202,6 +173,37 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 }), onDismiss: { [navigationController] _ in
                     navigationController?.popViewController(animated: true)
                 })
+            }
+
+            +++ Section(L10n.SettingsDetails.Privacy.title)
+
+            <<< PushRow<ServerLocationType> {
+                $0.title = L10n.Settings.ConnectionSection.LocationSendType.title
+                $0.selectorTitle = $0.title
+                $0.value = server.info.setting(for: .locationType) ?? .default
+                $0.options = ServerLocationType.allCases
+                $0.displayValueFor = { $0?.localizedDescription }
+                $0.onPresent { [server] _, to in
+                    to.enableDeselection = false
+                    if server.info.version <= .updateLocationGPSOptional || true {
+                        to.sectionKeyForValue = { _ in
+                            // so we get asked for section titles
+                            "section"
+                        }
+                        to.selectableRowSetup = { row in
+                            row.disabled = true
+                        }
+                        to.sectionHeaderTitleForKey = { _ in
+                            nil
+                        }
+                        to.sectionFooterTitleForKey = { _ in
+                            Version.updateLocationGPSOptional.coreRequiredString
+                        }
+                    }
+                }
+                $0.onChange { [server] row in
+                    server.info.setSetting(value: row.value, for: .locationType)
+                }
             }
 
             +++ Section()

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -144,7 +144,8 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
             }
 
             <<< PushRow<ServerLocationType> {
-                $0.title = "Send Location"
+                $0.title = L10n.Settings.ConnectionSection.LocationSendType.title
+                $0.selectorTitle = $0.title
                 $0.value = server.info.setting(for: .locationType) ?? .default
                 $0.options = ServerLocationType.allCases
                 $0.displayValueFor = { $0?.localizedDescription }

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -6,6 +6,7 @@ import ObjectMapper
 import PromiseKit
 import Shared
 import UIKit
+import Version
 
 class ConnectionSettingsViewController: HAFormViewController, RowControllerType {
     public var onDismissCallback: ((UIViewController) -> Void)?
@@ -147,8 +148,20 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 $0.value = server.info.setting(for: .locationType) ?? .default
                 $0.options = ServerLocationType.allCases
                 $0.displayValueFor = { $0?.localizedDescription }
-                $0.onPresent { _, to in
+                $0.onPresent { [server] _, to in
                     to.enableDeselection = false
+                    if server.info.version <= .updateLocationGPSOptional {
+                        to.sectionKeyForValue = { _ in
+                            // so we get asked for footer title
+                            return "section"
+                        }
+                        to.selectableRowSetup = { row in
+                            row.disabled = true
+                        }
+                        to.sectionFooterTitleForKey = { _ in
+                            Version.updateLocationGPSOptional.coreRequiredString
+                        }
+                    }
                 }
                 $0.onChange { [server] row in
                     server.info.setSetting(value: row.value, for: .locationType)

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -154,7 +154,7 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                     if server.info.version <= .updateLocationGPSOptional {
                         to.sectionKeyForValue = { _ in
                             // so we get asked for section titles
-                            return "section"
+                            "section"
                         }
                         to.selectableRowSetup = { row in
                             row.disabled = true
@@ -175,7 +175,9 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
             <<< ButtonRowWithPresent<ConnectionURLViewController> { row in
                 row.cellStyle = .value1
                 row.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
-                row.displayValueFor = { [server] _ in server.info.connection.address(for: .internal)?.absoluteString ?? "—" }
+                row.displayValueFor = { [server] _ in
+                    server.info.connection.address(for: .internal)?.absoluteString ?? "—"
+                }
                 row.presentationMode = .show(controllerProvider: .callback(builder: { [server] in
                     ConnectionURLViewController(server: server, urlType: .internal, row: row)
                 }), onDismiss: { [navigationController] _ in

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -500,7 +500,8 @@ public class HomeAssistantAPI {
             Current.Log.info("Location update payload: \(payloadDict)")
             return payloadDict
         }.then { [self] payload in
-            when(resolved:
+            when(
+                resolved:
                 UpdateSensors(trigger: update.Trigger, location: location).asVoid(),
                 Current.webhooks.send(
                     identifier: .location,

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -450,7 +450,7 @@ public class HomeAssistantAPI {
         location: CLLocation?,
         zone: RLMZone?
     ) -> Promise<Void> {
-        let update: WebhookUpdateLocation
+        let update: WebhookUpdateLocation?
         let sensorLocation: CLLocation?
         let localMetadata = WebhookResponseLocation.localMetdata(
             trigger: updateType,
@@ -470,6 +470,7 @@ public class HomeAssistantAPI {
                 let zone = Current.realm()
                     .objects(RLMZone.self)
                     .filter("%K == %@", #keyPath(RLMZone.serverIdentifier), server.identifier.rawValue)
+                    .filter(RLMZone.trackablePredicate)
                     .filter { $0.circularRegion.containsWithAccuracy(location) }
                     .sorted { zoneA, zoneB in
                         zoneA.circularRegion.distanceWithAccuracy(from: location) < zoneB.circularRegion.distanceWithAccuracy(from: location)
@@ -483,11 +484,11 @@ public class HomeAssistantAPI {
             } else if updateType == .BeaconRegionExit || updateType == .BeaconRegionEnter {
                 update = .init(trigger: updateType, usingNameOf: zone)
             } else {
-                update = .init()
+                update = .init(trigger: updateType)
             }
             sensorLocation = nil
         case .never:
-            update = .init()
+            update = .init(trigger: updateType)
             sensorLocation = nil
         }
 

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -457,8 +457,8 @@ public class HomeAssistantAPI {
             zone: zone
         )
 
-        switch server.info.setting(for: .locationType) ?? .always {
-        case .always:
+        switch server.info.setting(for: .locationType) ?? .exact {
+        case .exact:
             update = .init(trigger: updateType, location: rawLocation, zone: zone)
             location = rawLocation
         case .zoneOnly:

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -502,7 +502,7 @@ public class HomeAssistantAPI {
         }.then { [self] payload in
             when(
                 resolved:
-                UpdateSensors(trigger: update.Trigger, location: location).asVoid(),
+                UpdateSensors(trigger: updateType, location: location).asVoid(),
                 Current.webhooks.send(
                     identifier: .location,
                     server: server,

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -92,6 +92,10 @@ public final class RLMZone: Object, UpdatableModel {
         return true
     }
 
+    public static var trackablePredicate: NSPredicate {
+        "TrackingEnabled == true && isPassive == false"
+    }
+
     public var center: CLLocationCoordinate2D {
         .init(
             latitude: Latitude,

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -271,7 +271,8 @@ public final class RLMZone: Object, UpdatableModel {
             .filter(trackablePredicate)
             .filter { $0.circularRegion.containsWithAccuracy(location) }
             .sorted { zoneA, zoneB in
-                zoneA.circularRegion.distanceWithAccuracy(from: location) < zoneB.circularRegion.distanceWithAccuracy(from: location)
+                zoneA.circularRegion.distanceWithAccuracy(from: location)
+                    < zoneB.circularRegion.distanceWithAccuracy(from: location)
             }
             .first
     }

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -251,6 +251,10 @@ public final class RLMZone: Object, UpdatableModel {
         ).capitalized
     }
 
+    public var deviceTrackerName: String {
+        entityId.replacingOccurrences(of: "\(Domain).", with: "")
+    }
+
     public var Domain: String {
         "zone"
     }

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -30,7 +30,7 @@ public class WebhookUpdateLocation: Mappable {
 
     public required init?(map: Map) {}
 
-    public convenience init?(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
+    public convenience init(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
         self.init(trigger: trigger)
 
         let useLocation: Bool
@@ -46,8 +46,6 @@ public class WebhookUpdateLocation: Mappable {
             SetLocation(location: location)
         } else if let zone = zone {
             SetZone(zone: zone)
-        } else {
-            return nil
         }
     }
 

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -22,18 +22,16 @@ public class WebhookUpdateLocation: Mappable {
     // Not sent
     public var Trigger: LocationUpdateTrigger = .Unknown
 
-    init() {}
+    public init(trigger: LocationUpdateTrigger) {
+        if let battery = Current.device.batteries().first {
+            self.Battery = battery.level
+        }
+    }
 
     public required init?(map: Map) {}
 
     public convenience init?(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
-        self.init()
-
-        self.Trigger = trigger
-
-        if let battery = Current.device.batteries().first {
-            self.Battery = battery.level
-        }
+        self.init(trigger: trigger)
 
         let useLocation: Bool
 
@@ -51,6 +49,11 @@ public class WebhookUpdateLocation: Mappable {
         } else {
             return nil
         }
+    }
+
+    public init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
+        self.init(trigger: trigger)
+        self.LocationName = zone?.Name ?? LocationNames.NotHome.rawValue
     }
 
     public func SetZone(zone: RLMZone) {

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -51,7 +51,7 @@ public class WebhookUpdateLocation: Mappable {
         }
     }
 
-    public init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
+    public convenience init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
         self.init(trigger: trigger)
         self.LocationName = zone?.Name ?? LocationNames.NotHome.rawValue
     }

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -23,6 +23,7 @@ public class WebhookUpdateLocation: Mappable {
     public var Trigger: LocationUpdateTrigger = .Unknown
 
     public init(trigger: LocationUpdateTrigger) {
+        self.Trigger = trigger
         if let battery = Current.device.batteries().first {
             self.Battery = battery.level
         }
@@ -51,7 +52,7 @@ public class WebhookUpdateLocation: Mappable {
 
     public convenience init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
         self.init(trigger: trigger)
-        self.LocationName = zone?.Name ?? LocationNames.NotHome.rawValue
+        self.LocationName = zone?.entityId.replacingOccurrences(of: "zone.", with: "") ?? LocationNames.NotHome.rawValue
     }
 
     public func SetZone(zone: RLMZone) {

--- a/Sources/Shared/API/Models/WebhookUpdateLocation.swift
+++ b/Sources/Shared/API/Models/WebhookUpdateLocation.swift
@@ -8,30 +8,33 @@ public enum LocationNames: String {
     case NotHome = "not_home"
 }
 
-public class WebhookUpdateLocation: Mappable {
-    public var HorizontalAccuracy: CLLocationAccuracy?
-    public var Battery: Int?
-    public var Location: CLLocationCoordinate2D?
-    public var LocationName: String?
+public struct WebhookUpdateLocation: ImmutableMappable {
+    public var horizontalAccuracy: CLLocationAccuracy?
+    public var battery: Int?
+    public var location: CLLocationCoordinate2D?
+    public var locationName: String?
 
-    public var Speed: CLLocationSpeed?
-    public var Altitude: CLLocationDistance?
-    public var Course: CLLocationDirection?
-    public var VerticalAccuracy: CLLocationAccuracy?
+    public var speed: CLLocationSpeed?
+    public var altitude: CLLocationDistance?
+    public var course: CLLocationDirection?
+    public var verticalAccuracy: CLLocationAccuracy?
 
     // Not sent
-    public var Trigger: LocationUpdateTrigger = .Unknown
+    public var trigger: LocationUpdateTrigger
 
     public init(trigger: LocationUpdateTrigger) {
-        self.Trigger = trigger
+        self.trigger = trigger
         if let battery = Current.device.batteries().first {
-            self.Battery = battery.level
+            self.battery = battery.level
         }
     }
 
-    public required init?(map: Map) {}
+    public init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
+        self.init(trigger: trigger)
+        self.locationName = zone?.deviceTrackerName ?? LocationNames.NotHome.rawValue
+    }
 
-    public convenience init(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
+    public init(trigger: LocationUpdateTrigger, location: CLLocation?, zone: RLMZone?) {
         self.init(trigger: trigger)
 
         let useLocation: Bool
@@ -44,90 +47,73 @@ public class WebhookUpdateLocation: Mappable {
         }
 
         if let location = location, useLocation {
-            SetLocation(location: location)
+            self.location = location.coordinate
+
+            if location.speed > -1 {
+                self.speed = location.speed
+            }
+            if location.course > -1 {
+                self.course = location.course
+            }
+            if location.altitude > -1 {
+                self.altitude = location.altitude
+            }
+            if location.verticalAccuracy > -1 {
+                self.verticalAccuracy = location.verticalAccuracy
+            }
+            if location.horizontalAccuracy > -1 {
+                self.horizontalAccuracy = location.horizontalAccuracy
+            }
         } else if let zone = zone {
-            SetZone(zone: zone)
-        }
-    }
-
-    public convenience init(trigger: LocationUpdateTrigger, usingNameOf zone: RLMZone?) {
-        self.init(trigger: trigger)
-        self.LocationName = zone?.entityId.replacingOccurrences(of: "zone.", with: "") ?? LocationNames.NotHome.rawValue
-    }
-
-    public func SetZone(zone: RLMZone) {
-        HorizontalAccuracy = zone.Radius
-        Location = zone.center
-
-        #if os(iOS)
-        // https://github.com/home-assistant/home-assistant-iOS/issues/32
-        if let currentSSID = Current.connectivity.currentWiFiSSID(), zone.SSIDTrigger.contains(currentSSID) {
-            LocationName = zone.Name
-            return
-        }
-        #endif
-
-        if zone.isHome {
-            switch Trigger {
-            case .RegionEnter, .GPSRegionEnter, .BeaconRegionEnter:
-                LocationName = LocationNames.Home.rawValue
-            case .RegionExit, .GPSRegionExit:
-                LocationName = LocationNames.NotHome.rawValue
-            case .BeaconRegionExit:
-                ClearLocation()
-            default:
-                break
+            if trigger != .BeaconRegionExit {
+                self.location = zone.center
+                self.horizontalAccuracy = zone.Radius
             }
-        } else {
-            switch Trigger {
-            case .BeaconRegionEnter where !zone.isPassive:
-                LocationName = zone.Name
-            case .BeaconRegionExit:
-                ClearLocation()
-            default:
-                break
+
+            #if os(iOS)
+            // https://github.com/home-assistant/home-assistant-iOS/issues/32
+            if let currentSSID = Current.connectivity.currentWiFiSSID(), zone.SSIDTrigger.contains(currentSSID) {
+                self.location = zone.center
+                self.locationName = zone.Name
+                return
+            }
+            #endif
+
+            if zone.isHome {
+                switch trigger {
+                case .RegionEnter, .GPSRegionEnter, .BeaconRegionEnter:
+                    self.locationName = LocationNames.Home.rawValue
+                case .RegionExit, .GPSRegionExit:
+                    self.locationName = LocationNames.NotHome.rawValue
+                default:
+                    break
+                }
+            } else {
+                switch trigger {
+                case .BeaconRegionEnter where !zone.isPassive:
+                    self.locationName = zone.Name
+                case .BeaconRegionExit:
+                    break
+                default:
+                    break
+                }
             }
         }
-    }
-
-    public func SetLocation(location: CLLocation) {
-        Location = location.coordinate
-        if location.speed > -1 {
-            Speed = location.speed
-        }
-        if location.course > -1 {
-            Course = location.course
-        }
-        if location.altitude > -1 {
-            Altitude = location.altitude
-        }
-        if location.verticalAccuracy > -1 {
-            VerticalAccuracy = location.verticalAccuracy
-        }
-        if location.horizontalAccuracy > -1 {
-            HorizontalAccuracy = location.horizontalAccuracy
-        }
-    }
-
-    public func ClearLocation() {
-        HorizontalAccuracy = nil
-        Location = nil
-        Speed = nil
-        Altitude = nil
-        Course = nil
-        VerticalAccuracy = nil
     }
 
     // Mappable
-    public func mapping(map: Map) {
-        Battery <- map["battery"]
-        Location <- (map["gps"], CLLocationCoordinate2DTransform())
-        HorizontalAccuracy <- map["gps_accuracy"]
-        LocationName <- map["location_name"]
+    public init(map: Map) throws {
+        fatalError()
+    }
 
-        Speed <- map["speed"]
-        Altitude <- map["altitude"]
-        Course <- map["course"]
-        VerticalAccuracy <- map["vertical_accuracy"]
+    public func mapping(map: Map) {
+        battery >>> map["battery"]
+        location >>> (map["gps"], CLLocationCoordinate2DTransform())
+        horizontalAccuracy >>> map["gps_accuracy"]
+        locationName >>> map["location_name"]
+        speed >>> map["speed"]
+        altitude >>> map["altitude"]
+        course >>> map["course"]
+        verticalAccuracy >>> map["vertical_accuracy"]
     }
 }

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -13,9 +13,27 @@ public struct ServerSettingKey<ValueType>: RawRepresentable, Hashable, Expressib
     }
 }
 
+public enum ServerLocationType: String, CaseIterable, RawRepresentable {
+    case always
+    case zoneOnly
+    case never
+
+    public static var `default`: Self { .always }
+    public var localizedDescription: String {
+        switch self {
+        case .never: return NSLocalizedString("Never", comment: "")
+        case .always:
+            return NSLocalizedString("Always", comment: "")
+        case .zoneOnly:
+            return NSLocalizedString("Zone Name Only", comment: "")
+        }
+    }
+}
+
 public extension ServerSettingKey {
     static var localName: ServerSettingKey<String> { "local_name" }
     static var overrideDeviceName: ServerSettingKey<String> { "override_device_name" }
+    static var locationType: ServerSettingKey<ServerLocationType> { "location_type" }
 }
 
 public struct ServerInfo: Codable, Equatable {
@@ -89,12 +107,24 @@ public struct ServerInfo: Codable, Equatable {
 
     public static var defaultSortOrder: Int { -1 }
 
-    public mutating func setSetting<T>(value: T?, for key: ServerSettingKey<T>) {
+    public mutating func setSetting<T: RawRepresentable>(value: T?, for key: ServerSettingKey<T>) {
+        settings[key.rawValue] = value?.rawValue
+    }
+
+    public mutating func setSetting(value: String?, for key: ServerSettingKey<String>) {
         settings[key.rawValue] = value
     }
 
-    public func setting<T>(for key: ServerSettingKey<T>) -> T? {
-        settings[key.rawValue] as? T
+    public func setting<T: RawRepresentable>(for key: ServerSettingKey<T>) -> T? {
+        if let value = settings[key.rawValue] as? T.RawValue {
+            return T(rawValue: value)
+        } else {
+            return nil
+        }
+    }
+
+    public func setting(for key: ServerSettingKey<String>) -> String? {
+        settings[key.rawValue] as? String
     }
 
     public static func == (lhs: ServerInfo, rhs: ServerInfo) -> Bool {

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -14,18 +14,16 @@ public struct ServerSettingKey<ValueType>: RawRepresentable, Hashable, Expressib
 }
 
 public enum ServerLocationType: String, CaseIterable, RawRepresentable {
-    case always
+    case exact
     case zoneOnly
     case never
 
-    public static var `default`: Self { .always }
+    public static var `default`: Self { .exact }
     public var localizedDescription: String {
         switch self {
-        case .never: return NSLocalizedString("Never", comment: "")
-        case .always:
-            return NSLocalizedString("Always", comment: "")
-        case .zoneOnly:
-            return NSLocalizedString("Zone Name Only", comment: "")
+        case .never: return L10n.Settings.ConnectionSection.LocationSendType.Setting.never
+        case .exact: return L10n.Settings.ConnectionSection.LocationSendType.Setting.exact
+        case .zoneOnly: return L10n.Settings.ConnectionSection.LocationSendType.Setting.zoneOnly
         }
     }
 }

--- a/Sources/Shared/API/Webhook/Sensors/GeocoderSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/GeocoderSensor.swift
@@ -63,7 +63,7 @@ public class GeocoderSensor: SensorProvider {
 
             if let location = request.location {
                 let insideZones = Current.realm().objects(RLMZone.self)
-                    .filter("TrackingEnabled == true && isPassive == false")
+                    .filter(RLMZone.trackablePredicate)
                     .sorted(byKeyPath: "Radius")
                     .filter { $0.circularRegion.contains(location.coordinate) }
                     .map { $0.FriendlyName ?? $0.Name }

--- a/Sources/Shared/Common/ObjectMapperTransformers.swift
+++ b/Sources/Shared/Common/ObjectMapperTransformers.swift
@@ -94,7 +94,7 @@ open class CLLocationCoordinate2DTransform: TransformType {
     }
 
     open func transformToJSON(_ value: CLLocationCoordinate2D?) -> [Double]? {
-        guard let value = value else { return nil }
+        guard let value = value else { return [] }
         return value.toArray()
     }
 }

--- a/Sources/Shared/Common/ObjectMapperTransformers.swift
+++ b/Sources/Shared/Common/ObjectMapperTransformers.swift
@@ -94,7 +94,7 @@ open class CLLocationCoordinate2DTransform: TransformType {
     }
 
     open func transformToJSON(_ value: CLLocationCoordinate2D?) -> [Double]? {
-        guard let value = value else { return [] }
+        guard let value = value else { return nil }
         return value.toArray()
     }
 }

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -148,6 +148,6 @@ public extension Version {
     static var updateLocationGPSOptional: Version = .init(major: 2022, minor: 2, prerelease: "any0")
 
     var coreRequiredString: String {
-        String(format: NSLocalizedString("Requires core-%d.%d or later.", comment: ""), major, minor ?? -1)
+        L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))
     }
 }

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -145,4 +145,9 @@ public extension Version {
     static var actionSyncing: Version = .init(minor: 115, prerelease: "any0")
     static var localPushConfirm: Version = .init(major: 2021, minor: 10, prerelease: "any0")
     static var externalBusCommandRestart: Version = .init(major: 2021, minor: 12, prerelease: "b6")
+    static var updateLocationGPSOptional: Version = .init(major: 2022, minor: 2, prerelease: "any0")
+
+    var coreRequiredString: String {
+        String(format: NSLocalizedString("Requires core-%d.%d or later.", comment: ""), major, minor ?? -1)
+    }
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -42,6 +42,10 @@ public enum L10n {
   public static var openLabel: String { return L10n.tr("Localizable", "open_label") }
   /// Preview Output
   public static var previewOutput: String { return L10n.tr("Localizable", "preview_output") }
+  /// Requires %@ or later.
+  public static func requiresVersion(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "requires_version", String(describing: p1))
+  }
   /// Retry
   public static var retryLabel: String { return L10n.tr("Localizable", "retry_label") }
   /// Success
@@ -964,6 +968,18 @@ public enum L10n {
         public static var header: String { return L10n.tr("Localizable", "settings.connection_section.internal_url_ssids.header") }
         /// MyFunnyNetworkName
         public static var placeholder: String { return L10n.tr("Localizable", "settings.connection_section.internal_url_ssids.placeholder") }
+      }
+      public enum LocationSendType {
+        /// Location Sent
+        public static var title: String { return L10n.tr("Localizable", "settings.connection_section.location_send_type.title") }
+        public enum Setting {
+          /// Exact
+          public static var exact: String { return L10n.tr("Localizable", "settings.connection_section.location_send_type.setting.exact") }
+          /// Never
+          public static var never: String { return L10n.tr("Localizable", "settings.connection_section.location_send_type.setting.never") }
+          /// Zone Name Only
+          public static var zoneOnly: String { return L10n.tr("Localizable", "settings.connection_section.location_send_type.setting.zone_only") }
+        }
       }
       public enum RemoteUiUrl {
         /// Remote UI URL

--- a/Tests/Shared/Webhook/WebhookUpdateLocation.test.swift
+++ b/Tests/Shared/Webhook/WebhookUpdateLocation.test.swift
@@ -9,7 +9,7 @@ class WebhookUpdateLocationTests: XCTestCase {
             .GPSRegionEnter,
             .GPSRegionExit,
             .BeaconRegionEnter,
-            .BeaconRegionExit
+            .BeaconRegionExit,
         ] {
             Current.device.batteries = { [DeviceBattery(level: 44, state: .charging, attributes: [:])] }
 
@@ -26,7 +26,9 @@ class WebhookUpdateLocationTests: XCTestCase {
         }
     }
 
-    func testNameOfZone() {
+    func testNameOfZoneWhenSet() {
+        Current.device.batteries = { [DeviceBattery(level: 44, state: .charging, attributes: [:])] }
+
         let zone = with(RLMZone()) {
             $0.entityId = "zone.given_name"
             $0.serverIdentifier = "server1"
@@ -35,13 +37,31 @@ class WebhookUpdateLocationTests: XCTestCase {
             $0.Radius = 88.8
         }
 
-        let withZone = WebhookUpdateLocation(trigger: .BeaconRegionEnter, usingNameOf: zone)
-        XCTAssertEqual(withZone.Trigger, .BeaconRegionEnter)
-        XCTAssertEqual(withZone.LocationName, "given_name")
+        let model = WebhookUpdateLocation(trigger: .BeaconRegionEnter, usingNameOf: zone)
+        let json = model.toJSON()
+        XCTAssertEqual(json["battery"] as? Int, 44)
+        XCTAssertEqual(json["location_name"] as? String, "given_name")
+        XCTAssertNil(json["gps"])
+        XCTAssertNil(json["gps_accuracy"])
+        XCTAssertNil(json["speed"])
+        XCTAssertNil(json["altitude"])
+        XCTAssertNil(json["course"])
+        XCTAssertNil(json["vertical_accuracy"])
+    }
 
-        let withoutZone = WebhookUpdateLocation(trigger: .BeaconRegionExit, usingNameOf: nil)
-        XCTAssertEqual(withoutZone.Trigger, .BeaconRegionExit)
-        XCTAssertEqual(withoutZone.LocationName, "not_home")
+    func testNameOfZoneWithNoZone() {
+        Current.device.batteries = { [DeviceBattery(level: 44, state: .charging, attributes: [:])] }
+
+        let model = WebhookUpdateLocation(trigger: .BeaconRegionEnter, usingNameOf: nil)
+        let json = model.toJSON()
+        XCTAssertEqual(json["battery"] as? Int, 44)
+        XCTAssertEqual(json["location_name"] as? String, "not_home")
+        XCTAssertNil(json["gps"])
+        XCTAssertNil(json["gps_accuracy"])
+        XCTAssertNil(json["speed"])
+        XCTAssertNil(json["altitude"])
+        XCTAssertNil(json["course"])
+        XCTAssertNil(json["vertical_accuracy"])
     }
 
     func testBeaconEnterNotPassive() {


### PR DESCRIPTION
Requires home-assistant/core#62243.

## Summary
Allows sending exact locations (current behavior, gps coordinates), no locations (sets the device tracker to 'unknown' effectively), and zone-only locations (we send `home`, `other_zone_name` or `not_home` only).

## Screenshots
| Thing | Light | Dark |
| -- | -- | -- |
| Setting | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 13 55 29](https://user-images.githubusercontent.com/74188/146837890-d43d5427-9574-4d24-90b7-91c631f92ad0.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 13 55 30](https://user-images.githubusercontent.com/74188/146837899-d3fd3879-61f9-4b8e-8d71-4032e0c96867.png) |
| New Enough | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-19 at 14 04 41](https://user-images.githubusercontent.com/74188/146692573-250a1c3a-fe5e-4bf1-92dc-4e4d73cf65d7.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-19 at 14 04 43](https://user-images.githubusercontent.com/74188/146692576-7181c839-1f58-479d-9ab6-ff534096f623.png) |
| Too Old | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-19 at 14 06 08](https://user-images.githubusercontent.com/74188/146692579-929e14ae-0d53-497f-8625-8d53c5995b6e.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-19 at 14 06 09](https://user-images.githubusercontent.com/74188/146692581-c98f9259-d571-465c-8f6a-efda78624466.png) |

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#639
