### PR TITLE
Add updateDatabaseAndPanels call on viewDidAppear

### DIFF
--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -271,6 +271,11 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         loadActiveURLIfNeeded()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateDatabaseAndPanels()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         userActivity?.resignCurrent()
     }
@@ -740,7 +745,11 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         DispatchQueue.main.async { [self] in
             loadActiveURLIfNeeded()
         }
+    }
 
+    /// Updates the app database and panels for the current server
+    /// Called after view appears and on pull to refresh to avoid blocking app launch
+    private func updateDatabaseAndPanels() {
         Task {
             await Current.appDatabaseUpdater.update(server: server)
             Current.panelsUpdater.update()
@@ -1545,5 +1554,6 @@ extension WebViewController: WebViewControllerProtocol {
                 showNoActiveURLError()
             }
         }
+        updateDatabaseAndPanels()
     }
 }


### PR DESCRIPTION
Introduces updateDatabaseAndPanels, which updates the app database and panels for the current server. This method is now called in viewDidAppear and after certain actions to ensure data is refreshed without blocking app launch.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
