### PR TITLE
Save ClientEvents on local json file instead of GRDB to avoid crashes

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -95,7 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             text: "Application Starting" + (launchingForLocation ? " due to location change" : ""),
             type: .unknown
         )
-        Current.clientEventStore.addEvent(event).cauterize()
+        Current.clientEventStore.addEvent(event)
 
         zoneManager = ZoneManager()
 

--- a/Sources/App/Settings/ClientEventsLogView/ClientEventsLogView.swift
+++ b/Sources/App/Settings/ClientEventsLogView/ClientEventsLogView.swift
@@ -13,6 +13,9 @@ struct ClientEventsLogView: View {
             eventsList
         }
         .searchable(text: $viewModel.searchTerm)
+        .refreshable {
+            viewModel.loadEvents()
+        }
         .navigationTitle(L10n.Settings.EventLog.title)
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
@@ -31,14 +34,14 @@ struct ClientEventsLogView: View {
                         /* no-op */
                     }
                     Button(L10n.yesLabel, role: .destructive) {
-                        Current.clientEventStore.clearAllEvents().cauterize()
+                        Current.clientEventStore.clearAllEvents()
                         dismiss()
                     }
                 }
             }
         }
         .onAppear {
-            viewModel.subscribeEvents()
+            viewModel.loadEvents()
         }
     }
 

--- a/Sources/App/Settings/ClientEventsLogView/ClientEventsLogViewModel.swift
+++ b/Sources/App/Settings/ClientEventsLogView/ClientEventsLogViewModel.swift
@@ -7,34 +7,11 @@ final class ClientEventsLogViewModel: ObservableObject {
     @Published var searchTerm: String = ""
     @Published var typeFilter: ClientEvent.EventType?
 
-    private var eventsObservation: AnyDatabaseCancellable?
-
-    deinit {
-        eventsObservation?.cancel()
-    }
-
-    @MainActor
-    func subscribeEvents() {
-        observeChanges()
+    func loadEvents() {
+        events = Current.clientEventStore.getEvents().sorted(by: { $0.date > $1.date })
     }
 
     func resetTypeFilter() {
         typeFilter = nil
-    }
-
-    @MainActor
-    private func observeChanges() {
-        eventsObservation?.cancel()
-        let observation = ValueObservation.tracking(ClientEvent.fetchAll)
-        eventsObservation = observation.start(
-            in: Current.database,
-            onError: { error in
-                Current.Log.error("Client events observation failed with error: \(error)")
-            },
-            onChange: { @MainActor [weak self] _ in
-                // Observation uses main queue https://swiftpackageindex.com/groue/grdb.swift/v6.29.3/documentation/grdb/valueobservation#ValueObservation-Scheduling
-                self?.events = Current.clientEventStore.getEvents()
-            }
-        )
     }
 }

--- a/Sources/App/Settings/SettingsDetailViewController.swift
+++ b/Sources/App/Settings/SettingsDetailViewController.swift
@@ -555,7 +555,7 @@ class SettingsDetailViewController: HAFormViewController, TypedRowControllerType
                 let message =
                     "Server \(server.info.name) - Internal URL set but no internal SSIDs or hardware addresses set"
                 Current.Log.error(message)
-                Current.clientEventStore.addEvent(.init(text: message, type: .settings)).cauterize()
+                Current.clientEventStore.addEvent(.init(text: message, type: .settings))
             }
         }
     }

--- a/Sources/App/ZoneManager/ZoneManager.swift
+++ b/Sources/App/ZoneManager/ZoneManager.swift
@@ -108,6 +108,7 @@ class ZoneManager {
                 type: .locationUpdate,
                 payload: logPayload
             ))
+            return Promise()
         }.catch { error in
             Current.Log.error("final error for \(event): \(error)")
 
@@ -118,7 +119,7 @@ class ZoneManager {
                 text: "Didn't update: \(error.localizedDescription)",
                 type: .locationUpdate,
                 payload: updatedPayload
-            )).cauterize()
+            ))
         }
     }
 
@@ -168,7 +169,7 @@ class ZoneManager {
                 payload: [
                     "region": String(describing: region),
                 ]
-            )).cauterize()
+            ))
             locationManager.stopMonitoring(for: region)
         }
 
@@ -179,7 +180,7 @@ class ZoneManager {
                 payload: [
                     "region": String(describing: region),
                 ]
-            )).cauterize()
+            ))
 
             collector.ignoreNextState(for: region)
             locationManager.startMonitoring(for: region)

