### PR TITLE
Allow supplying client certificates

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 		114E9B4E24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */; };
 		114E9B4F24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */; };
 		114FACAE24B2ABA2006C581F /* Promise+WebhookJson.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */; };
+		114FBFFD28433D0900EE6BE6 /* CustomURLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FBFFC28433D0900EE6BE6 /* CustomURLCredentialStorage.swift */; };
+		114FBFFE28433D0900EE6BE6 /* CustomURLCredentialStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114FBFFC28433D0900EE6BE6 /* CustomURLCredentialStorage.swift */; };
 		11521BBC25400284009C5C72 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11521BBB25400284009C5C72 /* CrashReporter.swift */; };
 		11521BBD25400284009C5C72 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11521BBB25400284009C5C72 /* CrashReporter.swift */; };
 		115560E127010D8400A8F818 /* WidgetBasicContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */; };
@@ -1210,6 +1212,7 @@
 		114CBAEC283AB92D00A9BAFF /* SecTrust+TestAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecTrust+TestAdditions.swift"; sourceTree = "<group>"; };
 		114E9B4D24E89B1300B43EED /* INImage+MaterialDesignIcons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "INImage+MaterialDesignIcons.swift"; sourceTree = "<group>"; };
 		114FACAD24B2ABA2006C581F /* Promise+WebhookJson.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+WebhookJson.test.swift"; sourceTree = "<group>"; };
+		114FBFFC28433D0900EE6BE6 /* CustomURLCredentialStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLCredentialStorage.swift; sourceTree = "<group>"; };
 		11521BBB25400284009C5C72 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBasicContainerView.swift; sourceTree = "<group>"; };
 		115560E227010DAB00A8F818 /* WidgetBasicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBasicView.swift; sourceTree = "<group>"; };
@@ -2218,6 +2221,7 @@
 				117675EE252D5CA80047B1D3 /* WebhookResponseUpdateComplications.swift */,
 				11C4629524B19FC700031902 /* URLSessionTask+WebhookPersisted.swift */,
 				114CBAE72839E49E00A9BAFF /* CustomServerTrustManager.swift */,
+				114FBFFC28433D0900EE6BE6 /* CustomURLCredentialStorage.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -3461,7 +3465,6 @@
 				1120C57E274638330046C38B /* PerServerContainer.swift */,
 				11F20BFB274D5DA900DFB163 /* Server+Fakes.swift */,
 				113A8D48283C7B1700B9DA32 /* PeriodicUpdateManager.swift */,
-				11B6774C28303D35006E9B1A /* HASecTrustException.swift */,
 				11B6774C28303D35006E9B1A /* SecurityExceptions.swift */,
 			);
 			path = API;
@@ -5539,6 +5542,7 @@
 				11C4628C24B1230E00031902 /* WebhookResponseServiceCall.swift in Sources */,
 				B67CE8AA22200F220034C1D0 /* ConnectionInfo.swift in Sources */,
 				11EE9B4F24C6089800404AF8 /* RealmPersistable.swift in Sources */,
+				114FBFFE28433D0900EE6BE6 /* CustomURLCredentialStorage.swift in Sources */,
 				11358AED24FC9F300074C4E2 /* ActiveSensor.swift in Sources */,
 				B67CE8BC22200F220034C1D0 /* ClientEvent.swift in Sources */,
 				B67CE8BB22200F220034C1D0 /* UNNotificationContent+ClientEvent.swift in Sources */,
@@ -5733,6 +5737,7 @@
 				11F2F27E258725D300F61F7C /* NotificationAttachmentErrorImage.swift in Sources */,
 				1148A45024E9AF9200345050 /* MDIMigration.swift in Sources */,
 				110ED58F25A6743900489AF7 /* ConnectivityWrapper.swift in Sources */,
+				114FBFFD28433D0900EE6BE6 /* CustomURLCredentialStorage.swift in Sources */,
 				116740732519907400F51626 /* MacBridgeProtocol.swift in Sources */,
 				11F2F24125871CAF00F61F7C /* NotificationAttachmentParser.swift in Sources */,
 				114E9B4E24E89B1300B43EED /* INImage+MaterialDesignIcons.swift in Sources */,

