### PR TITLE
Removing cameras list entry from control center

### DIFF
--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -64,7 +64,6 @@ struct WidgetsBundle18: WidgetBundle {
         ControlButton()
         ControlOpenPage()
         ControlOpenEntity()
-        ControlOpenCamerasList()
         ControlOpenCamera()
         ControlOpenCoverEntity()
         ControlOpenInputBoolean()
@@ -73,6 +72,7 @@ struct WidgetsBundle18: WidgetBundle {
         ControlOpenSensor()
         ControlOpenSwitch()
         #if DEBUG
+        ControlOpenCamerasList()
         ControlOpenExperimentalDashboard()
         #endif
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Since it conflicts with Home Assistant frontend interests in managing "dashboard-like" UI, I'm removing the access to cameras list for now until we have a final decision over it.

Contributors can still access it while debugging in Xcode.

CC: @frenck 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
