### PR TITLE
Add option to always fallback to internal URL

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -203,7 +203,8 @@ private extension ConnectionInfo {
             internalSSIDs: Current.connectivity.currentWiFiSSID().map { [$0] },
             internalHardwareAddresses: nil,
             isLocalPushEnabled: true,
-            securityExceptions: authDetails.exceptions
+            securityExceptions: authDetails.exceptions,
+            alwaysFallbackToInternalURL: false
         )
 
         // default cloud to on

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -445,6 +445,11 @@ Home Assistant is free and open source home automation software with a focus on 
 "retry_label" = "Retry";
 "sensors.active.setting.time_until_idle" = "Time Until Idle";
 "sensors.geocoded_location.setting.use_zones" = "Use Zone Name";
+"settings.connection_section.always_fallback_internal.title" = "Always fallback to internal URL";
+"settings.connection_section.always_fallback_internal.footer" = "Enabling this with an unsecure URL (http) may compromise your security on public networks.";
+"settings.connection_section.always_fallback_internal.confirmation.title" = "Are you sure?";
+"settings.connection_section.always_fallback_internal.confirmation.message" = "If you have an unsecure connection this can expose your authentication token on public networks.";
+"settings.connection_section.always_fallback_internal.confirmation.confirm_button" = "I am sure";
 "settings.connection_section.activate_server" = "Activate";
 "settings.connection_section.activate_swipe_hint" = "Quickly activate using a three-finger swipe left or right when viewing a server.";
 "settings.connection_section.add_server" = "Add Server";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -155,7 +155,8 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 row.title = L10n.Settings.ConnectionSection.InternalBaseUrl.title
                 row.displayValueFor = { [server] _ in
                     if server.info.connection.internalSSIDs?.isEmpty ?? true,
-                       server.info.connection.internalHardwareAddresses?.isEmpty ?? true {
+                       server.info.connection.internalHardwareAddresses?.isEmpty ?? true,
+                       !server.info.connection.alwaysFallbackToInternalURL {
                         return "‼️ \(L10n.Settings.ConnectionSection.InternalBaseUrl.RequiresSetup.title)"
                     } else {
                         return server.info.connection.address(for: .internal)?.absoluteString ?? "—"

--- a/Sources/App/Settings/Connection/ConnectionURLViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLViewController.swift
@@ -64,6 +64,8 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
         let givenURL = (form.rowBy(tag: RowTag.url.rawValue) as? URLRow)?.value
         let useCloud = (form.rowBy(tag: RowTag.useCloud.rawValue) as? SwitchRow)?.value
         let localPush = (form.rowBy(tag: RowTag.localPush.rawValue) as? SwitchRow)?.value
+        let alwaysFallbackToInternalURL = (form.rowBy(tag: RowTag.alwaysFallbackToInternalURL.rawValue) as? SwitchRow)?
+            .value
 
         func commit() {
             server.update { info in
@@ -91,6 +93,8 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
                         .map { $0.lowercased() }
                         .filter { !$0.isEmpty }
                 }
+
+                info.connection.alwaysFallbackToInternalURL = alwaysFallbackToInternalURL ?? false
             }
 
             onDismissCallback?(self)
@@ -153,6 +157,7 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
         case hardwareAddresses
         case useCloud
         case localPush
+        case alwaysFallbackToInternalURL
     }
 
     private func updateNavigationItems(isChecking: Bool) {
@@ -226,7 +231,8 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
             <<< InfoLabelRow {
                 $0.tag = RowTag.internalURLWarning.rawValue
                 if server.info.connection.internalSSIDs?.isEmpty ?? true,
-                   server.info.connection.internalHardwareAddresses?.isEmpty ?? true {
+                   server.info.connection.internalHardwareAddresses?.isEmpty ?? true,
+                   !server.info.connection.alwaysFallbackToInternalURL {
                     #if targetEnvironment(macCatalyst)
                     $0.title = "‼️" + L10n.Settings.ConnectionSection.InternalBaseUrl.SsidBssidRequired.title
                     #else
@@ -289,6 +295,39 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
                 }
             }
         }
+
+        form +++ Section(footer: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.footer)
+            <<< SwitchRow(RowTag.alwaysFallbackToInternalURL.rawValue) {
+                $0.title = L10n.Settings.ConnectionSection.AlwaysFallbackInternal.title
+                $0.value = server.info.connection.alwaysFallbackToInternalURL
+
+                $0.cellUpdate { cell, _ in
+                    cell.switchControl.onTintColor = .red
+                }
+
+                $0.onChange { [weak self] row in
+                    if row.value ?? false {
+                        let alert = UIAlertController(
+                            title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.title,
+                            message: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.message,
+                            preferredStyle: .actionSheet
+                        )
+                        alert.addAction(UIAlertAction(title: L10n.cancelLabel, style: .cancel, handler: { _ in
+                            self?.server.info.connection.alwaysFallbackToInternalURL = false
+                            row.value = false
+                            row.cellUpdate { _, row in
+                                row.value = false
+                            }
+                            row.reload()
+                        }))
+                        alert.addAction(UIAlertAction(
+                            title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.confirmButton,
+                            style: .destructive
+                        ))
+                        self?.present(alert, animated: true)
+                    }
+                }
+            }
     }
 
     private func locationPermissionSection() -> Section {

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -693,8 +693,8 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
                 applicationState: UIApplication.shared.applicationState,
                 type: .userRequested
             )
-        }.catch { [weak self] error in
-            self?.showSwiftMessage(error: error)
+        }.catch { error in
+            Current.Log.error("Error when updating sensors from WKWebView reload: \(error)")
         }
     }
 

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -13,6 +13,7 @@ public struct ConnectionInfo: Codable, Equatable {
     public var webhookSecret: String?
     public var useCloud: Bool = false
     public var cloudhookURL: URL?
+    public var alwaysFallbackToInternalURL: Bool = false
     public var internalSSIDs: [String]? {
         didSet {
             overrideActiveURLType = nil
@@ -55,7 +56,8 @@ public struct ConnectionInfo: Codable, Equatable {
         internalSSIDs: [String]?,
         internalHardwareAddresses: [String]?,
         isLocalPushEnabled: Bool,
-        securityExceptions: SecurityExceptions
+        securityExceptions: SecurityExceptions,
+        alwaysFallbackToInternalURL: Bool
     ) {
         self.externalURL = externalURL
         self.internalURL = internalURL
@@ -67,6 +69,7 @@ public struct ConnectionInfo: Codable, Equatable {
         self.internalHardwareAddresses = internalHardwareAddresses
         self.isLocalPushEnabled = isLocalPushEnabled
         self.securityExceptions = securityExceptions
+        self.alwaysFallbackToInternalURL = alwaysFallbackToInternalURL
     }
 
     public init(from decoder: Decoder) throws {
@@ -81,6 +84,10 @@ public struct ConnectionInfo: Codable, Equatable {
         self.internalHardwareAddresses =
             try container.decodeIfPresent([String].self, forKey: .internalHardwareAddresses)
         self.useCloud = try container.decodeIfPresent(Bool.self, forKey: .useCloud) ?? false
+        self.alwaysFallbackToInternalURL = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .alwaysFallbackToInternalURL
+        ) ?? false
         self.isLocalPushEnabled = try container.decodeIfPresent(Bool.self, forKey: .isLocalPushEnabled) ?? true
         self.securityExceptions = try container.decodeIfPresent(
             SecurityExceptions.self,
@@ -189,6 +196,9 @@ public struct ConnectionInfo: Codable, Equatable {
         } else if let externalURL {
             activeURLType = .external
             url = externalURL
+        } else if let internalURL, alwaysFallbackToInternalURL {
+            activeURLType = .internal
+            url = internalURL
         } else {
             activeURLType = .none
             url = nil

--- a/Sources/Shared/API/Fixtures/ServerFixture.swift
+++ b/Sources/Shared/API/Fixtures/ServerFixture.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Shared
 
 public enum ServerFixture {
     public static let standard = Server(identifier: "123", getter: {
@@ -15,7 +14,8 @@ public enum ServerFixture {
                 internalSSIDs: nil,
                 internalHardwareAddresses: nil,
                 isLocalPushEnabled: false,
-                securityExceptions: .init(exceptions: [])
+                securityExceptions: .init(exceptions: []),
+                alwaysFallbackToInternalURL: false
             ),
             token: .init(
                 accessToken: "",

--- a/Sources/Shared/API/Server+Fakes.swift
+++ b/Sources/Shared/API/Server+Fakes.swift
@@ -14,7 +14,8 @@ extension ServerInfo {
                 internalSSIDs: ["MyWifi"],
                 internalHardwareAddresses: nil,
                 isLocalPushEnabled: true,
-                securityExceptions: .init()
+                securityExceptions: .init(),
+                alwaysFallbackToInternalURL: false
             ),
             token: .init(
                 accessToken: "FakeAccessToken",

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1682,6 +1682,20 @@ public enum L10n {
       public static var ssidPermissionAndAccuracyMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_and_accuracy_message") }
       /// Accessing SSIDs in the background requires 'Always' location permission. Tap here to change your settings.
       public static var ssidPermissionMessage: String { return L10n.tr("Localizable", "settings.connection_section.ssid_permission_message") }
+      public enum AlwaysFallbackInternal {
+        /// Enabling this with an unsecure URL (http) may compromise your security on public networks.
+        public static var footer: String { return L10n.tr("Localizable", "settings.connection_section.always_fallback_internal.footer") }
+        /// Always fallback to internal URL
+        public static var title: String { return L10n.tr("Localizable", "settings.connection_section.always_fallback_internal.title") }
+        public enum Confirmation {
+          /// I am sure
+          public static var confirmButton: String { return L10n.tr("Localizable", "settings.connection_section.always_fallback_internal.confirmation.confirm_button") }
+          /// If you have an unsecure connection this can expose your authentication token on public networks.
+          public static var message: String { return L10n.tr("Localizable", "settings.connection_section.always_fallback_internal.confirmation.message") }
+          /// Are you sure?
+          public static var title: String { return L10n.tr("Localizable", "settings.connection_section.always_fallback_internal.confirmation.title") }
+        }
+      }
       public enum DeleteServer {
         /// Are you sure you wish to delete this server?
         public static var message: String { return L10n.tr("Localizable", "settings.connection_section.delete_server.message") }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -15,7 +15,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         info.internalSSIDs = ["unit_tests"]
@@ -25,6 +26,58 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(info.activeURLType, .internal)
         XCTAssertEqual(info.webhookURL(), url?.appendingPathComponent("api/webhook/webhook_id1"))
         XCTAssertEqual(info.activeAPIURL(), url?.appendingPathComponent("api"))
+    }
+
+    func testInternalOnlyURLWithoutSSIDWithAlwaysFallbackEnabled() {
+        let url = URL(string: "http://example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: url,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
+        )
+
+        info.internalSSIDs = []
+        Current.connectivity.currentWiFiSSID = { "" }
+        info.alwaysFallbackToInternalURL = true
+
+        XCTAssertEqual(info.activeURL(), url)
+        XCTAssertEqual(info.activeURLType, .internal)
+        XCTAssertEqual(info.webhookURL(), url?.appendingPathComponent("api/webhook/webhook_id1"))
+        XCTAssertEqual(info.activeAPIURL(), url?.appendingPathComponent("api"))
+    }
+
+    func testInternalOnlyURLWithoutSSIDWithoutAlwaysFallbackEnabled() {
+        let url = URL(string: "http://example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: nil,
+            internalURL: url,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
+        )
+
+        info.internalSSIDs = []
+        Current.connectivity.currentWiFiSSID = { "" }
+        info.alwaysFallbackToInternalURL = false
+
+        XCTAssertEqual(info.activeURL(), nil)
+        XCTAssertEqual(info.activeURLType, .none)
+        XCTAssertEqual(info.webhookURL(), nil)
+        XCTAssertEqual(info.activeAPIURL(), nil)
     }
 
     func testInternalURLWithUndefinedSSID() {
@@ -39,7 +92,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         Current.connectivity.currentWiFiSSID = { nil }
@@ -62,7 +116,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         info.useCloud = true
@@ -84,7 +139,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         info.useCloud = false
@@ -106,7 +162,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), url)
@@ -145,7 +202,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), externalURL)
@@ -184,7 +242,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), externalURL)
@@ -213,7 +272,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         info.useCloud = true
@@ -254,7 +314,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), nil)
@@ -277,7 +338,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), externalURL)
@@ -326,7 +388,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         // valid override states
@@ -387,7 +450,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         XCTAssertEqual(info.activeURL(), nil)
@@ -410,7 +474,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: ["unit_tests"],
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         Current.connectivity.currentWiFiSSID = { nil }
@@ -439,7 +504,8 @@ class ConnectionInfoTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: false,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         let oldVersion = Version(major: 2022, minor: 2)

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -536,7 +536,8 @@ class ServerManagerTests: XCTestCase {
             internalSSIDs: ["internal_ssid"],
             internalHardwareAddresses: ["internal_hardware"],
             isLocalPushEnabled: true,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         let tokenInfo = TokenInfo(

--- a/Tests/Shared/Webhook/WebhookManager.test.swift
+++ b/Tests/Shared/Webhook/WebhookManager.test.swift
@@ -184,7 +184,8 @@ class WebhookManagerTests: XCTestCase {
             internalSSIDs: nil,
             internalHardwareAddresses: nil,
             isLocalPushEnabled: true,
-            securityExceptions: .init()
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false
         )
 
         let nextAPIWebhookURL = nextConnectionInfo.webhookURL()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Since we don't fallback to internal URL anymore for security reasons, this PR adds a toggle to allow fallbacking in case the user really needs it (with a warning before enabling).
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-11 at 14 44 31](https://github.com/user-attachments/assets/4c560a5d-8612-47bb-a709-d9fab07a58e5)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
