### PR TITLE
Actions widget with background execution

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -537,6 +537,13 @@
 		4278DFD32B45C7AE0087C9D7 /* Core.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4278DFAF2B45C6680087C9D7 /* Core.strings */; };
 		4279407F2B8369EC001D7E14 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 42805A142B0226050095414C /* AppIntentVocabulary.plist */; };
 		427940812B836A1A001D7E14 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 42805A142B0226050095414C /* AppIntentVocabulary.plist */; };
+		4296C36D2B90DB640051B63C /* IntentActionAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C36B2B90DB630051B63C /* IntentActionAppEntity.swift */; };
+		4296C36E2B90DB640051B63C /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C36C2B90DB630051B63C /* PerformAction.swift */; };
+		4296C3762B91F0F50051B63C /* WidgetActionsAppIntentTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C3742B91F0860051B63C /* WidgetActionsAppIntentTimelineProvider.swift */; };
+		4296C3772B91F26A0051B63C /* IntentActionAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C36B2B90DB630051B63C /* IntentActionAppEntity.swift */; };
+		4296C3782B91F6260051B63C /* PerformAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C36C2B90DB630051B63C /* PerformAction.swift */; };
+		4296C37A2B9205450051B63C /* WidgetActionsAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C3792B9205450051B63C /* WidgetActionsAppIntent.swift */; };
+		4296C37B2B92054C0051B63C /* WidgetActionsAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4296C3792B9205450051B63C /* WidgetActionsAppIntent.swift */; };
 		429C72202B28D0EC00BCD558 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429C721F2B28D0EC00BCD558 /* Haptics.swift */; };
 		42CA28BB2B1028330093B31A /* SimulatorThreadClientService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42CA28BA2B1028330093B31A /* SimulatorThreadClientService.swift */; };
 		42CE8FA72B45D1E900C707F9 /* CoreStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42CE8FA52B45D1E900C707F9 /* CoreStrings.swift */; };
@@ -1673,6 +1680,10 @@
 		4278DFD02B45C66A0087C9D7 /* ml */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ml; path = ml.lproj/Core.strings; sourceTree = "<group>"; };
 		4279407E2B8369EA001D7E14 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = bg; path = bg.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		42805A132B0226050095414C /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		4296C36B2B90DB630051B63C /* IntentActionAppEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntentActionAppEntity.swift; sourceTree = "<group>"; };
+		4296C36C2B90DB630051B63C /* PerformAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformAction.swift; sourceTree = "<group>"; };
+		4296C3742B91F0860051B63C /* WidgetActionsAppIntentTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetActionsAppIntentTimelineProvider.swift; sourceTree = "<group>"; };
+		4296C3792B9205450051B63C /* WidgetActionsAppIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WidgetActionsAppIntent.swift; path = Sources/Extensions/AppIntents/WidgetActionsAppIntent.swift; sourceTree = SOURCE_ROOT; };
 		429C721F2B28D0EC00BCD558 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		42CA28A62B1012DE0093B31A /* ThreadCredentialsSharingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadCredentialsSharingView.swift; sourceTree = "<group>"; };
 		42CA28AD2B101D4D0093B31A /* HACornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HACornerRadius.swift; sourceTree = "<group>"; };
@@ -2352,6 +2363,7 @@
 		111501A72528412C00DCFA94 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				4296C36A2B90DB630051B63C /* AppIntents */,
 				B66C58A6215086F0004AB261 /* Intents */,
 				11B6B5872948FB4B00B8B552 /* Matter */,
 				B627CB0C1D83C87B0057173E /* NotificationContent */,
