### PR TITLE
Fix barcode/assist/settings overlays, manage all overlays with 1 reference

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -26,7 +26,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     private var initialURL: URL?
 
     /// A view controller presented by a request from the webview
-    private weak var overlayAppController: UIViewController?
+    private var overlayAppController: UIViewController?
 
     private let settingsButton: UIButton = {
         let button = UIButton()
@@ -232,7 +232,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             let settingsView = SettingsViewController()
             settingsView.hidesBottomBarWhenPushed = true
             let navController = UINavigationController(rootViewController: settingsView)
-            navigationController?.present(navController, animated: true, completion: nil)
+            presentOverlayController(controller: navController)
         }
     }
 
@@ -1153,8 +1153,8 @@ extension WebViewController: WKScriptMessageHandler {
             preferredPipelineId: pipeline,
             autoStartRecording: autoStartRecording
         ))
-        present(assistView, animated: true, completion: nil)
-        overlayAppController = assistView
+
+        presentOverlayController(controller: assistView)
     }
 
     private func transferKeychainThreadCredentialsToHARequested() {
@@ -1194,15 +1194,20 @@ extension WebViewController: WKScriptMessageHandler {
         alternativeOptionLabel: String?,
         incomingMessageId: Int
     ) {
-        overlayAppController = BarcodeScannerHostingController(rootView: BarcodeScannerView(
+        let barcodeController = BarcodeScannerHostingController(rootView: BarcodeScannerView(
             title: title,
             description: description,
             alternativeOptionLabel: alternativeOptionLabel,
             incomingMessageId: incomingMessageId
         ))
-        overlayAppController?.modalPresentationStyle = .fullScreen
-        guard let overlayAppController else { return }
-        present(overlayAppController, animated: true)
+        barcodeController.modalPresentationStyle = .fullScreen
+        presentOverlayController(controller: barcodeController)
+    }
+
+    private func presentOverlayController(controller: UIViewController) {
+        overlayAppController?.dismiss(animated: false, completion: nil)
+        overlayAppController = controller
+        present(controller, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
overlayViewController reference was mistakenly weak, which was causing barcode scanner to not be displayed. On top of that now we can always have just one overlay, assist/barcode scanner/settings, presenting one will dismiss the previous one.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
