### PR TITLE
Make user-agent headers accurate across device types

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -136,6 +136,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
         config.userContentController = userContentController
         config.applicationNameForUserAgent = HomeAssistantAPI.applicationNameForUserAgent
+        config.defaultWebpagePreferences.preferredContentMode = .mobile
 
         webView = WKWebView(frame: view!.frame, configuration: config)
         webView.isOpaque = false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This change adds an explicit preferredContentMode setting to `WKWebViewConfiguration` to ensure the framework-generated user-agent header more accurately reflects the user's device type. Without this configuration value, requests from `WKWebView` on iPads running iPadOS 13 or later default to sending a user-agent string imitating a desktop Intel Mac.

Additionally, this change resolves https://github.com/home-assistant/iOS/issues/2908 regarding layout issues seen on some cards when running the app on iPadOS by preventing browser compatibility code from being incorrectly applied due to the user-agent value.

#### Current iPad user-agent:
> Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Home Assistant/2024.7 (io.robbie.HomeAssistant; build:2024.730; iPadOS 17.5.1) Mobile/HomeAssistant, like Safari

#### Current iPhone user-agent:
> Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Home Assistant/2024.7 (io.robbie.HomeAssistant; build:2024.730; iOS 17.5.1) Mobile/HomeAssistant, like Safari

#### iPad user-agent with this change applied:
> Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Home Assistant/2024.8 (io.robbie.HomeAssistant.dev; build:2024; iPadOS 17.5.0) Mobile/HomeAssistant, like Safari

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
