### PR TITLE
Fix overlapping zones with zone-only privacy level

### DIFF
--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -275,8 +275,8 @@ public final class RLMZone: Object, UpdatableModel {
             .filter(trackablePredicate)
             .filter { $0.circularRegion.containsWithAccuracy(location) }
             .sorted { zoneA, zoneB in
-                zoneA.circularRegion.distanceWithAccuracy(from: location)
-                    < zoneB.circularRegion.distanceWithAccuracy(from: location)
+                // match the smaller zone over the larger
+                zoneA.Radius < zoneB.Radius
             }
             .first
     }


### PR DESCRIPTION
Fixes #2064.

## Summary
When multiple zones contain the location when sending zone names only to the server, prefers the smaller radius.