### PR TITLE
Fix avatar row in settings with untrusted certificates

### DIFF
--- a/Sources/App/Settings/Eureka/AccountRow.swift
+++ b/Sources/App/Settings/Eureka/AccountRow.swift
@@ -1,3 +1,4 @@
+import Alamofire
 import Eureka
 import Foundation
 import HAKit
@@ -181,7 +182,7 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
             self.cachedUserName = user.name
             self.updateCell()
 
-            var lastTask: URLSessionDataTask? {
+            var lastTask: Request? {
                 didSet {
                     oldValue?.cancel()
                     lastTask?.resume()
@@ -205,13 +206,13 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
                     }
                 }.map { path throws -> URL in
                     let url = server.info.connection.activeURL().appendingPathComponent(path)
-                    if let lastTask = lastTask, lastTask.error == nil, lastTask.originalRequest?.url == url {
+                    if let lastTask = lastTask, lastTask.error == nil, lastTask.request?.url == url {
                         throw FetchAvatarError.alreadySet
                     }
                     return url
                 }.then { url -> Promise<Data> in
                     Promise<Data> { seal in
-                        api.manager.download(url).validate().responseData { result in
+                        lastTask = api.manager.download(url).validate().responseData { result in
                             seal.resolve(result.result)
                         }
                     }

--- a/Sources/App/Settings/Eureka/AccountRow.swift
+++ b/Sources/App/Settings/Eureka/AccountRow.swift
@@ -172,7 +172,8 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
             return
         }
 
-        let connection = Current.api(for: server).connection
+        let api = Current.api(for: server)
+        let connection = api.connection
 
         accountSubscription = connection.caches.user.subscribe { [weak self] _, user in
             guard let self = self else { return }
@@ -210,9 +211,9 @@ final class HomeAssistantAccountRow: Row<AccountCell>, RowType {
                     return url
                 }.then { url -> Promise<Data> in
                     Promise<Data> { seal in
-                        lastTask = URLSession.shared.dataTask(with: url, completionHandler: { data, _, error in
-                            seal.resolve(data, error)
-                        })
+                        api.manager.download(url).validate().responseData { result in
+                            seal.resolve(result.result)
+                        }
                     }
                 }.map { data throws -> UIImage in
                     if let image = UIImage(data: data) {


### PR DESCRIPTION
## Summary
Use an auth challenge aware URLSession to download the avatar. Missed this one internal use of URLSession.session in #2131.

## Screenshots
<img width=300 src="https://user-images.githubusercontent.com/74188/170800262-cf4e7446-7d7d-4bba-92cf-04f29e58659d.PNG">