### PR TITLE
Refresh controls when widgets initialize

### DIFF
--- a/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
@@ -12,6 +12,10 @@ struct WidgetBasicContainerView: View {
     init(emptyViewGenerator: @escaping () -> AnyView, contents: [WidgetBasicViewModel]) {
         self.emptyViewGenerator = emptyViewGenerator
         self.contents = contents
+
+        // Use the opportunity of widget refresh to also refresh control center controls
+        // since those controls dont have a refresh interval
+        DataWidgetsUpdater.updateControlCenterControls()
     }
 
     var body: some View {

--- a/Sources/Shared/DataWidgetsUpdater.swift
+++ b/Sources/Shared/DataWidgetsUpdater.swift
@@ -4,12 +4,16 @@ import WidgetKit
 #if os(iOS) || os(macOS)
 public enum DataWidgetsUpdater {
     public static func update() {
-        if #available(iOS 18.0, *) {
-            ControlCenter.shared.reloadAllControls()
-        }
+        DataWidgetsUpdater.updateControlCenterControls()
         WidgetCenter.shared.reloadTimelines(ofKind: WidgetsKind.gauge.rawValue)
         WidgetCenter.shared.reloadTimelines(ofKind: WidgetsKind.details.rawValue)
         WidgetCenter.shared.reloadTimelines(ofKind: WidgetsKind.sensors.rawValue)
+    }
+
+    public static func updateControlCenterControls() {
+        if #available(iOS 18.0, *) {
+            ControlCenter.shared.reloadAllControls()
+        }
     }
 }
 #endif


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Since we can't update controls using push notifications yet (due to notification limits), this PR uses the refresh interval opportunity from widgets to also update controls
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
