### PR TITLE
Include vocabulary plist for INShareFocusStatusIntent

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1567,6 +1567,7 @@
 		32DB55A889E2163C52C335D2 /* Pods-iOS-Shared-iOS-Tests-Shared.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS-Tests-Shared.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS-Tests-Shared/Pods-iOS-Shared-iOS-Tests-Shared.debug.xcconfig"; sourceTree = "<group>"; };
 		392B0C44197C98E2653932A5 /* Pods-iOS-Extensions-Matter-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Matter-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Matter-metadata.plist"; sourceTree = "<group>"; };
 		3F4DFB087A3A43F9A526B851 /* Pods_iOS_Shared_iOS_Tests_Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Shared_iOS_Tests_Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		42805A132B0226050095414C /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		479C2CCB032E2A0ECDE45B87 /* Pods-Tests-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-App/Pods-Tests-App.debug.xcconfig"; sourceTree = "<group>"; };
 		491E98FE25D543560077BBE3 /* LogbookEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookEntry.swift; sourceTree = "<group>"; };
 		553A33E097387AA44265DB13 /* Pods-iOS-App-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-App-metadata.plist"; path = "Pods/Pods-iOS-App-metadata.plist"; sourceTree = "<group>"; };
@@ -2617,6 +2618,7 @@
 			isa = PBXGroup;
 			children = (
 				B66C58A9215086F0004AB261 /* Info.plist */,
+				42805A142B0226050095414C /* AppIntentVocabulary.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -6162,6 +6164,14 @@
 				11EFB44C29D89FD100CE4B05 /* hu */,
 			);
 			name = Frontend.strings;
+			sourceTree = "<group>";
+		};
+		42805A142B0226050095414C /* AppIntentVocabulary.plist */ = {
+			isa = PBXVariantGroup;
+			children = (
+				42805A132B0226050095414C /* Base */,
+			);
+			name = AppIntentVocabulary.plist;
 			sourceTree = "<group>";
 		};
 		B60247FE1FBD343000998205 /* InfoPlist.strings */ = {

--- a/Sources/Extensions/Intents/Resources/Base.lproj/AppIntentVocabulary.plist
+++ b/Sources/Extensions/Intents/Resources/Base.lproj/AppIntentVocabulary.plist
@@ -9,7 +9,7 @@
 			<string>INShareFocusStatusIntent</string>
 			<key>IntentExamples</key>
 			<array>
-				<string>Share focus in home assistant</string>
+				<string>Share focus in Home Assistant</string>
 			</array>
 		</dict>
 	</array>

--- a/Sources/Extensions/Intents/Resources/Base.lproj/AppIntentVocabulary.plist
+++ b/Sources/Extensions/Intents/Resources/Base.lproj/AppIntentVocabulary.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IntentPhrases</key>
+	<array>
+		<dict>
+			<key>IntentName</key>
+			<string>INShareFocusStatusIntent</string>
+			<key>IntentExamples</key>
+			<array>
+				<string>Share focus in home assistant</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/Extensions/Intents/Resources/Info.plist
+++ b/Sources/Extensions/Intents/Resources/Info.plist
@@ -47,7 +47,6 @@
 				<string>WidgetActionsIntent</string>
 				<string>WidgetOpenPageIntent</string>
 				<string>INShareFocusStatusIntent</string>
-				<string>AssistIntent</string>
 			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Comply to: https://developer.apple.com/documentation/sirikit/registering_custom_vocabulary_with_sirikit/global_vocabulary_reference/intent_phrases

Pending translations to other languages.
Even though INShareFocusStatusIntent is an intent that apparently it's only used for iOS to tell HA when focus is active, we still get warning from Apple about having a siri vocabulary for it, perhaps we can keep it simple like what is in this PR just to address the warning.