### PR TITLE
Skip updating registration in push provider

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -179,7 +179,7 @@ public class HomeAssistantAPI {
         return firstly { () -> Promise<Void> in
             guard !Current.isAppExtension else {
                 Current.Log.info("skipping registration changes in extension")
-                return .value(())
+                return Promise<Void>.value(())
             }
 
             return updateRegistration().asVoid().recover { [self] error -> Promise<Void> in
@@ -207,7 +207,7 @@ public class HomeAssistantAPI {
                     throw error
                 }
             }
-        }.then { [self] in
+        }.then { [self] () -> Promise<Void> in
             var promises: [Promise<Void>] = []
 
             if !Current.isAppExtension {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -171,40 +171,54 @@ public class HomeAssistantAPI {
     }
 
     public func Connect(reason: ConnectReason) -> Promise<Void> {
+        Current.Log.info("running connect for \(reason)")
+
+        // websocket
         connection.connect()
 
-        return firstly {
-            updateRegistration().asVoid()
-        }.recover { [self] error -> Promise<Void> in
-            switch error as? WebhookError {
-            case .unmappableValue,
-                 .unexpectedType,
-                 .unacceptableStatusCode(404),
-                 .unacceptableStatusCode(410):
-                // cloudhook will send a 404 for deleted
-                // ha directly will send a 200 with an empty body for deleted
+        return firstly { () -> Promise<Void> in
+            guard !Current.isAppExtension else {
+                Current.Log.info("skipping registration changes in extension")
+                return .value(())
+            }
 
-                let message = "Integration is missing; registering."
-                return Current.clientEventStore.addEvent(ClientEvent(text: message, type: .networkRequest, payload: [
-                    "error": String(describing: error),
-                ])).then { [self] in
-                    register()
+            return updateRegistration().asVoid().recover { [self] error -> Promise<Void> in
+                switch error as? WebhookError {
+                case .unmappableValue,
+                     .unexpectedType,
+                     .unacceptableStatusCode(404),
+                     .unacceptableStatusCode(410):
+                    // cloudhook will send a 404 for deleted
+                    // ha directly will send a 200 with an empty body for deleted
+
+                    let message = "Integration is missing; registering."
+                    return Current.clientEventStore
+                        .addEvent(ClientEvent(text: message, type: .networkRequest, payload: [
+                            "error": String(describing: error),
+                        ])).then { [self] in
+                            register()
+                        }
+                case .unregisteredIdentifier,
+                     .unacceptableStatusCode,
+                     .replaced,
+                     .none:
+                    // not a WebhookError, or not one we think requires reintegration
+                    Current.Log.info("not re-registering, but failed to update registration: \(error)")
+                    throw error
                 }
-            case .unregisteredIdentifier,
-                 .unacceptableStatusCode,
-                 .replaced,
-                 .none:
-                // not a WebhookError, or not one we think requires reintegration
-                Current.Log.info("not re-registering, but failed to update registration: \(error)")
-                throw error
             }
         }.then { [self] in
-            when(fulfilled: [
-                getConfig(),
-                Current.modelManager.fetch(apis: [self]),
-                UpdateSensors(trigger: reason.updateSensorTrigger).asVoid(),
-                updateComplications(passively: false).asVoid(),
-            ]).asVoid()
+            var promises: [Promise<Void>] = []
+
+            if !Current.isAppExtension {
+                promises.append(getConfig())
+                promises.append(Current.modelManager.fetch(apis: [self]))
+                promises.append(updateComplications(passively: false).asVoid())
+            }
+
+            promises.append(UpdateSensors(trigger: reason.updateSensorTrigger).asVoid())
+
+            return when(fulfilled: promises).asVoid()
         }.get { _ in
             NotificationCenter.default.post(
                 name: Self.didConnectNotification,


### PR DESCRIPTION
## Summary
The push provider's periodic updating runs the 'connect' mechanism, which also updates the registration/integration. In iOS 16, this means we're updating the device name to 'iPhone' because our device name entitlement only exists in the main app. To avoid this issue, we no longer update the registration in the push provider.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
