### PR TITLE
Ask to navigate through frontend while fallback to loading through webview

### DIFF
--- a/Sources/App/WebView/Extensions/WebViewControllerProtocol+Implementation.swift
+++ b/Sources/App/WebView/Extensions/WebViewControllerProtocol+Implementation.swift
@@ -37,10 +37,11 @@ extension WebViewController: WebViewControllerProtocol {
         overlayedController?.dismissAllViewControllersAbove()
     }
 
-    func updateSettingsButton(state: String) {
-        // Possible values: connected, disconnected, auth-invalid
+    func updateFrontendConnectionState(state: String) {
         emptyStateTimer?.invalidate()
         emptyStateTimer = nil
+
+        // Possible values: connected, disconnected, auth-invalid
         if state == "connected" {
             hideEmptyState()
         } else {

--- a/Sources/App/WebView/WebViewControllerProtocol.swift
+++ b/Sources/App/WebView/WebViewControllerProtocol.swift
@@ -10,7 +10,7 @@ protocol WebViewControllerProtocol: AnyObject {
     func evaluateJavaScript(_ script: String, completion: ((Any?, (any Error)?) -> Void)?)
     func dismissOverlayController(animated: Bool, completion: (() -> Void)?)
     func dismissControllerAboveOverlayController()
-    func updateSettingsButton(state: String)
+    func updateFrontendConnectionState(state: String)
     func navigateToPath(path: String)
     func reload()
 }

--- a/Sources/App/WebView/WebViewWindowController.swift
+++ b/Sources/App/WebView/WebViewWindowController.swift
@@ -148,13 +148,17 @@ final class WebViewWindowController {
     }
 
     func navigate(to url: URL, on server: Server, avoidUnecessaryReload: Bool = false, isComingFromAppIntent: Bool) {
-        open(server: server).done { webViewController in
-            // Dismiss any overlayed controllers
-            webViewController.dismissOverlayController(animated: true, completion: nil)
-            if isComingFromAppIntent {
-                webViewController.openPanel(url)
-            } else {
-                webViewController.open(inline: url, avoidUnecessaryReload: avoidUnecessaryReload)
+        open(server: server).pipe { result in
+            switch result {
+            case let .fulfilled(webViewController):
+                webViewController.dismissOverlayController(animated: true, completion: nil)
+                if isComingFromAppIntent {
+                    webViewController.openPanel(url)
+                } else {
+                    webViewController.open(inline: url, avoidUnecessaryReload: avoidUnecessaryReload)
+                }
+            case .rejected:
+                Current.Log.error("Failed to open WebViewController for server \(server.identifier)")
             }
         }
     }

--- a/Tests/App/WebView/Mocks/MockWebViewController.swift
+++ b/Tests/App/WebView/Mocks/MockWebViewController.swift
@@ -52,7 +52,7 @@ final class MockWebViewController: WebViewControllerProtocol {
         dismissControllerAboveOverlayControllerCalled = true
     }
 
-    func updateSettingsButton(state: String) {
+    func updateFrontendConnectionState(state: String) {
         updateSettingsButtonCalled = true
         lastSettingButtonState = state
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This fixes issue where navigating to a specific page (via widget when the app is coming form a cold state) was not loading the proper page.

This PR also centers some webView call to specific functions to better track navigation.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
