### PR TITLE
Improve error handling in WebView navigation failure

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -1190,10 +1190,10 @@ extension WebViewController {
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         refreshControl.endRefreshing()
-        
+
         let nsError = error as NSError
         let shouldShowError: Bool
-        
+
         // Handle URLError
         if let urlError = error as? URLError {
             shouldShowError = urlError.code != .cancelled
@@ -1203,17 +1203,15 @@ extension WebViewController {
         }
         // Handle WebKitErrorDomain errors (e.g., Code 101 - invalid URL)
         else if nsError.domain == "WebKitErrorDomain" {
-            shouldShowError = true
+            shouldShowError = !nsError.isCancelled
             Current.Log.error("WebKit error during content load: \(error)")
-        }
-        // Handle other errors
-        else {
+        } else {
             shouldShowError = !error.isCancelled
             if shouldShowError {
                 Current.Log.error("Failure during content load: \(error)")
             }
         }
-        
+
         if shouldShowError {
             showEmptyState()
             showSwiftMessage(error: error)


### PR DESCRIPTION
Refactors the didFailProvisionalNavigation delegate method to better distinguish between URLError, WebKitErrorDomain, and other errors. Ensures appropriate logging and user feedback for different error types, and avoids showing error messages for cancelled requests.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
