### PR TITLE
iOS platform 15 for download_localized_strings.yml

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ end
 if ENV['ONLY_SUPPORT_MODULES']
   # some of our CI scripts only need e.g. SwiftLint
   # this allows us to skip a lot of installation when unnecessary
-  platform :ios, '12.0'
+  platform :ios, '15.0'
   support_modules
   workspace 'abstract.workspace'
 


### PR DESCRIPTION
## Summary

As the min target is [iOS 15](https://github.com/home-assistant/iOS/pull/2469), this just updates the platform version that gets used in the `Download Localized Strings` workflow.