### PR TITLE
Fix info icon usage in actions

### DIFF
--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -405,16 +405,13 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
             let actionsFooter = Current.isCatalyst ?
                 L10n.SettingsDetails.Actions.footerMac : L10n.SettingsDetails.Actions.footer
 
-            let learnAboutActionsButton = ButtonRow {
+            let learnAboutActionsButton = SettingsButtonRow {
                 $0.title = L10n.SettingsDetails.Actions.Learn.Button.title
-                $0.tag = "actions_learn_more"
-                $0.cellStyle = .value1
-                $0.cellUpdate { cell, _ in
-                    cell.accessoryType = .detailButton
-                }
-                $0.onCellSelection { _, _ in
+                $0.accessoryIcon = .openInNewIcon
+                $0.onCellSelection { _, row in
                     guard let url = URL(string: "https://companion.home-assistant.io/docs/core/actions/") else { return }
                     UIApplication.shared.open(url)
+                    row.deselect(animated: true)
                 }
             }
             form +++ learnAboutActionsButton

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -300,7 +300,7 @@ public enum L10n {
     }
     public enum State {
       public enum Loading {
-        /// Loading...
+        /// Loading…
         public static var title: String { return L10n.tr("Localizable", "carPlay.state.loading.title") }
       }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
https://github.com/home-assistant/iOS/issues/2549
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 11 11 38](https://github.com/home-assistant/iOS/assets/5808343/e691336d-1a3e-44d4-94cf-3d9af306f390)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