@@ -3159,6 +3171,33 @@
 				426740A72B17390A00C1DD73 /* Data+Hexadecimal.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4296C36A2B90DB630051B63C /* AppIntents */ = {
+			isa = PBXGroup;
+			children = (
+				4296C3722B91F06D0051B63C /* Widget */,
+				4296C36B2B90DB630051B63C /* IntentActionAppEntity.swift */,
+				4296C36C2B90DB630051B63C /* PerformAction.swift */,
+			);
+			path = AppIntents;
+			sourceTree = "<group>";
+		};
+		4296C3722B91F06D0051B63C /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				4296C3732B91F0730051B63C /* Actions */,
+			);
+			path = Widget;
+			sourceTree = "<group>";
+		};
+		4296C3732B91F0730051B63C /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				4296C3792B9205450051B63C /* WidgetActionsAppIntent.swift */,
+				4296C3742B91F0860051B63C /* WidgetActionsAppIntentTimelineProvider.swift */,
+			);
+			path = Actions;
 			sourceTree = "<group>";
 		};
 		42CA28A52B1012B00093B31A /* ThreadCredentialsSharing */ = {
@@ -5577,6 +5616,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4296C3762B91F0F50051B63C /* WidgetActionsAppIntentTimelineProvider.swift in Sources */,
 				110E694424E77125004AA96D /* WidgetActionsProvider.swift in Sources */,
 				424A7F482B188BF3008C8DF3 /* WidgetContentMargin.swift in Sources */,
 				115560E127010D8400A8F818 /* WidgetBasicContainerView.swift in Sources */,
@@ -5584,9 +5624,12 @@
 				115560E327010DAB00A8F818 /* WidgetBasicView.swift in Sources */,
 				1171507024DFCDE60065E874 /* Widgets.swift in Sources */,
 				424A7F462B188946008C8DF3 /* WidgetBackground.swift in Sources */,
+				4296C3772B91F26A0051B63C /* IntentActionAppEntity.swift in Sources */,
 				115560F227012FE100A8F818 /* WidgetOpenPageProvider.swift in Sources */,
 				1165705627018C4E003906A7 /* WidgetEmptyView.swift in Sources */,
 				1171508124DFCEC50065E874 /* WidgetActions.swift in Sources */,
+				4296C3782B91F6260051B63C /* PerformAction.swift in Sources */,
+				4296C37B2B92054C0051B63C /* WidgetActionsAppIntent.swift in Sources */,
 				110E694624E771AB004AA96D /* Color+Hex.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -5669,6 +5712,7 @@
 				42266B252B7A4BA900E94A71 /* BarcodeScannerViewModel.swift in Sources */,
 				11DE823024FAE66F00E636B8 /* UIWindow+Additions.swift in Sources */,
 				11DA6B4F2713912F008ADFAF /* OnboardingPermissionViewController.swift in Sources */,
+				4296C36E2B90DB640051B63C /* PerformAction.swift in Sources */,
 				42CA28BB2B1028330093B31A /* SimulatorThreadClientService.swift in Sources */,
 				1127383C2625512600F5E312 /* ButtonRowWithLoading.swift in Sources */,
 				420FE84E2B556CE500878E06 /* CarPlayEntitiesListViewModel.swift in Sources */,
@@ -5729,6 +5773,7 @@
 				425573E62B5838B600145217 /* MaterialDesignIcons+CarPlay.swift in Sources */,
 				42F1DA612B4D4F31002729BC /* CarPlayNoServerAlert.swift in Sources */,
 				11C590ED24A832CA0066085D /* YamlSection.swift in Sources */,
+				4296C36D2B90DB640051B63C /* IntentActionAppEntity.swift in Sources */,
 				42F1DA5B2B4BF7DF002729BC /* WindowSizeObserver.swift in Sources */,
 				42266B1D2B741FB400E94A71 /* BarcodeScannerCameraView.swift in Sources */,
 				11EFCDD624F5FA8D00314D85 /* WebViewSceneDelegate.swift in Sources */,
@@ -5768,6 +5813,7 @@
 				42F5CAEB2B10CED600409816 /* ThreadCredentialsSharing+build.swift in Sources */,
 				117EBC32261D398B00F5334A /* ZoneManagerAccuracyFuzzer.swift in Sources */,
 				113FB1132515A065000AC680 /* ScaleFactorMutator.swift in Sources */,
+				4296C37A2B9205450051B63C /* WidgetActionsAppIntent.swift in Sources */,
 				1185DFB3271FF53800ED7D9A /* OnboardingAuthStepSensors.swift in Sources */,
 				11108D632634C8FE009DAB0F /* LearnMoreButtonRow.swift in Sources */,
 				425573D12B5576E600145217 /* CarPlayDomainsListTemplate+Build.swift in Sources */,

--- a/Sources/Extensions/AppIntents/IntentActionAppEntity.swift
+++ b/Sources/Extensions/AppIntents/IntentActionAppEntity.swift
@@ -1,12 +1,5 @@
-//
-//  IntentActionAppEntity.swift
-//  
-//
-//  Created by Bruno Pantaleão on 29/02/2024.
-//
-
-import Foundation
 import AppIntents
+import Foundation
 import Shared
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
@@ -15,15 +8,15 @@ struct IntentActionAppEntity: AppEntity {
 
     struct IntentActionAppEntityQuery: EntityQuery, EntityStringQuery {
         func entities(for identifiers: [IntentActionAppEntity.ID]) async throws -> [IntentActionAppEntity] {
-            return getActionEntities().filter { identifiers.contains($0.id) }
+            getActionEntities().filter { identifiers.contains($0.id) }
         }
 
         func entities(matching string: String) async throws -> [IntentActionAppEntity] {
-            return getActionEntities().filter { $0.displayString.contains(string) }
+            getActionEntities().filter { $0.displayString.contains(string) }
         }
 
         func suggestedEntities() async throws -> [IntentActionAppEntity] {
-            return getActionEntities()
+            getActionEntities()
         }
 
         private func getActionEntities() -> [IntentActionAppEntity] {
@@ -31,6 +24,7 @@ struct IntentActionAppEntity: AppEntity {
             return Array(actions.map { IntentActionAppEntity(id: $0.ID, displayString: $0.Name) })
         }
     }
+
     static var defaultQuery = IntentActionAppEntityQuery()
 
     var id: String // if your identifier is not a String, conform the entity to EntityIdentifierConvertible.
@@ -44,4 +38,3 @@ struct IntentActionAppEntity: AppEntity {
         self.displayString = displayString
     }
 }
-

--- a/Sources/Extensions/AppIntents/IntentActionAppEntity.swift
+++ b/Sources/Extensions/AppIntents/IntentActionAppEntity.swift
@@ -1,0 +1,47 @@
+//
+//  IntentActionAppEntity.swift
+//  
+//
+//  Created by Bruno Pantaleão on 29/02/2024.
+//
+
+import Foundation
+import AppIntents
+import Shared
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct IntentActionAppEntity: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Action")
+
+    struct IntentActionAppEntityQuery: EntityQuery, EntityStringQuery {
+        func entities(for identifiers: [IntentActionAppEntity.ID]) async throws -> [IntentActionAppEntity] {
+            return getActionEntities().filter { identifiers.contains($0.id) }
+        }
+
+        func entities(matching string: String) async throws -> [IntentActionAppEntity] {
+            return getActionEntities().filter { $0.displayString.contains(string) }
+        }
+
+        func suggestedEntities() async throws -> [IntentActionAppEntity] {
+            return getActionEntities()
+        }
+
+        private func getActionEntities() -> [IntentActionAppEntity] {
+            let actions = Current.realm().objects(Action.self).sorted(byKeyPath: #keyPath(Action.Position))
+            return Array(actions.map { IntentActionAppEntity(id: $0.ID, displayString: $0.Name) })
+        }
+    }
+    static var defaultQuery = IntentActionAppEntityQuery()
+
+    var id: String // if your identifier is not a String, conform the entity to EntityIdentifierConvertible.
+    var displayString: String
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayString)")
+    }
+
+    init(id: String, displayString: String) {
+        self.id = id
+        self.displayString = displayString
+    }
+}
+

