### PR TITLE
Workaround iOS issue calling widget timelines several times

### DIFF
--- a/Sources/App/Scenes/WebViewSceneDelegate.swift
+++ b/Sources/App/Scenes/WebViewSceneDelegate.swift
@@ -127,6 +127,15 @@ final class WebViewSceneDelegate: NSObject, UIWindowSceneDelegate {
         })
         Current.appDatabaseUpdater.update()
         Current.panelsUpdater.update()
+
+        let widgetsCacheFile = AppConstants.widgetsCacheURL
+
+        // Clean up widgets cache file
+        do {
+            try FileManager.default.removeItem(at: widgetsCacheFile)
+        } catch {
+            Current.Log.error("Failed to remove widgets cache file: \(error)")
+        }
     }
 
     func windowScene(

--- a/Sources/Extensions/Widgets/Custom/AppIntents/CustomWidgetToggleAppIntent.swift
+++ b/Sources/Extensions/Widgets/Custom/AppIntents/CustomWidgetToggleAppIntent.swift
@@ -47,14 +47,6 @@ struct CustomWidgetToggleAppIntent: AppIntent {
             }
         }
         _ = try await ResetAllCustomWidgetConfirmationAppIntent().perform()
-
-        /* Since several entities when toggled may not report the correct state right away
-         This is a workaround to refresh the widget a little later
-         In theory through push notification we could always ask the widget to update through
-         and automation/blueprint etc, but it's currently not reliable https://developer.apple.com/forums/thread/773852 */
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            WidgetCenter.shared.reloadTimelines(ofKind: WidgetsKind.custom.rawValue)
-        }
         return .result()
     }
 }

--- a/Sources/Extensions/Widgets/Custom/AppIntents/UpdateWidgetItemConfirmationStateAppIntent.swift
+++ b/Sources/Extensions/Widgets/Custom/AppIntents/UpdateWidgetItemConfirmationStateAppIntent.swift
@@ -26,7 +26,7 @@ struct UpdateWidgetItemConfirmationStateAppIntent: AppIntent {
 
         if var widget = try CustomWidget.widgets()?.first(where: { $0.id == widgetId }),
            let magicItem = widget.items.first(where: { $0.serverUniqueId == serverUniqueId }) {
-            widget.itemsStates[magicItem.serverUniqueId] = .pendingConfirmation
+            widget.itemsStates = [magicItem.serverUniqueId: .pendingConfirmation]
             do {
                 try await Current.database.write { [widget] db in
                     try widget.update(db)

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -17,7 +17,7 @@ public enum Domain: String, CaseIterable {
     case person
     // TODO: Map more domains
 
-    public enum State: String {
+    public enum State: String, Codable {
         case locked
         case unlocked
         case jammed

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -110,6 +110,20 @@ public enum AppConstants {
         return eventsURL
     }
 
+    public static func widgetCachedStates(widgetId: String) -> URL {
+        let fileManager = FileManager.default
+        let directoryURL = Self.AppGroupContainer.appendingPathComponent("caches/widgets/", isDirectory: true)
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            } catch {
+                Current.Log.error("Failed to create Client Events file")
+            }
+        }
+        let eventsURL = directoryURL.appendingPathComponent("widgetId-\(widgetId).json")
+        return eventsURL
+    }
+
     public static var watchMagicItemsInfo: URL {
         let fileManager = FileManager.default
         let directoryURL = Self.AppGroupContainer.appendingPathComponent("caches", isDirectory: true)

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -110,9 +110,15 @@ public enum AppConstants {
         return eventsURL
     }
 
+    public static var widgetsCacheURL: URL = {
+        let fileManager = FileManager.default
+        let directoryURL = Self.AppGroupContainer.appendingPathComponent("caches/widgets", isDirectory: true)
+        return directoryURL
+    }()
+
     public static func widgetCachedStates(widgetId: String) -> URL {
         let fileManager = FileManager.default
-        let directoryURL = Self.AppGroupContainer.appendingPathComponent("caches/widgets/", isDirectory: true)
+        let directoryURL = Self.widgetsCacheURL
         if !fileManager.fileExists(atPath: directoryURL.path) {
             do {
                 try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
@@ -120,7 +126,7 @@ public enum AppConstants {
                 Current.Log.error("Failed to create Client Events file")
             }
         }
-        let eventsURL = directoryURL.appendingPathComponent("widgetId-\(widgetId).json")
+        let eventsURL = directoryURL.appendingPathComponent("/widgetId-\(widgetId).json")
         return eventsURL
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
There is a long term bug in iOS which calls widget timelines several times even though once would be enough to render the widget. Since apparently Apple is not giving attention to that and out custom widgets make data calls, this PRs ads a small cache to prevent unecessary data calls. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