--- a/Sources/App/ZoneManager/ZoneManager.swift
+++ b/Sources/App/ZoneManager/ZoneManager.swift
@@ -108,7 +108,7 @@ class ZoneManager {
                 type: .locationUpdate,
                 payload: logPayload
             ))
-            return Promise()
+            return Promise.value(())
         }.catch { error in
             Current.Log.error("final error for \(event): \(error)")
 

--- a/Sources/App/ZoneManager/ZoneManagerRegionFilter.swift
+++ b/Sources/App/ZoneManager/ZoneManagerRegionFilter.swift
@@ -152,6 +152,6 @@ class ZoneManagerRegionFilterImpl: ZoneManagerRegionFilter {
                 "stripped_zones": strippedZones.map(\.identifier),
                 "stripped_decision": decisionSource,
             ]
-        )).cauterize()
+        ))
     }
 }

--- a/Sources/Shared/API/Authentication/TokenManager.swift
+++ b/Sources/Shared/API/Authentication/TokenManager.swift
@@ -161,7 +161,7 @@ public class TokenManager {
                                 "error": String(describing: underlying),
                             ]
                         )
-                        Current.clientEventStore.addEvent(event).cauterize()
+                        Current.clientEventStore.addEvent(event)
                         Current.modelManager.unsubscribe()
                         Current.onboardingObservation.needed(.unauthenticated(
                             server.identifier.rawValue,

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -85,7 +85,7 @@ public class HomeAssistantAPI {
                         Current.clientEventStore.addEvent(.init(
                             text: "No active URL available to interact with API, please check if you have internal or external URL available, for internal URL you need to specify your network SSID otherwise for security reasons it won't be available.",
                             type: .networkRequest
-                        )).cauterize()
+                        ))
                         Current.Log.error("activeURL was not available when HAAPI called initializer")
                         return nil
                     }
@@ -205,12 +205,11 @@ public class HomeAssistantAPI {
                     // ha directly will send a 200 with an empty body for deleted
 
                     let message = "Integration is missing; registering."
-                    return Current.clientEventStore
+                    Current.clientEventStore
                         .addEvent(ClientEvent(text: message, type: .networkRequest, payload: [
                             "error": String(describing: error),
-                        ])).then { [self] in
-                            register()
-                        }
+                        ]))
+                    return register()
                 case .unregisteredIdentifier,
                      .unacceptableStatusCode,
                      .replaced,

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -98,7 +98,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
                     text: "Updated database App Entities for \(server.info.name)",
                     type: .database,
                     payload: ["entities_count": appEntities.count]
-                )).cauterize()
+                ))
             }
         } catch {
             Current.Log.error("Failed to get cache for App Entities, error: \(error.localizedDescription)")
@@ -106,7 +106,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
                 text: "Update database App Entities FAILED for \(server.info.name)",
                 type: .database,
                 payload: ["error": error.localizedDescription]
-            )).cauterize()
+            ))
         }
     }
 }

--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -144,7 +144,7 @@ public final class RLMZone: Object, UpdatableModel {
                     text: "Unable to create beacon region due to invalid UUID: \(uuidString)",
                     type: .locationUpdate
                 )
-            Current.clientEventStore.addEvent(event).cauterize()
+            Current.clientEventStore.addEvent(event)
             return nil
         }
 

--- a/Sources/Shared/API/Webhook/Networking/Promise+WebhookJson.swift
+++ b/Sources/Shared/API/Webhook/Networking/Promise+WebhookJson.swift
@@ -96,7 +96,7 @@ extension Promise where T == Data {
                     text: text,
                     type: .networkRequest,
                     payload: nil
-                )).cauterize()
+                ))
                 return .init(error: WebhookError.unacceptableStatusCode(statusCode))
             default:
                 break

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -281,7 +281,7 @@ public class WebhookManager: NSObject {
                         text: "Retrying with active URL - \(activeURL.absoluteString)",
                         type: .networkRequest
                     )
