### PR TITLE
Use a `switch` for `CMMotionActivityConfidence.description`

### DIFF
--- a/Sources/Shared/Common/Extensions/CMMotion+StringExtensions.swift
+++ b/Sources/Shared/Common/Extensions/CMMotion+StringExtensions.swift
@@ -48,13 +48,11 @@ extension CMMotionActivity {
 
 extension CMMotionActivityConfidence {
     var description: String {
-        if self == CMMotionActivityConfidence.low {
-            return "Low"
-        } else if self == CMMotionActivityConfidence.medium {
-            return "Medium"
-        } else if self == CMMotionActivityConfidence.high {
-            return "High"
+        switch self {
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        @unknown default: "Unknown"
         }
-        return "Unknown"
     }
 }


### PR DESCRIPTION
## Summary
- use a `switch` instead of if-else if-else
- use type inference for better readability