### PR TITLE
Address deprecated call in `SettingDetailViewController`

### DIFF
--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -793,7 +793,7 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 cell.selectionStyle = .default
             }
             $0.onCellSelection { _, row in
-                if CLLocationManager.authorizationStatus() == .notDetermined {
+                if locationManager.authorizationStatus == .notDetermined {
                     locationManager.requestAlwaysAuthorization()
                 } else {
                     UIApplication.shared.openSettings(destination: .location)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In continuation of https://github.com/home-assistant/iOS/pull/2607, this replaces the deprecated `CLLocationManager.authorizationStatus()` call.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

<img width="830" alt="Screenshot 2024-03-02 at 7 30 40" src="https://github.com/home-assistant/iOS/assets/35694712/9d9b2da2-76b2-404a-bb68-0e3a2d358a88">
