### PR TITLE
Improve SSL connection errors in onboarding

### DIFF
--- a/Sources/App/Onboarding/API/Steps/OnboardingAuthStepConnectivity.swift
+++ b/Sources/App/Onboarding/API/Steps/OnboardingAuthStepConnectivity.swift
@@ -43,6 +43,8 @@ struct OnboardingAuthStepConnectivity: OnboardingAuthPreStep {
                             return nil
                         }
 
+                        Current.Log.error("received SSL error: \((error as NSError).debugDescription)")
+
                         if let underlying = (error as NSError).userInfo[NSUnderlyingErrorKey] as? Error {
                             // higher-level error is like:
                             // > “fake.example.com” certificate is not trusted

--- a/Tests/App/Auth/OnboardingAuthStepConnectivity.swift
+++ b/Tests/App/Auth/OnboardingAuthStepConnectivity.swift
@@ -157,7 +157,7 @@ class OnboardingAuthStepConnectivityTests: XCTestCase {
             }
 
             XCTAssertThrowsError(try hang(step.perform(point: .beforeAuth))) { error in
-                XCTAssertEqual((error as? OnboardingAuthError)?.kind, .sslUntrusted(URLError(code)))
+                XCTAssertEqual((error as? OnboardingAuthError)?.kind, .sslUntrusted([URLError(code)]))
             }
         }
     }


### PR DESCRIPTION
## Summary
Evaluates the certificate directly to try and get better error messages from SSL errors.

## Screenshots
| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-07 at 16 34 31](https://user-images.githubusercontent.com/74188/167275480-6ff57e2c-bfeb-4593-96bb-defa2197b95f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-07 at 23 27 59](https://user-images.githubusercontent.com/74188/167284731-0488e550-45b6-4f09-b27c-f4d7f2ae7613.png) |

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
