### PR TITLE
Prevent throw for second thread credentials call

### DIFF
--- a/Sources/App/ThreadCredentialsSharing/ThreadClientService.swift
+++ b/Sources/App/ThreadCredentialsSharing/ThreadClientService.swift
@@ -33,7 +33,8 @@ final class ThreadClientService: THClientProtocol {
         let preferredCredential = try await client.preferredCredentials()
 
         // All credentials retrieve the rest of the credentials after user acceps permission dialog
-        var allCredentials = try await client.allCredentials()
+        // This call may fail, but we don't want to throw error since preferredCredential succeeded
+        var allCredentials: Set<THCredentials> = (try? await client.allCredentials()) ?? []
         allCredentials = allCredentials.filter { $0.borderAgentID != preferredCredential.borderAgentID }
         allCredentials.insert(preferredCredential)
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Prevent throw for second thread credentials call, since sometimes "preferredCredential" succeeds but "allCredentials" fail, we don't want to avoid showing the preferred credential.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
