### PR TITLE
Fix watch crash (Realm migration not called)

### DIFF
--- a/Sources/Extensions/Watch/Complication/ComplicationController.swift
+++ b/Sources/Extensions/Watch/Complication/ComplicationController.swift
@@ -15,7 +15,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         if complication.identifier != CLKDefaultComplicationIdentifier {
             // existing complications that were configured pre-7 have no identifier set
             // so we can only access the value if it's a valid one. otherwise, fall back to old matching behavior.
-            model = Current.realm(objectTypes: [WatchComplication.self]).object(
+            model = Current.realm().object(
                 ofType: WatchComplication.self,
                 forPrimaryKey: complication.identifier
             )
@@ -23,7 +23,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
             // we migrate pre-existing complications, and when still using watchOS 6 create new ones,
             // with the family as the identifier, so we can rely on this code path for older OS and older complications
             let matchedFamily = ComplicationGroupMember(family: complication.family)
-            model = Current.realm(objectTypes: [WatchComplication.self]).object(
+            model = Current.realm().object(
                 ofType: WatchComplication.self,
                 forPrimaryKey: matchedFamily.rawValue
             )
@@ -94,7 +94,7 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
     // MARK: - Complication Descriptors
 
     func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
-        let configured = Current.realm(objectTypes: [WatchComplication.self]).objects(WatchComplication.self)
+        let configured = Current.realm().objects(WatchComplication.self)
             .map(\.complicationDescriptor)
 
         let placeholders = ComplicationGroupMember.allCases

--- a/Sources/Extensions/Watch/ExtensionDelegate.swift
+++ b/Sources/Extensions/Watch/ExtensionDelegate.swift
@@ -111,14 +111,14 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
 
         if let identifier = userInfo?[CLKLaunchedComplicationIdentifierKey] as? String,
            identifier != CLKDefaultComplicationIdentifier {
-            complication = Current.realm(objectTypes: [WatchComplication.self]).object(
+            complication = Current.realm().object(
                 ofType: WatchComplication.self,
                 forPrimaryKey: identifier
             )
         } else if let date = userInfo?[CLKLaunchedTimelineEntryDateKey] as? Date,
                   let clkFamily = date.complicationFamilyFromEncodedDate {
             let family = ComplicationGroupMember(family: clkFamily)
-            complication = Current.realm(objectTypes: [WatchComplication.self]).object(
+            complication = Current.realm().object(
                 ofType: WatchComplication.self,
                 forPrimaryKey: family.rawValue
             )

--- a/Sources/Extensions/Watch/ExtensionDelegate.swift
+++ b/Sources/Extensions/Watch/ExtensionDelegate.swift
@@ -1,7 +1,6 @@
 import ClockKit
 import Communicator
 import PromiseKit
-import RealmSwift
 import Shared
 import UserNotifications
 import WatchKit

--- a/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
+++ b/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
@@ -51,19 +51,16 @@ struct WatchActionButtonView<ViewModel>: View where ViewModel: WatchHomeViewMode
             }
         }
         .disabled(state != .idle)
-        .modify { view in
-            if action.useCustomColors {
-                view.listRowBackground(
-                    action.useCustomColors ?
-                        Color(uiColor: .init(hex: action.backgroundColor))
-                        .clipShape(RoundedRectangle(cornerRadius: 14)) :
-                        Color.white
-                        .clipShape(RoundedRectangle(cornerRadius: 14))
-                )
-            } else {
-                view
-            }
-        }
+//        .modify { view in
+//            if action.useCustomColors {
+//                view.listRowBackground(
+//                    Color(uiColor: .init(hex: action.backgroundColor))
+//                        .clipShape(RoundedRectangle(cornerRadius: 14))
+//                )
+//            } else {
+//                view
+//            }
+//        }
     }
 
     private func resetState() {

--- a/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
+++ b/Sources/Extensions/Watch/Home/Views/WatchActionButtonView.swift
@@ -51,16 +51,16 @@ struct WatchActionButtonView<ViewModel>: View where ViewModel: WatchHomeViewMode
             }
         }
         .disabled(state != .idle)
-//        .modify { view in
-//            if action.useCustomColors {
-//                view.listRowBackground(
-//                    Color(uiColor: .init(hex: action.backgroundColor))
-//                        .clipShape(RoundedRectangle(cornerRadius: 14))
-//                )
-//            } else {
-//                view
-//            }
-//        }
+        .modify { view in
+            if action.useCustomColors {
+                view.listRowBackground(
+                    Color(uiColor: .init(hex: action.backgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                )
+            } else {
+                view
+            }
+        }
     }
 
     private func resetState() {

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -75,6 +75,8 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
             return Scene == nil
         case \Action.showInWatch:
             return Scene == nil
+        case \Action.useCustomColors:
+            return Scene == nil
         default:
             return true
         }

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -87,8 +87,8 @@ public extension Realm {
         // 20…25 - 2022-08-13 v2022.x undoing realm automatic migration
         // 26 - 2022-08-13 v2022.x bumping mdi version
         // 27 - 2024-01-18 v2024.x adding CarPlay toggle to Actions
-        // 28 - 2024-07-29 v2024.x Add option to use custom colors
-        let schemaVersion: UInt64 = 28
+        // 28…29 - 2024-07-29 v2024.x Add option to use custom colors
+        let schemaVersion: UInt64 = 29
 
         let config = Realm.Configuration(
             fileURL: storeURL,
@@ -198,7 +198,7 @@ public extension Realm {
                     }
                 }
 
-                if oldVersion < 28 {
+                if oldVersion < 29 {
                     migration.enumerateObjects(ofType: Action.className()) { _, newObject in
                         newObject?["useCustomColors"] = false
                     }

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -88,7 +88,15 @@ public extension Realm {
         // 26 - 2022-08-13 v2022.x bumping mdi version
         // 27 - 2024-01-18 v2024.x adding CarPlay toggle to Actions
         // 28…29 - 2024-07-29 v2024.x Add option to use custom colors
+
+        // Current schema version from database
+        if let currentSchemaVersion = try? schemaVersionAtURL(storeURL) {
+            Current.Log.verbose("Current schema version \(currentSchemaVersion)")
+        }
+
+        // New schema version
         let schemaVersion: UInt64 = 29
+        Current.Log.verbose("Schema version defined: \(schemaVersion)")
 
         let config = Realm.Configuration(
             fileURL: storeURL,

--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -87,7 +87,7 @@ public extension Realm {
         // 20…25 - 2022-08-13 v2022.x undoing realm automatic migration
         // 26 - 2022-08-13 v2022.x bumping mdi version
         // 27 - 2024-01-18 v2024.x adding CarPlay toggle to Actions
-        // 28…29 - 2024-07-29 v2024.x Add option to use custom colors
+        // 28 - 2024-07-29 v2024.x Add option to use custom colors
 
         // Current schema version from database
         if let currentSchemaVersion = try? schemaVersionAtURL(storeURL) {
@@ -95,7 +95,7 @@ public extension Realm {
         }
 
         // New schema version
-        let schemaVersion: UInt64 = 29
+        let schemaVersion: UInt64 = 28
         Current.Log.verbose("Schema version defined: \(schemaVersion)")
 
         let config = Realm.Configuration(
@@ -206,7 +206,7 @@ public extension Realm {
                     }
                 }
 
-                if oldVersion < 29 {
+                if oldVersion < 28 {
                     migration.enumerateObjects(ofType: Action.className()) { _, newObject in
                         newObject?["useCustomColors"] = false
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
For some reason Realm database migration was not being called event though scheme version was already bumped to 28, apparently this was caused by watch complication that was accessing realm passing specific object types

Test process:

- Checkout commit c257fa21f62acb964edb28c6d3db0796a86731f1
- Run App in iPhone and watch (with some Actions created)
- Checkout commit 2c8470e5fec8a6c715bfe7de113b3f35c37a4e84
- Run App in iPhone and watch
> - this was crashing in watch and now it is running the migration block.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
