### PR TITLE
Toggle scenes/actions for watchOS App all at once

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -361,6 +361,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings_details.actions.scenes.empty" = "No Scenes";
 "settings_details.actions.scenes.footer" = "When enabled, Scenes display alongside actions. When performed, they trigger scene changes.";
 "settings_details.actions.scenes.title" = "Scene Actions";
+"settings_details.actions.scenes.select_all" = "Select All";
 "settings_details.actions.title" = "Actions";
 "settings_details.general.app_icon.enum.beta" = "Beta";
 "settings_details.general.app_icon.enum.black" = "Black";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -443,7 +443,6 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
             )
 
             let scenes = realm.objects(RLMScene.self).sorted(byKeyPath: RLMScene.positionKeyPath)
-
             form +++ RealmSection<RLMScene>(
                 header: L10n.SettingsDetails.Actions.Scenes.title,
                 footer: L10n.SettingsDetails.Actions.Scenes.footer,
@@ -454,7 +453,29 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                         $0.disabled = true
                     },
                 ], getter: {
-                    Self.getSceneRows($0)
+                    var baseRows: [BaseRow] = []
+                    if $0 == scenes.first {
+                        let toggleAllSwitch = SwitchRow()
+                        toggleAllSwitch.title = "Select all"
+                        toggleAllSwitch.value = scenes.filter({ $0.actionEnabled }).count == scenes.count
+                        toggleAllSwitch.onChange { row in
+                            guard let value = row.value else { return }
+                            scenes.forEach { scene in
+                                do {
+                                    try scene.realm?.write {
+                                        scene.actionEnabled = value
+                                    }
+                                } catch {
+                                    /* no-op */
+                                }
+                            }
+                        }
+                        baseRows = [toggleAllSwitch]
+                    }
+
+                    baseRows += Self.getSceneRows($0)
+
+                    return baseRows
                 }
             )
 

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -456,19 +456,19 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     var baseRows: [BaseRow] = []
                     if $0 == scenes.first {
                         let toggleAllSwitch = SwitchRow()
-                        toggleAllSwitch.title = "Select all"
-                        toggleAllSwitch.value = scenes.filter({ $0.actionEnabled }).count == scenes.count
-                        toggleAllSwitch.onChange { row in
-                            guard let value = row.value else { return }
+                        toggleAllSwitch.title = NSLocalizedString(
+                            "Select All",
+                            comment: "Toggle to select/unselect all actions that are displayed in watchOS app"
+                        )
+                        toggleAllSwitch.value = scenes.filter(\.actionEnabled).count == scenes.count
+                        toggleAllSwitch.onChange { [weak self] row in
+                            guard let self = self,
+                                  let value = row.value else { return }
+                            self.realm.beginWrite()
                             scenes.forEach { scene in
-                                do {
-                                    try scene.realm?.write {
-                                        scene.actionEnabled = value
-                                    }
-                                } catch {
-                                    /* no-op */
-                                }
+                                scene.actionEnabled = value
                             }
+                            try? self.realm.commitWrite()
                         }
                         baseRows = [toggleAllSwitch]
                     }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -459,12 +459,12 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 }
             }
 
