### PR TITLE
Open non-frontend pages in external browser

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -386,7 +386,21 @@ class WebViewController: UIViewController, WKNavigationDelegate, WKUIDelegate, U
 
     public func open(inline url: URL) {
         loadViewIfNeeded()
-        webView.load(URLRequest(url: url))
+
+        // these paths do not show frontend pages, and so we don't want to display them in our webview
+        // otherwise the user will get stuck. e.g. /api is loaded by frigate to show video clips and images
+        let ignoredPaths = [
+            "/api",
+            "/static",
+            "/hacsfiles",
+            "/local",
+        ]
+
+        if ignoredPaths.allSatisfy({ !url.path.hasPrefix($0) }) {
+            webView.load(URLRequest(url: url))
+        } else {
+            openURLInBrowser(url, self)
+        }
     }
 
     private var lastNavigationWasServerError = false


### PR DESCRIPTION
## Summary
Fixes e.g. [Frigate](https://docs.frigate.video/)'s notifications which open a /api/something path to show a video. Non-frontend pages will cause us to potentially get stuck since there's no on-screen UI to go 'back'.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