--- a/Sources/Extensions/AppIntents/PerformAction.swift
+++ b/Sources/Extensions/AppIntents/PerformAction.swift
@@ -1,0 +1,78 @@
+//
+//  PerformAction.swift
+//
+//
+//  Created by Bruno Pantaleão on 29/02/2024.
+//
+
+import Foundation
+import AppIntents
+import Shared
+import PromiseKit
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct PerformAction: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
+    static let intentClassName = "PerformActionIntent"
+
+    static var title: LocalizedStringResource = "Perform Action"
+    static var description = IntentDescription("Performs an action defined in the app")
+
+    @Parameter(title: "Action")
+    var action: IntentActionAppEntity?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Perform \(\.$action)")
+    }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: (\.$action)) { action in
+            DisplayRepresentation(
+                title: "\(action!)",
+                subtitle: "Perform the action"
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard let intentAction = $action.wrappedValue,
+              let action = Current.realm().object(ofType: Action.self, forPrimaryKey: intentAction.id),
+              let server = Current.servers.server(for: action) else {
+            Current.Log.warning("ActionID either does not exist or is not a string in the payload")
+            return .result()
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            Current.api(for: server).HandleAction(actionID: action.ID, source: .AppShortcut).pipe { result in
+                switch result {
+                case .fulfilled:
+                    continuation.resume()
+                case .rejected(let error):
+                    Current.Log.error("Failed to run action \(intentAction.displayString), error: \(error.localizedDescription)")
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+
+        return .result()
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+fileprivate extension IntentDialog {
+    static func actionParameterDisambiguationIntro(count: Int, action: IntentActionAppEntity) -> Self {
+        "There are \(count) options matching ‘\(action)’."
+    }
+    static func actionParameterConfirmation(action: IntentActionAppEntity) -> Self {
+        "Just to confirm, you wanted ‘\(action)’?"
+    }
+    static var actionParameterConfiguration: Self {
+        "Which action?"
+    }
+    static func responseSuccess(action: IntentActionAppEntity) -> Self {
+        "Done"
+    }
+    static func responseFailure(error: String) -> Self {
+        "Failed: \(error)"
+    }
+}
+

--- a/Sources/Extensions/AppIntents/PerformAction.swift
+++ b/Sources/Extensions/AppIntents/PerformAction.swift
@@ -1,14 +1,7 @@
-//
-//  PerformAction.swift
-//
-//
-//  Created by Bruno Pantaleão on 29/02/2024.
-//
-
-import Foundation
 import AppIntents
-import Shared
+import Foundation
 import PromiseKit
+import Shared
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
 struct PerformAction: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
@@ -25,7 +18,7 @@ struct PerformAction: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
     }
 
     static var predictionConfiguration: some IntentPredictionConfiguration {
-        IntentPrediction(parameters: (\.$action)) { action in
+        IntentPrediction(parameters: \.$action) { action in
             DisplayRepresentation(
                 title: "\(action!)",
                 subtitle: "Perform the action"
@@ -46,8 +39,11 @@ struct PerformAction: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
                 switch result {
                 case .fulfilled:
                     continuation.resume()
-                case .rejected(let error):
-                    Current.Log.error("Failed to run action \(intentAction.displayString), error: \(error.localizedDescription)")
+                case let .rejected(error):
+                    Current.Log
+                        .error(
+                            "Failed to run action \(intentAction.displayString), error: \(error.localizedDescription)"
+                        )
                     continuation.resume(throwing: error)
                 }
             }
@@ -58,21 +54,24 @@ struct PerformAction: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
 }
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
-fileprivate extension IntentDialog {
+private extension IntentDialog {
     static func actionParameterDisambiguationIntro(count: Int, action: IntentActionAppEntity) -> Self {
         "There are \(count) options matching ‘\(action)’."
     }
+
     static func actionParameterConfirmation(action: IntentActionAppEntity) -> Self {
         "Just to confirm, you wanted ‘\(action)’?"
     }
+
     static var actionParameterConfiguration: Self {
         "Which action?"
     }
+
     static func responseSuccess(action: IntentActionAppEntity) -> Self {
         "Done"
     }
+
     static func responseFailure(error: String) -> Self {
         "Failed: \(error)"
     }
 }
-

--- a/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
@@ -1,6 +1,6 @@
+import AppIntents
 import Shared
 import WidgetKit
-import AppIntents
 
 @available(iOS 17, *)
 struct WidgetActionsAppIntentTimelineProvider: AppIntentTimelineProvider {

--- a/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
@@ -1,0 +1,63 @@
+import Shared
+import WidgetKit
+import AppIntents
+
+@available(iOS 17, *)
+struct WidgetActionsAppIntentTimelineProvider: AppIntentTimelineProvider {
+    typealias Entry = WidgetActionsEntry
+    typealias Intent = WidgetActionsAppIntent
+
+    func snapshot(for configuration: WidgetActionsAppIntent, in context: Context) async -> WidgetActionsEntry {
+        Self.entry(for: configuration, in: context)
+    }
+
+    func timeline(for configuration: Intent, in context: Context) async -> Timeline<Entry> {
+        .init(entries: [Self.entry(for: configuration, in: context)], policy: .never)
+    }
+
+    func placeholder(in context: Context) -> WidgetActionsEntry {
+        let count = WidgetBasicContainerView.maximumCount(family: context.family)
+        let actions = stride(from: 0, to: count, by: 1).map { _ in
+            with(Action()) {
+                $0.Text = "Redacted Text"
+                $0.IconName = MaterialDesignIcons.bedEmptyIcon.name
+            }
+        }
+
+        return WidgetActionsEntry(actions: actions)
+    }
+
+    private static func entry(for configuration: Intent, in context: Context) -> Entry {
+        if let existing = configuration.actions?.compactMap({ $0.asAction() }), !existing.isEmpty {
+            return .init(actions: existing)
+        } else {
+            return .init(actions: Self.defaultActions(in: context))
+        }
+    }
+
+    private static func defaultActions(in context: Context) -> [Action] {
+        let allActions = Current.realm().objects(Action.self).sorted(byKeyPath: #keyPath(Action.Position))
+        let maxCount = WidgetBasicContainerView.maximumCount(family: context.family)
+
+        switch allActions.count {
+        case 0: return []
+        case ...maxCount: return Array(allActions)
+        default: return Array(allActions[0 ..< maxCount])
+        }
+    }
+}
+
+@available(iOS 17, *)
+extension IntentActionAppEntity {
+    func asAction() -> Action? {
+        guard id.isEmpty == false else {
+            return nil
+        }
+
+        guard let result = Current.realm().object(ofType: Action.self, forPrimaryKey: id) else {
+            return nil
+        }
+
+        return result
+    }
+}

--- a/Sources/Extensions/AppIntents/WidgetActionsAppIntent.swift
+++ b/Sources/Extensions/AppIntents/WidgetActionsAppIntent.swift
@@ -1,12 +1,5 @@
-//
-//  WidgetActions.swift
-//  
-//
-//  Created by Bruno Pantaleão on 01/03/2024.
-//
-
-import Foundation
 import AppIntents
+import Foundation
 
 @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
 struct WidgetActionsAppIntent: AppIntent, WidgetConfigurationIntent, CustomIntentMigratedAppIntent {
@@ -15,7 +8,19 @@ struct WidgetActionsAppIntent: AppIntent, WidgetConfigurationIntent, CustomInten
     static var title: LocalizedStringResource = "Actions"
     static var description = IntentDescription("View and run actions")
 
-    @Parameter(title: "Actions", size: [.systemSmall: 1, .systemMedium: 8, .systemLarge: 16, .systemExtraLarge: 32, .accessoryInline: 1, .accessoryCorner: 1, .accessoryCircular: 1, .accessoryRectangular: 2])
+    @Parameter(
+        title: "Actions",
+        size: [
+            .systemSmall: 1,
+            .systemMedium: 8,
+            .systemLarge: 16,
+            .systemExtraLarge: 32,
+            .accessoryInline: 1,
+            .accessoryCorner: 1,
+            .accessoryCircular: 1,
+            .accessoryRectangular: 2,
+        ]
+    )
     var actions: [IntentActionAppEntity]?
 
     static var parameterSummary: some ParameterSummary {
@@ -32,9 +37,8 @@ struct WidgetActionsAppIntent: AppIntent, WidgetConfigurationIntent, CustomInten
 }
 
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
-fileprivate extension IntentDialog {
+private extension IntentDialog {
     static var actionsParameterConfiguration: Self {
         "Which actions?"
     }
 }
-

--- a/Sources/Extensions/AppIntents/WidgetActionsAppIntent.swift
+++ b/Sources/Extensions/AppIntents/WidgetActionsAppIntent.swift
@@ -1,0 +1,40 @@
+//
+//  WidgetActions.swift
+//  
+//
+//  Created by Bruno Pantaleão on 01/03/2024.
+//
+
+import Foundation
+import AppIntents
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct WidgetActionsAppIntent: AppIntent, WidgetConfigurationIntent, CustomIntentMigratedAppIntent {
+    static let intentClassName = "WidgetActionsIntent"
+
+    static var title: LocalizedStringResource = "Actions"
+    static var description = IntentDescription("View and run actions")
+
+    @Parameter(title: "Actions", size: [.systemSmall: 1, .systemMedium: 8, .systemLarge: 16, .systemExtraLarge: 32, .accessoryInline: 1, .accessoryCorner: 1, .accessoryCircular: 1, .accessoryRectangular: 2])
+    var actions: [IntentActionAppEntity]?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary()
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard let action = $actions.wrappedValue?.first else { return .result() }
+        let intent = PerformAction()
+        intent.action = action
+        let result = try await intent.perform()
+        return .result()
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+fileprivate extension IntentDialog {
+    static var actionsParameterConfiguration: Self {
+        "Which actions?"
+    }
+}
+

--- a/Sources/Extensions/Widgets/Actions/WidgetActions.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActions.swift
@@ -1,9 +1,45 @@
+import AppIntents
 import Intents
 import Shared
 import SwiftUI
 import WidgetKit
 
+@available(iOS 17, *)
 struct WidgetActions: Widget {
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: WidgetActionsIntent.widgetKind,
+            provider: WidgetActionsAppIntentTimelineProvider()
+        ) { timelineEntry in
+            WidgetBasicContainerView(
+                emptyViewGenerator: {
+                    AnyView(WidgetEmptyView(message: L10n.Widgets.Actions.notConfigured))
+                },
+                contents: timelineEntry.actions.map { action in
+                    WidgetBasicViewModel(
+                        id: action.ID,
+                        title: action.Text,
+                        subtitle: nil,
+                        interactionType: .appIntent(.action),
+                        icon: MaterialDesignIcons(serversideValueNamed: action.IconName),
+                        textColor: .init(hex: action.TextColor),
+                        iconColor: .init(hex: action.IconColor),
+                        backgroundColor: .init(hex: action.BackgroundColor)
+                    )
+                }
+            )
+        }
+        .contentMarginsDisabledIfAvailable()
+        .configurationDisplayName(L10n.Widgets.Actions.title)
+        .description(L10n.Widgets.Actions.description)
+        .supportedFamilies(WidgetActionSupportedFamilies.families)
+        .onBackgroundURLSessionEvents(matching: nil) { identifier, completion in
+            Current.webhooks.handleBackground(for: identifier, completionHandler: completion)
+        }
+    }
+}
+
+struct LegacyWidgetActions: Widget {
     var body: some WidgetConfiguration {
         IntentConfiguration(
             kind: WidgetActionsIntent.widgetKind,
@@ -19,7 +55,7 @@ struct WidgetActions: Widget {
                             id: action.ID,
                             title: action.Text,
                             subtitle: nil,
-                            widgetURL: action.widgetLinkURL,
+                            interactionType: .widgetURL(action.widgetLinkURL),
                             icon: MaterialDesignIcons(serversideValueNamed: action.IconName),
                             textColor: .init(hex: action.TextColor),
                             iconColor: .init(hex: action.IconColor),
@@ -32,17 +68,21 @@ struct WidgetActions: Widget {
         .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.Widgets.Actions.title)
         .description(L10n.Widgets.Actions.description)
-        .supportedFamilies({
-            var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
-
-            if #available(iOS 15, *) {
-                supportedFamilies.append(.systemExtraLarge)
-            }
-
-            return supportedFamilies
-        }())
+        .supportedFamilies(WidgetActionSupportedFamilies.families)
         .onBackgroundURLSessionEvents(matching: nil) { identifier, completion in
             Current.webhooks.handleBackground(for: identifier, completionHandler: completion)
         }
+    }
+}
+
+enum WidgetActionSupportedFamilies {
+    static var families: [WidgetFamily] {
+        var supportedFamilies: [WidgetFamily] = [.systemSmall, .systemMedium, .systemLarge]
+
+        if #available(iOS 15, *) {
+            supportedFamilies.append(.systemExtraLarge)
+        }
+
+        return supportedFamilies
     }
 }

--- a/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import Foundation
 import Shared
 import SwiftUI
@@ -7,7 +8,7 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
         id: String,
         title: String,
         subtitle: String?,
-        widgetURL: URL,
+        interactionType: InteractionType,
         icon: MaterialDesignIcons,
         showsChevron: Bool = false,
         textColor: Color = Color.black,
@@ -17,7 +18,7 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
         self.id = id
         self.title = title
         self.subtitle = subtitle
-        self.widgetURL = widgetURL
+        self.interactionType = interactionType
         self.textColor = textColor
         self.icon = icon
         self.showsChevron = showsChevron
@@ -29,7 +30,7 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
 
     var title: String
     var subtitle: String?
-    var widgetURL: URL
+    var interactionType: InteractionType
 
     var icon: MaterialDesignIcons
     var showsChevron: Bool
@@ -37,6 +38,15 @@ struct WidgetBasicViewModel: Identifiable, Hashable {
     var backgroundColor: Color
     var textColor: Color
     var iconColor: Color
+
+    enum InteractionType: Hashable {
+        case widgetURL(URL)
+        case appIntent(WidgetIntentType)
+    }
+
+    enum WidgetIntentType: Hashable {
+        case action
+    }
 }
 
 enum WidgetBasicSizeStyle {

--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
@@ -22,7 +22,7 @@ struct WidgetOpenPage: Widget {
                                 id: panel.identifier!,
                                 title: panel.displayString,
                                 subtitle: showSubtitle ? Current.servers.server(for: panel)?.info.name : nil,
-                                widgetURL: panel.widgetURL,
+                                interactionType: .widgetURL(panel.widgetURL),
                                 icon: panel.materialDesignIcon,
                                 showsChevron: true,
                                 textColor: .white,

--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -4,7 +4,15 @@ import WidgetKit
 @main
 struct Widgets: WidgetBundle {
     var body: some Widget {
-        WidgetActions()
+        actionsWidget()
         WidgetOpenPage()
+    }
+
+    private func actionsWidget() -> some Widget {
+        if #available(iOS 17, *) {
+            return WidgetActions()
+        } else {
+            return LegacyWidgetActions()
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR upgrades 2 Siri intents to AppIntents and adds a new widget which can run actions (and scene actions) in background
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
