### PR TITLE
Revert "Adding back warning about internal URL usage"

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewController.swift
@@ -156,7 +156,8 @@ class ConnectionSettingsViewController: HAFormViewController, RowControllerType 
                 row.displayValueFor = { [server] _ in
                     if server.info.connection.internalSSIDs?.isEmpty ?? true,
                        server.info.connection.internalHardwareAddresses?.isEmpty ?? true,
-                       !server.info.connection.alwaysFallbackToInternalURL {
+                       !server.info.connection.alwaysFallbackToInternalURL,
+                       !ConnectionInfo.shouldFallbackToInternalURL {
                         return "‼️ \(L10n.Settings.ConnectionSection.InternalBaseUrl.RequiresSetup.title)"
                     } else {
                         return server.info.connection.address(for: .internal)?.absoluteString ?? "—"

--- a/Sources/App/Settings/Connection/ConnectionURLViewController.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLViewController.swift
@@ -232,7 +232,8 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
                 $0.tag = RowTag.internalURLWarning.rawValue
                 if server.info.connection.internalSSIDs?.isEmpty ?? true,
                    server.info.connection.internalHardwareAddresses?.isEmpty ?? true,
-                   !server.info.connection.alwaysFallbackToInternalURL {
+                   !server.info.connection.alwaysFallbackToInternalURL,
+                   !ConnectionInfo.shouldFallbackToInternalURL {
                     #if targetEnvironment(macCatalyst)
                     $0.title = "‼️" + L10n.Settings.ConnectionSection.InternalBaseUrl.SsidBssidRequired.title
                     #else
@@ -296,39 +297,41 @@ final class ConnectionURLViewController: HAFormViewController, TypedRowControlle
             }
         }
 
-        form +++ Section(footer: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.footer)
-            <<< SwitchRow(RowTag.alwaysFallbackToInternalURL.rawValue) {
-                $0.title = L10n.Settings.ConnectionSection.AlwaysFallbackInternal.title
-                $0.value = server.info.connection.alwaysFallbackToInternalURL
+        if !ConnectionInfo.shouldFallbackToInternalURL {
+            form +++ Section(footer: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.footer)
+                <<< SwitchRow(RowTag.alwaysFallbackToInternalURL.rawValue) {
+                    $0.title = L10n.Settings.ConnectionSection.AlwaysFallbackInternal.title
+                    $0.value = server.info.connection.alwaysFallbackToInternalURL
 
-                $0.cellUpdate { cell, _ in
-                    cell.switchControl.onTintColor = .red
-                }
+                    $0.cellUpdate { cell, _ in
+                        cell.switchControl.onTintColor = .red
+                    }
 
-                $0.onChange { [weak self] row in
-                    if row.value ?? false {
-                        let alert = UIAlertController(
-                            title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.title,
-                            message: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.message,
-                            preferredStyle: .alert
-                        )
-                        alert.addAction(UIAlertAction(title: L10n.cancelLabel, style: .cancel, handler: { _ in
-                            self?.server.info.connection.alwaysFallbackToInternalURL = false
-                            row.value = false
-                            row.cellUpdate { _, row in
+                    $0.onChange { [weak self] row in
+                        if row.value ?? false {
+                            let alert = UIAlertController(
+                                title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.title,
+                                message: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation.message,
+                                preferredStyle: .alert
+                            )
+                            alert.addAction(UIAlertAction(title: L10n.cancelLabel, style: .cancel, handler: { _ in
+                                self?.server.info.connection.alwaysFallbackToInternalURL = false
                                 row.value = false
-                            }
-                            row.reload()
-                        }))
-                        alert.addAction(UIAlertAction(
-                            title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation
-                                .confirmButton,
-                            style: .destructive
-                        ))
-                        self?.present(alert, animated: true)
+                                row.cellUpdate { _, row in
+                                    row.value = false
+                                }
+                                row.reload()
+                            }))
+                            alert.addAction(UIAlertAction(
+                                title: L10n.Settings.ConnectionSection.AlwaysFallbackInternal.Confirmation
+                                    .confirmButton,
+                                style: .destructive
+                            ))
+                            self?.present(alert, animated: true)
+                        }
                     }
                 }
-            }
+        }
     }
 
     private func locationPermissionSection() -> Section {

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -6,6 +6,11 @@ import Communicator
 #endif
 
 public struct ConnectionInfo: Codable, Equatable {
+    // TODO: Remove when location permission enforcement is in place
+    /// Developer toggle used while enforcement of location permision is not ready
+    /// Used as feature toggle
+    public static var shouldFallbackToInternalURL = true
+
     private var externalURL: URL?
     private var internalURL: URL?
     private var remoteUIURL: URL?
@@ -200,13 +205,19 @@ public struct ConnectionInfo: Codable, Equatable {
             activeURLType = .internal
             url = internalURL
         } else {
-            activeURLType = .none
-            url = nil
-            /*
-             No URL that can be used in this context is available
-             This can happen when only internal URL is set and
-             user tries to access the App remotely
-             */
+            // TODO: Remove when location permission enforcement is in place
+            if ConnectionInfo.shouldFallbackToInternalURL {
+                activeURLType = .internal
+                url = internalURL
+            } else {
+                activeURLType = .none
+                url = nil
+                /*
+                 No URL that can be used in this context is available
+                 This can happen when only internal URL is set and
+                 user tries to access the App remotely
+                 */
+            }
         }
 
         return url?.sanitized()

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -3,6 +3,10 @@ import Version
 import XCTest
 
 class ConnectionInfoTests: XCTestCase {
+    override func setUp() async throws {
+        ConnectionInfo.shouldFallbackToInternalURL = false
+    }
+
     func testInternalOnlyURL() {
         let url = URL(string: "http://example.com:8123")
         var info = ConnectionInfo(


### PR DESCRIPTION
Reverts home-assistant/iOS#3341


Reverting while we redesign this flow for a better UX for non-technical users