### PR TITLE
Refactor deletions to use deleteAll with keys parameter

### DIFF
--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -291,12 +291,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
                 if !idsToDelete.isEmpty {
                     try AppEntityRegistryListForDisplay
-                        .filter(Column(DatabaseTables.AppEntityRegistryListForDisplay.serverId.rawValue) == serverId)
-                        .filter(
-                            idsToDelete
-                                .contains(Column(DatabaseTables.AppEntityRegistryListForDisplay.id.rawValue))
-                        )
-                        .deleteAll(db)
+                        .deleteAll(db, keys: idsToDelete)
                 }
             }
         } catch {
@@ -339,8 +334,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
                 if !idsToDelete.isEmpty {
                     try AppEntityRegistry
-                        .filter(idsToDelete.contains(Column(DatabaseTables.EntityRegistry.id.rawValue)))
-                        .deleteAll(db)
+                        .deleteAll(db, keys: idsToDelete)
                 }
             }
             Current.Log
@@ -386,8 +380,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
                 if !idsToDelete.isEmpty {
                     try AppDeviceRegistry
-                        .filter(idsToDelete.contains(Column(DatabaseTables.DeviceRegistry.id.rawValue)))
-                        .deleteAll(db)
+                        .deleteAll(db, keys: idsToDelete)
                 }
             }
             Current.Log


### PR DESCRIPTION
Updated database deletion logic to use the deleteAll(db, keys:) method instead of filtering with contains and then calling deleteAll. This simplifies the code and leverages the keys-based deletion API.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
