### PR TITLE
Update badge manually for clear_notification

### DIFF
--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -86,7 +86,7 @@ private struct HandlerClearNotification: NotificationCommandHandler {
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
         }
         if let aps = payload["aps"] as? [String: Any],
-           let badge = payload["badge"] as? Int
+           let badge = aps["badge"] as? Int
         {
             UIApplication.shared.applicationIconBadgeNumber = badge
         }

--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -85,9 +85,14 @@ private struct HandlerClearNotification: NotificationCommandHandler {
         if !keys.isEmpty {
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
         }
+        if let aps = payload["aps"] as? [String: Any],
+           let badge = payload["badge"] as? Int
+        {
+            UIApplication.shared.applicationIconBadgeNumber = badge
+        }
         // https://stackoverflow.com/a/56657888/6324550
         return Promise<Void> { seal in
-            DispatchQueue.main.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 seal.fulfill(())
             }
         }

--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -85,11 +85,12 @@ private struct HandlerClearNotification: NotificationCommandHandler {
         if !keys.isEmpty {
             UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: keys)
         }
+        #if os(iOS)
         if let aps = payload["aps"] as? [String: Any],
-           let badge = aps["badge"] as? Int
-        {
+           let badge = aps["badge"] as? Int {
             UIApplication.shared.applicationIconBadgeNumber = badge
         }
+        #endif
         // https://stackoverflow.com/a/56657888/6324550
         return Promise<Void> { seal in
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
I had the same issue as #2462 where the badge isn't updating every time when sending badge update with the clear_notification command, mostly when I'm not getting it through local push but sometimes with local push too. Since I'm not in the developer team, I can't test push related stuff. (It might also need to be released to testflight in order to be tested if HA is not prepared to handle using the sandbox push environment for development builds)

AFAIK, the badge should be handled by the OS. But since that is not happening, we should try setting it manually.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I haven't noticed it not clearing notifications like someone mentioned in that issue but the increased delay should resolve that.
