### PR TITLE
Fix frontend settings reset by preserving WebView cache across scene lifecycle

### DIFF
--- a/Sources/App/Scenes/WebViewSceneDelegate.swift
+++ b/Sources/App/Scenes/WebViewSceneDelegate.swift
@@ -96,7 +96,7 @@ final class WebViewSceneDelegate: NSObject, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        windowController?.clearCachedControllers()
+        // NOTE: Do not call clearCachedControllers() here - causes frontend settings loss
         windowController = nil
         window = nil
         urlHandler = nil


### PR DESCRIPTION
## Summary

Closes #3862

Fixes the long-standing issue where user frontend settings (dashboard selection, theme, sidebar configuration, timezone) periodically reset as if the app were freshly installed. This has been reported for years across iPhone, iPad, and Mac apps.

**Root Cause:** The app was aggressively clearing WebView cache on every scene disconnect via `clearCachedControllers()` in `sceneDidDisconnect`. Scene disconnects happen frequently during normal app lifecycle (backgrounding, multitasking, memory pressure), causing WebView recreation and loss of frontend settings stored in WebKit localStorage/IndexedDB.

**Fix:** Remove the unnecessary `clearCachedControllers()` call from scene disconnect while preserving appropriate cleanup during logout/error states via the existing onboarding observer.

**Context:** I'm a software engineer (Rust/Go/Ruby) but not an iOS developer. I used Claude to investigate the codebase and identify this root cause after experiencing the bug myself on multiple devices running internal-URL-only configurations.

## Screenshots
N/A - Internal bug fix with no UI changes

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#N/A

## Any other notes

This is a focused, surgical fix that:

- Preserves WebView state during normal app lifecycle  
- Maintains proper cleanup on logout/error (unchanged)
- Adds protective comment to prevent regression
- Addresses community reports spanning multiple years and device types

The fix is conservative and low-risk - it only removes an overly aggressive cache clearing operation while leaving all legitimate cleanup paths intact.