### PR TITLE
Add "Full Screen" setting

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -386,6 +386,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings_details.general.app_icon.enum.white" = "White";
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.device_name.title" = "Device Name";
+"settings_details.general.full_screen.title" = "Full Screen";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";
 "settings_details.general.menu_bar_text.title" = "Menu Bar Text";
 "settings_details.general.open_in_browser.chrome" = "Google Chrome";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -238,6 +238,15 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     }
                 }
 
+                <<< SwitchRow {
+                    $0.title = L10n.SettingsDetails.General.FullScreen.title
+                    $0.hidden = .isCatalyst
+                    $0.value = Current.settingsStore.fullScreen
+                    $0.onChange { row in
+                        Current.settingsStore.fullScreen = row.value ?? false
+                    }
+                }
+
         case "location":
             title = L10n.SettingsDetails.Location.title
             form

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -82,6 +82,14 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         }
     }
 
+    override var prefersStatusBarHidden: Bool {
+        Current.settingsStore.fullScreen
+    }
+
+    override var prefersHomeIndicatorAutoHidden: Bool {
+        Current.settingsStore.fullScreen
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -768,6 +776,11 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
         if !Current.isCatalyst {
             let zoomValue = Current.settingsStore.pinchToZoom ? "true" : "false"
             webView.evaluateJavaScript("setOverrideZoomEnabled(\(zoomValue))", completionHandler: nil)
+        }
+
+        if reason == .settingChange {
+            setNeedsStatusBarAppearanceUpdate()
+            setNeedsUpdateOfHomeIndicatorAutoHidden()
         }
     }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1286,6 +1286,10 @@ public enum L10n {
         /// Device Name
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.device_name.title") }
       }
+      public enum FullScreen {
+        /// Full Screen
+        public static var title: String { return L10n.tr("Localizable", "settings_details.general.full_screen.title") }
+      }
       public enum LaunchOnLogin {
         /// Launch App on Login
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.launch_on_login.title") }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -157,6 +157,16 @@ public class SettingsStore {
         }
     }
 
+    public var fullScreen: Bool {
+        get {
+            prefs.bool(forKey: "fullScreen")
+        }
+        set {
+            prefs.set(newValue, forKey: "fullScreen")
+            NotificationCenter.default.post(name: Self.webViewRelatedSettingDidChange, object: nil)
+        }
+    }
+
     public var periodicUpdateInterval: TimeInterval? {
         get {
             if prefs.object(forKey: "periodicUpdateInterval") == nil {


### PR DESCRIPTION
Fixes #1720.

## Summary
On iPhone, this turns off the status bar text but continues to use the space, since the frontend doesn't handle the top safe area.

On iPad, this turns off the status bar and doesn't reserve any space.

## Screenshots
| - | On | Off |
| -- | -- | -- |
| iPad | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) (15 2) - 2022-03-05 at 19 18 14](https://user-images.githubusercontent.com/74188/156907781-b155d227-5429-4218-accd-f25ee4823e13.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) (15 2) - 2022-03-05 at 19 18 37](https://user-images.githubusercontent.com/74188/156907787-4162dab4-4cd9-4431-ae4a-7944db706330.png) |
| iPhone | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2022-03-05 at 19 22 08](https://user-images.githubusercontent.com/74188/156907836-b9ea1aab-a014-4df6-893a-e8f69eb669d4.png) | ![Simulator Screen Shot - iPhone 13 Pro (15 2) - 2022-03-05 at 19 22 41](https://user-images.githubusercontent.com/74188/156907838-22810255-7976-4908-af83-98d282467e61.png) |


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
