### PR TITLE
Minor redis & deploy improvements

### DIFF
--- a/.github/workflows/push_deploy.yml
+++ b/.github/workflows/push_deploy.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'Sources/PushServer/**'
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -19,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "deploy Sources/PushServer -c app.fly.toml"
+          args: "deploy Sources/PushServer -c app.fly.toml --detach"
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "deploy Sources/PushServer -c redis.fly.toml"
+          args: "deploy Sources/PushServer -c redis.fly.toml --detach"

--- a/Sources/PushServer/Sources/App/RateLimits/RateLimits.swift
+++ b/Sources/PushServer/Sources/App/RateLimits/RateLimits.swift
@@ -11,6 +11,12 @@ public struct RateLimitsValues: Codable, Equatable {
     public var successful: Int
     public var errors: Int
 
+    // minimizing storage cost
+    enum CodingKeys: String, CodingKey {
+        case successful = "s"
+        case errors = "e"
+    }
+
     public var exceedsMaximum: Bool {
         (successful + errors) >= Self.dailyMaximum
     }
@@ -57,7 +63,7 @@ class RateLimitsImpl: RateLimits {
     private var expirationDate: Date?
 
     static func key(for identifier: String) -> String {
-        "rateLimits:\(identifier)"
+        "r\(identifier)"
     }
 
     private var currentExpirationDate: Date {

--- a/Sources/PushServer/Sources/App/configure.swift
+++ b/Sources/PushServer/Sources/App/configure.swift
@@ -25,7 +25,11 @@ public func configure(_ app: Application) throws {
         app.logger.notice("using redis server for rate limits")
         app.redis.configuration = try RedisConfiguration(
             hostname: server,
-            password: Environment.get("REDIS_PASSWORD")
+            password: Environment.get("REDIS_PASSWORD"),
+            pool: .init(
+                maximumConnectionCount: .maximumPreservedConnections(6),
+                connectionRetryTimeout: .seconds(60)
+            )
         )
         app.rateLimits.cache = app.caches.redis
     } else {


### PR DESCRIPTION
- Reduces Redis storage usage by minimizing keys & values.
- Increases Redis initial connection timeout from 10ms to 60s. This is the _intended_ duration by the library, but a healthy amount of default values in [the Vapor side](https://github.com/vapor/redis/blob/8037b6f66aec6a3bfbd13c7e881a80b3ac9e4f15/Sources/Redis/RedisConfiguration.swift#L27) causes `nil` to be passed down, which causes a `?? .milliseconds(10)` in [the Redis library](https://gitlab.com/Mordil/RediStack/-/blob/8ff8b03907ca0ff9d9f1778c932dbb0ae6884bd9/Sources/RediStack/Configuration.swift#L295).
- Makes APNS deploys cancel earlier ones, and detaches from the deploy so the GHA can exit earlier.