### PR TITLE
Use same variable for status bar color as frontend

### DIFF
--- a/Sources/App/Resources/WebSocketBridge.js
+++ b/Sources/App/Resources/WebSocketBridge.js
@@ -8,6 +8,7 @@ const notifyThemeColors = () => {
 
         [
             '--app-header-background-color',
+            '--app-theme-color',
             '--primary-background-color',
             '--text-primary-color',
             '--primary-color',

--- a/Sources/App/Utilities/ThemeColors.swift
+++ b/Sources/App/Utilities/ThemeColors.swift
@@ -6,6 +6,7 @@ public struct ThemeColors: Codable {
     public enum Color: String, CaseIterable {
         // these are in WebSocketBridge.js in this repo (we inject it)
         case appHeaderBackgroundColor = "--app-header-background-color"
+        case appThemeColor = "--app-theme-color"
         case primaryBackgroundColor = "--primary-background-color"
         case textPrimaryColor = "--text-primary-color"
         case primaryColor = "--primary-color"
@@ -77,6 +78,7 @@ private extension ThemeColors.Color {
         case .primaryBackgroundColor: return UIColor(red: 0.98, green: 0.98, blue: 0.98, alpha: 1.0)
         case .primaryColor: return UIColor.white
         case .textPrimaryColor: return UIColor.white
+        case .appThemeColor: return UIColor(red: 0.01, green: 0.66, blue: 0.96, alpha: 1.0)
         }
     }
 }

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -344,12 +344,12 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         webView?.scrollView.backgroundColor = cachedColors[.primaryBackgroundColor]
 
         if let statusBarView = view.viewWithTag(111) {
-            statusBarView.backgroundColor = cachedColors[.appHeaderBackgroundColor]
+            statusBarView.backgroundColor = cachedColors[.appThemeColor]
         }
 
         refreshControl.tintColor = cachedColors[.primaryColor]
 
-        let headerBackgroundIsLight = cachedColors[.appHeaderBackgroundColor].isLight
+        let headerBackgroundIsLight = cachedColors[.appThemeColor].isLight
         underlyingPreferredStatusBarStyle = headerBackgroundIsLight ? .darkContent : .lightContent
 
         setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
We were using `--app-header-background-color` for status bar in the app and frontend uses `--app-theme-color`, this PR changes that to keep consistency with frontend

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
