### PR TITLE
Don't automatically consider hardware address for internal URL

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -200,7 +200,7 @@ private extension ConnectionInfo {
             webhookID: "",
             webhookSecret: nil,
             internalSSIDs: Current.connectivity.currentWiFiSSID().map { [$0] },
-            internalHardwareAddresses: Current.connectivity.currentNetworkHardwareAddress().map { [$0] },
+            internalHardwareAddresses: nil,
             isLocalPushEnabled: true,
             securityExceptions: authDetails.exceptions
         )

--- a/Tests/App/Auth/OnboardingAuth.test.swift
+++ b/Tests/App/Auth/OnboardingAuth.test.swift
@@ -165,7 +165,7 @@ class OnboardingAuthTests: XCTestCase {
         XCTAssertEqual(connectionInfo.address(for: .internal), instance.internalURL)
         XCTAssertEqual(connectionInfo.address(for: .external), instance.externalURL)
         XCTAssertEqual(connectionInfo.internalSSIDs, ["unit_test"])
-        XCTAssertEqual(connectionInfo.internalHardwareAddresses, ["unit_test_addr"])
+        XCTAssertEqual(connectionInfo.internalHardwareAddresses, nil)
 
         XCTAssertEqual(Current.servers.server(for: server.identifier)?.info, server.info)
     }


### PR DESCRIPTION
## Summary
Stops inserting the current network hardware address, since it may be hardware which is connected to other networks. Allow the user to choose this later.

## Any other notes
Since we can't directly tell when a hardware address is a valid way to consider internal, don't automatically include it. This resolves an issue where we'd think any Wi-Fi connection was internal which is invalid logic.