### PR TITLE
Fix discovery of instances older than 0.110

### DIFF
--- a/Sources/Shared/API/Responses/DiscoveredHomeAssistant.swift
+++ b/Sources/Shared/API/Responses/DiscoveredHomeAssistant.swift
@@ -30,6 +30,12 @@ public struct DiscoveredHomeAssistant: ImmutableMappable {
         self.version = try map.value("version", using: VersionTransform())
         self.externalURL = try? map.value("external_url", using: URLTransform())
         self.internalURL = try? map.value("internal_url", using: URLTransform())
+
+        if externalURL == nil, internalURL == nil {
+            // compatibility with HA <0.110
+            self.externalURL = try? map.value("base_url", using: URLTransform())
+        }
+
         self.locationName = (try? map.value("location_name")) ?? "Home"
 
         if let url = internalURL ?? externalURL {


### PR DESCRIPTION
## Summary
Version 0.110 started sending internal_url/external_url, but older versions than that send base_url.

## Any other notes
This is really only a problem because versions older than 0.104 do not support including the device id in the registration, but we don't know the version number until we pull the config from the webhook, which can only be created after registering the device. Thus, if you're using a version older than 0.104 and doing manual setup, it'll still always fail, but discovery-based will start working after this.