### PR TITLE
Enable Realm database compaction on launch

### DIFF
--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -212,7 +212,14 @@ public extension Realm {
                     }
                 }
             },
-            deleteRealmIfMigrationNeeded: false
+            deleteRealmIfMigrationNeeded: false,
+            shouldCompactOnLaunch: { realmFileSizeInBytes, usedBytes in
+                // from https://www.mongodb.com/docs/realm/sdk/swift/realm-files/compacting/
+                let maxFileSize = 10 * 1024 * 1024
+                // Check for the realm file size to be greater than the max file size, and the amount of bytes
+                // currently used to be less than 50% of the total realm file size
+                return (realmFileSizeInBytes > maxFileSize) && (Double(usedBytes) / Double(realmFileSizeInBytes)) < 0.5
+            }
         )
 
         do {


### PR DESCRIPTION
Fixes #2207.

## Summary
By default, Realm does not compact its database and [they recommend doing so in production](https://www.mongodb.com/docs/realm/sdk/swift/realm-files/compacting/):

> Every production application should implement a `shouldCompactOnLaunch` callback to periodically reduce the realm file size.

This enables compaction when the database contains more than 50% free space in its on-disk representation. We periodically delete old models at runtime by age, so we expect this to be the case.