### PR TITLE
Fix device name reporting "iPad" on macOS 13

### DIFF
--- a/Sources/MacBridge/MacBridgeImpl.swift
+++ b/Sources/MacBridge/MacBridgeImpl.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import ServiceManagement
+import SystemConfiguration
 
 @objc(HAMacBridgeImpl) final class MacBridgeImpl: NSObject, MacBridge {
     let networkMonitor: MacBridgeNetworkMonitor
@@ -27,6 +28,10 @@ import ServiceManagement
         ] {
             NotificationCenter.default.addObserver(self, selector: #selector(fixWindows), name: name, object: nil)
         }
+    }
+
+    var deviceName: String {
+        SCDynamicStoreCopyComputerName(nil, nil) as? String ?? "Unknown"
     }
 
     var terminationWillBeginNotification: Notification.Name {

--- a/Sources/Shared/Environment/DeviceWrapper.swift
+++ b/Sources/Shared/Environment/DeviceWrapper.swift
@@ -80,7 +80,9 @@ public class DeviceWrapper {
     }
 
     public lazy var deviceName: () -> String = {
-        #if os(iOS)
+        #if targetEnvironment(macCatalyst)
+        return Current.macBridge.deviceName
+        #elseif os(iOS)
         return UIDevice.current.name
         #elseif os(watchOS)
         return WKInterfaceDevice.current().name

--- a/Sources/Shared/Environment/MacBridgeProtocol.swift
+++ b/Sources/Shared/Environment/MacBridgeProtocol.swift
@@ -5,6 +5,8 @@ import Foundation
 @objc(MacBridge) public protocol MacBridge: NSObjectProtocol {
     init()
 
+    var deviceName: String { get }
+
     var distributedNotificationCenter: NotificationCenter { get }
     var workspaceNotificationCenter: NotificationCenter { get }
 


### PR DESCRIPTION
## Summary
Instead of showing "iPad" we now show the correct name again.

## Any other notes
`UIDevice.current.name` on Catalyst incorrectly protects the computer name behind an entitlement which isn't granted on Mac (we have it on other platforms). Since Mac doesn't have this entitlement, bridge to AppKit land and grab the value from there.