### PR TITLE
Avoid reload lovelace when opened from OpenPageIntent

### DIFF
--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -248,7 +248,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         if let url = urlString(from: response) {
             Current.Log.info("launching URL \(url)")
             Current.sceneManager.webViewWindowControllerPromise.done {
-                $0.open(from: .notification, server: server, urlString: url)
+                $0.open(from: .notification, server: server, urlString: url, isOpenPageIntent: false)
             }
         }
 

--- a/Sources/App/WebView/IncomingURLHandler.swift
+++ b/Sources/App/WebView/IncomingURLHandler.swift
@@ -67,6 +67,13 @@ class IncomingURLHandler {
                 let queryParameters = components.queryItems
                 let isFromWidget = components.popWidgetAuthenticity()
                 let server = components.popWidgetServer(isFromWidget: isFromWidget)
+                let isOpenPageIntent: Bool = {
+                    if let value = queryParameters?.first(where: { $0.name == "openPageIntent" })?.value {
+                        return Bool(value) ?? false
+                    } else {
+                        return false
+                    }
+                }()
 
                 guard let rawURL = components.url?.absoluteString else {
                     return false
@@ -81,17 +88,25 @@ class IncomingURLHandler {
                             from: .deeplink,
                             urlString: rawURL,
                             skipConfirm: true,
-                            queryParameters: queryParameters
+                            queryParameters: queryParameters,
+                            isOpenPageIntent: false
                         )
                     })
                 } else if let server {
-                    windowController.open(from: .deeplink, server: server, urlString: rawURL, skipConfirm: isFromWidget)
+                    windowController.open(
+                        from: .deeplink,
+                        server: server,
+                        urlString: rawURL,
+                        skipConfirm: isFromWidget,
+                        isOpenPageIntent: isOpenPageIntent
+                    )
                 } else {
                     windowController.openSelectingServer(
                         from: .deeplink,
                         urlString: rawURL,
                         skipConfirm: isFromWidget,
-                        queryParameters: queryParameters
+                        queryParameters: queryParameters,
+                        isOpenPageIntent: isOpenPageIntent
                     )
                 }
             case .assist:
@@ -210,13 +225,15 @@ class IncomingURLHandler {
                             from: .deeplink,
                             server: server,
                             urlString: urlString,
-                            skipConfirm: true
+                            skipConfirm: true,
+                            isOpenPageIntent: false
                         )
                     } else {
                         windowController.openSelectingServer(
                             from: .deeplink,
                             urlString: urlString,
-                            skipConfirm: true
+                            skipConfirm: true,
+                            isOpenPageIntent: false
                         )
                     }
                     return true

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -828,6 +828,19 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         }
     }
 
+    /// Used for OpenPage intent
+    public func openPanel(_ url: URL) {
+        loadViewIfNeeded()
+        if #available(iOS 16.0, *),
+           let webViewURL = webView.url,
+           webViewURL.path().contains(url.path()) {
+            Current.Log.info("Open page did not reload webview because path component matches current URL")
+            return
+        } else {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
     public func showSettingsViewController() {
         getLatestConfig()
         if Current.sceneManager.supportsMultipleScenes, Current.isCatalyst {

--- a/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
+++ b/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
@@ -24,10 +24,9 @@ struct OpenPageAppIntent: AppIntent {
               .servers.all.first else { return .result() }
         #if !WIDGET_EXTENSION
         if let url =
-            AppConstants.navigateDeeplinkURL(
+            AppConstants.openPageDeeplinkURL(
                 path: page.panel.path,
-                serverId: server.identifier.rawValue,
-                avoidUnecessaryReload: true
+                serverId: server.identifier.rawValue
             ) {
             DispatchQueue.main.async {
                 UIApplication.shared.open(url)

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -79,6 +79,17 @@ public enum AppConstants {
         )
     }
 
+    public static func openPageDeeplinkURL(path: String, serverId: String) -> URL? {
+        if #available(iOS 16.0, watchOS 9.0, *) {
+            AppConstants.navigateDeeplinkURL(path: path, serverId: serverId, avoidUnecessaryReload: true)?
+                .appending(queryItems: [
+                    .init(name: "openPageIntent", value: "true"),
+                ])
+        } else {
+            AppConstants.navigateDeeplinkURL(path: path, serverId: serverId, avoidUnecessaryReload: true)
+        }
+    }
+
     public static func assistDeeplinkURL(serverId: String, pipelineId: String, startListening: Bool) -> URL? {
         URL(
             string: "\(AppConstants.deeplinkURL.absoluteString)assist?serverId=\(serverId)&pipelineId=\(pipelineId)&startListening=\(startListening)"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A bit hacky but this PR avoids reloading lovelace when opened from OpenPageIntent (shortcuts, widgets, control center) and there is a lovelace open already, ignoring the tab.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
