### PR TITLE
Add "reset app entities database" option in debug section

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1003,3 +1003,4 @@ Home Assistant is free and open source home automation software with a focus on 
 "permission.screen.bluetooth.secondary_button" = "Skip";
 "permission.screen.bluetooth.subtitle" = "The Home Assistant app can find devices using Bluetooth of this device. Allow Bluetooth access for the Home Assistant app.";
 "yes_label" = "Yes";
+"debug.reset.entities_database.title" = "Reset app entities database";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -641,6 +641,15 @@ public enum L10n {
     }
   }
 
+  public enum Debug {
+    public enum Reset {
+      public enum EntitiesDatabase {
+        /// Reset app entities database
+        public static var title: String { return L10n.tr("Localizable", "debug.reset.entities_database.title") }
+      }
+    }
+  }
+
   public enum Extensions {
     public enum Map {
       public enum Location {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add option to reset entities database in case user endup with some clutter from previous server.
TODO: Handle old cache information automatically

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
