### PR TITLE
Avoid INStartCallIntent warning for using com.apple.developer.usernotifications.communication entitlement

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -738,5 +738,9 @@
 		<key>TemporaryFullAccuracyReasonManualUpdate</key>
 		<string>[localized in strings file]</string>
 	</dict>
+    <key>NSUserActivityTypes</key>
+    <array>
+        <string>INSendMessageIntent</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Avoid INStartCallIntent warning for using com.apple.developer.usernotifications.communication entitlement
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="642" alt="Screenshot 2023-12-14 at 13 14 24" src="https://github.com/home-assistant/iOS/assets/5808343/da3d469f-9e41-4ea0-9e27-bc0564e4ccd2">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
