### PR TITLE
Save panels to database on background thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ Brewfile.lock.json
 vendor/bundle
 .env.development
 .bundle/
+.claude/settings.local.json

--- a/Sources/Shared/Panels/PanelsUpdater.swift
+++ b/Sources/Shared/Panels/PanelsUpdater.swift
@@ -62,16 +62,18 @@ final class PanelsUpdater: PanelsUpdaterProtocol {
             )
         }
 
-        do {
-            try Current.database().write { db in
-                try AppPanel.filter(Column(DatabaseTables.AppPanel.serverId.rawValue) == server.identifier.rawValue)
-                    .deleteAll(db)
-                for panel in appPanels {
-                    try panel.save(db)
+        DispatchQueue.global(qos: .utility).async {
+            do {
+                try Current.database().write { db in
+                    try AppPanel.filter(Column(DatabaseTables.AppPanel.serverId.rawValue) == server.identifier.rawValue)
+                        .deleteAll(db)
+                    for panel in appPanels {
+                        try panel.save(db)
+                    }
                 }
+            } catch {
+                Current.Log.error("Error saving panels in database: \(error)")
             }
-        } catch {
-            Current.Log.error("Error saving panels in database: \(error)")
         }
     }
 }


### PR DESCRIPTION
Moved the database write operation for saving panels to a background thread using DispatchQueue.global(qos: .utility). This prevents blocking the main thread during potentially long-running database operations.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
