### PR TITLE
fix: Explicitly add lokalise tap before brew bundle

### DIFF
--- a/.github/workflows/download_localized_strings.yml
+++ b/.github/workflows/download_localized_strings.yml
@@ -18,7 +18,10 @@ jobs:
           ssh-key: ${{ secrets.HOMEASSISTANT_SSH_DEPLOY_KEY }}
 
       - name: Install Brews
-        run: brew bundle
+        run: |
+          brew update
+          brew tap lokalise/cli-2
+          brew bundle
 
       - name: Install Gems
         run: bundle install --jobs 4 --retry 3


### PR DESCRIPTION
The brew bundle command was failing with 'No available formula with the name lokalise2' because the third-party tap wasn't being added reliably.

This fix explicitly runs:
1. brew update - to refresh formulae
2. brew tap lokalise/cli-2 - to add the third-party tap
3. brew bundle - to install dependencies

Fixes the Download Localized Strings workflow failure.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
