### PR TITLE
Remove NDEF from nfc formats. Workaround to deploy to appstore

### DIFF
--- a/Configuration/Entitlements/App-ios.entitlements
+++ b/Configuration/Entitlements/App-ios.entitlements
@@ -14,7 +14,6 @@
 	<true/>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
 	<key>com.apple.developer.siri</key>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Distribute pipeline is failing for iOS since the drop support to older iOS versions were merged with error `The sdk version '17.0' and min OS version '15.0' are not compatible for the entitlement 'com.apple.developer.nfc.readersession.formats' because 'NDEF is disallowed`

I found several mentions from other developers about this `bug` from Apple since iOS 13 and the workaround is to simply remove NDEF from nfc formats, even doing that the reading and writting tags keeps working fine.

 
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
