### PR TITLE
Add Actions custom colors back

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -444,6 +444,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings_details.actions.server_controlled.update.title" = "Update server Actions";
 "settings_details.actions.title" = "Actions";
 "settings_details.actions.watch.available.title" = "Show in Watch";
+"settings_details.actions.use_custom_colors.title" = "Use custom colors";
 "settings_details.general.app_icon.enum.beta" = "Beta";
 "settings_details.general.app_icon.enum.black" = "Black";
 "settings_details.general.app_icon.enum.blue" = "Blue";

--- a/Sources/Extensions/Watch/Home/Mocks/MockWatchHomeViewModel.swift
+++ b/Sources/Extensions/Watch/Home/Mocks/MockWatchHomeViewModel.swift
@@ -14,7 +14,10 @@ final class MockWatchHomeViewModel: WatchHomeViewModelProtocol {
                 id: "1",
                 name: "Hello",
                 iconName: "ab_testing",
-                iconColor: "#4479b3"
+                iconColor: "#4479b3",
+                backgroundColor: "#4479b3",
+                textColor: "#4479b3",
+                useCustomColors: true
             ),
         ]
     }

--- a/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
+++ b/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
@@ -47,14 +47,23 @@ struct WatchActionButtonView<ViewModel>: View where ViewModel: WatchHomeViewMode
                     .frame(width: 30, height: 30)
                     .animation(.easeInOut, value: state)
                 Text(action.name)
-                    .foregroundStyle(.black)
+                    .foregroundStyle(action.useCustomColors ? Color(uiColor: .init(hex: action.textColor)) : .white)
             }
         }
         .disabled(state != .idle)
-        .listRowBackground(
-            Color.white
-                .clipShape(RoundedRectangle(cornerRadius: 14))
-        )
+        .modify { view in
+            if action.useCustomColors {
+                view.listRowBackground(
+                    action.useCustomColors ?
+                        Color(uiColor: .init(hex: action.backgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 14)) :
+                        Color.white
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                )
+            } else {
+                view
+            }
+        }
     }
 
     private func resetState() {

--- a/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
+++ b/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
@@ -90,7 +90,6 @@ struct WatchActionButtonView<ViewModel>: View where ViewModel: WatchHomeViewMode
                 ProgressView()
                     .progressViewStyle(.circular)
                     .frame(width: 24, height: 24)
-                    .tint(.black)
                     .shadow(color: .white, radius: 10)
             case .success:
                 makeActionImage(systemName: "checkmark.circle.fill")
@@ -103,6 +102,6 @@ struct WatchActionButtonView<ViewModel>: View where ViewModel: WatchHomeViewMode
     private func makeActionImage(systemName: String) -> some View {
         Image(systemName: systemName)
             .font(.system(size: 24))
-            .foregroundStyle(.black)
+            .foregroundStyle(.white)
     }
 }

--- a/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
@@ -10,6 +10,9 @@ struct WatchActionItem: Equatable {
     let name: String
     let iconName: String
     let iconColor: String
+    let backgroundColor: String
+    let textColor: String
+    let useCustomColors: Bool
 }
 
 protocol WatchHomeViewModelProtocol: ObservableObject {
@@ -139,7 +142,10 @@ private extension Action {
             id: ID,
             name: Text,
             iconName: IconName,
-            iconColor: IconColor
+            iconColor: IconColor,
+            backgroundColor: BackgroundColor,
+            textColor: TextColor,
+            useCustomColors: useCustomColors
         )
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActions.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActions.swift
@@ -22,7 +22,10 @@ struct WidgetActions: Widget {
                         subtitle: nil,
                         interactionType: .appIntent(.action(id: action.ID, name: action.Name)),
                         icon: MaterialDesignIcons(serversideValueNamed: action.IconName),
-                        iconColor: .init(hex: action.IconColor)
+                        textColor: .init(hex: action.TextColor),
+                        iconColor: .init(hex: action.IconColor),
+                        backgroundColor: .init(hex: action.BackgroundColor),
+                        useCustomColors: action.useCustomColors
                     )
                 }
             )
@@ -52,7 +55,10 @@ struct LegacyWidgetActions: Widget {
                             subtitle: nil,
                             interactionType: .widgetURL(action.widgetLinkURL),
                             icon: MaterialDesignIcons(serversideValueNamed: action.IconName),
-                            iconColor: .init(hex: action.IconColor)
+                            textColor: .init(hex: action.TextColor),
+                            iconColor: .init(hex: action.IconColor),
+                            backgroundColor: .init(hex: action.BackgroundColor),
+                            useCustomColors: action.useCustomColors
                         )
                     }
                 )

--- a/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicView.swift
@@ -34,7 +34,7 @@ struct WidgetBasicView: View {
             .font(sizeStyle.textFont)
             .fontWeight(.semibold)
             .multilineTextAlignment(.leading)
-            .foregroundStyle(Color(uiColor: .label))
+            .foregroundStyle(model.useCustomColors ? model.textColor : Color(uiColor: .label))
             .lineLimit(2)
     }
 
