### PR TITLE
fix: Exclude custom widgetFamily environment from widget extension ta…

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		4238DCA52DD1F1E300126434 /* AppSessionValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4238DCA32DD1F1E300126434 /* AppSessionValues.swift */; };
 		4238E8532EB0D41200BDF010 /* ConnectionSecurityLevelBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4238E8522EB0D41200BDF010 /* ConnectionSecurityLevelBlockView.swift */; };
 		4238E8572EB0EA4A00BDF010 /* ConnectionSecurityLevelBlockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4238E8562EB0EA4A00BDF010 /* ConnectionSecurityLevelBlockViewModel.swift */; };
+		42392EAC2F30A7870051D155 /* WidgetFamily+AppPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42392EAA2F30A7870051D155 /* WidgetFamily+AppPreview.swift */; };
 		4239D1832C4FFCCE003497FC /* WatchUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4239D1802C4FFB75003497FC /* WatchUserDefaults.swift */; };
 		423B5E092D67781A0000CB95 /* WidgetBasicContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */; };
 		423B5E0A2D6778370000CB95 /* WidgetBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424A7F452B188946008C8DF3 /* WidgetBackground.swift */; };
@@ -2352,6 +2353,7 @@
 		4238DCA32DD1F1E300126434 /* AppSessionValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionValues.swift; sourceTree = "<group>"; };
 		4238E8522EB0D41200BDF010 /* ConnectionSecurityLevelBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionSecurityLevelBlockView.swift; sourceTree = "<group>"; };
 		4238E8562EB0EA4A00BDF010 /* ConnectionSecurityLevelBlockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionSecurityLevelBlockViewModel.swift; sourceTree = "<group>"; };
+		42392EAA2F30A7870051D155 /* WidgetFamily+AppPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetFamily+AppPreview.swift"; sourceTree = "<group>"; };
 		4239D1802C4FFB75003497FC /* WatchUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchUserDefaults.swift; sourceTree = "<group>"; };
 		423F44EF2C17238200766A99 /* ChatBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbleView.swift; sourceTree = "<group>"; };
 		423F44FE2C186E4500766A99 /* WatchCommunicatorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCommunicatorService.swift; sourceTree = "<group>"; };
@@ -3700,6 +3702,7 @@
 			isa = PBXGroup;
 			children = (
 				115560E027010D8400A8F818 /* WidgetBasicContainerView.swift */,
+				42392EAA2F30A7870051D155 /* WidgetFamily+AppPreview.swift */,
 				42B74A612D36B08600C37304 /* WidgetBasicView.swift */,
 				428CB3362CF7FC0800F1320E /* WidgetFamilySizes.swift */,
 				1165705527018C4E003906A7 /* WidgetEmptyView.swift */,
@@ -9336,6 +9339,7 @@
 				4273C48B2C8858470065A5B4 /* ControlOpenPageValueProvider.swift in Sources */,
 				427FEE072D9C03DE0047C00C /* OnboardingScanningInstanceRow.swift in Sources */,
 				420FE84B2B556BB100878E06 /* CarPlayActionsTemplate+Build.swift in Sources */,
+				42392EAC2F30A7870051D155 /* WidgetFamily+AppPreview.swift in Sources */,
 				426D2F032F17E8530062C359 /* HomeEntityTileView.swift in Sources */,
 				42DF6B2F2CCF918D00D7EC14 /* BluetoothPermissionView.swift in Sources */,
 				425573C72B5572AD00145217 /* CarPlayServerListTemplate+Build.swift in Sources */,

--- a/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
@@ -34,21 +34,6 @@ struct WidgetBasicContainerView: View {
     }
 }
 
-// Only define custom widgetFamily environment when not compiling for the widget extension,
-// as WidgetKit already provides the native \.widgetFamily environment variable.
-#if !WIDGET_EXTENSION
-extension WidgetFamily: @retroactive EnvironmentKey {
-    public static var defaultValue: WidgetFamily = .systemMedium
-}
-
-extension EnvironmentValues {
-    var widgetFamily: WidgetFamily {
-        get { self[WidgetFamily.self] }
-        set { self[WidgetFamily.self] = newValue }
-    }
-}
-#endif
-
 @available(iOS 18, *)
 struct WidgetBasicContainerView_Previews: PreviewProvider {
     struct WidgetBasicContainerViewPreviewData {
@@ -74,7 +59,9 @@ struct WidgetBasicContainerView_Previews: PreviewProvider {
                 familySize: .systemSmall
             )
             .previewContext(WidgetPreviewContext(family: WidgetFamily.systemSmall))
-            .environment(\.widgetFamily, .systemSmall)
+            #if !WIDGET_EXTENSION
+                .environment(\.widgetFamily, .systemSmall)
+            #endif
         }
 
     static var systemMediumConfigurations: SnapshottablePreviewConfigurations<WidgetBasicContainerViewPreviewData> =
@@ -88,7 +75,9 @@ struct WidgetBasicContainerView_Previews: PreviewProvider {
                 familySize: .systemMedium
             )
             .previewContext(WidgetPreviewContext(family: WidgetFamily.systemMedium))
-            .environment(\.widgetFamily, .systemMedium)
+            #if !WIDGET_EXTENSION
+                .environment(\.widgetFamily, .systemMedium)
+            #endif
         }
 
     static var systemLargeConfigurations: SnapshottablePreviewConfigurations<WidgetBasicContainerViewPreviewData> =
@@ -102,7 +91,9 @@ struct WidgetBasicContainerView_Previews: PreviewProvider {
                 familySize: .systemLarge
             )
             .previewContext(WidgetPreviewContext(family: WidgetFamily.systemLarge))
-            .environment(\.widgetFamily, .systemLarge)
+            #if !WIDGET_EXTENSION
+                .environment(\.widgetFamily, .systemLarge)
+            #endif
         }
 
     private static func maxTiles(for familySize: WidgetFamily) -> Int {

--- a/Sources/Extensions/Widgets/Common/WidgetFamily+AppPreview.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetFamily+AppPreview.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WidgetKit
+
+#if !WIDGET_EXTENSION
+extension WidgetFamily: @retroactive EnvironmentKey {
+    public static var defaultValue: WidgetFamily = .systemMedium
+}
+
+extension EnvironmentValues {
+    var widgetFamily: WidgetFamily {
+        get { self[WidgetFamily.self] }
+        set { self[WidgetFamily.self] = newValue }
+    }
+}
+#endif


### PR DESCRIPTION
…rget

The custom EnvironmentKey extension for widgetFamily conflicts with WidgetKit's native \.widgetFamily environment variable when compiled for the widget extension.

This wraps the custom definition with #if !WIDGET_EXTENSION so it's only available in the main app target (for widget preview in the widget creator).

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
