### PR TITLE
Group by server, widget selection order

### DIFF
--- a/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
@@ -38,8 +38,12 @@ struct IntentDetailsTableAppEntityQuery: EntityQuery {
         getSensorEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
     }
 
-    func suggestedEntities() async throws -> [IntentSensorsAppEntity] {
-        getSensorEntities().flatMap(\.value)
+    func suggestedEntities() async throws -> IntentItemCollection<IntentSensorsAppEntity> {
+        let sensorsPerServer = getSensorEntities()
+        
+        return .init(sections: sensorsPerServer.map { (key: Server, value: [IntentSensorsAppEntity]) in
+                .init(.init(stringLiteral: key.info.name), items: value)
+        })
     }
 
     func defaultResult() async -> IntentSensorsAppEntity? {

--- a/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
@@ -40,9 +40,9 @@ struct IntentDetailsTableAppEntityQuery: EntityQuery {
 
     func suggestedEntities() async throws -> IntentItemCollection<IntentSensorsAppEntity> {
         let sensorsPerServer = getSensorEntities()
-        
+
         return .init(sections: sensorsPerServer.map { (key: Server, value: [IntentSensorsAppEntity]) in
-                .init(.init(stringLiteral: key.info.name), items: value)
+            .init(.init(stringLiteral: key.info.name), items: value)
         })
     }
 

--- a/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
@@ -70,15 +70,14 @@ struct WidgetSensorsAppIntentTimelineProvider: AppIntentTimelineProvider {
         let sensorsGroupedByServer = Dictionary(grouping: configuration.sensors ?? [], by: { $0.serverId })
 
         var sensorValues: [WidgetSensorsEntry.SensorData] = []
-        
+
         for sensor in configuration.sensors ?? [] {
             guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == sensor.serverId }) else {
                 throw WidgetSensorsDataError.noServers
             }
-            
+
             let sensorData = try await fetchSensorData(for: sensor, server: server)
             sensorValues.append(sensorData)
-
         }
 
         return WidgetSensorsEntry(sensorData: sensorValues)

--- a/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
@@ -70,16 +70,15 @@ struct WidgetSensorsAppIntentTimelineProvider: AppIntentTimelineProvider {
         let sensorsGroupedByServer = Dictionary(grouping: configuration.sensors ?? [], by: { $0.serverId })
 
         var sensorValues: [WidgetSensorsEntry.SensorData] = []
-
-        for (serverId, sensors) in sensorsGroupedByServer {
-            guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+        
+        for sensor in configuration.sensors ?? [] {
+            guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == sensor.serverId }) else {
                 throw WidgetSensorsDataError.noServers
             }
+            
+            let sensorData = try await fetchSensorData(for: sensor, server: server)
+            sensorValues.append(sensorData)
 
-            for sensor in sensors {
-                let sensorData = try await fetchSensorData(for: sensor, server: server)
-                sensorValues.append(sensorData)
-            }
         }
 
         return WidgetSensorsEntry(sensorData: sensorValues)


### PR DESCRIPTION
## Summary
Fixed two issues mentioned in #3067;

Sensors in the suggested sensors view should be grouped by server now
The order of the selected sensors is now respected if they come from two different servers

## Screenshots
![Screenshot 2024-10-27 at 08 06 20](https://github.com/user-attachments/assets/fe4ae23c-013d-49b1-a3dc-6fd12ae46bfb)

## Any other notes
The `for` loop bothers me, Swift feels a lot like Kotlin and a `map` seems more appriopiate.
Because an async call happens in it I could not get `map` working that is nice to read, let me know if there is a better option chatgpt gave me this

```
let sensorValues = try await withThrowingTaskGroup(of: WidgetSensorsEntry.SensorData?.self) { group in
    for sensor in configuration.sensors ?? [] {
        group.addTask {
            guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == sensor.serverId }) else {
                throw WidgetSensorsDataError.noServers
            }
            return try await fetchSensorData(for: sensor, server: server)
        }
    }

    return try await group.compactMap { $0 }
}
```