### PR TITLE
Remove legacy actions migration for watch config

### DIFF
--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationViewModel.swift
@@ -100,7 +100,6 @@ final class WatchConfigurationViewModel: ObservableObject {
                 Current.Log.info("Watch configuration exists")
             } else {
                 Current.Log.error("No watch config found")
-                convertLegacyActionsToWatchConfig()
             }
         } catch {
             Current.Log.error("Failed to access database (GRDB), error: \(error.localizedDescription)")
@@ -111,25 +110,6 @@ final class WatchConfigurationViewModel: ObservableObject {
     @MainActor
     private func setConfig(_ config: WatchConfig) {
         watchConfig = config
-    }
-
-    @MainActor
-    private func convertLegacyActionsToWatchConfig() {
-        var newWatchConfig = WatchConfig()
-        let actions = Current.realm().objects(Action.self).sorted(by: { $0.Position < $1.Position })
-            .filter(\.showInWatch)
-
-        guard !actions.isEmpty else { return }
-
-        let newWatchActionItems = actions.map { action in
-            MagicItem(id: action.ID, serverId: action.serverIdentifier, type: .action)
-        }
-        newWatchConfig.items = newWatchActionItems
-        watchConfig = newWatchConfig
-        let success = save()
-        if !success {
-            Current.Log.error("Failed to migrate actions to watch config, failed to save config.")
-        }
     }
 
     private func showError(message: String) {


### PR DESCRIPTION
Deleted the convertLegacyActionsToWatchConfig method and its invocation, as legacy action migration to watch configuration is no longer needed.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
