### PR TITLE
fix ha-blue icon

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -387,6 +387,15 @@
 				<key>UIPrerenderedIcon</key>
 				<true/>
 			</dict>
+			<key>ha-blue</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>release</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
 			<key>non-binary</key>
 			<dict>
 				<key>CFBundleIconFiles</key>

--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -387,15 +387,6 @@
 				<key>UIPrerenderedIcon</key>
 				<true/>
 			</dict>
-			<key>ha-blue</key>
-			<dict>
-				<key>CFBundleIconFiles</key>
-				<array>
-					<string>default</string>
-				</array>
-				<key>UIPrerenderedIcon</key>
-				<true/>
-			</dict>
 			<key>non-binary</key>
 			<dict>
 				<key>CFBundleIconFiles</key>


### PR DESCRIPTION
Fixes error from Apple `ITMS-90032: Invalid Image Path - - No image found at the path referenced under key 'CFBundleAlternateIcons': 'default'`

Follow up from #2418