### PR TITLE
Add Emerge integration

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -47,6 +47,7 @@ jobs:
           P12_VALUE_IOS_APP_STORE: ${{ secrets.P12_VALUE_IOS_APP_STORE }}
           P12_VALUE_MAC_APP_STORE: ${{ secrets.P12_VALUE_MAC_APP_STORE }}
           P12_VALUE_MAC_DEVELOPER_ID: ${{ secrets.P12_VALUE_MAC_DEVELOPER_ID }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           # hard-coded so it doesn't cause 'ios' to be *** everywhere in the logs

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,41 @@
+name: Size build
+
+on:
+  pull_request:
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
+  FASTLANE_SKIP_UPDATE_CHECK: true
+  FASTLANE_XCODE_LIST_TIMEOUT: 60
+  FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+  HOMEBREW_NO_INSTALL_CLEANUP: TRUE
+  BUNDLE_PATH: vendor/bundle
+
+jobs:
+  build:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Brews
+        run: brew bundle
+
+      - name: Install Gems
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Install Pods
+        run: bundle exec pod install --repo-update
+
+      - name: Build app
+        run: |
+          bundle exec fastlane ios size
+        env:
+          P12_KEY_IOS_APP_STORE: ${{ secrets.P12_KEY_IOS_APP_STORE }}
+          P12_KEY_MAC_APP_STORE: ${{ secrets.P12_KEY_MAC_APP_STORE }}
+          P12_KEY_MAC_DEVELOPER_ID: ${{ secrets.P12_KEY_MAC_DEVELOPER_ID }}
+          P12_VALUE_IOS_APP_STORE: ${{ secrets.P12_VALUE_IOS_APP_STORE }}
+          P12_VALUE_MAC_APP_STORE: ${{ secrets.P12_VALUE_MAC_APP_STORE }}
+          P12_VALUE_MAC_DEVELOPER_ID: ${{ secrets.P12_VALUE_MAC_DEVELOPER_ID }}
+          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_TOKEN }}
+          # hard-coded so it doesn't cause 'ios' to be *** everywhere in the logs
+          SENTRY_PROJECT: ios

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
       json
       mini_magick (>= 4.9.4, < 5.0.0)
     fastlane-plugin-clean_testflight_testers (0.3.0)
+    fastlane-plugin-emerge (0.5.1)
+      faraday (~> 1.1)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -311,6 +313,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-appicon
   fastlane-plugin-clean_testflight_testers
+  fastlane-plugin-emerge
   rubocop
 
 BUNDLED WITH

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -491,9 +491,8 @@ private_lane :upload_binary_to_apple do |options|
 end
 
 platform :ios do
-  lane :build do
+  private_lane :create_archive do
     setup_ha_ci if is_ci
-
     specifiers = provisioning_profile_specifiers(sdk: 'iphoneos')
     ipa_path = build_ios_app(
       export_method: 'app-store',
@@ -506,11 +505,20 @@ platform :ios do
         provisioningProfiles: specifiers
       }
     )
+    emerge if ENV['EMERGE_API_TOKEN']
+    ipa_path
+  end
+
+  lane :build do
+    ipa_path = create_archive
     upload_binary_to_apple(
       type: 'ios',
       path: ipa_path
     )
-    emerge if ENV['EMERGE_API_TOKEN']
+  end
+
+  lane :size do
+    create_archive
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -510,6 +510,7 @@ platform :ios do
       type: 'ios',
       path: ipa_path
     )
+    emerge if ENV['EMERGE_API_TOKEN']
   end
 end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-appicon'
 gem 'fastlane-plugin-clean_testflight_testers'
+gem 'fastlane-plugin-emerge'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -154,6 +154,14 @@ Run tests
 
 
 
+### ios size
+
+```sh
+[bundle exec] fastlane ios size
+```
+
+
+
 ----
 
 


### PR DESCRIPTION
## Summary
The nice folks at [Emerge](https://emergetools.com) have given us access to their platform for sizing the app and doing some non-live performance testing. This integrates it it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Turning off Bitcode by switching to Xcode 14 is causing our binary size to bloat, and to investigate this best I'll fix this long-term by keeping track of size changes.

This adds emerge to a few places:
1. Individual builds that are submitted to Apple
2. Pull requests

The PR builds do not get sent to Apple nor are they uploaded because we do not want to allow in-development changes to go anywhere with our official signing information.