### PR TITLE
Load about:blank when no active URL in WebView

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -712,6 +712,10 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     }
 
     private func showNoActiveURLError() {
+        // Load about:blank in webview to prevent any current connections
+        load(request: URLRequest(url: URL(string: "about:blank")!))
+        Current.Log.info("Loading about:blank in webview due to no activeURL")
+
         // Alert the user that there's no URL that the App can use
         let controller = ConnectionSecurityLevelBlockView(server: server).embeddedInHostingController()
         controller.modalPresentationStyle = .fullScreen
@@ -724,7 +728,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             WebViewControllerOverlayedViewTags.settingsView.rawValue,
             WebViewControllerOverlayedViewTags.onboardingPermissions.rawValue,
         ].contains(presentedViewController?.view.tag ?? -1) else {
-            Current.Log.info("No active URL scree was not presented because of high priority view already visible")
+            Current.Log.info("'No active URL' screen was not presented because of high priority view already visible")
             return
         }
 


### PR DESCRIPTION
When there is no active URL, the webview now loads about:blank to prevent any current connections. Also fixed a log message typo for clarity.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
