### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/home-assistant/iOS/security/code-scanning/19](https://github.com/home-assistant/iOS/security/code-scanning/19)

To address the issue, add an explicit `permissions` block at the top (root) level of the workflow (`.github/workflows/ci.yml`) to restrict the default permissions for all jobs. The ideal minimal permissions are:
- For read-only jobs (`lint`, `test`, `size`), set `contents: read`.
- For jobs needing to post or update pull request comments (`check-swiftlint-disables`), set `pull-requests: write` (or in a more granular setup, add it per-job).
To keep the change simple and clear, add the following at the root of the workflow, just after the `name` line and before `env`, to ensure all jobs have the minimum permissions:

```yaml
permissions:
  contents: read
  pull-requests: write
```

If granular and stricter permissions are needed, add `permissions: contents: read` at the top, and add a `permissions: pull-requests: write` block only inside the `check-swiftlint-disables` job definition.

This solution does not change workflow functionality, but ensures jobs run with only the necessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
