### PR TITLE
Add active and problem state groups for entity icons

### DIFF
--- a/Sources/App/WebView/ExperimentalSpace/EntityTile/EntityIconColorProvider.swift
+++ b/Sources/App/WebView/ExperimentalSpace/EntityTile/EntityIconColorProvider.swift
@@ -10,8 +10,12 @@ enum EntityIconColorProvider {
         rgbColor: [Int]?,
         hsColor: [Double]?
     ) -> Color {
-        guard state == Domain.State.on.rawValue else {
-            return .secondary
+        guard Domain.activeStates.map(\.rawValue).contains(state) else {
+            if Domain.problemStates.map(\.rawValue).contains(state) {
+                return .red
+            } else {
+                return .secondary
+            }
         }
 
         // Check color_mode first if available to prioritize the correct attribute

--- a/Sources/App/WebView/ExperimentalSpace/EntityTile/MoreInfoDialog/EntityMoreInfoDialogView.swift
+++ b/Sources/App/WebView/ExperimentalSpace/EntityTile/MoreInfoDialog/EntityMoreInfoDialogView.swift
@@ -53,7 +53,7 @@ struct EntityMoreInfoDialogView: View {
                 await loadAreaName()
             }
         }
-        .presentationBackground(Color(uiColor: .systemBackground).opacity(0.9))
+        .presentationBackground(Color.clear)
     }
 
     // MARK: - Area Lookup

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -45,6 +45,24 @@ public enum Domain: String, CaseIterable {
         case unavailable
     }
 
+    /// States that represent an "active" condition
+    /// such as for displaying accent color for entity tile icon
+    public static var activeStates: [State] = [
+        .on,
+        .open,
+        .unlocked,
+        .unlocking,
+        .locking,
+        .opening,
+        .closing,
+    ]
+
+    /// States that represent a "problem" condition
+    public static var problemStates: [State] = [
+        .jammed,
+        .unavailable,
+    ]
+
     public var states: [State] {
         var states: [State] = []
         switch self {


### PR DESCRIPTION
Introduces Domain.activeStates and Domain.problemStates to group entity states for icon color logic. Updates EntityIconColorProvider to use these groups, showing red for problem states and secondary color for inactive states. Also changes the MoreInfoDialogView background to be fully transparent.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
