### PR TITLE
Remove legacy CarPlay config conversion logic

### DIFF
--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationViewModel.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationViewModel.swift
@@ -47,7 +47,6 @@ final class CarPlayConfigurationViewModel: ObservableObject {
                 Current.Log.info("CarPlay configuration exists")
             } else {
                 Current.Log.error("No CarPlay config found")
-                convertLegacyActionsToCarPlayConfig()
             }
         } catch {
             Current.Log.error("Failed to access database (GRDB), error: \(error.localizedDescription)")
@@ -58,22 +57,6 @@ final class CarPlayConfigurationViewModel: ObservableObject {
     @MainActor
     private func setConfig(_ config: CarPlayConfig) {
         self.config = config
-    }
-
-    @MainActor
-    private func convertLegacyActionsToCarPlayConfig() {
-        var newConfig = CarPlayConfig()
-        let actions = Current.realm().objects(Action.self).sorted(by: { $0.Position < $1.Position })
-            .filter(\.showInCarPlay)
-
-        guard !actions.isEmpty else { return }
-
-        let newActionItems = actions.map { action in
-            MagicItem(id: action.ID, serverId: action.serverIdentifier, type: .action)
-        }
-        newConfig.quickAccessItems = newActionItems
-        setConfig(newConfig)
-        save()
     }
 
     @discardableResult


### PR DESCRIPTION
Eliminated the convertLegacyActionsToCarPlayConfig method and its invocation. This streamlines the CarPlayConfigurationViewModel by removing support for migrating legacy actions, likely because such migration is no longer needed.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
