### PR TITLE
Add back the button to create complication

### DIFF
--- a/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
+++ b/Sources/App/Settings/AppleWatch/ComplicationListViewController.swift
@@ -35,10 +35,6 @@ class ComplicationListViewController: HAFormViewController {
 
         title = L10n.SettingsDetails.Watch.title
 
-        navigationItem.rightBarButtonItems = [
-            UIBarButtonItem(title: L10n.addButtonLabel, style: .plain, target: self, action: #selector(add(_:))),
-        ]
-
         form +++ InfoLabelRow {
             $0.title = L10n.Watch.Configurator.List.description
             $0.displayType = .primary
@@ -153,6 +149,20 @@ class ComplicationListViewController: HAFormViewController {
                     }
                 }
             )
+        }
+
+        form +++ ButtonRow {
+            $0.title = L10n.addButtonLabel
+            $0.onCellSelection { [weak self] _, _ in
+                guard let self else { return }
+                let editListViewController = ComplicationFamilySelectViewController(
+                    allowMultiple: supportsMultipleComplications,
+                    currentFamilies: Set(Current.realm().objects(WatchComplication.self).map(\.Family))
+                )
+                editListViewController.onDismissCallback = { $0.dismiss(animated: true, completion: nil) }
+                let navigationController = UINavigationController(rootViewController: editListViewController)
+                present(navigationController, animated: true, completion: nil)
+            }
         }
     }
 }


### PR DESCRIPTION
The button was removed by mistake when migrating screens around it to SwiftUI

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
