### PR TITLE
Exclude Mac Catalyst from MatterSupport import check

### DIFF
--- a/Sources/Shared/Environment/MatterWrapper.swift
+++ b/Sources/Shared/Environment/MatterWrapper.swift
@@ -5,7 +5,7 @@ import PromiseKit
 
 public class MatterWrapper {
     public var isAvailable: Bool = {
-        #if canImport(MatterSupport)
+        #if canImport(MatterSupport) && !targetEnvironment(macCatalyst)
         if #available(iOS 16.1, *) {
             return true
         } else {


### PR DESCRIPTION
Updated the isAvailable property to exclude macCatalyst from the MatterSupport import check, ensuring Matter features are only enabled on supported platforms.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
