### PR TITLE
Add mac server quick switch picker and button to open current page in external browser

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1162,4 +1162,5 @@ Home Assistant is free and open source home automation software with a focus on 
 "widgets.sensors.description" = "Display state of sensors";
 "widgets.sensors.not_configured" = "No Sensors Configured";
 "widgets.sensors.title" = "Sensors";
+"web_view.server_selection.title" = "Choose server";
 "yes_label" = "Yes";

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -260,7 +260,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
         let menuActions = Current.servers.all.map { server in
             UIAction(title: server.info.name, handler: { [weak self] _ in
-                picker.setTitle(server.info.name, for: .normal)
                 self?.openServer(server)
             })
         }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3817,6 +3817,13 @@ public enum L10n {
     }
   }
 
+  public enum WebView {
+    public enum ServerSelection {
+      /// Choose server
+      public static var title: String { return L10n.tr("Localizable", "web_view.server_selection.title") }
+    }
+  }
+
   public enum Widgets {
     public enum Action {
       public enum Name {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![CleanShot 2025-02-05 at 15 38 01@2x](https://github.com/user-attachments/assets/c9ef5733-3bd3-4d58-99c5-bccea1367a92)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
