### PR TITLE
Allow custom widget on iOS 17 and close other controllers when create widget is triggered

### DIFF
--- a/Sources/App/Settings/Widgets/Builder/WidgetBuilderView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetBuilderView.swift
@@ -6,7 +6,7 @@ struct WidgetBuilderView: View {
 
     var body: some View {
         List {
-            if #available(iOS 18, *) {
+            if #available(iOS 17, *) {
                 header
                 yourWidgetsSection
             }

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -119,6 +119,8 @@ final class WebViewWindowController {
 
     func navigate(to url: URL, on server: Server) {
         open(server: server).done { webViewController in
+            // Dismiss any overlayed controllers
+            webViewController.overlayAppController?.dismiss(animated: false)
             webViewController.open(inline: url)
         }
     }

--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -34,6 +34,7 @@ struct WidgetsBundle17: WidgetBundle {
     }
 
     var body: some Widget {
+        WidgetCustom()
         WidgetAssist()
         WidgetScripts()
         WidgetGauge()
@@ -51,6 +52,7 @@ struct WidgetsBundle18: WidgetBundle {
     }
 
     var body: some Widget {
+        // Controls
         ControlAssist()
         ControlLight()
         ControlSwitch()
@@ -58,6 +60,8 @@ struct WidgetsBundle18: WidgetBundle {
         ControlScript()
         ControlScene()
         ControlOpenPage()
+
+        // Widgets
         WidgetCustom()
         WidgetAssist()
         WidgetScripts()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
