### PR TITLE
Fix settings navigation bar not appearing on macOS 13

### DIFF
--- a/Sources/App/Scenes/SettingsSceneDelegate.swift
+++ b/Sources/App/Scenes/SettingsSceneDelegate.swift
@@ -86,6 +86,10 @@ extension SettingsSceneDelegate: UINavigationControllerDelegate {
         if #available(iOS 14, *), navigationController.traitCollection.userInterfaceIdiom == .mac {
             let shouldBeHidden = navigationController.viewControllers.count <= 1
 
+            if #available(iOS 16, *) {
+                navigationController.navigationBar.preferredBehavioralStyle = .pad
+            }
+
             if navigationController.isNavigationBarHidden != shouldBeHidden {
                 navigationController.setNavigationBarHidden(shouldBeHidden, animated: true)
             }


### PR DESCRIPTION
Fixes #2300.

## Summary
macOS 13, by default when linked against its SDK, places the navigation item contents in the toolbar. However, we already have a toolbar in settings, so it doesn't do anything and thus pushed screens are problematic.

## Any other notes
This all needs to be rewritten into SwiftUI so we can use a native Mac UI. 😅 