### PR TITLE
Prevent crash on creating automation from a server controlled iOS Action

### DIFF
--- a/Sources/App/Settings/ActionConfigurator.swift
+++ b/Sources/App/Settings/ActionConfigurator.swift
@@ -305,7 +305,9 @@ class ActionConfigurator: HAFormViewController, TypedRowControllerType {
     private func saveAndAutomate() {
         if form.validate().count == 0 {
             Current.Log.verbose("Category form is valid, calling dismiss callback!")
-            shouldSave = true
+            if !action.isServerControlled {
+                shouldSave = true
+            }
             shouldOpenAutomationEditor = true
             onDismissCallback?(self)
         }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -716,6 +716,17 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 _ = vc.navigationController?.popViewController(animated: true)
 
                 if let vc = vc as? ActionConfigurator {
+                    defer {
+                        if vc.shouldOpenAutomationEditor {
+                            vc.navigationController?.dismiss(animated: true, completion: {
+                                Current.sceneManager.webViewWindowControllerPromise.then(\.webViewControllerPromise)
+                                    .done { controller in
+                                        controller.openActionAutomationEditor(actionId: vc.action.ID)
+                                    }
+                            })
+                        }
+                    }
+
                     if vc.shouldSave == false {
                         Current.Log.verbose("Not saving action to DB and returning early!")
                         return
@@ -734,15 +745,6 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     }.done {
                         self?.updatePositions()
                     }.cauterize()
-
-                    if vc.shouldOpenAutomationEditor {
-                        vc.navigationController?.dismiss(animated: true, completion: {
-                            Current.sceneManager.webViewWindowControllerPromise.then(\.webViewControllerPromise)
-                                .done { controller in
-                                    controller.openActionAutomationEditor(actionId: vc.action.ID)
-                                }
-                        })
-                    }
                 }
             })
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When user tap on "Create automation" inside the action configuration screen the app was crashing because it was trying to save the action which was controlled server-side (created in yaml). This was fixed in this PR
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
