### PR TITLE
Make widgets available in lock screen

### DIFF
--- a/Sources/Extensions/Widgets/Actions/WidgetActions.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActions.swift
@@ -33,10 +33,10 @@ struct WidgetActions: Widget {
         .configurationDisplayName(L10n.Widgets.Actions.title)
         .description(L10n.Widgets.Actions.description)
         .supportedFamilies({
-            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge, .systemExtraLarge]
 
-            if #available(iOS 15, *) {
-                supportedFamilies.append(.systemExtraLarge)
+            if #available(iOS 16.0, *) {
+                supportedFamilies.append(contentsOf: [.accessoryCircular, .accessoryRectangular])
             }
 
             return supportedFamilies

--- a/Sources/Extensions/Widgets/Common/WidgetBackground.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBackground.swift
@@ -2,10 +2,14 @@ import Foundation
 import SwiftUI
 
 extension View {
-    func widgetBackground(_ backgroundView: some View) -> some View {
+    func widgetBackground(_ backgroundView: AnyView?) -> some View {
         if #available(iOS 17.0, *) {
             return containerBackground(for: .widget) {
-                backgroundView
+                if let backgroundView {
+                    backgroundView
+                } else {
+                    EmptyView()
+                }
             }
         } else {
             return background(backgroundView)

--- a/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
@@ -22,13 +22,11 @@ struct WidgetBasicContainerView: View {
             default: multiView(for: contents)
             }
         }
-        .widgetBackground(Color.clear)
+        .widgetBackground(nil)
     }
 
     func singleView(for model: WidgetBasicViewModel) -> some View {
         ZStack {
-            model.backgroundColor
-                .opacity(0.8)
             WidgetBasicView(model: model, sizeStyle: .single)
                 .widgetURL(model.widgetURL.withWidgetAuthenticity())
         }
@@ -135,5 +133,64 @@ struct WidgetBasicContainerView: View {
         case .systemExtraLarge: return 32
         @unknown default: return 8
         }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview(as: .accessoryRectangular, widget: {
+    WidgetOpenPage()
+}, timeline: {
+    WidgetOpenPageEntry(
+        date: Date(), pages: [
+            .init(
+                panel: DummyContent.panel,
+                server: DummyContent.server
+            ),
+        ]
+    )
+})
+
+@available(iOS 17.0, *)
+#Preview(as: .accessoryRectangular, widget: {
+    WidgetActions()
+}, timeline: {
+    WidgetActionsEntry(actions: [
+        .init(),
+    ])
+})
+
+fileprivate enum DummyContent {
+    static var panel: HAPanel {
+        .init(
+            icon: nil, title: "This is a title", path: "lovelace", component: "", showInSidebar: true
+        )
+    }
+
+    static var server: Server {
+        Server(identifier: "123", getter: {
+            .init(
+                name: "A Name",
+                connection: .init(
+                    externalURL: nil,
+                    internalURL: nil,
+                    cloudhookURL: nil,
+                    remoteUIURL: nil,
+                    webhookID: "",
+                    webhookSecret: nil,
+                    internalSSIDs: nil,
+                    internalHardwareAddresses: nil,
+                    isLocalPushEnabled: false,
+                    securityExceptions: .init(exceptions: [])
+                ),
+                token: .init(
+                    accessToken: "",
+                    refreshToken: "",
+                    expiration: Date()
+                ),
+                version: "123"
+            )
+        }, setter: { _ in
+            true
+        })
     }
 }

--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
@@ -38,10 +38,10 @@ struct WidgetOpenPage: Widget {
         .configurationDisplayName(L10n.Widgets.OpenPage.title)
         .description(L10n.Widgets.OpenPage.description)
         .supportedFamilies({
-            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge, .systemExtraLarge]
 
-            if #available(iOS 15, *) {
-                supportedFamilies.append(.systemExtraLarge)
+            if #available(iOS 16.0, *) {
+                supportedFamilies.append(contentsOf: [.accessoryCircular, .accessoryRectangular])
             }
 
             return supportedFamilies

--- a/Sources/Shared/API/WebSocket/HAPanel.swift
+++ b/Sources/Shared/API/WebSocket/HAPanel.swift
@@ -37,6 +37,14 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
 
         self.title = Current.localized.frontend(possibleFrontendKey) ?? title
     }
+
+    public init(icon: String?, title: String, path: String, component: String, showInSidebar: Bool) {
+        self.icon = icon
+        self.title = title
+        self.path = path
+        self.component = component
+        self.showInSidebar = showInSidebar
+    }
 }
 
 public struct HAPanels: HADataDecodable, Codable, Equatable {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Thats a work in progress PR, main goal is to make widgets available on Lock Screen

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

<img width="2075" alt="Screenshot 2024-02-01 at 11 11 49" src="https://github.com/home-assistant/iOS/assets/5808343/a14fec0d-3b37-4618-9fa3-ea60c3ba4561">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
