### PR TITLE
Replace default 2 fingers swipe gesture to make it more intuitive in iOS

### DIFF
--- a/Sources/Shared/HAGesture.swift
+++ b/Sources/Shared/HAGesture.swift
@@ -100,8 +100,8 @@ public extension [HAGesture: HAGestureAction] {
     static var defaultGestures: [HAGesture: HAGestureAction] {
         [
             .swipeRight: .showSidebar,
-            ._2FingersSwipeRight: .nextPage,
-            ._2FingersSwipeLeft: .backPage,
+            ._2FingersSwipeRight: .backPage,
+            ._2FingersSwipeLeft: .nextPage,
             ._3FingersSwipeUp: .showServersList,
             ._3FingersSwipeRight: .nextServer,
             ._3FingersSwipeLeft: .previousServer,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Since the swipe right in a native app goes back, swiping with 2 fingers right makes more sense to also go back instead of forward
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
