### PR TITLE
Convert webhook secret to bytes from hex

### DIFF
--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -239,6 +239,23 @@ public struct ConnectionInfo: Codable, Equatable {
 
         return false
     }
+
+    /// Secret as byte array
+    var webhookSecretBytes: [UInt8]? {
+        guard let webhookSecret = webhookSecret, webhookSecret.count.isMultiple(of: 2) else {
+            return nil
+        }
+
+        var stringIterator = webhookSecret.makeIterator()
+
+        return Array(AnyIterator<UInt8> {
+            guard let first = stringIterator.next(), let second = stringIterator.next() else {
+                return nil
+            }
+
+            return UInt8(String(first) + String(second), radix: 16)
+        })
+    }
 }
 
 class ServerRequestAdapter: RequestAdapter {

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -248,11 +248,11 @@ public struct ConnectionInfo: Codable, Equatable {
         }
 
         guard version >= .fullWebhookSecretKey else {
-            return .init(
-                webhookSecret.utf8[
-                    webhookSecret.startIndex ..< webhookSecret.index(webhookSecret.startIndex, offsetBy: 32)
-                ]
-            )
+            if let end = webhookSecret.index(webhookSecret.startIndex, offsetBy: 32, limitedBy: webhookSecret.endIndex) {
+                return .init(webhookSecret.utf8[webhookSecret.startIndex ..< end])
+            } else {
+                return nil
+            }
         }
 
         var stringIterator = webhookSecret.makeIterator()

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -1,5 +1,6 @@
 import Alamofire
 import Foundation
+import Version
 #if os(watchOS)
 import Communicator
 #endif
@@ -241,9 +242,17 @@ public struct ConnectionInfo: Codable, Equatable {
     }
 
     /// Secret as byte array
-    var webhookSecretBytes: [UInt8]? {
+    func webhookSecretBytes(version: Version) -> [UInt8]? {
         guard let webhookSecret = webhookSecret, webhookSecret.count.isMultiple(of: 2) else {
             return nil
+        }
+
+        guard version >= .fullWebhookSecretKey else {
+            return .init(
+                webhookSecret.utf8[
+                    webhookSecret.startIndex ..< webhookSecret.index(webhookSecret.startIndex, offsetBy: 32)
+                ]
+            )
         }
 
         var stringIterator = webhookSecret.makeIterator()

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -248,7 +248,11 @@ public struct ConnectionInfo: Codable, Equatable {
         }
 
         guard version >= .fullWebhookSecretKey else {
-            if let end = webhookSecret.index(webhookSecret.startIndex, offsetBy: 32, limitedBy: webhookSecret.endIndex) {
+            if let end = webhookSecret.index(
+                webhookSecret.startIndex,
+                offsetBy: 32,
+                limitedBy: webhookSecret.endIndex
+            ) {
                 return .init(webhookSecret.utf8[webhookSecret.startIndex ..< end])
             } else {
                 return nil

--- a/Sources/Shared/API/Webhook/Networking/Promise+WebhookJson.swift
+++ b/Sources/Shared/API/Webhook/Networking/Promise+WebhookJson.swift
@@ -14,7 +14,7 @@ extension Promise where T == Data? {
         on queue: DispatchQueue? = nil,
         statusCode: Int? = nil,
         sodium: Sodium = Sodium(),
-        secretGetter: @escaping () -> String?,
+        secretGetter: @escaping () -> [UInt8]?,
         options: JSONSerialization.ReadingOptions = [.allowFragments]
     ) -> Promise<Any> {
         then { optionalData -> Promise<Any> in
@@ -38,7 +38,7 @@ extension Promise where T == Data {
         on queue: DispatchQueue? = nil,
         statusCode: Int? = nil,
         sodium: Sodium = Sodium(),
-        secretGetter: @escaping () -> String?,
+        secretGetter: @escaping () -> [UInt8]?,
         options: JSONSerialization.ReadingOptions = [.allowFragments]
     ) -> Promise<Any> {
         definitelyWebhookJson(
@@ -55,7 +55,7 @@ extension Promise where T == Data {
         on queue: DispatchQueue?,
         statusCode: Int?,
         sodium: Sodium,
-        secretGetter: @escaping () -> String?,
+        secretGetter: @escaping () -> [UInt8]?,
         options: JSONSerialization.ReadingOptions = [.allowFragments]
     ) -> Promise<Any> {
         if let statusCode = statusCode {
@@ -97,7 +97,7 @@ extension Promise where T == Data {
 
             guard let decrypted = sodium.secretBox.open(
                 nonceAndAuthenticatedCipherText: decoded,
-                secretKey: secret.bytes
+                secretKey: .init(secret)
             ) else {
                 throw WebhookJsonParseError.decrypt
             }

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -223,7 +223,7 @@ public class WebhookManager: NSObject {
             Promise.value(data).webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: (response as? HTTPURLResponse)?.statusCode,
-                secretGetter: { server.info.connection.webhookSecret }
+                secretGetter: { server.info.connection.webhookSecretBytes }
             )
         }.map { possible in
             if let value = possible as? ResponseType {
@@ -423,7 +423,7 @@ public class WebhookManager: NSObject {
             Promise.value(data).webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: (response as? HTTPURLResponse)?.statusCode,
-                secretGetter: { server.info.connection.webhookSecret }
+                secretGetter: { server.info.connection.webhookSecretBytes }
             )
         }.asVoid()
     }
@@ -561,7 +561,7 @@ extension WebhookManager: URLSessionDataDelegate {
             }.webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: statusCode,
-                secretGetter: { server.info.connection.webhookSecret }
+                secretGetter: { server.info.connection.webhookSecretBytes }
             )
 
             // logging

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -223,7 +223,7 @@ public class WebhookManager: NSObject {
             Promise.value(data).webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: (response as? HTTPURLResponse)?.statusCode,
-                secretGetter: { server.info.connection.webhookSecretBytes }
+                secretGetter: { server.info.connection.webhookSecretBytes(version: server.info.version) }
             )
         }.map { possible in
             if let value = possible as? ResponseType {
@@ -423,7 +423,7 @@ public class WebhookManager: NSObject {
             Promise.value(data).webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: (response as? HTTPURLResponse)?.statusCode,
-                secretGetter: { server.info.connection.webhookSecretBytes }
+                secretGetter: { server.info.connection.webhookSecretBytes(version: server.info.version) }
             )
         }.asVoid()
     }
@@ -561,7 +561,7 @@ extension WebhookManager: URLSessionDataDelegate {
             }.webhookJson(
                 on: DispatchQueue.global(qos: .utility),
                 statusCode: statusCode,
-                secretGetter: { server.info.connection.webhookSecretBytes }
+                secretGetter: { server.info.connection.webhookSecretBytes(version: server.info.version) }
             )
 
             // logging

--- a/Sources/Shared/API/Webhook/Networking/WebhookRequest.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookRequest.swift
@@ -56,7 +56,7 @@ public struct WebhookRequest: ImmutableMappable {
     }
 
     private func encryptedData(server: Server) -> String? {
-        guard let secret = server.info.connection.webhookSecretBytes else {
+        guard let secret = server.info.connection.webhookSecretBytes(version: server.info.version) else {
             return nil
         }
 

--- a/Sources/Shared/API/Webhook/Networking/WebhookRequest.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookRequest.swift
@@ -56,7 +56,7 @@ public struct WebhookRequest: ImmutableMappable {
     }
 
     private func encryptedData(server: Server) -> String? {
-        guard let secret = server.info.connection.webhookSecret else {
+        guard let secret = server.info.connection.webhookSecretBytes else {
             return nil
         }
 
@@ -72,11 +72,9 @@ public struct WebhookRequest: ImmutableMappable {
             return nil
         }
 
-        let key: Bytes = Array(secret.bytes[0 ..< sodium.secretBox.KeyBytes])
-
         guard let encryptedData: Bytes = sodium.secretBox.seal(
             message: jsonStr.bytes,
-            secretKey: key
+            secretKey: .init(secret)
         ) else {
             Current.Log.error("Unable to generate encrypted webhook payload! Secret: \(secret), JSON: \(jsonStr)")
             return nil

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -147,7 +147,7 @@ public extension Version {
     static var externalBusCommandRestart: Version = .init(major: 2021, minor: 12, prerelease: "b6")
     static var updateLocationGPSOptional: Version = .init(major: 2022, minor: 2, prerelease: "any0")
     static var fullWebhookSecretKey: Version = .init(major: 2022, minor: 3)
-    
+
     var coreRequiredString: String {
         L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))
     }

--- a/Sources/Shared/Environment/Constants.swift
+++ b/Sources/Shared/Environment/Constants.swift
@@ -146,7 +146,8 @@ public extension Version {
     static var localPushConfirm: Version = .init(major: 2021, minor: 10, prerelease: "any0")
     static var externalBusCommandRestart: Version = .init(major: 2021, minor: 12, prerelease: "b6")
     static var updateLocationGPSOptional: Version = .init(major: 2022, minor: 2, prerelease: "any0")
-
+    static var fullWebhookSecretKey: Version = .init(major: 2022, minor: 3)
+    
     var coreRequiredString: String {
         L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))
     }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -1,6 +1,6 @@
 @testable import Shared
-import XCTest
 import Version
+import XCTest
 
 class ConnectionInfoTests: XCTestCase {
     func testInternalOnlyURL() {
@@ -389,12 +389,77 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(
             info.webhookSecretBytes(version: oldVersion),
             // incorrectly using ascii/utf8 of the first 32 characters
-            [97, 98, 99, 100, 101, 102, 48, 102, 101, 100, 99, 98, 97, 48, 97, 98, 99, 100, 101, 102, 48, 102, 101, 100, 99, 98, 97, 48, 97, 98, 99, 100]
+            [
+                97,
+                98,
+                99,
+                100,
+                101,
+                102,
+                48,
+                102,
+                101,
+                100,
+                99,
+                98,
+                97,
+                48,
+                97,
+                98,
+                99,
+                100,
+                101,
+                102,
+                48,
+                102,
+                101,
+                100,
+                99,
+                98,
+                97,
+                48,
+                97,
+                98,
+                99,
+                100,
+            ]
         )
         XCTAssertEqual(
             info.webhookSecretBytes(version: newVersion),
             // using the full hex representation
-            [0xab, 0xcd, 0xef, 0x0f, 0xed, 0xcb, 0xa0, 0xab, 0xcd, 0xef, 0x0f, 0xed, 0xcb, 0xa0, 0xab, 0xcd, 0xef, 0x0a, 0xbc, 0xde, 0xf0, 0xfe, 0xdc, 0xba, 0x0a, 0xbc, 0xde, 0xf0, 0xfe, 0xdc, 0xba]
+            [
+                0xAB,
+                0xCD,
+                0xEF,
+                0x0F,
+                0xED,
+                0xCB,
+                0xA0,
+                0xAB,
+                0xCD,
+                0xEF,
+                0x0F,
+                0xED,
+                0xCB,
+                0xA0,
+                0xAB,
+                0xCD,
+                0xEF,
+                0x0A,
+                0xBC,
+                0xDE,
+                0xF0,
+                0xFE,
+                0xDC,
+                0xBA,
+                0x0A,
+                0xBC,
+                0xDE,
+                0xF0,
+                0xFE,
+                0xDC,
+                0xBA,
+            ]
         )
     }
 }


### PR DESCRIPTION
Refs home-assistant/core#67429.

## Summary
Fixes the logic for decryption to use the full key, rather than half of it, when decoding/encoding the additional encryption we use for webhooks only.

## Any other notes
This encryption is largely superfluous in the era of Let's Encrypt's dominance, but we're going to be reusing it for end-to-end encrypted notifications.