### PR TITLE
Navigate to default server when deeplink to the app passing "?server=default"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   cocoapods

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -72,7 +72,7 @@ class IncomingURLHandler {
             } else if let server = server {
                 windowController.open(from: .deeplink, server: server, urlString: rawURL, skipConfirm: isFromWidget)
             } else {
-                windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: isFromWidget)
+                windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: isFromWidget, queryParameters: queryParameters)
             }
         default:
             Current.Log.warning("Can't route incoming URL: \(url)")

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -72,7 +72,12 @@ class IncomingURLHandler {
             } else if let server = server {
                 windowController.open(from: .deeplink, server: server, urlString: rawURL, skipConfirm: isFromWidget)
             } else {
-                windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: isFromWidget, queryParameters: queryParameters)
+                windowController.openSelectingServer(
+                    from: .deeplink,
+                    urlString: rawURL,
+                    skipConfirm: isFromWidget,
+                    queryParameters: queryParameters
+                )
             }
         default:
             Current.Log.warning("Can't route incoming URL: \(url)")

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -50,6 +50,7 @@ class IncomingURLHandler {
             components.scheme = nil
             components.host = nil
 
+            let queryParameters = components.queryItems
             let isFromWidget = components.popWidgetAuthenticity()
             let server = components.popWidgetServer(isFromWidget: isFromWidget)
 
@@ -61,7 +62,7 @@ class IncomingURLHandler {
                presenting is SFSafariViewController {
                 // Dismiss my.* controller if it's on top - we don't get any other indication
                 presenting.dismiss(animated: true, completion: { [windowController] in
-                    windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: true)
+                    windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: true, queryParameters: queryParameters)
                 })
             } else if let server = server {
                 windowController.open(from: .deeplink, server: server, urlString: rawURL, skipConfirm: isFromWidget)

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -62,7 +62,12 @@ class IncomingURLHandler {
                presenting is SFSafariViewController {
                 // Dismiss my.* controller if it's on top - we don't get any other indication
                 presenting.dismiss(animated: true, completion: { [windowController] in
-                    windowController.openSelectingServer(from: .deeplink, urlString: rawURL, skipConfirm: true, queryParameters: queryParameters)
+                    windowController.openSelectingServer(
+                        from: .deeplink,
+                        urlString: rawURL,
+                        skipConfirm: true,
+                        queryParameters: queryParameters
+                    )
                 })
             } else if let server = server {
                 windowController.open(from: .deeplink, server: server, urlString: rawURL, skipConfirm: isFromWidget)

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -216,8 +216,10 @@ class WebViewWindowController {
                 open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
             } else {
                 if let selectedServer = servers.first(where: { server in
-                    let sanitizedServerName = server.info.name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-                    let sanitizedSelectedServerName = serverName?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+                    let sanitizedServerName = server.info.name.lowercased()
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let sanitizedSelectedServerName = serverName?.lowercased()
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
                     return sanitizedServerName == sanitizedSelectedServerName
                 }) {
                     open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -217,9 +217,9 @@ class WebViewWindowController {
             } else {
                 if let selectedServer = servers.first(where: { server in
                     let sanitizedServerName = server.info.name.lowercased()
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
                     let sanitizedSelectedServerName = serverName?.lowercased()
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
                     return sanitizedServerName == sanitizedSelectedServerName
                 }) {
                     open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -216,9 +216,7 @@ class WebViewWindowController {
                 open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
             } else {
                 if let selectedServer = servers.first(where: { server in
-                    let sanitizedServerName = server.info.name.lowercased()
-                        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    return sanitizedServerName == serverName?.lowercased()
+                    return server.info.name.lowercased() == serverName?.lowercased()
                 }) {
                     open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)
                 } else {

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -216,7 +216,7 @@ class WebViewWindowController {
                 open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
             } else {
                 if let selectedServer = servers.first(where: { server in
-                    return server.info.name.lowercased() == serverName?.lowercased()
+                    server.info.name.lowercased() == serverName?.lowercased()
                 }) {
                     open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)
                 } else {

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -202,9 +202,15 @@ class WebViewWindowController {
         }
     }
 
-    func openSelectingServer(from: OpenSource, urlString openUrlRaw: String, skipConfirm: Bool = false, queryParameters: [URLQueryItem]? = nil) {
+    func openSelectingServer(
+        from: OpenSource,
+        urlString openUrlRaw: String,
+        skipConfirm: Bool = false,
+        queryParameters: [URLQueryItem]? = nil
+    ) {
         if let first = Current.servers.all.first,
-           (Current.servers.all.count == 1 || queryParameters?.first(where: { $0.name == "server" })?.value == "default") {
+           Current.servers.all.count == 1 || queryParameters?.first(where: { $0.name == "server" })?
+           .value == "default" {
             open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
         } else if Current.servers.all.count > 1 {
             let prompt: String?

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -208,10 +208,23 @@ class WebViewWindowController {
         skipConfirm: Bool = false,
         queryParameters: [URLQueryItem]? = nil
     ) {
-        if let first = Current.servers.all.first,
-           Current.servers.all.count == 1 || queryParameters?.first(where: { $0.name == "server" })?
-           .value == "default" {
-            open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
+        let serverName = queryParameters?.first(where: { $0.name == "server" })?.value
+        let servers = Current.servers.all
+
+        if let first = servers.first, Current.servers.all.count == 1 || serverName != nil {
+            if serverName == "default" || serverName == nil {
+                open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
+            } else {
+                if let selectedServer = servers.first(where: { server in
+                    let sanitizedServerName = server.info.name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+                    let sanitizedSelectedServerName = serverName?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+                    return sanitizedServerName == sanitizedSelectedServerName
+                }) {
+                    open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)
+                } else {
+                    open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
+                }
+            }
         } else if Current.servers.all.count > 1 {
             let prompt: String?
 

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -202,8 +202,9 @@ class WebViewWindowController {
         }
     }
 
-    func openSelectingServer(from: OpenSource, urlString openUrlRaw: String, skipConfirm: Bool = false) {
-        if let first = Current.servers.all.first, Current.servers.all.count == 1 {
+    func openSelectingServer(from: OpenSource, urlString openUrlRaw: String, skipConfirm: Bool = false, queryParameters: [URLQueryItem]? = nil) {
+        if let first = Current.servers.all.first,
+           (Current.servers.all.count == 1 || queryParameters?.first(where: { $0.name == "server" })?.value == "default") {
             open(from: from, server: first, urlString: openUrlRaw, skipConfirm: skipConfirm)
         } else if Current.servers.all.count > 1 {
             let prompt: String?

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -218,9 +218,7 @@ class WebViewWindowController {
                 if let selectedServer = servers.first(where: { server in
                     let sanitizedServerName = server.info.name.lowercased()
                         .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    let sanitizedSelectedServerName = serverName?.lowercased()
-                        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                    return sanitizedServerName == sanitizedSelectedServerName
+                    return sanitizedServerName == serverName?.lowercased()
                 }) {
                     open(from: from, server: selectedServer, urlString: openUrlRaw, skipConfirm: skipConfirm)
                 } else {


### PR DESCRIPTION
## Summary
Navigate to default server when deeplink to the app passing "?server=default".
Currently when you use deep link to navigate to one lovelace page and you have multiple HA servers in your iOS App it always asks which server you want to use.
With this change you are able to default to your current server by using a query item "?server=default"

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#


https://github.com/home-assistant/iOS/assets/5808343/c29ac74e-8ea4-4d5a-93ec-53ef7c64ced6



