### PR TITLE
Display bluetooth permission request until user make a choice

### DIFF
--- a/Sources/App/Onboarding/Screens/Bluetooth/BluetoothPermissionView.swift
+++ b/Sources/App/Onboarding/Screens/Bluetooth/BluetoothPermissionView.swift
@@ -13,7 +13,7 @@ struct BluetoothPermissionView: View {
             title: L10n.Permission.Screen.Bluetooth.title,
             subtitle: L10n.Permission.Screen.Bluetooth.subtitle,
             reasons: [],
-            showSkipButton: true,
+            showSkipButton: false,
             showCloseButton: true,
             continueAction: {
                 // Request BT permission
@@ -22,11 +22,6 @@ struct BluetoothPermissionView: View {
             dismissAction: nil
         )
         .interactiveDismissDisabled(true)
-        .onAppear {
-            // Permission will be prompted twice, if ignored, it wont display anymore
-            let btScreenDisplayerCount = BluetoothPermissionScreenDisplayedCount()
-            btScreenDisplayerCount.value = (btScreenDisplayerCount.value ?? 0) + 1
-        }
         .onChange(of: viewModel.shouldDismiss) { newValue in
             if newValue {
                 dismiss()

--- a/Sources/App/WebView/WebViewExternalMessageHandler.swift
+++ b/Sources/App/WebView/WebViewExternalMessageHandler.swift
@@ -375,13 +375,6 @@ final class WebViewExternalMessageHandler {
             improvManager.delegate = self
             improvManager.scan()
         default:
-            guard (BluetoothPermissionScreenDisplayedCount().value ?? 0) < 2 else {
-                Current.Log
-                    .info(
-                        "Bluetooth permission screen already displayed twice and no decision was made by the user, permission won't be asked again."
-                    )
-                return
-            }
             let bluetoothPermissionView = UIHostingController(rootView: BluetoothPermissionView())
             webViewController?.presentOverlayController(controller: bluetoothPermissionView, animated: true)
         }

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -454,9 +454,3 @@ public class SettingsStore {
         return String(text.filter { okayChars.contains($0) })
     }
 }
-
-public class BluetoothPermissionScreenDisplayedCount: UserDefaultsValueSync<Int> {
-    public init() {
-        super.init(settingsKey: "bluetoothPermissionScreenPresentedCount")
-    }
-}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Before the screen was shown twice then never again if the user skips it, but then there is no way for the user to manually enable bluetooth.
With this change the user can still close the permission screen but it will be prompted again to make a choice as soon as devices & integrations page loads.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
