### PR TITLE
Bump Xcode version in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Home Assistant for Apple Platforms
 
 ## Getting Started
 
-Home Assistant uses Bundler, Homebrew and Cocoapods to manage build dependencies. You'll need Xcode 14.1 (or later) which you can download from the [App Store](https://developer.apple.com/download/). You can get the app running using the following commands:
+Home Assistant uses Bundler, Homebrew and Cocoapods to manage build dependencies. You'll need Xcode 14.3 (or later) which you can download from the [App Store](https://developer.apple.com/download/). You can get the app running using the following commands:
 
 ```bash
 git clone https://github.com/home-assistant/iOS.git


### PR DESCRIPTION
## Summary
The mentioned version (Xcode 14.1) only supports Swift 5.7.
This PR updates it to Xcode 14.3 which supports Swift 5.8 that's commonly used throughout the project.