### PR TITLE
Fixup misleading nomenclature: s/frontend cache/client cache/g

### DIFF
--- a/Sources/App/Resources/bg.lproj/Localizable.strings
+++ b/Sources/App/Resources/bg.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant е безплатен и с отворен код софтуер 
 "settings.reset_section.reset_alert.title" = "Нулиране";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Нулиране";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Сървър";
 "settings.server_select.title" = "Сървър";
 "settings.status_section.header" = "Състояние";

--- a/Sources/App/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/cy-GB.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.reset_section.reset_alert.title" = "Ailosod";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Ailosod";
-"settings.reset_section.reset_web_cache.title" = "Ailosod frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Ailosod client cache";
 "settings.server_select.page_title" = "Server";
 "settings.server_select.title" = "Server";
 "settings.status_section.header" = "Statws";

--- a/Sources/App/Resources/en-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/en-GB.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Reset";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Server";
 "settings.server_select.title" = "Server";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Reset";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Server";
 "settings.server_select.title" = "Server";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/es-ES.lproj/Localizable.strings
+++ b/Sources/App/Resources/es-ES.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Reset";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Servidor";
 "settings.server_select.title" = "Servidor";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/App/Resources/es-MX.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Reset";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Server";
 "settings.server_select.title" = "Server";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/he.lproj/Localizable.strings
+++ b/Sources/App/Resources/he.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant היא תוכנת אוטומציה ביתית חינמית ובק
 "settings.reset_section.reset_alert.title" = "איפוס";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "איפוס";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "שרת";
 "settings.server_select.title" = "שרת";
 "settings.status_section.header" = "מצב";

--- a/Sources/App/Resources/ml.lproj/Localizable.strings
+++ b/Sources/App/Resources/ml.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "settings.reset_section.reset_alert.title" = "Reset";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Reset";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "സെർവർ";
 "settings.server_select.title" = "സെർവർ";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/nl.lproj/Localizable.strings
+++ b/Sources/App/Resources/nl.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant is gratis en open source domotica-software met een focus op lokal
 "settings.reset_section.reset_alert.title" = "Herstel";
 "settings.reset_section.reset_app.title" = "App resetten (servers en gegevens verwijderen)";
 "settings.reset_section.reset_row.title" = "Herstel";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Server";
 "settings.server_select.title" = "Server";
 "settings.status_section.header" = "Status";

--- a/Sources/App/Resources/vi.lproj/Localizable.strings
+++ b/Sources/App/Resources/vi.lproj/Localizable.strings
@@ -663,7 +663,7 @@ Home Assistant là phần mềm tự động hóa gia đình mã nguồn mở v�
 "settings.reset_section.reset_alert.title" = "Đặt lại";
 "settings.reset_section.reset_app.title" = "Reset App (Remove servers and data)";
 "settings.reset_section.reset_row.title" = "Đặt lại";
-"settings.reset_section.reset_web_cache.title" = "Reset frontend cache";
+"settings.reset_section.reset_web_cache.title" = "Reset client cache";
 "settings.server_select.page_title" = "Máy chủ";
 "settings.server_select.title" = "Máy chủ";
 "settings.status_section.header" = "Trạng thái";

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -973,11 +973,11 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     }
 
     private func resetFrontendCacheIfNeeded(completion: (() -> Void)? = nil) {
-        // Reset the frontend cache if needed, e.g. after a server version change
+        // Reset the client cache if needed, e.g. after a server version change
         if Current.settingsStore.serverNeedsFrontendReset[server.identifier.rawValue] ?? false {
-            Current.Log.info("Resetting frontend cache for server \(server.info.name)")
+            Current.Log.info("Resetting client cache for server \(server.info.name)")
             Current.websiteDataStoreHandler.cleanCache { [weak self] in
-                Current.Log.info("Frontend cache reset completed")
+                Current.Log.info("Client cache reset completed")
                 guard let self else { return }
                 Current.settingsStore.serverNeedsFrontendReset[server.identifier.rawValue] = nil
                 completion?()

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -332,7 +332,7 @@ public class HomeAssistantAPI {
 
                 if let version = try? Version(hassVersion: config.Version) {
                     if serverInfo.version != version {
-                        // Reset frontend cache since server version changed
+                        // Reset client cache since server version changed
                         Current.settingsStore.serverNeedsFrontendReset[server.identifier.rawValue] = true
                     }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2395,7 +2395,7 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "settings.reset_section.reset_row.title") }
       }
       public enum ResetWebCache {
-        /// Reset frontend cache
+        /// Reset client cache
         public static var title: String { return L10n.tr("Localizable", "settings.reset_section.reset_web_cache.title") }
       }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This commit replaces every instance of a misleading reference to a "frontend cache" where there is no such thing with a correct, however generalized, reference to the "client cache."

In objective fact, a "frontend cache" is a term reserved for server-side caching reverse proxies centralized on and attributable to a frontend itself. No such resource exists in any Home Assistant deployment. This incorrect use of terms is confusing and misleading, and therefore is herein replaced. I will confess to having been thusly misled despite (and perhaps _because of_) being employed in the relevant technology industries for going on two decades.

The only relevant cache is attributable to the client, whether it is a browser or whether it is a dedicated platform client. This change categorically prevents the mistaken apprehension that any server-side cache attributable to the frontend requires resetting, and at the very least, is *less incorrect.* If the word "client" is objectionable, valid alternatives e.g. "browser" and "user," or simply eschewing the misleading qualifier entirely (not recommended), remain available.

This change makes absolutely no attempt to alter localised strings where the word "frontend" has already been translated. Wheresoever these strings exist, it remains the responsibility of the repository maintainer to find and reconcile them. You may choose whatever replacements you like; but these must not be misleading to the point of falsely indicating the presence of an application component.

There remain functions whose names reference a FrontendCache; while these names remain properly incorrect, this PR also makes absolutely no attempt to rename them, since they (a) do not affect the user and (b) I am not interested in refactoring anyone's actual code and maintaining referential integrity, which would likely require further updates to unit tests, and so on. Honestly, the only such functions I have identified are `resetFrontendCacheIfNeeded()` and `serverNeedsFrontendReset()` (which is even worse; you aren't resetting the frontend here at all!) in WebViewController.swift, but I am not going to touch them. If consistency requires correction of even this mistake, edits and expansions to this pull request will be gratefully accepted. I strongly suggest, however, you take the user-facing linguistic win as an atomic operation.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
It is a misuse of a single word. Screenshots of every appearance will not be provided.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#
No string matching the case-insensitive expression "frontend cache" appears in the documentation (indeed, this is the reason for the other corrections); therefore, no correction is required here.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
cf. https://community.home-assistant.io/t/how-to-clear-the-frontend-cache/670491/91

This pull request is part of a set against the following repositories (crosslinks may be updated after the PR is opened):
  - [home-assistant/android](https://github.com/home-assistant/android/pull/5711)
  - [home-assistant/iOS](https://github.com/home-assistant/iOS/pull/3784) (you are here)
  - [hacs/integration](https://github.com/hacs/integration/pull/4788)