### PR TITLE
simplify for loop

### DIFF
--- a/Sources/Extensions/AppIntents/Widget/Script/WidgetScriptsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Script/WidgetScriptsAppIntentTimelineProvider.swift
@@ -128,7 +128,6 @@ struct WidgetScriptsAppIntentTimelineProvider: AppIntentTimelineProvider {
     private func suggestions() async -> [Server: [HAAppEntity]] {
         await withCheckedContinuation { continuation in
             var entities: [Server: [HAAppEntity]] = [:]
-            var serverCheckedCount = 0
             for server in Current.servers.all.sorted(by: { $0.info.name < $1.info.name }) {
                 do {
                     let scripts: [HAAppEntity] = try Current.database.read { db in
@@ -141,11 +140,8 @@ struct WidgetScriptsAppIntentTimelineProvider: AppIntentTimelineProvider {
                 } catch {
                     Current.Log.error("Failed to load scripts from database: \(error.localizedDescription)")
                 }
-                serverCheckedCount += 1
-                if serverCheckedCount == Current.servers.all.count {
-                    continuation.resume(returning: entities)
-                }
             }
+            continuation.resume(returning: entities)
         }
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
@@ -136,7 +136,6 @@ struct WidgetSensorsAppIntentTimelineProvider: AppIntentTimelineProvider {
     private func suggestions() async -> [Server: [HAAppEntity]] {
         await withCheckedContinuation { continuation in
             var entities: [Server: [HAAppEntity]] = [:]
-            var serverCheckedCount = 0
             for server in Current.servers.all.sorted(by: { $0.info.name < $1.info.name }) {
                 do {
                     let sensors: [HAAppEntity] = try Current.database.read { db in
@@ -149,11 +148,8 @@ struct WidgetSensorsAppIntentTimelineProvider: AppIntentTimelineProvider {
                 } catch {
                     Current.Log.error("Failed to load sensors from database: \(error.localizedDescription)")
                 }
-                serverCheckedCount += 1
-                if serverCheckedCount == Current.servers.all.count {
-                    continuation.resume(returning: entities)
-                }
             }
+            continuation.resume(returning: entities)
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Really small mr, I just came across it looking into the scripts widget. I assume the for loop only returns when all sync operations are finished, removing the need to manually check for it

The preview still seems to work fine when adding a widget
