### PR TITLE
Replace ctrlKey with metaKey in keyboard event

### DIFF
--- a/Sources/App/WebView/WebViewJavascriptCommands.swift
+++ b/Sources/App/WebView/WebViewJavascriptCommands.swift
@@ -19,7 +19,7 @@ enum WebViewJavascriptCommands {
         code: 'KeyK',
         keyCode: 75,
         which: 75,
-        ctrlKey: true,
+        metaKey: true,
         bubbles: true,
         cancelable: true
     });

--- a/Tests/App/WebView/WebViewJavascriptCommandsTests.swift
+++ b/Tests/App/WebView/WebViewJavascriptCommandsTests.swift
@@ -30,7 +30,7 @@ struct WebViewJavascriptCommandsTests {
             code: 'KeyK',
             keyCode: 75,
             which: 75,
-            ctrlKey: true,
+            metaKey: true,
             bubbles: true,
             cancelable: true
         });


### PR DESCRIPTION
Updated the JavaScript keyboard event to use metaKey instead of ctrlKey for the 'KeyK' shortcut. Adjusted corresponding test to match this change.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
