### PR TITLE
Server privacy setting for sensors

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -751,3 +751,6 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.connection_section.location_send_type.setting.never" = "Never";
 /* e.g. value here is e.g. core-2021.12 or frontend-2021.12 */
 "requires_version" = "Requires %@ or later.";
+"settings.connection_section.sensor_send_type.title" = "Sensors Sent";
+"settings.connection_section.sensor_send_type.setting.all" = "All";
+"settings.connection_section.sensor_send_type.setting.none" = "None";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -177,15 +177,15 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
 
             +++ Section(L10n.SettingsDetails.Privacy.title)
 
-            <<< PushRow<ServerLocationType> {
+            <<< PushRow<ServerLocationPrivacy> {
                 $0.title = L10n.Settings.ConnectionSection.LocationSendType.title
                 $0.selectorTitle = $0.title
-                $0.value = server.info.setting(for: .locationType) ?? .default
-                $0.options = ServerLocationType.allCases
+                $0.value = server.info.setting(for: .locationPrivacy)
+                $0.options = ServerLocationPrivacy.allCases
                 $0.displayValueFor = { $0?.localizedDescription }
                 $0.onPresent { [server] _, to in
                     to.enableDeselection = false
-                    if server.info.version <= .updateLocationGPSOptional || true {
+                    if server.info.version <= .updateLocationGPSOptional {
                         to.sectionKeyForValue = { _ in
                             // so we get asked for section titles
                             "section"
@@ -202,7 +202,7 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                     }
                 }
                 $0.onChange { [server] row in
-                    server.info.setSetting(value: row.value, for: .locationType)
+                    server.info.setSetting(value: row.value, for: .locationPrivacy)
                     HomeAssistantAPI.manuallyUpdate(
                         applicationState: UIApplication.shared.applicationState,
                         type: .programmatic

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -203,6 +203,10 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 }
                 $0.onChange { [server] row in
                     server.info.setSetting(value: row.value, for: .locationType)
+                    HomeAssistantAPI.manuallyUpdate(
+                        applicationState: UIApplication.shared.applicationState,
+                        type: .programmatic
+                    ).cauterize()
                 }
             }
 

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -210,6 +210,21 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 }
             }
 
+            <<< PushRow<ServerSensorPrivacy> {
+                $0.title = L10n.Settings.ConnectionSection.SensorSendType.title
+                $0.selectorTitle = $0.title
+                $0.value = server.info.setting(for: .sensorPrivacy)
+                $0.options = ServerSensorPrivacy.allCases
+                $0.displayValueFor = { $0?.localizedDescription }
+                $0.onPresent { _, to in
+                    to.enableDeselection = false
+                }
+                $0.onChange { [server] row in
+                    server.info.setSetting(value: row.value, for: .sensorPrivacy)
+                    Current.api(for: server).registerSensors().cauterize()
+                }
+            }
+
             +++ Section()
 
             <<< ButtonRow {

--- a/Sources/App/Settings/Sensors/SensorListViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorListViewController.swift
@@ -79,7 +79,7 @@ class SensorListViewController: HAFormViewController, SensorObserver {
         refreshControl.beginRefreshing()
 
         firstly {
-            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState)
+            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
         }.ensure { [refreshControl] in
             refreshControl.endRefreshing()
         }.cauterize()

--- a/Sources/App/Settings/Sensors/SensorListViewController.swift
+++ b/Sources/App/Settings/Sensors/SensorListViewController.swift
@@ -79,7 +79,10 @@ class SensorListViewController: HAFormViewController, SensorObserver {
         refreshControl.beginRefreshing()
 
         firstly {
-            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
+            HomeAssistantAPI.manuallyUpdate(
+                applicationState: UIApplication.shared.applicationState,
+                type: .userRequested
+            )
         }.ensure { [refreshControl] in
             refreshControl.endRefreshing()
         }.cauterize()

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -257,7 +257,7 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                         row.updateCell()
 
                         firstly {
-                            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState)
+                            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
                         }.ensure {
                             row.value = false
                             row.updateCell()

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -257,7 +257,10 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                         row.updateCell()
 
                         firstly {
-                            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
+                            HomeAssistantAPI.manuallyUpdate(
+                                applicationState: UIApplication.shared.applicationState,
+                                type: .userRequested
+                            )
                         }.ensure {
                             row.value = false
                             row.updateCell()

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -651,7 +651,10 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
     @objc private func updateSensors() {
         // called via menu/keyboard shortcut too
         firstly {
-            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
+            HomeAssistantAPI.manuallyUpdate(
+                applicationState: UIApplication.shared.applicationState,
+                type: .userRequested
+            )
         }.catch { [weak self] error in
             self?.showSwiftMessage(error: error)
         }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -651,7 +651,7 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
     @objc private func updateSensors() {
         // called via menu/keyboard shortcut too
         firstly {
-            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState)
+            HomeAssistantAPI.manuallyUpdate(applicationState: UIApplication.shared.applicationState, type: .userRequested)
         }.catch { [weak self] error in
             self?.showSwiftMessage(error: error)
         }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -728,7 +728,7 @@ public class HomeAssistantAPI {
 
     public func registerSensors() -> Promise<Void> {
         firstly {
-            Current.sensors.sensors(reason: .registration, serverVersion: server.info.version).map(\.sensors)
+            Current.sensors.sensors(reason: .registration, server: server).map(\.sensors)
         }.get { sensors in
             Current.Log.verbose("Registering sensors \(sensors.map(\.UniqueID))")
         }.thenMap { [server] sensor in
@@ -755,7 +755,7 @@ public class HomeAssistantAPI {
                 reason: .trigger(trigger.rawValue),
                 limitedTo: limitedTo,
                 location: location,
-                serverVersion: server.info.version
+                server: server
             )
         }.map { sensorResponse -> (SensorResponse, [[String: Any]]) in
             Current.Log.info("updating sensors \(sensorResponse.sensors.map { $0.UniqueID ?? "unknown" })")

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -457,7 +457,7 @@ public class HomeAssistantAPI {
             zone: zone
         )
 
-        switch server.info.setting(for: .locationType) ?? .exact {
+        switch server.info.setting(for: .locationPrivacy) {
         case .exact:
             update = .init(trigger: updateType, location: rawLocation, zone: zone)
             location = rawLocation

--- a/Sources/Shared/API/Models/WebhookSensor.swift
+++ b/Sources/Shared/API/Models/WebhookSensor.swift
@@ -40,6 +40,7 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
         self.UniqueID = sensor.UniqueID
         self.State = "unavailable"
         self.Icon = "mdi:dots-square"
+        self.Type = sensor.Type
     }
 
     convenience init(name: String, uniqueID: String) {

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -7,7 +7,7 @@ public protocol SettingValue {
 }
 
 extension Optional: SettingValue {
-    public static var `default`: Optional<Wrapped> { .none }
+    public static var `default`: Wrapped? { .none }
 }
 
 public struct ServerSettingKey<ValueType: SettingValue>: RawRepresentable, Hashable, ExpressibleByStringLiteral {

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -3,11 +3,11 @@ import HAKit
 import Version
 
 public protocol SettingValue {
-    static var `default`: Self { get }
+    static var defaultSettingValue: Self { get }
 }
 
 extension Optional: SettingValue {
-    public static var `default`: Wrapped? { .none }
+    public static var defaultSettingValue: Wrapped? { .none }
 }
 
 public struct ServerSettingKey<ValueType: SettingValue>: RawRepresentable, Hashable, ExpressibleByStringLiteral {
@@ -26,7 +26,7 @@ public enum ServerLocationPrivacy: String, CaseIterable, RawRepresentable, Setti
     case zoneOnly
     case never
 
-    public static var `default`: Self { .exact }
+    public static var defaultSettingValue: Self { .exact }
     public var localizedDescription: String {
         switch self {
         case .never: return L10n.Settings.ConnectionSection.LocationSendType.Setting.never
@@ -40,7 +40,7 @@ public enum ServerSensorPrivacy: String, CaseIterable, RawRepresentable, Setting
     case all
     case none
 
-    public static var `default`: Self { .all }
+    public static var defaultSettingValue: Self { .all }
     public var localizedDescription: String {
         switch self {
         case .all: return L10n.Settings.ConnectionSection.SensorSendType.Setting.all
@@ -128,7 +128,7 @@ public struct ServerInfo: Codable, Equatable {
     public static var defaultSortOrder: Int { -1 }
 
     public mutating func setSetting<T: RawRepresentable>(value: T?, for key: ServerSettingKey<T>) {
-        settings[key.rawValue] = value?.rawValue ?? T.default
+        settings[key.rawValue] = value?.rawValue ?? T.defaultSettingValue
     }
 
     public mutating func setSetting(value: String?, for key: ServerSettingKey<String?>) {
@@ -139,7 +139,7 @@ public struct ServerInfo: Codable, Equatable {
         if let value = settings[key.rawValue] as? T.RawValue, let result = T(rawValue: value) {
             return result
         } else {
-            return T.default
+            return T.defaultSettingValue
         }
     }
 

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -36,10 +36,24 @@ public enum ServerLocationPrivacy: String, CaseIterable, RawRepresentable, Setti
     }
 }
 
+public enum ServerSensorPrivacy: String, CaseIterable, RawRepresentable, SettingValue {
+    case all
+    case none
+
+    public static var `default`: Self { .all }
+    public var localizedDescription: String {
+        switch self {
+        case .all: return L10n.Settings.ConnectionSection.SensorSendType.Setting.all
+        case .none: return L10n.Settings.ConnectionSection.SensorSendType.Setting.none
+        }
+    }
+}
+
 public extension ServerSettingKey {
     static var localName: ServerSettingKey<String?> { "local_name" }
     static var overrideDeviceName: ServerSettingKey<String?> { "override_device_name" }
     static var locationPrivacy: ServerSettingKey<ServerLocationPrivacy> { "privacy_location" }
+    static var sensorPrivacy: ServerSettingKey<ServerSensorPrivacy> { "privacy_sensor" }
 }
 
 public struct ServerInfo: Codable, Equatable {

--- a/Sources/Shared/API/Webhook/Networking/WebhookResponseUpdateSensors.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookResponseUpdateSensors.swift
@@ -52,7 +52,7 @@ struct WebhookResponseUpdateSensors: WebhookResponseHandler {
             }
 
             return firstly { () -> Guarantee<[WebhookSensor]> in
-                Current.sensors.sensors(reason: .registration, serverVersion: api.server.info.version).map(\.sensors)
+                Current.sensors.sensors(reason: .registration, server: api.server).map(\.sensors)
             }.filterValues { sensor in
                 if let uniqueID = sensor.UniqueID {
                     return needsRegistering.contains(uniqueID)

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -163,14 +163,6 @@ public class SensorContainer {
                     return nil
                 }
             }.flatMap { $0 }
-        }.mapValues { [weak self] sensor -> WebhookSensor in
-            guard let self = self else { return sensor }
-
-            if self.isEnabled(sensor: sensor) {
-                return sensor
-            } else {
-                return WebhookSensor(redacting: sensor)
-            }
         }
 
         lastUpdate = .init(sensors: generatedSensors.map { [lastSentSensors] new in
@@ -200,7 +192,15 @@ public class SensorContainer {
             })
         })
 
-        return generatedSensors.map(SensorResponse.init(sensors:))
+        return generatedSensors.mapValues { [weak self] sensor -> WebhookSensor in
+            guard let self = self else { return sensor }
+
+            if self.isEnabled(sensor: sensor) {
+                return sensor
+            } else {
+                return WebhookSensor(redacting: sensor)
+            }
+        }.map(SensorResponse.init(sensors:))
     }
 
     private func notifySignal(reason: SensorContainerUpdateReason) {

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -82,6 +82,15 @@ public class SensorContainer {
         return !disabledSensorIDs.contains(id)
     }
 
+    public func isAllowedToSend(sensor: WebhookSensor, for server: Server) -> Bool {
+        guard isEnabled(sensor: sensor) else { return false }
+
+        switch server.info.setting(for: .sensorPrivacy) {
+        case .all: return true
+        case .none: return false
+        }
+    }
+
     public func setEnabled(_ value: Bool, for sensor: WebhookSensor) {
         guard let id = sensor.UniqueID else { return }
 
@@ -195,7 +204,7 @@ public class SensorContainer {
         return generatedSensors.mapValues { [weak self] sensor -> WebhookSensor in
             guard let self = self else { return sensor }
 
-            if self.isEnabled(sensor: sensor) {
+            if self.isAllowedToSend(sensor: sensor, for: server) {
                 return sensor
             } else {
                 return WebhookSensor(redacting: sensor)

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -132,13 +132,13 @@ public class SensorContainer {
         reason: SensorProviderRequest.Reason,
         limitedTo: [SensorProvider.Type]? = nil,
         location: CLLocation? = nil,
-        serverVersion: Version
+        server: Server
     ) -> Guarantee<SensorResponse> {
         let request = SensorProviderRequest(
             reason: reason,
             dependencies: providerDependencies,
             location: location,
-            serverVersion: serverVersion
+            serverVersion: server.info.version
         )
 
         let generatedSensors = firstly {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -985,6 +985,16 @@ public enum L10n {
         /// Remote UI URL
         public static var title: String { return L10n.tr("Localizable", "settings.connection_section.remote_ui_url.title") }
       }
+      public enum SensorSendType {
+        /// Sensors Sent
+        public static var title: String { return L10n.tr("Localizable", "settings.connection_section.sensor_send_type.title") }
+        public enum Setting {
+          /// All
+          public static var all: String { return L10n.tr("Localizable", "settings.connection_section.sensor_send_type.setting.all") }
+          /// None
+          public static var `none`: String { return L10n.tr("Localizable", "settings.connection_section.sensor_send_type.setting.none") }
+        }
+      }
       public enum ValidateError {
         /// Edit URL
         public static var editUrl: String { return L10n.tr("Localizable", "settings.connection_section.validate_error.edit_url") }

--- a/Tests/Shared/Webhook/WebhookResponseUpdateSensors.test.swift
+++ b/Tests/Shared/Webhook/WebhookResponseUpdateSensors.test.swift
@@ -67,7 +67,7 @@ class WebhookResponseUpdateSensorsTests: XCTestCase {
     func testUpdatedRequiringRegistration() throws {
         // it's probably too much work to mock out the sensors here, so this implicitly
         // depends on one of the registered sensors. to make this more obvious, grab one.
-        let sensors = try hang(Promise(Current.sensors.sensors(reason: .registration, serverVersion: .init()))).sensors
+        let sensors = try hang(Promise(Current.sensors.sensors(reason: .registration, server: api.server))).sensors
         let handler = WebhookResponseUpdateSensors(api: api)
         let request = WebhookRequest(type: "update_sensor_states", data: [:])
 


### PR DESCRIPTION
## Summary
When set to "None", all sensors sent to the server will be redacted.

## Screenshots
| Thing | Light | Dark |
| -- | -- | -- |
| Settings | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 21 59 01](https://user-images.githubusercontent.com/74188/146879285-d51cbe25-762f-459f-8ee2-6c3407620b1e.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 21 59 02](https://user-images.githubusercontent.com/74188/146879298-7e72e020-16d7-4b75-a2cb-e4e49f16d53a.png) |
| Detail | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 21 59 07](https://user-images.githubusercontent.com/74188/146879316-7bb54369-455c-4b84-9a68-3e424a76e98c.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2021-12-20 at 21 59 09](https://user-images.githubusercontent.com/74188/146879322-895acc93-5752-405a-82da-8eb021861639.png) |

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#644

## Any other notes
This also updates location when changing location privacy & sensors when changing sensor privacy, so the data server-side will be most-up-to-date.