### PR TITLE
Fix production builds by only applying device name provisioning in App target

### DIFF
--- a/Configuration/Entitlements/activate_special_entitlements.sh
+++ b/Configuration/Entitlements/activate_special_entitlements.sh
@@ -19,10 +19,12 @@ else
     echo "warning: Push provider disabled"
 fi
 
-if [[ $CI && $CONFIGURATION != "Release" ]]; then
-  echo "warning: Device name disabled for CI"
-elif [[ ${ENABLE_DEVICE_NAME} -eq 1 ]]; then
-    /usr/libexec/PlistBuddy -c "add com.apple.developer.device-information.user-assigned-device-name bool true" "$ENTITLEMENTS_FILE"
-else
-    echo "warning: Device name disabled"
+if [[ $TARGET_NAME = "App" ]]; then
+  if [[ $CI && $CONFIGURATION != "Release" ]]; then
+    echo "warning: Device name disabled for CI"
+  elif [[ ${ENABLE_DEVICE_NAME} -eq 1 && $FULL_PRODUCT_NAME = "" ]]; then
+      /usr/libexec/PlistBuddy -c "add com.apple.developer.device-information.user-assigned-device-name bool true" "$ENTITLEMENTS_FILE"
+  else
+      echo "warning: Device name disabled"
+  fi
 fi

--- a/Configuration/Entitlements/activate_special_entitlements.sh
+++ b/Configuration/Entitlements/activate_special_entitlements.sh
@@ -22,7 +22,7 @@ fi
 if [[ $TARGET_NAME = "App" ]]; then
   if [[ $CI && $CONFIGURATION != "Release" ]]; then
     echo "warning: Device name disabled for CI"
-  elif [[ ${ENABLE_DEVICE_NAME} -eq 1 && $FULL_PRODUCT_NAME = "" ]]; then
+  elif [[ ${ENABLE_DEVICE_NAME} -eq 1 ]]; then
       /usr/libexec/PlistBuddy -c "add com.apple.developer.device-information.user-assigned-device-name bool true" "$ENTITLEMENTS_FILE"
   else
       echo "warning: Device name disabled"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -506,7 +506,6 @@ platform :ios do
         provisioningProfiles: specifiers
       }
     )
-    upload_archive_to_sentry
     upload_binary_to_apple(
       type: 'ios',
       path: ipa_path
@@ -544,7 +543,6 @@ platform :mac do
         provisioningProfiles: specifiers.transform_values { |v| v.sub(/Mac Dev ID/, 'Mac App Store') }
       }
     )
-    upload_archive_to_sentry
 
     notarize_attempts = 0
 


### PR DESCRIPTION
## Summary
The push provider target also runs the entitlement additions but we do not have access to the device name entitlement there.

## Any other notes
Also disables Sentry as it was stalling the builds in testing and we don't use it anyway.