### PR TITLE
Workaround to avoid iOS 18 crash widgets that use Realm

### DIFF
--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Extensions-Widgets.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Extensions-Widgets.xcscheme
@@ -99,7 +99,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "_XCWidgetKind"
-            value = "WidgetScripts"
+            value = "WidgetActions"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntentTimelineProvider.swift
@@ -99,13 +99,20 @@ struct WidgetDetailsAppIntentTimelineProvider: AppIntentTimelineProvider {
         let upperText = String(params[0])
         let lowerText = String(params[1])
         let detailsText = String(params[2])
+
+        let action = await withCheckedContinuation { continuation in
+            configuration.action?.asAction { action in
+                continuation.resume(returning: action)
+            }
+        }
+
         return .init(
             upperText: upperText != "?" ? upperText : nil,
             lowerText: lowerText != "?" ? lowerText : nil,
             detailsText: detailsText != "?" ? detailsText : nil,
 
             runAction: configuration.runAction,
-            action: configuration.action?.asAction()
+            action: action
         )
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
@@ -105,6 +105,13 @@ struct WidgetGaugeAppIntentTimelineProvider: AppIntentTimelineProvider {
         let valueText = String(params[1])
         let maxText = String(params[2])
         let minText = String(params[3])
+
+        let action = await withCheckedContinuation { continuation in
+            configuration.action?.asAction { action in
+                continuation.resume(returning: action)
+            }
+        }
+
         return .init(
             gaugeType: configuration.gaugeType,
 
@@ -115,7 +122,7 @@ struct WidgetGaugeAppIntentTimelineProvider: AppIntentTimelineProvider {
             max: maxText != "?" ? maxText : nil,
 
             runAction: configuration.runAction,
-            action: configuration.action?.asAction()
+            action: action
         )
     }
 }

--- a/Sources/Extensions/Widgets/Actions/WidgetActionsProvider.swift
+++ b/Sources/Extensions/Widgets/Actions/WidgetActionsProvider.swift
@@ -23,7 +23,7 @@ struct WidgetActionsProvider: IntentTimelineProvider {
     }
 
     private static func defaultActions(in context: Context) -> [Action] {
-        let allActions = WidgetActionsDataSource.actions
+        let allActions = WidgetActionsDataSource.getActions()
         let maxCount = WidgetBasicContainerView.maximumCount(family: context.family)
 
         switch allActions.count {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Workaround for iOS 18 to avoid 'Realm accessed from incorrect thread.' if not called from main thread while in iOS 17 it reports the same error if called in the main thread.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
