### PR TITLE
Continue navigationlink match button size

### DIFF
--- a/Sources/App/Onboarding/Screens/OnboardingWelcomeView.swift
+++ b/Sources/App/Onboarding/Screens/OnboardingWelcomeView.swift
@@ -43,16 +43,15 @@ struct OnboardingWelcomeView: View {
     }
 
     private var continueButton: some View {
-        NavigationLink(L10n.continueLabel) {
-            OnboardingScanningView()
-        }
-        .font(.callout.bold())
-        .foregroundStyle(.white)
-        .frame(maxWidth: .infinity)
-        .frame(height: 55)
-        .background(Color.asset(Asset.Colors.haPrimary))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding(Spaces.two)
+        NavigationLink(destination: OnboardingScanningView()) {
+            Text(L10n.continueLabel)
+                .font(.callout.bold())
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 55)
+                .background(Color.asset(Asset.Colors.haPrimary))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }.padding(Spaces.two)
     }
 }
 


### PR DESCRIPTION
## Summary
Make the NavigationLink match the size of the button. The button only triggers when pressing the button text, which makes it frustrating to press (See https://github.com/home-assistant/iOS/issues/3076 bug description)

This pr makes the clickable part of the button larger making it easier to press.