### PR TITLE
Add "Mac native features only" experimental mode

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		422E25ED2C7FF28900256D87 /* ControlScriptsValueProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422E25EC2C7FF28900256D87 /* ControlScriptsValueProvider.swift */; };
 		422E25EE2C80019D00256D87 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 420B100B2B1D204400D383D8 /* Assets.xcassets */; };
 		422E626C2CDCF00A00987BD0 /* AreaProvider.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422E626B2CDCF00A00987BD0 /* AreaProvider.test.swift */; };
+		422F951F2CFDF7C5003B7514 /* HAApplicationShortcutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422F951E2CFDF7C5003B7514 /* HAApplicationShortcutItem.swift */; };
 		4235075D2CDB756800A19902 /* HAServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4235075C2CDB756800A19902 /* HAServices.swift */; };
 		4235075E2CDB756800A19902 /* HAServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4235075C2CDB756800A19902 /* HAServices.swift */; };
 		4239D1832C4FFCCE003497FC /* WatchUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4239D1802C4FFB75003497FC /* WatchUserDefaults.swift */; };
@@ -1848,6 +1849,7 @@
 		42266B242B7A4BA900E94A71 /* BarcodeScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerViewModel.swift; sourceTree = "<group>"; };
 		422E25EC2C7FF28900256D87 /* ControlScriptsValueProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlScriptsValueProvider.swift; sourceTree = "<group>"; };
 		422E626B2CDCF00A00987BD0 /* AreaProvider.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaProvider.test.swift; sourceTree = "<group>"; };
+		422F951E2CFDF7C5003B7514 /* HAApplicationShortcutItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAApplicationShortcutItem.swift; sourceTree = "<group>"; };
 		4235075C2CDB756800A19902 /* HAServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAServices.swift; sourceTree = "<group>"; };
 		4239D1802C4FFB75003497FC /* WatchUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUserDefaults.swift; sourceTree = "<group>"; };
 		423F44EF2C17238200766A99 /* ChatBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbleView.swift; sourceTree = "<group>"; };
@@ -4611,6 +4613,7 @@
 				42B94BD92B9606CD00DEE060 /* Assist */,
 				42FCCFDD2B9B1AB00057783F /* BarcodeScanner */,
 				B657A8E91CA646EB00121384 /* AppDelegate.swift */,
+				422F951E2CFDF7C5003B7514 /* HAApplicationShortcutItem.swift */,
 				42B1A7442C1305C300904548 /* WatchCommunicatorService.swift */,
 				D03D893720E0AF1B00D4F28D /* ClientEvents */,
 				42A47A8E2C4548BC00C9B43D /* Improv */,
@@ -6853,6 +6856,7 @@
 				11A71C7124A4648000D9565F /* ZoneManagerEquatableRegion.swift in Sources */,
 				42FCD0132B9B29740057783F /* ThreadCredentialsManagementViewModel.swift in Sources */,
 				11E99A5027156854003C8A65 /* OnboardingTerminalViewController.swift in Sources */,
