### PR TITLE
Hide empty state when going to background and show again if needed after returning to the app

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -122,6 +122,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     }
 
     deinit {
+        removeEmptyStateObservations()
         self.urlObserver = nil
         self.tokens.forEach { $0.cancel() }
     }
@@ -317,6 +318,11 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
+    }
+
+    private func removeEmptyStateObservations() {
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
 
     func showEmptyState() {

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -331,7 +331,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         }, completion: nil)
     }
 
-    // To avoid keeping the empty state on screen when user is disconencted in background
+    // To avoid keeping the empty state on screen when user is disconnected in background
     // due to innectivity, we reset the empty state timer
     @objc func resetEmptyStateTimerWithLatestConnectedState() {
         let state: FrontEndConnectionState = isConnected ? .connected : .disconnected

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -322,7 +322,11 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
     private func removeEmptyStateObservations() {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
     func showEmptyState() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR hides the empty state when the App is sent to background and displays it again after the App returns to foreground with 4 seconds of not being connected.
This avoids users seeing the empty state when coming back from background and disconnected due to inactivity.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
