### PR TITLE
Add "triggerSource" to service calls

### DIFF
--- a/Sources/App/Settings/ActionConfigurator.swift
+++ b/Sources/App/Settings/ActionConfigurator.swift
@@ -128,28 +128,6 @@ class ActionConfigurator: HAFormViewController, TypedRowControllerType {
             }
         }
 
-        if !Current.isCatalyst {
-            firstSection <<< SwitchRow {
-                $0.title = L10n.SettingsDetails.Actions.CarPlay.Available.title
-                $0.value = action.showInCarPlay
-                $0.disabled = .init(booleanLiteral: !action.canConfigure(\Action.showInCarPlay))
-            }.onChange { row in
-                if let value = row.value {
-                    self.action.showInCarPlay = value
-                }
-            }
-
-            firstSection <<< SwitchRow("showInWatch") {
-                $0.title = L10n.SettingsDetails.Actions.Watch.Available.title
-                $0.value = action.showInWatch
-                $0.disabled = .init(booleanLiteral: !action.canConfigure(\Action.showInWatch))
-            }.onChange { row in
-                if let value = row.value {
-                    self.action.showInWatch = value
-                }
-            }
-        }
-
         if action.canConfigure(\Action.IconName) {
             visuals <<< SearchPushRow<MaterialDesignIcons> {
                 $0.options = MaterialDesignIcons.allCases

--- a/Sources/App/WatchCommunicatorService.swift
+++ b/Sources/App/WatchCommunicatorService.swift
@@ -198,6 +198,7 @@ final class WatchCommunicatorService {
             domain: domain,
             service: serviceName,
             serviceData: serviceData,
+            triggerSource: .Watch,
             shouldLog: true
         ).pipe { result in
             switch result {

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -434,7 +434,8 @@ extension IncomingURLHandler {
                             return api.CallService(
                                 domain: serviceDomain,
                                 service: serviceName,
-                                serviceData: serviceData
+                                serviceData: serviceData,
+                                triggerSource: .URLHandler
                             )
                         } else {
                             throw XCallbackError.generalError
@@ -550,7 +551,12 @@ extension IncomingURLHandler {
 
         firstly { () -> Promise<Void> in
             if let api = Current.apis.first {
-                return api.CallService(domain: domain, service: service, serviceData: serviceData)
+                return api.CallService(
+                    domain: domain,
+                    service: service,
+                    serviceData: serviceData,
+                    triggerSource: .URLHandler
+                )
             } else {
                 throw HomeAssistantAPI.APIError.notConfigured
             }
@@ -598,10 +604,10 @@ extension IncomingURLHandler {
             return
         }
 
-        let source: HomeAssistantAPI.ActionSource = {
+        let source: HomeAssistantAPI.AppTriggerSource = {
             if
                 let sourceString = serviceData["source"],
-                let source = HomeAssistantAPI.ActionSource(rawValue: sourceString) {
+                let source = HomeAssistantAPI.AppTriggerSource(rawValue: sourceString) {
                 return source
             } else {
                 return .URLHandler

--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
@@ -170,7 +170,7 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
             displayItemResultIcon(on: item, success: false)
             return
         }
-        api.executeMagicItem(item: magicItem, currentItemState: currentItemState) { success in
+        api.executeMagicItem(item: magicItem, currentItemState: currentItemState, source: .CarPlay) { success in
             self.displayItemResultIcon(on: item, success: success)
         }
     }

--- a/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
@@ -47,7 +47,7 @@ final class ScriptAppIntent: AppIntent {
             }
             let domain = Domain.script.rawValue
             let service = script.entityId.replacingOccurrences(of: "\(domain).", with: "")
-            api.CallService(domain: domain, service: service, serviceData: [:])
+            api.CallService(domain: domain, service: service, serviceData: [:], triggerSource: .AppIntent)
                 .pipe { [weak self] result in
                     switch result {
                     case .fulfilled:

--- a/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -119,7 +119,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
             return
         }
 
-        api.executeMagicItem(item: magicItem) { success in
+        api.executeMagicItem(item: magicItem, source: .Watch) { success in
             completion(success)
         }
     }

--- a/Sources/Extensions/Widgets/Scene/SceneAppIntent.swift
+++ b/Sources/Extensions/Widgets/Scene/SceneAppIntent.swift
@@ -47,7 +47,8 @@ final class SceneAppIntent: AppIntent {
             api.CallService(
                 domain: Domain.scene.rawValue,
                 service: "turn_on",
-                serviceData: ["entity_id": scene.entityId]
+                serviceData: ["entity_id": scene.entityId],
+                triggerSource: .AppIntent
             )
             .pipe { [weak self] result in
                 switch result {

--- a/Sources/Shared/API/Models/Action.swift
+++ b/Sources/Shared/API/Models/Action.swift
@@ -215,7 +215,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         case .event:
             let data = api.actionEvent(actionID: ID, actionName: Name, source: .Preview)
             let eventDataStrings = data.eventData.map { $0 + ": " + $1 }.sorted()
-            let sourceStrings = HomeAssistantAPI.ActionSource.allCases.map(\.description).sorted()
+            let sourceStrings = HomeAssistantAPI.AppTriggerSource.allCases.map(\.description).sorted()
 
             let indentation = "\n    "
 
@@ -252,7 +252,7 @@ public final class Action: Object, ImmutableMappable, UpdatableModel {
         components.host = "perform_action"
         components.path = "/" + ID
         components.queryItems = [
-            .init(name: "source", value: HomeAssistantAPI.ActionSource.Widget.rawValue),
+            .init(name: "source", value: HomeAssistantAPI.AppTriggerSource.Widget.rawValue),
         ]
         return components.url!
     }

--- a/Sources/Shared/Intents/CallServiceIntentHandler.swift
+++ b/Sources/Shared/Intents/CallServiceIntentHandler.swift
@@ -127,6 +127,7 @@ class CallServiceIntentHandler: NSObject, CallServiceIntentHandling {
                 domain: domain,
                 service: service,
                 serviceData: payloadDict,
+                triggerSource: .AppIntent,
                 shouldLog: true
             ) ?? .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
         }.done { _ in


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To leverage the features from the legacy iOS Actions, this PR adds triggerSource to all service calls in the app so users can automate based on which device (watch/phone/car) triggered that.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