-                    Current.clientEventStore.addEvent(event).cauterize()
+                    Current.clientEventStore.addEvent(event)
                     let promise: Promise<Any> = sendEphemeral(
                         server: server,
                         request: request,

--- a/Sources/Shared/API/Webhook/Networking/WebhookResponseLocation.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookResponseLocation.swift
@@ -71,7 +71,7 @@ struct WebhookResponseLocation: WebhookResponseHandler {
                 text: notificationOptions.body,
                 type: .locationUpdate,
                 payload: try? request.asDictionary()
-            )).cauterize()
+            ))
 
             guard notificationOptions.shouldNotify else {
                 return nil

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -2,7 +2,13 @@ import Foundation
 import GRDB
 import PromiseKit
 
-public struct ClientEventStore {
+public protocol ClientEventStoreProtocol {
+    func addEvent(_ event: ClientEvent)
+    func getEvents() -> [ClientEvent]
+    func clearAllEvents()
+}
+
+final class ClientEventStore: ClientEventStoreProtocol {
     static var jsonCacheName = "databases/clientEvents.json"
     public func addEvent(_ event: ClientEvent) {
         Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -3,7 +3,7 @@ import GRDB
 import PromiseKit
 
 public struct ClientEventStore {
-    static var jsonCacheName = "clientEvents.json"
+    static var jsonCacheName = "databases/clientEvents.json"
     public func addEvent(_ event: ClientEvent) {
         Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")
         let eventsCacheLimit = 1000
@@ -45,15 +45,8 @@ public struct ClientEventStore {
     }
 
     private func saveJSONData(_ events: [ClientEvent]) {
-        guard let containerURL = FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID) else {
-            Current.Log.error("Failed to get container URL for saving client events")
-            return
-        }
-
-        let fileURL = containerURL.appendingPathComponent(ClientEventStore.jsonCacheName)
-
         do {
+            let fileURL = AppConstants.clientEventsFile
             let jsonData = try JSONEncoder().encode(events)
             try jsonData.write(to: fileURL)
             Current.Log.verbose("JSON saved successfully for client events, file URL: \(fileURL.absoluteString)")

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -3,55 +3,62 @@ import GRDB
 import PromiseKit
 
 public struct ClientEventStore {
-    public var addEvent: ((_ event: ClientEvent) -> Promise<Void>) = { event in
-        Current.Log.verbose("Adding client event: \(event)")
-        do {
-            try Current.database.write { db in
-                try event.save(db)
-            }
-            Current.clientEventStore.cleanup()
-        } catch {
-            Current.Log.error("Failed to save client event: \(error)")
+    static var jsonCacheName = "clientEvents.json"
+    public func addEvent(_ event: ClientEvent) {
+        Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")
+        let eventsCacheLimit = 1000
+        var events = getEvents()
+        events.append(event)
+        if events.count > eventsCacheLimit {
+            events = events.suffix(eventsCacheLimit)
         }
-        return .value(())
-    }
-
-    /// Keep only the last 1000 event entries
-    private func cleanup() {
-        do {
-            try Current.database.write { db in
-                let count = try ClientEvent.fetchCount(db)
-                if count > 1000 {
-                    let toDelete = count - 1000
-                    try ClientEvent.order(Column("date")).limit(toDelete).deleteAll(db)
-                }
-            }
-        } catch {
-            Current.Log.error("Failed to cleanup client events: \(error)")
-        }
+        saveJSONData(events)
     }
 
     public func getEvents() -> [ClientEvent] {
+        guard let containerURL = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID) else {
+            Current.Log.error("Failed to get container URL for get client events")
+            return []
+        }
+
+        let fileURL = containerURL.appendingPathComponent(ClientEventStore.jsonCacheName)
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            Current.Log.error("Client events cache file doesn't exist at path: \(fileURL.absoluteString)")
+            return []
+        }
+
+        let data = FileManager.default.contents(atPath: fileURL.path) ?? Data()
+
         do {
-            return try Current.database.read { db in
-                try ClientEvent
-                    .order(Column(DatabaseTables.ClientEvent.date.rawValue).desc)
-                    .fetchAll(db)
-            }
+            let clientEvents = try JSONDecoder().decode([ClientEvent].self, from: data)
+            return clientEvents
         } catch {
-            Current.Log.error("Failed to save client event: \(error)")
+            Current.Log.error("Failed to decode client events data from cache, error: \(error)")
             return []
         }
     }
 
-    public func clearAllEvents() -> Promise<Void> {
-        do {
-            _ = try Current.database.write { db in
-                try ClientEvent.deleteAll(db)
-            }
-        } catch {
-            Current.Log.error("Failed to delete all client events: \(error)")
+    public func clearAllEvents() {
+        saveJSONData([])
+    }
+
+    private func saveJSONData(_ events: [ClientEvent]) {
+        guard let containerURL = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID) else {
+            Current.Log.error("Failed to get container URL for saving client events")
+            return
         }
-        return .value(())
+
+        let fileURL = containerURL.appendingPathComponent(ClientEventStore.jsonCacheName)
+
+        do {
+            let jsonData = try JSONEncoder().encode(events)
+            try jsonData.write(to: fileURL)
+            Current.Log.verbose("JSON saved successfully for client events, file URL: \(fileURL.absoluteString)")
+        } catch {
+            Current.Log.error("Error saving JSON for client events: \(error)")
+        }
     }
 }

--- a/Sources/Shared/Common/Extensions/XCGLogger+Export.swift
+++ b/Sources/Shared/Common/Extensions/XCGLogger+Export.swift
@@ -86,6 +86,17 @@ public extension XCGLogger {
                     .info("No App config database file added to export logs, error: \(error.localizedDescription)")
             }
 
+            // In case App Client Events does not exist it can safely fail
+            do {
+                try archive.addEntry(
+                    with: AppConstants.clientEventsFile.lastPathComponent,
+                    fileURL: AppConstants.clientEventsFile
+                )
+            } catch {
+                Current.Log
+                    .info("No Client Events file added to export logs, error: \(error.localizedDescription)")
+            }
+
             for logFile in try fileManager.contentsOfDirectory(
                 at: Shared.AppConstants.LogsDirectory,
                 includingPropertiesForKeys: nil

--- a/Sources/Shared/Database/DatabaseTables.swift
+++ b/Sources/Shared/Database/DatabaseTables.swift
@@ -5,6 +5,8 @@ public enum GRDBDatabaseTable: String {
     case watchConfig
     case assistPipelines
     case carPlayConfig
+    // Dropped since 2025.2, now saved as json file
+    // Context: https://github.com/groue/GRDB.swift/issues/1626#issuecomment-2623927815
     case clientEvent
     case appEntityRegistryListForDisplay
     case appPanel
@@ -41,15 +43,8 @@ public enum DatabaseTables {
         case quickAccessItems
     }
 
-    // Client events
-    public enum ClientEvent: String {
-        case id
-        case text
-        case type
-        case jsonPayload
-        case date
-    }
-
+    // Table where it is store frontend related values such as
+    // precision for sensors
     public enum AppEntityRegistryListForDisplay: String {
         case id
         case serverId
@@ -57,6 +52,7 @@ public enum DatabaseTables {
         case registry
     }
 
+    // Sidebar dashboard panels
     public enum AppPanel: String {
         case id
         case serverId

--- a/Sources/Shared/Database/Tables/ClientEventTable.swift
+++ b/Sources/Shared/Database/Tables/ClientEventTable.swift
@@ -2,24 +2,25 @@ import Foundation
 import GRDB
 
 final class ClientEventTable: DatabaseTableProtocol {
+    // In this particular case we will drop it if existent
     func createIfNeeded(database: DatabaseQueue) {
         do {
-            let shouldCreateTable = try database.read { db in
+            /*
+             ClientEvent used to be saved in GRDB, but because of a problem of one process holding
+             lock on the database and causing crash 0xdead10cc now it is saved as a json file
+             More information: https://github.com/groue/GRDB.swift/issues/1626#issuecomment-2623927815
+             */
+            let shouldDeleteTable = try database.read { db in
                 try !db.tableExists(GRDBDatabaseTable.clientEvent.rawValue)
             }
-            if shouldCreateTable {
+            if shouldDeleteTable {
                 try database.write { db in
-                    try db.create(table: GRDBDatabaseTable.clientEvent.rawValue) { t in
-                        t.primaryKey(DatabaseTables.ClientEvent.id.rawValue, .text).notNull()
-                        t.column(DatabaseTables.ClientEvent.text.rawValue, .text).notNull()
-                        t.column(DatabaseTables.ClientEvent.type.rawValue, .text).notNull()
-                        t.column(DatabaseTables.ClientEvent.jsonPayload.rawValue, .jsonText).notNull()
-                        t.column(DatabaseTables.ClientEvent.date.rawValue, .date).notNull()
-                    }
+                    try db.drop(table: GRDBDatabaseTable.clientEvent.rawValue)
+                    Current.Log.verbose("Dropped table: \(GRDBDatabaseTable.clientEvent.rawValue) sucessfully")
                 }
             }
         } catch {
-            let errorMessage = "Failed create GRDB table, error: \(error.localizedDescription)"
+            let errorMessage = "Failed to read client event GRDB info, error: \(error.localizedDescription)"
             Current.Log.error(errorMessage)
         }
     }

--- a/Sources/Shared/Database/Tables/ClientEventTable.swift
+++ b/Sources/Shared/Database/Tables/ClientEventTable.swift
@@ -11,12 +11,11 @@ final class ClientEventTable: DatabaseTableProtocol {
              More information: https://github.com/groue/GRDB.swift/issues/1626#issuecomment-2623927815
              */
             let shouldDeleteTable = try database.read { db in
-                try !db.tableExists(GRDBDatabaseTable.clientEvent.rawValue)
+                try db.tableExists(GRDBDatabaseTable.clientEvent.rawValue)
             }
             if shouldDeleteTable {
                 try database.write { db in
                     try db.drop(table: GRDBDatabaseTable.clientEvent.rawValue)
-                    Current.Log.verbose("Dropped table: \(GRDBDatabaseTable.clientEvent.rawValue) sucessfully")
                 }
             }
         } catch {

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -96,6 +96,20 @@ public enum AppConstants {
         return databaseURL
     }
 
+    public static var clientEventsFile: URL {
+        let fileManager = FileManager.default
+        let directoryURL = Self.AppGroupContainer.appendingPathComponent("databases", isDirectory: true)
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            } catch {
+                Current.Log.error("Failed to create Client Events file")
+            }
+        }
+        let eventsURL = directoryURL.appendingPathComponent("clientEvents.json")
+        return eventsURL
+    }
+
     public static var LogsDirectory: URL {
         let fileManager = FileManager.default
         let directoryURL = AppGroupContainer.appendingPathComponent("logs", isDirectory: true)

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -46,7 +46,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                             payload: [
                                 "error": error.localizedDescription,
                             ]
-                        )).cauterize()
+                        ))
                     }
                 }
             )
@@ -67,7 +67,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                             payload: [
                                 "error": error.localizedDescription,
                             ]
-                        )).cauterize()
+                        ))
                     }
                 }
             )
@@ -103,7 +103,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                 payload: [
                     "error": error.localizedDescription,
                 ]
-            )).cauterize()
+            ))
         }
     }
 

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -91,7 +91,7 @@ public class AppEnvironment {
     public var calendar: () -> Calendar = { Calendar.autoupdatingCurrent }
 
     /// Provides the Client Event store used for local logging.
-    public var clientEventStore = ClientEventStore()
+    public var clientEventStore: ClientEventStoreProtocol = ClientEventStore()
 
     /// Provides the Realm used for many data storage tasks.
     public var realm: () -> Realm = Realm.live

--- a/Tests/Shared/ClientEventTests.swift
+++ b/Tests/Shared/ClientEventTests.swift
@@ -8,14 +8,11 @@ class ClientEventTests: XCTestCase {
     var store: ClientEventStore!
     override func setUp() {
         super.setUp()
-        do {
-            _ = try Current.database.write { db in
-                try ClientEvent.deleteAll(db)
-            }
-        } catch {
-            XCTFail("Error setting up database: \(error)")
-        }
         store = ClientEventStore()
+    }
+
+    override func tearDown() {
+        store.clearAllEvents()
     }
 
     func testStartsEmpty() {
@@ -54,7 +51,7 @@ class ClientEventTests: XCTestCase {
 
     func testCanWriteClientEvent() throws {
         let event = ClientEvent(text: "Yo", type: .notification)
-        try hang(store.addEvent(event))
+        store.addEvent(event)
         XCTAssertEqual(1, store.getEvents().count)
     }
 
@@ -62,7 +59,7 @@ class ClientEventTests: XCTestCase {
         let date = Date()
         Current.date = { date }
         let event = ClientEvent(text: "Yo", type: .notification)
-        try hang(store.addEvent(event))
+        store.addEvent(event)
         let retrieved = store.getEvents().first
         XCTAssertEqual(retrieved?.text, "Yo")
         XCTAssertEqual(retrieved?.type, .notification)
@@ -71,8 +68,9 @@ class ClientEventTests: XCTestCase {
 
     func testCanClearEvents() throws {
         let event = ClientEvent(text: "Yo", type: .notification)
-        try hang(store.addEvent(event))
+        store.addEvent(event)
         XCTAssertEqual(1, store.getEvents().count)
-        try hang(store.clearAllEvents())
+        store.clearAllEvents()
+        XCTAssertEqual(0, store.getEvents().count)
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
More context can be found here: https://github.com/groue/GRDB.swift/issues/1626#issuecomment-2623927815

This PR tries to workaround crashes related to database lock in multiple OS processes, now client events are saved on jsonfile instead of GRDB

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
