### PR TITLE
Custom zoom level option for map dynamic attachment

### DIFF
--- a/Sources/Extensions/NotificationContent/MapViewController.swift
+++ b/Sources/Extensions/NotificationContent/MapViewController.swift
@@ -89,7 +89,11 @@ class MapViewController: UIViewController, NotificationCategory, MKMapViewDelega
 
         mapView.accessibilityIdentifier = "notification_map"
 
-        let span = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        let span = MKCoordinateSpan(
+            latitudeDelta: CLLocationDegrees(templateValue: haDict["latitude_delta"]) ?? 0.1,
+            longitudeDelta: CLLocationDegrees(templateValue: haDict["longitude_delta"]) ?? 0.1
+        )
+
         let region = MKCoordinateRegion(center: location, span: span)
         mapView.setRegion(region, animated: true)
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
The dynamic map attachment for push notifications has a fixed span for the region it shows. For certain cases you might want to show the map with a different zoom level. This pull request adds the `latitude_delta` and `longitude_delta` for this specific purpose.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#891
