### PR TITLE
implement dependabot to check for updates for github actions;

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "GitHub Actions:"
+    schedule:
+      interval: "weekly"
+      time: "02:00"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Github does have the [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot) feature create pull request for dependecies that are outdated. This pr implements this for github actions.

## Screenshots
No user facing changes.

## Link to pull request in Documentation repository
NA

## Any other notes
NA
