### PR TITLE
🔧 Fix deprecated `Data.init`

### DIFF
--- a/Sources/Shared/Extensions/Data+Hexadecimal.swift
+++ b/Sources/Shared/Extensions/Data+Hexadecimal.swift
@@ -22,7 +22,7 @@ public extension Data {
             }
         }
 
-        self.init(bytes: byteArray)
+        self.init(byteArray)
     }
 }
 


### PR DESCRIPTION
## Summary
Replaces deprecated `Data.init`.

## Screenshots
<img width="755" alt="Screenshot 2024-03-19 at 14 08 48" src="https://github.com/home-assistant/iOS/assets/35694712/ba5f7c24-e730-44d8-a31d-e5cbef5c32f6">
<img width="579" alt="Screenshot 2024-03-19 at 14 07 58" src="https://github.com/home-assistant/iOS/assets/35694712/93a1848d-d35c-4b4a-89b3-4f0769dc10c1">
