### PR TITLE
Fix a warning - remove unused `userInterfaceStyle` property

### DIFF
--- a/Sources/Vehicle/Templates/Domains/CarPlayDomainsListTemplate.swift
+++ b/Sources/Vehicle/Templates/Domains/CarPlayDomainsListTemplate.swift
@@ -29,7 +29,6 @@ class CarPlayDomainsListTemplate: CarPlayTemplateProvider {
     }
 
     func updateList(domains: [Domain]) {
-        let userInterfaceStyle = interfaceController?.carTraitCollection.userInterfaceStyle
         let items: [CPListItem] = domains.map { domain in
             let itemTitle = domain.localizedDescription
             let listItem = CPListItem(
@@ -39,7 +38,7 @@ class CarPlayDomainsListTemplate: CarPlayTemplateProvider {
                     .carPlayIcon() : domain.icon
                     .carPlayIcon()
             )
-            listItem.accessoryType = CPListItemAccessoryType.disclosureIndicator
+            listItem.accessoryType = .disclosureIndicator
             listItem.handler = { [weak self] _, completion in
                 self?.viewModel.listItemHandler(domain: domain.rawValue)
                 completion()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

🚮 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Screenshot 2024-02-29 at 8 06 20](https://github.com/home-assistant/iOS/assets/35694712/2de12347-01f9-4e42-a689-fa814a64c2fb)
