### PR TITLE
Potentially fix invalid authentication issues

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -74,7 +74,7 @@ public class HomeAssistantAPI {
             },
             fetchAuthToken: { completion in
                 tokenManager.bearerToken.done {
-                    completion(.success($0))
+                    completion(.success($0.0))
                 }.catch {
                     completion(.failure($0))
                 }


### PR DESCRIPTION
## Summary
There is a potential race condition in token retrieving which could result in providing an old access token to a WebView external auth request. This should at least make it not provide the wrong one, even though the race condition will still occur with the saved keychain data.

## Any other notes
My hunch is that a server's info is updated using stale data just as an access token is updated, which would cause the "grab the server.info.token" to use the wrong access token when constructing the dictionary.

Grabbing it from the server is unnecessary here - we're in the promise chain for getting the new access token anyway, so we can avoid the underlying issue by using the right token when we know it works.

I can sort of reproduce this by hammering server info updates and grabbing the dictionary but not in any way that is reliable enough to write a test around. It may be worth trying to add some sanity checks into the token expirations in the future too. Some additional logging here should make it a little easier to figure out what's going on if/when this reproduces.