### PR TITLE
Update iOS version checks from 16.0 to 26.0 in SettingsView

### DIFF
--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -85,14 +85,14 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var iOSView: some View {
-        if #available(iOS 16.0, *) {
+        if #available(iOS 26.0, *) {
             iOSViewModern
         } else {
             iOSViewLegacy
         }
     }
 
-    @available(iOS 16.0, *)
+    @available(iOS 26.0, *)
     private var iOSViewModern: some View {
         NavigationStack {
             iOSListContent
@@ -105,6 +105,7 @@ struct SettingsView: View {
     private var iOSViewLegacy: some View {
         NavigationView {
             iOSListContent
+                .navigationViewStyle(.stack)
         }
     }
 
@@ -122,7 +123,7 @@ struct SettingsView: View {
             // General section
             Section {
                 ForEach(SettingsItem.generalItems, id: \.self) { item in
-                    if #available(iOS 16.0, *) {
+                    if #available(iOS 26.0, *) {
                         NavigationLink(value: item) {
                             settingsItemLabel(item)
                         }
@@ -137,7 +138,7 @@ struct SettingsView: View {
             // Integrations section
             Section {
                 ForEach(SettingsItem.integrationItems, id: \.self) { item in
-                    if #available(iOS 16.0, *) {
+                    if #available(iOS 26.0, *) {
                         NavigationLink(value: item) {
                             settingsItemLabel(item)
                         }
@@ -153,7 +154,7 @@ struct SettingsView: View {
             if shouldShowWatchSection {
                 Section(header: Text("Apple Watch")) {
                     ForEach(SettingsItem.watchItems, id: \.self) { item in
-                        if #available(iOS 16.0, *) {
+                        if #available(iOS 26.0, *) {
                             NavigationLink(value: item) {
                                 settingsItemLabel(item)
                             }
@@ -170,7 +171,7 @@ struct SettingsView: View {
             if UIDevice.current.userInterfaceIdiom == .phone {
                 Section {
                     ForEach(SettingsItem.carPlayItems, id: \.self) { item in
-                        if #available(iOS 16.0, *) {
+                        if #available(iOS 26.0, *) {
                             NavigationLink(value: item) {
                                 settingsItemLabel(item)
                             }
@@ -186,7 +187,7 @@ struct SettingsView: View {
             // Legacy section
             Section {
                 ForEach(SettingsItem.legacyItems, id: \.self) { item in
-                    if #available(iOS 16.0, *) {
+                    if #available(iOS 26.0, *) {
                         NavigationLink(value: item) {
                             settingsItemLabel(item)
                         }
@@ -214,7 +215,7 @@ struct SettingsView: View {
                             }
                         }
                     } else {
-                        if #available(iOS 16.0, *) {
+                        if #available(iOS 26.0, *) {
                             NavigationLink(value: item) {
                                 settingsItemLabel(item)
                             }
@@ -272,7 +273,7 @@ struct SettingsView: View {
             }
         }
         .sheet(isPresented: $showAbout) {
-            if #available(iOS 16.0, *) {
+            if #available(iOS 26.0, *) {
                 NavigationStack {
                     aboutViewContent
                 }


### PR DESCRIPTION
All @available and #available checks for iOS 16.0 have been updated to iOS 26.0 in SettingsView.swift. This change ensures that modern navigation and UI features are only used on iOS 26.0 and above.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
