### PR TITLE
Improve loader handling in camera player views

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -15,6 +15,7 @@ struct CameraPlayerView: View {
     @State private var appEntity: HAAppEntity?
     @State private var name: String?
     @State private var controlsVisible = true
+    @State private var showLoader = true
 
     enum PlayerType {
         case webRTC
@@ -29,28 +30,33 @@ struct CameraPlayerView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            NavigationStack {
-                content
-                    .toolbar {
-                        ToolbarItem(placement: .primaryAction) {
-                            if controlsVisible {
-                                CloseButton {
-                                    dismiss()
+        ZStack {
+            ZStack(alignment: .topLeading) {
+                NavigationStack {
+                    content
+                        .toolbar {
+                            ToolbarItem(placement: .primaryAction) {
+                                if controlsVisible {
+                                    CloseButton {
+                                        dismiss()
+                                    }
                                 }
                             }
                         }
-                    }
-                    .modify { view in
-                        if #available(iOS 18.0, *) {
-                            view.toolbarVisibility(controlsVisible ? .automatic : .hidden, for: .navigationBar)
-                        } else {
-                            view
+                        .modify { view in
+                            if #available(iOS 18.0, *) {
+                                view.toolbarVisibility(controlsVisible ? .automatic : .hidden, for: .navigationBar)
+                            } else {
+                                view
+                            }
                         }
-                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                nameBadge
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            nameBadge
+            if showLoader {
+                HAProgressView(style: .extraLarge)
+            }
         }
         .onAppear {
             appEntity = HAAppEntity.entity(id: cameraEntityId, serverId: server.identifier.rawValue)
@@ -98,6 +104,7 @@ struct CameraPlayerView: View {
                     cameraEntityId: cameraEntityId,
                     cameraName: cameraName,
                     controlsVisible: $controlsVisible,
+                    showLoader: $showLoader,
                     onWebRTCUnsupported: {
                         fallbackToHLS()
                     }

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
@@ -5,6 +5,7 @@ import WebRTC
 
 protocol AppCameraView {
     var controlsVisible: Binding<Bool> { get set }
+    var showLoader: Binding<Bool> { get set }
 }
 
 @available(iOS 16.0, *)
@@ -21,6 +22,7 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
     @State private var isPlaying: Bool = false
     @State private var isVideoPlaying: Bool = false
     var controlsVisible: Binding<Bool>
+    var showLoader: Binding<Bool>
     @State var hideControlsWorkItem: DispatchWorkItem?
 
     private let server: Server
@@ -33,6 +35,7 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
         cameraEntityId: String,
         cameraName: String? = nil,
         controlsVisible: Binding<Bool>,
+        showLoader: Binding<Bool>,
         onWebRTCUnsupported: (() -> Void)? = nil
     ) {
         self.server = server
@@ -40,6 +43,7 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
         self.cameraName = cameraName
         self.onWebRTCUnsupported = onWebRTCUnsupported
         self.controlsVisible = controlsVisible
+        self.showLoader = showLoader
         self._viewModel = .init(wrappedValue: WebRTCViewPlayerViewModel(server: server, cameraEntityId: cameraEntityId))
     }
 
@@ -50,8 +54,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                     player
                     controls
                 }
-                HAProgressView(style: .large)
-                    .opacity(viewModel.showLoader ? 1.0 : 0.0)
                 errorView
             }
             .background(.black)
@@ -75,6 +77,9 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                 if isUnsupported {
                     onWebRTCUnsupported?()
                 }
+            }
+            .onChange(of: viewModel.showLoader) { showLoader in
+                self.showLoader.wrappedValue = showLoader
             }
         }
         .toolbar {

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import HAKit
 import Shared
+import SwiftUI
 import WebRTC
 
 enum WebRTCSignalType: String {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1054,7 +1054,7 @@ public enum L10n {
   public enum ConnectionSecurityLevelBlock {
     /// Due to your connection security choice ('Most secure'), there's no URL that we are allowed to use.
     public static var body: String { return L10n.tr("Localizable", "connection_security_level_block.body") }
-    /// Tip: Double check your device settings and app permissions, make sure it is allowing local network access and location access set to 'Always' (so it also works in background) and 'Full' (so the app can identify which network you are using and detect your home network).
+    /// Tip: Double check your device settings and app permissions. Make sure the app is allowed local network access and location access is set to 'Always' (so it also works in background) and 'Full' (so the app can identify which network you are using and detect your home network).
     public static var tip: String { return L10n.tr("Localizable", "connection_security_level_block.tip") }
     /// You're disconnected
     public static var title: String { return L10n.tr("Localizable", "connection_security_level_block.title") }


### PR DESCRIPTION
Refactored loader visibility logic by introducing a showLoader state in CameraPlayerView and passing it to WebRTCVideoPlayerView. The loader is now displayed at the top level, and its state is synchronized with the WebRTC view model. Also updated a connection security tip string for clarity.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
