### PR TITLE
Limit toast expanded width to 400 points

### DIFF
--- a/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
+++ b/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
@@ -96,7 +96,8 @@ public struct ToastView: View {
             let topOffset: CGFloat = 11 + max(safeArea.top - 59, 0)
 
             /// Expanded Properties
-            let expandedWidth = size.width - 20
+            let maxToastWidth: CGFloat = 400
+            let expandedWidth = min(size.width - 20, maxToastWidth)
             let expandedHeight: CGFloat = haveDynamicIsland ? 90 : 70
             let scaleX: CGFloat = isExpanded ? 1 : (dynamicIslandWidth / expandedWidth)
             let scaleY: CGFloat = isExpanded ? 1 : (dynamicIslandHeight / expandedHeight)


### PR DESCRIPTION
Introduces a maxToastWidth constant to cap the expanded width of the toast view at 400 points, ensuring it does not exceed this value regardless of screen size.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
