### PR TITLE
Add Firefox Focus/Klar as browsers for opening links

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -581,6 +581,8 @@
 		<string>twitter</string>
 		<string>shortcuts</string>
 		<string>firefox</string>
+		<string>firefox-focus</string>
+		<string>firefox-klar</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -395,6 +395,8 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings_details.general.open_in_browser.chrome" = "Google Chrome";
 "settings_details.general.open_in_browser.default" = "System Default";
 "settings_details.general.open_in_browser.firefox" = "Mozilla Firefox";
+"settings_details.general.open_in_browser.firefoxFocus" = "Mozilla Firefox Focus";
+"settings_details.general.open_in_browser.firefoxKlar" = "Mozilla Firefox Klar";
 "settings_details.general.open_in_browser.safari" = "Apple Safari";
 "settings_details.general.open_in_browser.safari_in_app" = "Apple Safari (in app)";
 "settings_details.general.open_in_browser.title" = "Open Links In";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -911,6 +911,8 @@ enum AppIcon: String, CaseIterable {
 enum OpenInBrowser: String, CaseIterable {
     case Chrome
     case Firefox
+    case FirefoxFocus
+    case FirefoxKlar
     case Safari
     case SafariInApp
 
@@ -920,6 +922,10 @@ enum OpenInBrowser: String, CaseIterable {
             return L10n.SettingsDetails.General.OpenInBrowser.chrome
         case .Firefox:
             return L10n.SettingsDetails.General.OpenInBrowser.firefox
+        case .FirefoxFocus:
+            return L10n.SettingsDetails.General.OpenInBrowser.firefoxFocus
+        case .FirefoxKlar:
+            return L10n.SettingsDetails.General.OpenInBrowser.firefoxKlar
         case .Safari:
             if #available(iOS 14, *) {
                 return L10n.SettingsDetails.General.OpenInBrowser.default
@@ -937,6 +943,10 @@ enum OpenInBrowser: String, CaseIterable {
             return OpenInChromeController.sharedInstance.isChromeInstalled()
         case .Firefox:
             return OpenInFirefoxControllerSwift().isFirefoxInstalled()
+        case .FirefoxFocus:
+            return OpenInFirefoxControllerSwift(type: .focus).isFirefoxInstalled()
+        case .FirefoxKlar:
+            return OpenInFirefoxControllerSwift(type: .klar).isFirefoxInstalled()
         default:
             return true
         }

--- a/Sources/App/Utilities/OpenInFirefoxControllerSwift.swift
+++ b/Sources/App/Utilities/OpenInFirefoxControllerSwift.swift
@@ -8,12 +8,32 @@ import Foundation
 import UIKit
 
 open class OpenInFirefoxControllerSwift {
-    let firefoxScheme = "firefox:"
-    let basicURL = URL(string: "firefox://")!
+    enum FirefoxType {
+        case regular
+        case focus
+        case klar
+
+        var urlScheme: String {
+            switch self {
+            case .regular:
+                return "firefox"
+            case .focus:
+                return "firefox-focus"
+            case .klar:
+                return "firefox-klar"
+            }
+        }
+    }
+
+    let type: FirefoxType
 
     // This would need to be changed if used from an extension… but you
     // can't open arbitrary URLs from an extension anyway.
     let app = UIApplication.shared
+
+    init(type: FirefoxType = .regular) {
+        self.type = type
+    }
 
     private func encodeByAddingPercentEscapes(_ input: String) -> String {
         NSString(string: input).addingPercentEncoding(
@@ -22,14 +42,14 @@ open class OpenInFirefoxControllerSwift {
     }
 
     open func isFirefoxInstalled() -> Bool {
-        app.canOpenURL(basicURL)
+        app.canOpenURL(URL(string: "\(type.urlScheme)://")!)
     }
 
     open func openInFirefox(_ url: URL) {
         let scheme = url.scheme
         if scheme == "http" || scheme == "https" {
             let escaped = encodeByAddingPercentEscapes(url.absoluteString)
-            if let firefoxURL = URL(string: "firefox://open-url?url=\(escaped)") {
+            if let firefoxURL = URL(string: "\(self.type.urlScheme)://open-url?url=\(escaped)") {
                 app.open(firefoxURL, options: [:], completionHandler: nil)
             }
         }

--- a/Sources/App/Utilities/Utils.swift
+++ b/Sources/App/Utilities/Utils.swift
@@ -33,6 +33,10 @@ func openURLInBrowser(_ urlToOpen: URL, _ sender: UIViewController?) {
         OpenInChromeController.sharedInstance.openInChrome(urlToOpen, callbackURL: nil)
     case .Firefox where OpenInFirefoxControllerSwift().isFirefoxInstalled():
         OpenInFirefoxControllerSwift().openInFirefox(urlToOpen)
+    case .FirefoxFocus where OpenInFirefoxControllerSwift(type: .focus).isFirefoxInstalled():
+        OpenInFirefoxControllerSwift(type: .focus).openInFirefox(urlToOpen)
+    case .FirefoxKlar where OpenInFirefoxControllerSwift(type: .klar).isFirefoxInstalled():
+        OpenInFirefoxControllerSwift(type: .klar).openInFirefox(urlToOpen)
     case .SafariInApp where sender != nil:
         let sfv = SFSafariViewController(url: urlToOpen)
         sender!.present(sfv, animated: true)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1313,6 +1313,10 @@ public enum L10n {
         public static var `default`: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.default") }
         /// Mozilla Firefox
         public static var firefox: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.firefox") }
+        /// Mozilla Firefox Focus
+        public static var firefoxFocus: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.firefoxFocus") }
+        /// Mozilla Firefox Klar
+        public static var firefoxKlar: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.firefoxKlar") }
         /// Apple Safari
         public static var safari: String { return L10n.tr("Localizable", "settings_details.general.open_in_browser.safari") }
         /// Apple Safari (in app)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This adds support to open URLs in Firefox Focus/Klar. Firefox Focus and Klar are the same project
(see https://github.com/mozilla-mobile/focus-ios; and https://support.mozilla.org/en-US/kb/difference-between-firefox-focus-and-firefox-klar), but use different app scheme prefixes on account of the FOCUS name being used by a Mozilla partner in Germany, Austria and Switzerland.

This PR adapts and reuses the existing Firefox URL opener to being able to accept a different scheme for each app, defaulting to the standard `firefox://` prefix for regular Firefox.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
From reading the developer docs, I'm unclear on if/how I should update the `Localizable.strings` files for other languages at this point. If there's something else I need to do for this PR, just let me know 👍 

This has been tested with Firefox Focus on the iOS Simulator. I've tried but as I'm not a subscribed/paid Apple developer, my personal certificate won't allow me to deploy to an actual device, even for debugging (Xcode complains about my personal team not having access to Wifi metadata, amongst a few other missing privileges).

Also, I've done my best with fastline linting/autocorrect but my local setup is having some issue with finding CFPropertyList-3.0.5 and it crashing out at the end. So, it looks okay but again let me know - or CI/GitHub Actions will I'm sure.