--- a/Sources/Shared/API/Authentication/AuthenticationAPI.swift
+++ b/Sources/Shared/API/Authentication/AuthenticationAPI.swift
@@ -20,9 +20,18 @@ public class AuthenticationAPI {
     let server: Server
     let session: Session
 
+    private static func configuration(credentialStorage: CustomURLCredentialStorage) -> URLSessionConfiguration {
+        with(URLSessionConfiguration.ephemeral) {
+            $0.urlCredentialStorage = credentialStorage
+        }
+    }
+
     init(server: Server) {
         self.server = server
-        self.session = Session(serverTrustManager: CustomServerTrustManager(server: server))
+        self.session = Session(
+            configuration: Self.configuration(credentialStorage: .init(server: server)),
+            serverTrustManager: CustomServerTrustManager(server: server)
+        )
     }
 
     public func refreshTokenWith(tokenInfo: TokenInfo) -> Promise<TokenInfo> {
@@ -70,7 +79,10 @@ public class AuthenticationAPI {
         baseURL: URL,
         exceptions: SecurityExceptions
     ) -> Promise<TokenInfo> {
-        let session = Session(serverTrustManager: CustomServerTrustManager(exceptions: exceptions))
+        let session = Session(
+            configuration: Self.configuration(credentialStorage: .init(exceptions: exceptions)),
+            serverTrustManager: CustomServerTrustManager(exceptions: exceptions)
+        )
 
         return Promise { seal in
             let routeInfo = RouteInfo(

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -93,7 +93,8 @@ public class HomeAssistantAPI {
         let manager = HomeAssistantAPI.configureSessionManager(
             urlConfig: urlConfig,
             interceptor: newInterceptor(),
-            trustManager: newServerTrustManager()
+            trustManager: newServerTrustManager(),
+            credentialStorage: newCredentialStorage()
         )
         self.manager = manager
 
@@ -114,9 +115,11 @@ public class HomeAssistantAPI {
         urlConfig: URLSessionConfiguration = .default,
         delegate: SessionDelegate = SessionDelegate(),
         interceptor: Interceptor = .init(),
-        trustManager: ServerTrustManager? = nil
+        trustManager: ServerTrustManager? = nil,
+        credentialStorage: URLCredentialStorage? = nil
     ) -> Session {
         let configuration = urlConfig
+        configuration.urlCredentialStorage = credentialStorage
 
         var headers = configuration.httpAdditionalHeaders ?? [:]
         headers["User-Agent"] = Self.userAgent
@@ -146,11 +149,16 @@ public class HomeAssistantAPI {
         CustomServerTrustManager(server: server)
     }
 
+    private func newCredentialStorage() -> CustomURLCredentialStorage {
+        CustomURLCredentialStorage(server: server)
+    }
+
     public func VideoStreamer() -> MJPEGStreamer {
         MJPEGStreamer(manager: HomeAssistantAPI.configureSessionManager(
             delegate: MJPEGStreamerSessionDelegate(),
             interceptor: newInterceptor(),
-            trustManager: newServerTrustManager()
+            trustManager: newServerTrustManager(),
+            credentialStorage: newCredentialStorage()
         ))
     }
 

--- a/Sources/Shared/API/Webhook/Networking/CustomURLCredentialStorage.swift
+++ b/Sources/Shared/API/Webhook/Networking/CustomURLCredentialStorage.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+final class CustomURLCredentialStorage: URLCredentialStorage {
+    let exceptions: () -> SecurityExceptions
+
+    init(server: Server) {
+        self.exceptions = { server.info.connection.securityExceptions }
+        super.init()
+    }
+
+    init(exceptions: SecurityExceptions) {
+        self.exceptions = { exceptions }
+        super.init()
+    }
+
+    override func defaultCredential(for space: URLProtectionSpace) -> URLCredential? {
+        exceptions().identity?.credential
+    }
+}


### PR DESCRIPTION
TODO:
- [ ] Update HAKit to support providing arbitrary URLCredentials
- [ ] Passphrase prompting (rather than crashing)
- [ ] Verify the rest of the functionality

## Summary
- Only PKCS12 files containing a key & certificate are supported.
- Fails with Caddy, which doesn't appear to prompt.
- Does work with nginx.

Continues the credential threading of #2131 by prompting for client certificates when the server requests. There are 2 kind of client certificate requests:

1. Required, where failing to provide one will error
2. Optional, where failing to provide one continues to work

ASWebAuthenticationSession doesn't support customizing networking, so this also implements a (pretty simple) wrapper around the login flow in an in-app web view. This has the upside of not doing a second certificate trusting screen for self-signed certs too.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