-            scenesUpdateObserver = scenes.observe { _ in
-                toggleAllSwitch.cellUpdate { cell, row in
+            toggleAllSwitch.cellUpdate { [weak self] cell, _ in
+                self?.scenesUpdateObserver = scenes.observe { _ in
                     cell.switchControl.setOn(scenes.filter(\.actionEnabled).count == scenes.count, animated: true)
                 }
-                toggleAllSwitch.updateCell()
             }
+            toggleAllSwitch.updateCell()
 
             form +++ Section(L10n.SettingsDetails.Actions.Scenes.title)
             <<< toggleAllSwitch

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -446,29 +446,29 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
             let scenes = realm.objects(RLMScene.self).sorted(byKeyPath: RLMScene.positionKeyPath)
 
             let toggleAllSwitch = SwitchRow()
-            toggleAllSwitch.title = L10n.SettingsDetails.Actions.Scenes.selectAll
-
-            scenesUpdateObserver = scenes.observe { _ in
-                // Access UISwitch directly to set state to avoid triggering "on value change"
-                toggleAllSwitch.cell.switchControl.setOn(
-                    scenes.filter(\.actionEnabled).count == scenes.count,
-                    animated: true
-                )
-            }
-
-            toggleAllSwitch.onChange { [weak self] row in
-                guard let self = self,
-                      let value = row.value else { return }
-                self.realm.reentrantWrite {
-                    scenes.forEach { scene in
-                        scene.actionEnabled = value
+            with(toggleAllSwitch) {
+                $0.title = L10n.SettingsDetails.Actions.Scenes.selectAll
+                $0.onChange { [weak self] row in
+                    guard let self = self,
+                          let value = row.value else { return }
+                    self.realm.reentrantWrite {
+                        scenes.forEach { scene in
+                            scene.actionEnabled = value
+                        }
                     }
                 }
             }
-            form +++ toggleAllSwitch
 
+            scenesUpdateObserver = scenes.observe { _ in
+                toggleAllSwitch.cellUpdate { cell, row in
+                    cell.switchControl.setOn(scenes.filter(\.actionEnabled).count == scenes.count, animated: true)
+                }
+                toggleAllSwitch.updateCell()
+            }
+
+            form +++ Section(L10n.SettingsDetails.Actions.Scenes.title)
+            <<< toggleAllSwitch
             form +++ RealmSection<RLMScene>(
-                header: L10n.SettingsDetails.Actions.Scenes.title,
                 footer: L10n.SettingsDetails.Actions.Scenes.footer,
                 collection: AnyRealmCollection(scenes),
                 emptyRows: [

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -22,7 +22,6 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
     private var notificationTokens: [NotificationToken] = []
     private var notificationCenterTokens: [AnyObject] = []
     private var reorderingRows: [String: BaseRow] = [:]
-    private var scenesUpdateObserver: NotificationToken?
 
     deinit {
         notificationCenterTokens.forEach(NotificationCenter.default.removeObserver)
@@ -459,15 +458,16 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 }
             }
 
-            toggleAllSwitch.cellUpdate { [weak self] cell, _ in
-                self?.scenesUpdateObserver = scenes.observe { _ in
+            var scenesUpdateObserver: NotificationToken?
+            toggleAllSwitch.cellUpdate { cell, _ in
+                scenesUpdateObserver = scenes.observe { _ in
                     cell.switchControl.setOn(scenes.filter(\.actionEnabled).count == scenes.count, animated: true)
                 }
             }
             toggleAllSwitch.updateCell()
 
             form +++ Section(L10n.SettingsDetails.Actions.Scenes.title)
-            <<< toggleAllSwitch
+                <<< toggleAllSwitch
             form +++ RealmSection<RLMScene>(
                 footer: L10n.SettingsDetails.Actions.Scenes.footer,
                 collection: AnyRealmCollection(scenes),

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -456,19 +456,16 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     var baseRows: [BaseRow] = []
                     if $0 == scenes.first {
                         let toggleAllSwitch = SwitchRow()
-                        toggleAllSwitch.title = NSLocalizedString(
-                            "Select All",
-                            comment: "Toggle to select/unselect all actions that are displayed in watchOS app"
-                        )
+                        toggleAllSwitch.title = L10n.SettingsDetails.Actions.Scenes.selectAll
                         toggleAllSwitch.value = scenes.filter(\.actionEnabled).count == scenes.count
                         toggleAllSwitch.onChange { [weak self] row in
                             guard let self = self,
                                   let value = row.value else { return }
-                            self.realm.beginWrite()
-                            scenes.forEach { scene in
-                                scene.actionEnabled = value
+                            self.realm.reentrantWrite {
+                                scenes.forEach { scene in
+                                    scene.actionEnabled = value
+                                }
                             }
-                            try? self.realm.commitWrite()
                         }
                         baseRows = [toggleAllSwitch]
                     }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1227,6 +1227,8 @@ public enum L10n {
         public static var empty: String { return L10n.tr("Localizable", "settings_details.actions.scenes.empty") }
         /// When enabled, Scenes display alongside actions. When performed, they trigger scene changes.
         public static var footer: String { return L10n.tr("Localizable", "settings_details.actions.scenes.footer") }
+        /// Select All
+        public static var selectAll: String { return L10n.tr("Localizable", "settings_details.actions.scenes.select_all") }
         /// Scene Actions
         public static var title: String { return L10n.tr("Localizable", "settings_details.actions.scenes.title") }
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
When you open your watchOS App for the first time you may encounter several scenes already active to be used in the watch App (specially if you have Philips Hue in HA), this change allows you to unselect all scenes at once (hide from watch app) if you want.

## Screenshots
https://github.com/home-assistant/iOS/assets/5808343/e2f0f9fb-704d-4240-a817-4cf7318269b3

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
