### PR TITLE
Fix SelectionOptionView alignment when option text is short

### DIFF
--- a/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/SelectionOptionView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/SelectionOptionView.swift
@@ -89,13 +89,12 @@ private struct SelectionOptionRow: View {
 
     var body: some View {
         Button(action: onTap) {
-            HStack(alignment: .top, spacing: DesignSystem.Spaces.two) {
+            HStack(alignment: .center, spacing: DesignSystem.Spaces.two) {
                 // Radio button or checkbox
                 SelectionIndicator(
                     isSelected: isSelected,
                     isMultipleSelection: allowsMultipleSelection
                 )
-                .padding(.top, DesignSystem.Spaces.half)
 
                 VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
                     Text(option.title)
@@ -170,6 +169,18 @@ private struct SelectionIndicator: View {
         SelectionOption(
             value: "less_secure",
             title: "Less secure: Do not allow this app to know when you're home",
+            subtitle: nil,
+            isRecommended: false
+        ),
+        SelectionOption(
+            value: "long",
+            title: "Less secure: Do not allow this app to know when you're home Less secure: Do not allow this app to know when you're home Less secure: Do not allow this app to know when you're home",
+            subtitle: nil,
+            isRecommended: false
+        ),
+        SelectionOption(
+            value: "short",
+            title: "Less secure",
             subtitle: nil,
             isRecommended: false
         ),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="748" height="650" alt="CleanShot 2025-11-17 at 16 46 13@2x" src="https://github.com/user-attachments/assets/ad8dcd50-0add-400f-ab30-7b2fd84d3c94" />

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
