### PR TITLE
Preserve order getEntities function

### DIFF
--- a/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
@@ -113,7 +113,7 @@ struct IntentScriptEntity: AppEntity {
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
 struct IntentScriptAppEntityQuery: EntityQuery, EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [IntentScriptEntity] {
-        getScriptEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
+        getScriptEntities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func entities(matching string: String) async throws -> IntentItemCollection<IntentScriptEntity> {
@@ -135,12 +135,12 @@ struct IntentScriptAppEntityQuery: EntityQuery, EntityStringQuery {
         })
     }
 
-    private func getScriptEntities(matching string: String? = nil) -> [Server: [IntentScriptEntity]] {
-        var scriptEntities: [Server: [IntentScriptEntity]] = [:]
+    private func getScriptEntities(matching string: String? = nil) -> [(Server, [IntentScriptEntity])] {
+        var scriptEntities: [(Server, [IntentScriptEntity])] = []
         let entities = ControlEntityProvider(domain: .script).getEntities(matching: string)
 
         for (server, values) in entities {
-            scriptEntities[server] = values.map({ entity in
+            scriptEntities.append((server, values.map({ entity in
                 IntentScriptEntity(
                     id: entity.id,
                     entityId: entity.entityId,
@@ -149,7 +149,7 @@ struct IntentScriptAppEntityQuery: EntityQuery, EntityStringQuery {
                     displayString: entity.name,
                     iconName: entity.icon ?? SFSymbol.applescriptFill.rawValue
                 )
-            })
+            })))
         }
 
         return scriptEntities

--- a/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
@@ -7,7 +7,7 @@ import Shared
 struct IntentSensorsAppEntity: AppEntity {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Sensor")
 
-    static let defaultQuery = IntentDetailsTableAppEntityQuery()
+    static let defaultQuery = IntentSensorsAppEntityQuery()
 
     // UniqueID: serverId-entityId
     var id: String
@@ -33,9 +33,9 @@ struct IntentSensorsAppEntity: AppEntity {
 }
 
 @available(iOS 17.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
-struct IntentDetailsTableAppEntityQuery: EntityQuery {
+struct IntentSensorsAppEntityQuery: EntityQuery {
     func entities(for identifiers: [IntentSensorsAppEntity.ID]) async throws -> [IntentSensorsAppEntity] {
-        getSensorEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
+        getSensorEntities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func suggestedEntities() async throws -> IntentItemCollection<IntentSensorsAppEntity> {
@@ -47,22 +47,22 @@ struct IntentDetailsTableAppEntityQuery: EntityQuery {
     }
 
     func defaultResult() async -> IntentSensorsAppEntity? {
-        try? getSensorEntities().flatMap(\.value).first
+        getSensorEntities().flatMap(\.1).first
     }
 
-    private func getSensorEntities(matching string: String? = nil) -> [Server: [IntentSensorsAppEntity]] {
-        var sensorEntities: [Server: [IntentSensorsAppEntity]] = [:]
+    private func getSensorEntities(matching string: String? = nil) -> [(Server, [IntentSensorsAppEntity])] {
+        var sensorEntities: [(Server, [IntentSensorsAppEntity])] = []
         let entities = ControlEntityProvider(domain: .sensor).getEntities(matching: string)
 
         for (server, values) in entities {
-            sensorEntities[server] = values.map({ entity in
+            sensorEntities.append((server, values.map({ entity in
                 IntentSensorsAppEntity(
                     id: entity.id,
                     entityId: entity.entityId,
                     serverId: entity.serverId,
                     displayString: entity.name
                 )
-            })
+            })))
         }
 
         return sensorEntities

--- a/Sources/Extensions/Widgets/Light/IntentLightEntity.swift
+++ b/Sources/Extensions/Widgets/Light/IntentLightEntity.swift
@@ -38,7 +38,7 @@ struct IntentLightEntity: AppEntity {
 @available(iOS 18.0, *)
 struct IntentLightAppEntityQuery: EntityQuery, EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [IntentLightEntity] {
-        getLightEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
+        getLightEntities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func entities(matching string: String) async throws -> IntentItemCollection<IntentLightEntity> {
@@ -60,12 +60,12 @@ struct IntentLightAppEntityQuery: EntityQuery, EntityStringQuery {
         })
     }
 
-    private func getLightEntities(matching string: String? = nil) -> [Server: [IntentLightEntity]] {
-        var lightEntities: [Server: [IntentLightEntity]] = [:]
+    private func getLightEntities(matching string: String? = nil) -> [(Server, [IntentLightEntity])] {
+        var lightEntities: [(Server, [IntentLightEntity])] = []
         let entities = ControlEntityProvider(domain: .light).getEntities(matching: string)
 
         for (server, values) in entities {
-            lightEntities[server] = values.map({ entity in
+            lightEntities.append((server, values.map({ entity in
                 IntentLightEntity(
                     id: entity.id,
                     entityId: entity.entityId,
@@ -73,7 +73,7 @@ struct IntentLightAppEntityQuery: EntityQuery, EntityStringQuery {
                     displayString: entity.name,
                     iconName: entity.icon ?? SFSymbol.lightbulbFill.rawValue
                 )
-            })
+            })))
         }
 
         return lightEntities

--- a/Sources/Extensions/Widgets/Scene/Control/IntentSceneEntity.swift
+++ b/Sources/Extensions/Widgets/Scene/Control/IntentSceneEntity.swift
@@ -40,7 +40,7 @@ struct IntentSceneEntity: AppEntity {
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
 struct IntentSceneAppEntityQuery: EntityQuery, EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [IntentSceneEntity] {
-        getSceneEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
+        getSceneEntities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func entities(matching string: String) async throws -> IntentItemCollection<IntentSceneEntity> {
@@ -58,12 +58,12 @@ struct IntentSceneAppEntityQuery: EntityQuery, EntityStringQuery {
         })
     }
 
-    private func getSceneEntities(matching string: String? = nil) -> [Server: [IntentSceneEntity]] {
-        var sceneEntities: [Server: [IntentSceneEntity]] = [:]
+    private func getSceneEntities(matching string: String? = nil) -> [(Server, [IntentSceneEntity])] {
+        var sceneEntities: [(Server, [IntentSceneEntity])] = []
         let entities = ControlEntityProvider(domain: .scene).getEntities(matching: string)
 
         for (server, values) in entities {
-            sceneEntities[server] = values.map({ entity in
+            sceneEntities.append((server, values.map({ entity in
                 IntentSceneEntity(
                     id: entity.id,
                     entityId: entity.entityId,
@@ -72,7 +72,7 @@ struct IntentSceneAppEntityQuery: EntityQuery, EntityStringQuery {
                     displayString: entity.name,
                     iconName: entity.icon ?? SFSymbol.moonStarsCircleFill.rawValue
                 )
-            })
+            })))
         }
 
         return sceneEntities

--- a/Sources/Extensions/Widgets/Switch/IntentSwitchEntity.swift
+++ b/Sources/Extensions/Widgets/Switch/IntentSwitchEntity.swift
@@ -38,7 +38,7 @@ struct IntentSwitchEntity: AppEntity {
 @available(iOS 18.0, *)
 struct IntentSwitchAppEntityQuery: EntityQuery, EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [IntentSwitchEntity] {
-        await getSwitchEntities().flatMap(\.value).filter { identifiers.contains($0.id) }
+        await getSwitchEntities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func entities(matching string: String) async throws -> IntentItemCollection<IntentSwitchEntity> {
@@ -60,12 +60,12 @@ struct IntentSwitchAppEntityQuery: EntityQuery, EntityStringQuery {
         })
     }
 
-    private func getSwitchEntities(matching string: String? = nil) async -> [Server: [IntentSwitchEntity]] {
-        var switchEntities: [Server: [IntentSwitchEntity]] = [:]
+    private func getSwitchEntities(matching string: String? = nil) async -> [(Server, [IntentSwitchEntity])] {
+        var switchEntities: [(Server, [IntentSwitchEntity])] = []
         let entities = ControlEntityProvider(domain: .switch).getEntities(matching: string)
 
         for (server, values) in entities {
-            switchEntities[server] = values.map({ entity in
+            switchEntities.append((server, values.map({ entity in
                 IntentSwitchEntity(
                     id: entity.id,
                     entityId: entity.entityId,
@@ -73,7 +73,7 @@ struct IntentSwitchAppEntityQuery: EntityQuery, EntityStringQuery {
                     displayString: entity.name,
                     iconName: entity.icon ?? SFSymbol.lightswitchOnFill.rawValue
                 )
-            })
+            })))
         }
 
         return switchEntities

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -36,8 +36,8 @@ public final class ControlEntityProvider {
         return state
     }
 
-    public func getEntities(matching string: String? = nil) -> [Server: [HAAppEntity]] {
-        var entitiesPerServer: [Server: [HAAppEntity]] = [:]
+    public func getEntities(matching string: String? = nil) -> [(Server, [HAAppEntity])] {
+        var entitiesPerServer: [(Server, [HAAppEntity])] = []
         for server in Current.servers.all.sorted(by: { $0.info.name < $1.info.name }) {
             do {
                 var entities: [HAAppEntity] = try Current.database().read { db in
@@ -51,7 +51,7 @@ public final class ControlEntityProvider {
                         entity.name.lowercased().contains(string.lowercased())
                     })
                 }
-                entitiesPerServer[server] = entities
+                entitiesPerServer.append((server, entities))
             } catch {
                 Current.Log.error("Failed to load entities from database: \(error.localizedDescription)")
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Changed the implementation of `getEntities(matching string: String? = nil)` to return an array of key values pairs instead of a dictioniary. The intent of the function seems to return a sorted list of entities grouped by server name since the servers are sorted `Current.servers.all.sorted(by: { $0.info.name < $1.info.name })`. A dictioniary does not guarantee order, resulting in unpredicting results in my `Sensor` widget configure window. Sometimes one server is first, the next time the other. 

Apple also recommends using a KeyValuePair when order is important:

https://developer.apple.com/documentation/swift/keyvaluepairs
`Use a KeyValuePairs instance when you need an ordered collection of key-value pairs and don’t require the fast key lookup that the Dictionary type provides.`

Because there are typically (I think?) not many servers configured the loss of fast lookup seems acceptable to me.

## Screenshots
Here an overview of the `getEntities` function while debugging showing the problem. I adjusted the function slightly to temp store the values, `servers` contains the value of `Current.servers.all.sorted(by: { $0.info.name < $1.info.name })` The entitiesPerSever does not have the same order as the `servers` variable, while they should have

![Screenshot 2024-10-29 at 17 16 04](https://github.com/user-attachments/assets/3ff0620b-2a26-45aa-800f-7fb3093727c6)

## Any other notes
This is also an issue for other widgets like the script widget. I only fixed the function in `IntentSensorsAppEntity` though
, they have the same problem in the calling function because they return an dictionary not preserving order;
`private func getScriptEntities(matching string: String? = nil) -> [Server: [IntentScriptEntity]] {`
