### PR TITLE
Caching derived data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
         id: cache_gems
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: >-
+            ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
 
       - uses: actions/cache@v2
         name: "Cache Derived Data"
@@ -93,7 +94,7 @@ jobs:
           path: |
             ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/Build
             ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/SourcePackages
-          key: ${{ runner.os }}-derivedData-cache-${{ hashFiles('**/Podfile.lock', 
+          key: ${{ runner.os }}-derivedData-cache-${{ hashFiles('**/Podfile.lock',
             'HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-derivedData-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,19 @@ jobs:
         id: cache_gems
         with:
           path: vendor/bundle
-          key: >-
-            ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
-      
+          key: ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
+
       - uses: actions/cache@v2
         name: "Cache Derived Data"
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/Build
             ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/SourcePackages
-          key: ${{ runner.os }}-derivedData-cache-${{ hashFiles('**/Podfile.lock', 'HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-derivedData-cache-${{ hashFiles('**/Podfile.lock', 
+            'HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-derivedData-cache
-            
+
       - name: Avoid inode changes for DerivedData
         run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,19 @@ jobs:
           path: vendor/bundle
           key: >-
             ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
+      
+      - uses: actions/cache@v2
+        name: "Cache Derived Data"
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/Build
+            ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/SourcePackages
+          key: ${{ runner.os }}-derivedData-cache-${{ hashFiles('**/Podfile.lock', 'HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-derivedData-cache
+            
+      - name: Avoid inode changes for DerivedData
+        run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
 
       - name: Install Brews
         # right now, we don't need anything from brew for tests, so save some time


### PR DESCRIPTION
## Summary
CI action takes too long.
It could be a good idea to cache Derived Data folder in the github action.
The point is to cache Build and SourcePackages and set the IgnoreFileSystemDeviceInodeChanges parameter to yes, as described in https://stackoverflow.com/a/54055857/1012432.
The thing is that SPM  revokes DerivedData when running in another machine and it downloads and recompile all again.

Another way to get the same result is to add the parameter IgnoreFileSystemDeviceInodeChanges=1 to xcodeBuild.


## Link to pull request in Documentation repository
There was a try but seems it didn't work and was removed on  https://github.com/home-assistant/iOS/pull/1242.
It was a good try, but maybe the IgnoreFileSystemDeviceInodeChanges option was not setted.



## Any other notes
In some projects i worked it was possible to reduce a pipeline from 30 minutes to 5 minutes. But the first run will always be of 30 minutes.

Please take a look at the execution on the fork I made https://github.com/juanlao/iOS/actions/runs/1803337837 it is 13 minutes long.
Hope this helps