@@ -87,7 +87,7 @@ struct WidgetBasicView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.asset(Asset.Colors.tileBackground))
+        .background(model.useCustomColors ? model.backgroundColor : Color.asset(Asset.Colors.tileBackground))
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .overlay {
             RoundedRectangle(cornerRadius: 14)

--- a/Sources/Extensions/Widgets/Common/WidgetBasicViewModel.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicViewModel.swift
@@ -9,14 +9,20 @@ struct WidgetBasicViewModel: Identifiable, Hashable, Encodable {
         subtitle: String?,
         interactionType: InteractionType,
         icon: MaterialDesignIcons,
-        iconColor: Color = Color.black
+        textColor: Color = Color(uiColor: .label),
+        iconColor: Color = Color.asset(Asset.Colors.haPrimary),
+        backgroundColor: Color = Color.asset(Asset.Colors.tileBackground),
+        useCustomColors: Bool = false
     ) {
         self.id = id
         self.title = title
         self.subtitle = subtitle
         self.interactionType = interactionType
+        self.textColor = textColor
         self.icon = icon
         self.iconColor = iconColor
+        self.backgroundColor = backgroundColor
+        self.useCustomColors = useCustomColors
     }
 
     var id: String
@@ -27,7 +33,10 @@ struct WidgetBasicViewModel: Identifiable, Hashable, Encodable {
 
     var icon: MaterialDesignIcons
 
+    var backgroundColor: Color
+    var textColor: Color
     var iconColor: Color
+    var useCustomColors: Bool
 
     enum InteractionType: Hashable, Encodable {
         case widgetURL(URL)

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -24,6 +24,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
     @objc public dynamic var serverIdentifier: String = ""
     @objc public dynamic var showInCarPlay: Bool = true
     @objc public dynamic var showInWatch: Bool = true
+    @objc public dynamic var useCustomColors: Bool = false
 
     static func primaryKey(sourceIdentifier: String, serverIdentifier: String) -> String {
         #warning("multiserver - primary key duplication")
@@ -94,6 +95,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         self.serverIdentifier = try map.value("serverIdentifier")
         self.showInCarPlay = try map.value("showInCarPlay")
         self.showInWatch = try map.value("showInWatch")
+        self.useCustomColors = try map.value("useCustomColors")
         super.init()
     }
 
@@ -111,6 +113,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         serverIdentifier >>> map["serverIdentifier"]
         showInCarPlay >>> map["showInCarPlay"]
         showInWatch >>> map["showInWatch"]
+        useCustomColors >>> map["useCustomColors"]
     }
 
     static func didUpdate(objects: [Action], server: Server, realm: Realm) {
@@ -170,6 +173,10 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
 
         if let showInWatch = object.showInWatch {
             self.showInWatch = showInWatch
+        }
+
+        if let useCustomColors = object.useCustomColors {
+            self.useCustomColors = useCustomColors
         }
 
         return true

--- a/Sources/Shared/API/Responses/MobileAppConfig/MobileAppConfigAction.swift
+++ b/Sources/Shared/API/Responses/MobileAppConfig/MobileAppConfigAction.swift
@@ -10,6 +10,7 @@ public struct MobileAppConfigAction: ImmutableMappable, UpdatableModelSource {
     var iconColor: String?
     var showInCarPlay: Bool?
     var showInWatch: Bool?
+    var useCustomColors: Bool?
 
     public init(map: Map) throws {
         self.name = try map.value("name")
@@ -20,6 +21,7 @@ public struct MobileAppConfigAction: ImmutableMappable, UpdatableModelSource {
         self.iconColor = try? map.value("icon.color")
         self.showInCarPlay = try? map.value("show_in_carplay")
         self.showInWatch = try? map.value("show_in_watch")
+        self.useCustomColors = try? map.value("use_custom_colors")
     }
 
     public var primaryKey: String { name }

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -87,7 +87,8 @@ public extension Realm {
         // 20…25 - 2022-08-13 v2022.x undoing realm automatic migration
         // 26 - 2022-08-13 v2022.x bumping mdi version
         // 27 - 2024-01-18 v2024.x adding CarPlay toggle to Actions
-        let schemaVersion: UInt64 = 27
+        // 28 - 2024-07-29 v2024.x Add option to use custom colors
+        let schemaVersion: UInt64 = 28
 
         let config = Realm.Configuration(
             fileURL: storeURL,
@@ -194,6 +195,12 @@ public extension Realm {
                     migration.enumerateObjects(ofType: Action.className()) { _, newObject in
                         newObject?["showInCarPlay"] = true
                         newObject?["showInWatch"] = true
+                    }
+                }
+
+                if oldVersion < 28 {
+                    migration.enumerateObjects(ofType: Action.className()) { _, newObject in
+                        newObject?["useCustomColors"] = false
                     }
                 }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1544,6 +1544,10 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "settings_details.actions.server_controlled.update.title") }
         }
       }
+      public enum UseCustomColors {
+        /// Use custom colors
+        public static var title: String { return L10n.tr("Localizable", "settings_details.actions.use_custom_colors.title") }
+      }
       public enum Watch {
         public enum Available {
           /// Show in Watch


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Based on user feedback, color customisation is important on their iOS Actions, in widgets and Apple Watch, so this PR adds this option back but with a little modification, we will first enforce the tile card design as the standard, if the user wants to use custom colors it has to enable "custom colors" toggle in actions configuration screen. (I will also make a PR in Core to be able to configure that via YAML)

This PR also makes the "default" background color for watch items to be dark instead of white.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![IMG_5128](https://github.com/user-attachments/assets/75fa1b9f-0c84-463c-88ac-779e64eb0895)
![incoming-73C08CA7-76A4-4728-827B-B0220D2A83F9](https://github.com/user-attachments/assets/35cbd770-5bbc-490c-827e-463edec2cf55)
![incoming-56AC10D8-6709-4511-B37D-FB5D76A193A1](https://github.com/user-attachments/assets/12d69b5a-d138-43a1-863f-b111b23c6fa1)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
