### PR TITLE
Retry notarize if it fails, allow Mac/iOS distributes to independently fail

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     runs-on: macos-11
     strategy:
+      fail-fast: false
       matrix:
         kind: [mac, ios]
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -545,12 +545,28 @@ platform :mac do
       }
     )
     upload_archive_to_sentry
-    notarize(
-      package: developer_id_app_path,
-      # not the _app_ bundle id, just an id that notarize uses for referencing
-      bundle_id: 'io.home-assistant.fastlane.developer-id',
-      verbose: true
-    )
+    
+    notarize_attempts = 0
+    
+    begin
+      notarize(
+        package: developer_id_app_path,
+        # not the _app_ bundle id, just an id that notarize uses for referencing
+        bundle_id: 'io.home-assistant.fastlane.developer-id',
+        verbose: true
+      )
+    rescue StandardError => e
+      puts "Failed with #{e}; retrying notarize in a few seconds..."
+      
+      sleep 5
+    
+      # retry a few times, then give up
+      notarize_attempts += 1
+    
+      retry if notarize_attempts <= 3
+      raise e
+    end
+    
     sh(
       'ditto',
       '-c',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -545,9 +545,9 @@ platform :mac do
       }
     )
     upload_archive_to_sentry
-    
+
     notarize_attempts = 0
-    
+
     begin
       notarize(
         package: developer_id_app_path,
@@ -557,16 +557,16 @@ platform :mac do
       )
     rescue StandardError => e
       puts "Failed with #{e}; retrying notarize in a few seconds..."
-      
+
       sleep 5
-    
+
       # retry a few times, then give up
       notarize_attempts += 1
-    
+
       retry if notarize_attempts <= 3
       raise e
     end
-    
+
     sh(
       'ditto',
       '-c',


### PR DESCRIPTION
## Summary
Potentially fixes the distribute failures occurring. It looks like Apple's notarize server is down though, so blippity blip blip.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
