### PR TITLE
Fix Open Page widget selection bug

### DIFF
--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPageProvider.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPageProvider.swift
@@ -33,12 +33,15 @@ struct WidgetOpenPageProvider: IntentTimelineProvider {
     ) {
         OpenPageIntentHandler.panels { panels in
             var intentsToDisplay = panels
+
             if !existing.isEmpty {
-                intentsToDisplay = panels.filter { intentPanel in
-                    existing.contains(intentPanel)
+                intentsToDisplay = existing.compactMap { existingValue in
+                    intentsToDisplay.first {
+                        $0.identifier == existingValue.identifier &&
+                            $0.server == existingValue.server
+                    }
                 }
             }
-
             completion(Array(intentsToDisplay.prefix(WidgetBasicContainerView.maximumCount(family: context.family))))
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Open Page widget had a an issue that depending on the servers you have configured and it's panels, it could select the wrong one for the widget.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
