### PR TITLE
Redesign error notification when retry over "disconnect" screen

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -691,11 +691,12 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         Current.Log.error(error)
         var config = swiftMessagesConfig()
         config.duration = duration
+        config.dimMode = .none
 
-        let view = MessageView.viewFromNib(layout: .messageView)
+        let view = MessageView.viewFromNib(layout: .cardView)
         view.configureContent(
             title: L10n.Connection.Error.genericTitle,
-            body: error.localizedDescription,
+            body: nil,
             iconImage: nil,
             iconText: nil,
             buttonImage: MaterialDesignIcons.helpCircleIcon.image(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR removed the error description from the bottom toast/notification since sometimes the error provided by iOS is misleading in the scenario that the user is facing at the moment. User can still look into more info tapping the question mark icon.

This PR also changed the design of this dialog and does not add an overlay on the "disconnected screen".
 
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Before/After
![CleanShot 2025-06-30 at 10 52 32@2x](https://github.com/user-attachments/assets/91b881a9-a90e-40dc-8af0-456e20eee3d5)



## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
