### PR TITLE
Fix a just-deleted server being readded using old info

### DIFF
--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -132,6 +132,9 @@ class ServerManagerTests: XCTestCase {
         }
         try XCTAssertNil(keychain.getData("fake1"))
 
+        // grab it, which may also side-effect insert into cache, if buggy
+        _ = server1.info
+
         expectingObserver {
             // we just deleted it, so we re-add it to make sure _that_ works
             let tempFake1 = with(info1) {


### PR DESCRIPTION
## Summary
The cache for server infos was inserting the old 'fallback' value when read after deletion, which caused it to be used if the server was re-added while the app was still in memory afterwards.