### PR TITLE
Wrap CoreMediaIO inside macCatalyst condition

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
@@ -55,6 +55,7 @@ class HACoreBlahObject {
         }
     }
 }
+
 #if targetEnvironment(macCatalyst)
 #if canImport(CoreMediaIO)
 import CoreMediaIO

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahObject.swift
@@ -55,7 +55,7 @@ class HACoreBlahObject {
         }
     }
 }
-
+#if targetEnvironment(macCatalyst)
 #if canImport(CoreMediaIO)
 import CoreMediaIO
 
@@ -74,7 +74,6 @@ class HACoreMediaObject: HACoreBlahObject {
 }
 #endif
 
-#if targetEnvironment(macCatalyst)
 import CoreAudio
 
 class HACoreAudioObject: HACoreBlahObject {

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
@@ -13,6 +13,7 @@ public protocol HACoreBlahProperty {
     func getPropertyDataSize(objectID: UInt32, dataSize: UnsafeMutablePointer<UInt32>) -> OSStatus
     func getPropertyData(objectID: UInt32, dataSize: UInt32, output: UnsafeMutableRawPointer) -> OSStatus
 }
+
 #if targetEnvironment(macCatalyst)
 #if canImport(CoreMediaIO)
 public struct HACoreMediaProperty<Type>: HACoreBlahProperty {
@@ -148,7 +149,6 @@ extension HACoreMediaProperty {
     }
 }
 #endif
-
 
 extension HACoreAudioProperty {
     static var deviceUID: HACoreAudioProperty<Unmanaged<CFString>> {

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
@@ -1,9 +1,9 @@
 import Foundation
 
+#if targetEnvironment(macCatalyst)
 #if canImport(CoreMediaIO)
 import CoreMediaIO
 #endif
-#if targetEnvironment(macCatalyst)
 import CoreAudio
 #endif
 
@@ -13,7 +13,7 @@ public protocol HACoreBlahProperty {
     func getPropertyDataSize(objectID: UInt32, dataSize: UnsafeMutablePointer<UInt32>) -> OSStatus
     func getPropertyData(objectID: UInt32, dataSize: UInt32, output: UnsafeMutableRawPointer) -> OSStatus
 }
-
+#if targetEnvironment(macCatalyst)
 #if canImport(CoreMediaIO)
 public struct HACoreMediaProperty<Type>: HACoreBlahProperty {
     public typealias ValueType = Type
@@ -49,7 +49,6 @@ public struct HACoreMediaProperty<Type>: HACoreBlahProperty {
 }
 #endif
 
-#if targetEnvironment(macCatalyst)
 public struct HACoreAudioProperty<Type>: HACoreBlahProperty {
     public typealias ValueType = Type
     public let address: AudioObjectPropertyAddress
@@ -82,7 +81,6 @@ public struct HACoreAudioProperty<Type>: HACoreBlahProperty {
         }
     }
 }
-#endif
 
 #if canImport(CoreMediaIO)
 extension HACoreMediaProperty {
@@ -151,7 +149,7 @@ extension HACoreMediaProperty {
 }
 #endif
 
-#if targetEnvironment(macCatalyst)
+
 extension HACoreAudioProperty {
     static var deviceUID: HACoreAudioProperty<Unmanaged<CFString>> {
         /*

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreMediaObjectCamera.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreMediaObjectCamera.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if canImport(CoreMediaIO)
+#if canImport(CoreMediaIO) && targetEnvironment(macCatalyst)
 import CoreMediaIO
 
 class HACoreMediaObjectCamera: HACoreMediaObject {

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreMediaObjectSystem.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreMediaObjectSystem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if canImport(CoreMediaIO)
+#if canImport(CoreMediaIO) && targetEnvironment(macCatalyst)
 import CoreMediaIO
 
 class HACoreMediaObjectSystem: HACoreMediaObject {

--- a/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
@@ -22,7 +22,6 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
         #endif
         #endif
 
-
         var id: UInt32 {
             switch self {
             case .invalid: return .max
@@ -32,7 +31,6 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
             case let .coreMedia(id): return id
             #endif
             #endif
-
             }
         }
     }
@@ -81,8 +79,7 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
         addObserver(object: .coreMedia(id), property: property)
     }
     #endif
-#endif
-
+    #endif
 }
 
 public class InputOutputDeviceSensor: SensorProvider {

--- a/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
@@ -17,20 +17,22 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
 
         #if targetEnvironment(macCatalyst)
         case coreAudio(AudioObjectID)
-        #endif
         #if canImport(CoreMediaIO)
         case coreMedia(CMIOObjectID)
         #endif
+        #endif
+
 
         var id: UInt32 {
             switch self {
             case .invalid: return .max
             #if targetEnvironment(macCatalyst)
             case let .coreAudio(id): return id
-            #endif
             #if canImport(CoreMediaIO)
             case let .coreMedia(id): return id
             #endif
+            #endif
+
             }
         }
     }
@@ -40,11 +42,11 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
     required init(signal: @escaping () -> Void) {
         self.signal = signal
 
+        #if targetEnvironment(macCatalyst)
         #if canImport(CoreMediaIO)
         addCoreMediaObserver(for: CMIOObjectID(kCMIOObjectSystemObject), property: .allDevices)
         #endif
 
-        #if targetEnvironment(macCatalyst)
         addCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject), property: .allDevices)
         #endif
     }
@@ -70,7 +72,6 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
     ) {
         addObserver(object: .coreAudio(id), property: property)
     }
-    #endif
 
     #if canImport(CoreMediaIO)
     func addCoreMediaObserver<PropertyType>(
@@ -80,6 +81,8 @@ private class InputOutputDeviceUpdateSignaler: SensorProviderUpdateSignaler {
         addObserver(object: .coreMedia(id), property: property)
     }
     #endif
+#endif
+
 }
 
 public class InputOutputDeviceSensor: SensorProvider {
@@ -89,19 +92,19 @@ public class InputOutputDeviceSensor: SensorProvider {
 
     public let request: SensorProviderRequest
 
+    #if targetEnvironment(macCatalyst)
     #if canImport(CoreMediaIO)
     let cameraSystemObject: HACoreMediaObjectSystem
     #endif
-    #if targetEnvironment(macCatalyst)
     let audioSystemObject: HACoreAudioObjectSystem
     #endif
 
     public required init(request: SensorProviderRequest) {
         self.request = request
+        #if targetEnvironment(macCatalyst)
         #if canImport(CoreMediaIO)
         self.cameraSystemObject = HACoreMediaObjectSystem()
         #endif
-        #if targetEnvironment(macCatalyst)
         self.audioSystemObject = HACoreAudioObjectSystem()
         #endif
     }


### PR DESCRIPTION
Apparently `#if canImport(CoreMediaIO)` is now true even if you are trying to run the App on iOS instead of macOS, so this PR wraps it also under `#if targetEnvironment(macCatalyst)`