### PR TITLE
Fix widgets memory issue

### DIFF
--- a/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Actions/WidgetActionsAppIntentTimelineProvider.swift
@@ -1,4 +1,5 @@
 import AppIntents
+import RealmSwift
 import Shared
 import WidgetKit
 
@@ -14,7 +15,10 @@ struct WidgetActionsAppIntentTimelineProvider: AppIntentTimelineProvider {
     func timeline(for configuration: Intent, in context: Context) async -> Timeline<Entry> {
         .init(
             entries: [Self.entry(for: configuration, in: context)],
-            policy: .after(Current.date().addingTimeInterval(expiration.converted(to: .seconds).value))
+            policy: .after(
+                Current.date()
+                    .addingTimeInterval(WidgetActionsDataSource.expiration.converted(to: .seconds).value)
+            )
         )
     }
 
@@ -30,10 +34,6 @@ struct WidgetActionsAppIntentTimelineProvider: AppIntentTimelineProvider {
         return WidgetActionsEntry(actions: actions)
     }
 
-    private var expiration: Measurement<UnitDuration> {
-        .init(value: 24, unit: .hours)
-    }
-
     private static func entry(for configuration: Intent, in context: Context) -> Entry {
         if let existing = configuration.actions?.compactMap({ $0.asAction() }), !existing.isEmpty {
             return .init(actions: existing)
@@ -43,7 +43,7 @@ struct WidgetActionsAppIntentTimelineProvider: AppIntentTimelineProvider {
     }
 
     private static func defaultActions(in context: Context) -> [Action] {
-        let allActions = Current.realm().objects(Action.self).sorted(byKeyPath: #keyPath(Action.Position))
+        let allActions = WidgetActionsDataSource.actions
         let maxCount = WidgetBasicContainerView.maximumCount(family: context.family)
 
         switch allActions.count {
@@ -61,10 +61,24 @@ extension IntentActionAppEntity {
             return nil
         }
 
-        guard let result = Current.realm().object(ofType: Action.self, forPrimaryKey: id) else {
+        guard let result = Realm.getRealm(objectTypes: [Action.self, RLMScene.self]).object(
+            ofType: Action.self,
+            forPrimaryKey: id
+        ) else {
             return nil
         }
 
         return result
+    }
+}
+
+enum WidgetActionsDataSource {
+    static var expiration: Measurement<UnitDuration> {
+        .init(value: 24, unit: .hours)
+    }
+
+    static var actions: Results<Action> {
+        Realm.getRealm(objectTypes: [Action.self, RLMScene.self]).objects(Action.self)
+            .sorted(byKeyPath: #keyPath(Action.Position))
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsProvider.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsProvider.swift
@@ -23,7 +23,7 @@ struct WidgetActionsProvider: IntentTimelineProvider {
     }
 
     private static func defaultActions(in context: Context) -> [Action] {
-        let allActions = Current.realm().objects(Action.self).sorted(byKeyPath: #keyPath(Action.Position))
+        let allActions = WidgetActionsDataSource.actions
         let maxCount = WidgetBasicContainerView.maximumCount(family: context.family)
 
         switch allActions.count {

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
@@ -14,8 +14,6 @@ struct WidgetAssistProvider: IntentTimelineProvider {
     typealias Intent = AssistInAppIntent
     typealias Entry = WidgetAssistEntry
 
-    @Environment(\.diskCache) var diskCache: DiskCache
-
     func placeholder(in context: Context) -> WidgetAssistEntry {
         .init()
     }

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -29,6 +29,12 @@ public extension Realm {
 
     /// The live data store, located in shared storage.
     static let live: () -> Realm = {
+        getRealm()
+    }
+
+    // swiftlint:disable cyclomatic_complexity
+    /// Mainly used to specify objectTypes in a context such as an extension, otherwise always use "Realm.live"
+    static func getRealm(objectTypes: [ObjectBase.Type]? = nil) -> Realm {
         if NSClassFromString("XCTest") != nil {
             do {
                 return try Realm(configuration: .init(inMemoryIdentifier: "Tests", deleteRealmIfMigrationNeeded: true))
@@ -227,7 +233,8 @@ public extension Realm {
                 // Check for the realm file size to be greater than the max file size, and the amount of bytes
                 // currently used to be less than 50% of the total realm file size
                 return (realmFileSizeInBytes > maxFileSize) && (Double(usedBytes) / Double(realmFileSizeInBytes)) < 0.5
-            }
+            },
+            objectTypes: objectTypes
         )
 
         do {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When Realm was accessed it was bringing up to 20mb to memory, which helped exceeding 30mb (extensions limit) causing crash on widgets.

Specifying realm object types help use just enough memory needed

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
