### PR TITLE
Define initial Assist widget configuration to use preferred pipeline

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,7 @@
 "app_intents.perform_action.response_failure" = "Failed: %@";
 "app_intents.perform_action.response_success" = "Done";
 "app_intents.widget_action.actions_parameter_configuration" = "Which actions?";
+"app_intents.assist.preferred_pipeline.title" = "Preferred";
 "assist.pipelines_picker.title" = "Assist Pipelines";
 "cancel_label" = "Cancel";
 "carPlay.action.intro.item.body" = "Tap to continue on your iPhone";

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
@@ -14,13 +14,31 @@ struct WidgetAssistProvider: IntentTimelineProvider {
     typealias Intent = AssistInAppIntent
     typealias Entry = WidgetAssistEntry
 
+    private let defaultEntry = {
+        var intentServer: IntentServer? = {
+            if let server = Current.servers.all.first {
+                return IntentServer(server: server)
+            } else {
+                return nil
+            }
+        }()
+        return WidgetAssistEntry(
+            server: intentServer,
+            pipeline: IntentAssistPipeline(
+                identifier: "0",
+                display: L10n.AppIntents.Assist.PreferredPipeline.title
+            ),
+            withVoice: .init(true)
+        )
+    }()
+
     func placeholder(in context: Context) -> WidgetAssistEntry {
         .init()
     }
 
     func getSnapshot(for configuration: Intent, in context: Context, completion: @escaping (Entry) -> Void) {
         guard let server = configuration.server, let pipeline = configuration.pipeline else {
-            completion(.init())
+            completion(defaultEntry)
             return
         }
         let entry = WidgetAssistEntry(
@@ -34,8 +52,8 @@ struct WidgetAssistProvider: IntentTimelineProvider {
     func getTimeline(for configuration: Intent, in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
         completion(.init(entries: [
             WidgetAssistEntry(
-                server: configuration.server,
-                pipeline: configuration.pipeline,
+                server: configuration.server ?? defaultEntry.server,
+                pipeline: configuration.pipeline ?? defaultEntry.pipeline,
                 withVoice: Bool(truncating: configuration.withVoice ?? 1)
             ),
         ], policy: .never))

--- a/Sources/Shared/Intents/AssistInApp/AssistInAppIntentHandler.swift
+++ b/Sources/Shared/Intents/AssistInApp/AssistInAppIntentHandler.swift
@@ -56,8 +56,15 @@ class AssistInAppIntentHandler: NSObject, AssistInAppIntentHandling {
         for intent: AssistInAppIntent,
         with completion: @escaping (INObjectCollection<IntentAssistPipeline>?, (any Error)?) -> Void
     ) {
+        var outputPipelines = [
+            IntentAssistPipeline(
+                identifier: "0",
+                display: L10n.AppIntents.Assist.PreferredPipeline.title
+            ),
+        ]
+
         guard let server = Current.servers.server(for: intent) else {
-            completion(nil, nil)
+            completion(.init(items: outputPipelines), nil)
             return
         }
 
@@ -66,10 +73,10 @@ class AssistInAppIntentHandler: NSObject, AssistInAppIntentHandling {
                 completion(nil, nil)
                 return
             }
-            let result: [IntentAssistPipeline] = pipelines.map { pipeline in
-                IntentAssistPipeline(identifier: pipeline.id, display: pipeline.name)
+            for pipeline in pipelines {
+                outputPipelines.append(IntentAssistPipeline(identifier: pipeline.id, display: pipeline.name))
             }
-            completion(.init(items: result), nil)
+            completion(.init(items: outputPipelines), nil)
         }
     }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -252,6 +252,12 @@ public enum L10n {
   }
 
   public enum AppIntents {
+    public enum Assist {
+      public enum PreferredPipeline {
+        /// Preferred
+        public static var title: String { return L10n.tr("Localizable", "app_intents.assist.preferred_pipeline.title") }
+      }
+    }
     public enum PerformAction {
       /// Which action?
       public static var actionParameterConfiguration: String { return L10n.tr("Localizable", "app_intents.perform_action.action_parameter_configuration") }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Instead of leaving the widget in a "configuration pending" mode, this PR sets the preferred pipeline and first server available as the initial widget config

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
