### PR TITLE
Hack copy-paste logic on mac catalyst

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -79,6 +79,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         underlyingPreferredStatusBarStyle
     }
 
+    #if targetEnvironment(macCatalyst)
     override var keyCommands: [UIKeyCommand]? {
         [
             UIKeyCommand(
@@ -93,6 +94,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             ),
         ]
     }
+    #endif
 
     init(server: Server, shouldLoadImmediately: Bool = false) {
         self.server = server


### PR DESCRIPTION
Copy/Paste WKWebView on Mac Catalyst apps is known to be buggy and unreliable, while Apple does not fix this, this PR adds a hack alternative which links shift + command + c/v to custom copy paste methods, same used by the new mac top bar copy/paste icons

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
