### PR TITLE
Fix WebView reloading itself when hostname contains uppercase

### DIFF
--- a/Sources/Shared/Common/Extensions/URL+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/URL+Extensions.swift
@@ -3,9 +3,9 @@ import Foundation
 extension URL {
     /// Return true if receiver's host and scheme is equal to `otherURL`
     public func baseIsEqual(to otherURL: URL) -> Bool {
-        host == otherURL.host
+        host?.lowercased() == otherURL.host?.lowercased()
             && portWithFallback == otherURL.portWithFallback
-            && scheme == otherURL.scheme
+            && scheme?.lowercased() == otherURL.scheme?.lowercased()
             && user == otherURL.user
             && password == otherURL.password
     }


### PR DESCRIPTION
## Summary
The webview resolves itself to the lowercased version of the URL, so any comparisons we do to determine if we need to reload result in reloading.

## Any other notes
Some reports of this [on Reddit](https://www.reddit.com/r/homeassistant/comments/snz9g0/every_time_app_loses_focus_causes_lovelace_to/). This was found in the (only) logs I've received so far, and I can reproduce the issue for this specific reason. Could be other oversights.