### PR TITLE
Use only the Action real name (not identifier) when displaying in Car…

### DIFF
--- a/Sources/Vehicle/Templates/Actions/CarPlayActionsTemplate.swift
+++ b/Sources/Vehicle/Templates/Actions/CarPlayActionsTemplate.swift
@@ -78,8 +78,8 @@ final class CarPlayActionsTemplate: CarPlayTemplateProvider {
             let materialDesignIcon = MaterialDesignIcons(named: action.IconName)
                 .carPlayIcon()
             let item = CPListItem(
-                text: action.Name,
-                detailText: action.Text,
+                text: action.Text,
+                detailText: nil,
                 image: materialDesignIcon
             )
             item.handler = { [weak self] _, _ in


### PR DESCRIPTION
…Play

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To keep it aligned between platforms, now CarPlay will display only the "name" that is configured when setting up the action, not the identifier.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 14 26 31](https://github.com/home-assistant/iOS/assets/5808343/8c8d2f5b-4dab-4e1c-8b23-27282b046fd5)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
