### PR TITLE
Add button to manually sync server Actions

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -417,6 +417,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings_details.actions.scenes.title" = "Scene Actions";
 "settings_details.actions.title" = "Actions";
 "settings_details.actions.watch.available.title" = "Show in Watch";
+"settings_details.actions.server_controlled.update.title" = "Update server Actions";
 "settings_details.general.app_icon.enum.beta" = "Beta";
 "settings_details.general.app_icon.enum.black" = "Black";
 "settings_details.general.app_icon.enum.blue" = "Blue";

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -462,6 +462,21 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 }
             )
 
+            form +++ ButtonRow {
+                $0.title = L10n.SettingsDetails.Actions.ServerControlled.Update.title
+                $0.onCellSelection { _, _ in
+                    let result = Current.modelManager.fetch()
+                    result.pipe { result in
+                        switch result {
+                        case .fulfilled:
+                            break
+                        case let .rejected(error):
+                            Current.Log.error("Failed to manually update server Actions: \(error.localizedDescription)")
+                        }
+                    }
+                }
+            }
+
             let scenes = realm.objects(RLMScene.self).sorted(byKeyPath: RLMScene.positionKeyPath)
 
             let toggleAllSwitch = SwitchRow()

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -126,6 +126,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
     }
 
     public func update(with object: MobileAppConfigAction, server: Server, using realm: Realm) -> Bool {
+        Current.Log.info("Updating server configured Actions")
         if self.realm == nil {
             ID = object.name
             Name = object.name

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1451,6 +1451,12 @@ public enum L10n {
         /// Scene Actions
         public static var title: String { return L10n.tr("Localizable", "settings_details.actions.scenes.title") }
       }
+      public enum ServerControlled {
+        public enum Update {
+          /// Update server Actions
+          public static var title: String { return L10n.tr("Localizable", "settings_details.actions.server_controlled.update.title") }
+        }
+      }
       public enum Watch {
         public enum Available {
           /// Show in Watch


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Some users have pointed out thei Actions sometimes are not sync, this is to help out define if the time of the sync is relevant. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="703" alt="Screenshot 2024-04-22 at 13 41 04" src="https://github.com/home-assistant/iOS/assets/5808343/41cd1ff7-7cc3-4cf5-9814-fe59289553f9">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
