### PR TITLE
Add speech recognition privacy description

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -619,6 +619,8 @@
 	<string>We use Siri to allow created shortcuts to interact with the app.</string>
 	<key>NFCReaderUsageDescription</key>
 	<string>Reading and writing NFC tags allows you to trigger events.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Used to dictate text to Assist.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Take photos and send them to your Home Assistant server.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Sources/App/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/en.lproj/InfoPlist.strings
@@ -14,3 +14,4 @@
 "NSSiriUsageDescription" = "We use Siri to allow created shortcuts to interact with the app.";
 "SEND_LOCATION_APP_SHORTCUT_TITLE" = "Send Location";
 "TemporaryFullAccuracyReasonManualUpdate" = "Grant full accuracy to use your current location for your device tracker.";
+"NSSpeechRecognitionUsageDescription" = "Used to dictate text to Assist.";


### PR DESCRIPTION
## Summary
In addition to microphone permission, this is required for speech recognition in Assist.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