+				422F951F2CFDF7C5003B7514 /* HAApplicationShortcutItem.swift in Sources */,
 				1101568424D770B2009424C9 /* NFCWriter.swift in Sources */,
 				11E7C4B02702E03000667342 /* WidgetOpenPageIntent+Observation.swift in Sources */,
 				1187DE4624D7E1BD00F0A6A6 /* SimulatorNFCManager.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -102,6 +102,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
 
         setupWatchCommunicator()
+        setupUIApplicationShortcutItems()
 
         return true
     }
@@ -414,6 +415,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     @objc private func menuRelatedSettingDidChange(_ note: Notification) {
         UIMenuSystem.main.setNeedsRebuild()
+    }
+
+    private func setupUIApplicationShortcutItems() {
+        if Current.isCatalyst {
+            UIApplication.shared.shortcutItems = [.init(
+                type: HAApplicationShortcutItem.openSettings.rawValue,
+                localizedTitle: L10n.ShortcutItem.OpenSettings.title,
+                localizedSubtitle: nil,
+                icon: .init(systemSymbol: .gear)
+            )]
+        }
     }
 
     // swiftlint:disable:next file_length

--- a/Sources/App/HAApplicationShortcutItem.swift
+++ b/Sources/App/HAApplicationShortcutItem.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum HAApplicationShortcutItem: String {
+    case sendLocation
+    case openSettings
+}

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1056,4 +1056,5 @@ Home Assistant is free and open source home automation software with a focus on 
 "widgets.sensors.title" = "Sensors";
 "network.error.no_active_url.title" = "No URL available to load";
 "network.error.no_active_url.body" = "Open companion app settings and check your server settings, internal URL will only be used if local network is defined (SSID), if you are using VPN try setting your external URL as the same as internal URL.";
+"shortcut_item.open_settings.title" = "Open Settings";
 "yes_label" = "Yes";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -42,8 +42,14 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
             } <<< ButtonRow {
                 $0.title = L10n.Settings.ConnectionSection.activateServer
                 $0.onCellSelection { [server] _, _ in
-                    Current.sceneManager.webViewWindowControllerPromise.done {
-                        $0.open(server: server)
+                    if Current.isCatalyst, Current.settingsStore.macNativeFeaturesOnly {
+                        if let url = server.info.connection.activeURL() {
+                            UIApplication.shared.open(url)
+                        }
+                    } else {
+                        Current.sceneManager.webViewWindowControllerPromise.done {
+                            $0.open(server: server)
+                        }
                     }
                 }
             }

--- a/Sources/App/Settings/Observation/Action+Observation.swift
+++ b/Sources/App/Settings/Observation/Action+Observation.swift
@@ -21,7 +21,9 @@ extension Action {
             }
 
             let updateShortcuts = Promise<Void> { seal in
-                UIApplication.shared.shortcutItems = collection.map(\.uiShortcut)
+                if !Current.isCatalyst {
+                    UIApplication.shared.shortcutItems = collection.map(\.uiShortcut)
+                }
                 seal.fulfill(())
             }
 

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -176,6 +176,20 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                     })
                 }
 
+                +++
+                Section(
+                    footer: "This will open Safari instead of the App webview, while keeping the native features such as widgets working."
+                ) {
+                    $0.hidden = .function([], { _ in !Current.isCatalyst })
+                }
+                <<< SwitchRow("macNativeFeaturesOnly") {
+                    $0.title = "Native Features Only (Experimental)"
+                    $0.value = Current.settingsStore.macNativeFeaturesOnly
+                    $0.onChange { row in
+                        Current.settingsStore.macNativeFeaturesOnly = row.value ?? false
+                    }
+                }
+
                 +++ Section {
                     $0.hidden = .function([], { _ in !Current.updater.isSupported })
                 }

--- a/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
+++ b/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
@@ -27,13 +27,22 @@ struct OpenPageAppIntent: AppIntent {
 
         #if !WIDGET_EXTENSION
         DispatchQueue.main.async {
-            Current.sceneManager.webViewWindowControllerPromise.done { windowController in
-                windowController.open(
-                    from: .deeplink,
-                    server: server,
-                    urlString: urlString,
-                    skipConfirm: true
-                )
+            if Current.isCatalyst, Current.settingsStore.macNativeFeaturesOnly {
+                if let activeURL = server.info.connection.activeURL(),
+                   let pageURL = URL(string: "\(activeURL)\(urlString)") {
+                    UIApplication.shared.open(pageURL)
+                } else {
+                    Current.Log.error("Failed to open page \(urlString) on server \(server.info.name)")
+                }
+            } else {
+                Current.sceneManager.webViewWindowControllerPromise.done { windowController in
+                    windowController.open(
+                        from: .deeplink,
+                        server: server,
+                        urlString: urlString,
+                        skipConfirm: true
+                    )
+                }
             }
         }
         #endif

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2523,6 +2523,13 @@ public enum L10n {
     }
   }
 
+  public enum ShortcutItem {
+    public enum OpenSettings {
+      /// Open Settings
+      public static var title: String { return L10n.tr("Localizable", "shortcut_item.open_settings.title") }
+    }
+  }
+
   public enum Thread {
     public enum ActiveOperationalDataSet {
       /// Active operational data set

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -188,6 +188,15 @@ public class SettingsStore {
         }
     }
 
+    public var macNativeFeaturesOnly: Bool {
+        get {
+            prefs.bool(forKey: "macNativeFeaturesOnly")
+        }
+        set {
+            prefs.set(newValue, forKey: "macNativeFeaturesOnly")
+        }
+    }
+
     public var periodicUpdateInterval: TimeInterval? {
         get {
             if prefs.object(forKey: "periodicUpdateInterval") == nil {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This opens HA server in safari instead of in the catalyst WKWebView

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![CleanShot 2024-12-02 at 16 25 51@2x](https://github.com/user-attachments/assets/7e93bb29-8e23-45ad-ae46-c976ca2ed81c)
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
