### PR TITLE
Fix location error recovery for OneShotError wrapper

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -915,7 +915,7 @@ public class HomeAssistantAPI {
                             api.SubmitLocation(updateType: .Manual, location: location, zone: nil)
                         }).asVoid()
                     }.recover { error -> Promise<Void> in
-                        if error is CLError {
+                        if error is CLError || error is OneShotError {
                             Current.Log.info("couldn't get location, sending remaining sensor data")
                             return updateWithoutLocation()
                         } else {


### PR DESCRIPTION
## Summary
Fixes #3691 - kCLErrorDomain errors on macOS with WiFi disabled.

Claude found the problem, but I did build and test to verify.

Root Cause:
- oneShotLocation() wraps CLError in OneShotError enum before throwing
- Error recovery in manuallyUpdate() only checked for raw CLError type
- This type mismatch prevented error recovery from triggering
- Errors propagated to UI instead of being handled gracefully

The Fix:
- Updated error recovery to also handle OneShotError type
- Now location failures are properly caught and sensor updates continue without location data
- No more error dialogs when WiFi is disabled on macOS
