### PR TITLE
Add unit tests for API models

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1082,6 +1082,11 @@
 		42D5ACCE2C636F2B00D9C4E2 /* WatchConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5ACCD2C636F2B00D9C4E2 /* WatchConfigurationViewModel.swift */; };
 		42D5ACD92C64C0E000D9C4E2 /* MagicItemAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5ACD82C64C0E000D9C4E2 /* MagicItemAddView.swift */; };
 		42D5ACDB2C64C82600D9C4E2 /* MagicItemAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5ACDA2C64C82600D9C4E2 /* MagicItemAddViewModel.swift */; };
+		42D5B1AA2F3233380027DE70 /* ColorExtensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5B1A62F3233380027DE70 /* ColorExtensions.test.swift */; };
+		42D5B1AB2F3233380027DE70 /* Float+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5B1A82F3233380027DE70 /* Float+HA.test.swift */; };
+		42D5B1AC2F3233380027DE70 /* Bool+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5B1A52F3233380027DE70 /* Bool+HA.test.swift */; };
+		42D5B1AD2F3233380027DE70 /* DictionaryExtensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5B1A72F3233380027DE70 /* DictionaryExtensions.test.swift */; };
+		42D5B1AE2F3233380027DE70 /* String+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D5B1A92F3233380027DE70 /* String+HA.test.swift */; };
 		42D996E52D89863A001737A0 /* Bool+HA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D996E42D89863A001737A0 /* Bool+HA.swift */; };
 		42D996E62D89863A001737A0 /* Bool+HA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D996E42D89863A001737A0 /* Bool+HA.swift */; };
 		42DB4D0B2CEE292D00F6C20D /* AppEntitiesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4297ADA42C89C43F00790812 /* AppEntitiesModel.swift */; };
@@ -1228,13 +1233,13 @@
 		5B715903CB3450FE351399BC /* Pods-iOS-Extensions-Share-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 207E35C8F1554A9AD616FFA2 /* Pods-iOS-Extensions-Share-metadata.plist */; };
 		5FFBC80F835393915C4748CF /* Pods_iOS_Extensions_PushProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A370326321B07E5ACE0BCB65 /* Pods_iOS_Extensions_PushProvider.framework */; };
 		65286F3B745551AD4090EE6B /* Pods-iOS-SharedTesting-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4053903E4C54A6803204286E /* Pods-iOS-SharedTesting-metadata.plist */; };
-		692BCBBA4EEEABCC76DBBECA /* Database/GRDB+Initialization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */; };
+		692BCBBA4EEEABCC76DBBECA /* GRDB+Initialization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */; };
 		6FCEBAA2C8E9C5403055E73D /* IntentFanEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5E2F9F8F008EEA30C533FD /* IntentFanEntity.swift */; };
 		78BE7D5D003D9F8C7486DD69 /* Pods_iOS_Shared_iOS_Tests_Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F4DFB087A3A43F9A526B851 /* Pods_iOS_Shared_iOS_Tests_Shared.framework */; };
 		81A0C1BBDEFF4F8C5FC314BE /* Pods_iOS_Extensions_NotificationContent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F356D0219C7F8A24234511B /* Pods_iOS_Extensions_NotificationContent.framework */; };
 		84F7755EFB03C3F463292ABF /* Pods-watchOS-Shared-watchOS-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */; };
 		8E5FA96C740F1D671966CEA9 /* Pods-iOS-Extensions-NotificationContent-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B613440AEDD4209862503F5D /* Pods-iOS-Extensions-NotificationContent-metadata.plist */; };
-		A2F3A140CDD1EF1AEA6DFAB9 /* Database/DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */; };
+		A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */; };
 		A5A3C1932BE1F4A40EA78754 /* Pods-iOS-Extensions-Matter-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392B0C44197C98E2653932A5 /* Pods-iOS-Extensions-Matter-metadata.plist */; };
 		B6022213226DAC9D00E8DBFE /* ScaledFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6022212226DAC9D00E8DBFE /* ScaledFont.swift */; };
 		B60248001FBD343000998205 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B60247FE1FBD343000998205 /* InfoPlist.strings */; };
@@ -1488,7 +1493,7 @@
 		B6E2D4D52270706300446DFA /* ha-loading.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4D42270706200446DFA /* ha-loading.json */; };
 		B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
 		B9820AF29664869FD0B25CDF /* Pods_iOS_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD90A8F251D0671EFAC931ED /* Pods_iOS_App.framework */; };
-		BECCC152A4E3F69A8EF5A6F3 /* Database/TableSchemaTests.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */; };
+		BECCC152A4E3F69A8EF5A6F3 /* TableSchemaTests.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */; };
 		C10D762EFE08D347D0538339 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B2F5238669D8A7416FBD2B55 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist */; };
 		C6478E5ADCB3EB7EC959EB53 /* Pods_iOS_Extensions_Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29FC93E25AB875716E2F35D4 /* Pods_iOS_Extensions_Intents.framework */; };
 		CA6886D02384DA18A91F37DD /* Pods-iOS-Extensions-Intents-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = E41A4AAEF642A72ACDB6C006 /* Pods-iOS-Extensions-Intents-metadata.plist */; };
@@ -1530,7 +1535,7 @@
 		D0EEF322214DE56B00D1D360 /* LocationTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF321214DE56B00D1D360 /* LocationTrigger.swift */; };
 		D0EEF324214DF2B700D1D360 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E857A11CB1CCCC00F96925 /* Utils.swift */; };
 		D0EEF335214EB77100D1D360 /* CLLocation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C17E20D1F64D00BD810B /* CLLocation+Extensions.swift */; };
-		DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */; };
+		DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */; };
 		FC8E9421FDB864726918B612 /* Pods-watchOS-WatchExtension-Watch-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9249824D575933DFA1530BB2 /* Pods-watchOS-WatchExtension-Watch-metadata.plist */; };
 		FD3BC66329B9FF8F00B19FBE /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */; };
 		FD3BC66C29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */; };
@@ -1821,6 +1826,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00DB08A32260CCBDB77F6DE4 /* ActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActionTests.swift; path = Tests/Shared/ActionTests.swift; sourceTree = "<group>"; };
 		0194775556E59C6E64735937 /* Pods-watchOS-Shared-watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-Shared-watchOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-Shared-watchOS/Pods-watchOS-Shared-watchOS.release.xcconfig"; sourceTree = "<group>"; };
 		05C398FF0F9BA764B69CA36B /* Pods-iOS-Extensions-NotificationService.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationService.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationService/Pods-iOS-Extensions-NotificationService.beta.xcconfig"; sourceTree = "<group>"; };
 		05E6CF2BD91E8443547F3026 /* Pods-iOS-Extensions-Today.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Today.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Today/Pods-iOS-Extensions-Today.release.xcconfig"; sourceTree = "<group>"; };
@@ -2879,6 +2885,11 @@
 		42D5ACCF2C639AB700D9C4E2 /* MagicItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicItem.swift; sourceTree = "<group>"; };
 		42D5ACD82C64C0E000D9C4E2 /* MagicItemAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicItemAddView.swift; sourceTree = "<group>"; };
 		42D5ACDA2C64C82600D9C4E2 /* MagicItemAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicItemAddViewModel.swift; sourceTree = "<group>"; };
+		42D5B1A52F3233380027DE70 /* Bool+HA.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+HA.test.swift"; sourceTree = "<group>"; };
+		42D5B1A62F3233380027DE70 /* ColorExtensions.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.test.swift; sourceTree = "<group>"; };
+		42D5B1A72F3233380027DE70 /* DictionaryExtensions.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensions.test.swift; sourceTree = "<group>"; };
+		42D5B1A82F3233380027DE70 /* Float+HA.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float+HA.test.swift"; sourceTree = "<group>"; };
+		42D5B1A92F3233380027DE70 /* String+HA.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HA.test.swift"; sourceTree = "<group>"; };
 		42D6EAB22F0FF88800FA249B /* ToastShowPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastShowPayload.swift; sourceTree = "<group>"; };
 		42D6EAB72F0FF8EB00FA249B /* ExternalBusPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalBusPayload.swift; sourceTree = "<group>"; };
 		42D6EAB92F0FF90500FA249B /* ToastHidePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastHidePayload.swift; sourceTree = "<group>"; };
@@ -3000,12 +3011,13 @@
 		46CC96812D7136F400F784CA /* Array+SafeSubscripting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeSubscripting.swift"; sourceTree = "<group>"; };
 		46F103252D721504002BC586 /* LocationHistoryListViewSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHistoryListViewSnapshot.test.swift; sourceTree = "<group>"; };
 		479C2CCB032E2A0ECDE45B87 /* Pods-Tests-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-App/Pods-Tests-App.debug.xcconfig"; sourceTree = "<group>"; };
+		480076B98486FF79EE49B24F /* NotificationCategory.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotificationCategory.test.swift; path = Tests/Shared/NotificationCategory.test.swift; sourceTree = "<group>"; };
 		491E98FE25D543560077BBE3 /* LogbookEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogbookEntry.swift; sourceTree = "<group>"; };
 		553A33E097387AA44265DB13 /* Pods-iOS-App-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-App-metadata.plist"; path = "Pods/Pods-iOS-App-metadata.plist"; sourceTree = "<group>"; };
 		574F428FD5AD613411644AE4 /* Pods-iOS-Extensions-PushProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-PushProvider.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-PushProvider/Pods-iOS-Extensions-PushProvider.release.xcconfig"; sourceTree = "<group>"; };
 		57B9C3C07B5A002D749B5CDA /* Pods_Tests_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		592EED7A6C2444872F11C17B /* Pods-iOS-Extensions-NotificationService-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-NotificationService-metadata.plist"; path = "Pods/Pods-iOS-Extensions-NotificationService-metadata.plist"; sourceTree = "<group>"; };
-		5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
+		5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
 		6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Widgets-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Widgets-metadata.plist"; sourceTree = "<group>"; };
 		675CE4281FE5F1920B13D553 /* Pods-iOS-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.debug.xcconfig"; sourceTree = "<group>"; };
 		6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-Shared-watchOS-metadata.plist"; path = "Pods/Pods-watchOS-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
@@ -3017,7 +3029,8 @@
 		7A6E8DF7DED57BAD4EF47D11 /* Pods_iOS_Extensions_Today.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_Today.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D94AB7BD65F15C8FEE0912E /* Pods-iOS-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.release.xcconfig"; sourceTree = "<group>"; };
 		80854D28D2FCD1482E92ED31 /* Pods-Tests-App.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-App.beta.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-App/Pods-Tests-App.beta.xcconfig"; sourceTree = "<group>"; };
-		892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
+		83665C7787A368557ACE467E /* MagicItemAddViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MagicItemAddViewModelTests.swift; path = Tests/App/MagicItem/MagicItemAddViewModelTests.swift; sourceTree = "<group>"; };
+		892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
 		8965FD50AC78F092CEB5F076 /* Pods-iOS-Extensions-Widgets.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Widgets.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Widgets/Pods-iOS-Extensions-Widgets.beta.xcconfig"; sourceTree = "<group>"; };
 		89E1823CF2D12BD3161FCC86 /* Pods-iOS-SharedTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-SharedTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-SharedTesting/Pods-iOS-SharedTesting.debug.xcconfig"; sourceTree = "<group>"; };
 		8A34A5417D650BBBE9D2D7C0 /* ControlFanValueProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlFanValueProvider.swift; sourceTree = "<group>"; };
@@ -3031,8 +3044,9 @@
 		9C4E5E25229D986B0044C8EC /* HomeAssistant.beta.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = HomeAssistant.beta.xcconfig; sourceTree = "<group>"; };
 		9C4E5E27229D992A0044C8EC /* HomeAssistant.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = HomeAssistant.xcconfig; sourceTree = "<group>"; };
 		9C7970E308CFEAEAFA05E004 /* Pods-iOS-Extensions-NotificationContent.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationContent.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationContent/Pods-iOS-Extensions-NotificationContent.release.xcconfig"; sourceTree = "<group>"; };
-		9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/TableSchemaTests.test.swift; sourceTree = "<group>"; };
+		9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/TableSchemaTests.test.swift; sourceTree = "<group>"; };
 		A0CE1C12B4ACF0A6876B6F7F /* Pods-iOS-Extensions-Today.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Today.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Today/Pods-iOS-Extensions-Today.beta.xcconfig"; sourceTree = "<group>"; };
+		A249501CBC93DEAB21ECB236 /* LocationHistoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocationHistoryTests.swift; path = Tests/Shared/LocationHistoryTests.swift; sourceTree = "<group>"; };
 		A370326321B07E5ACE0BCB65 /* Pods_iOS_Extensions_PushProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_PushProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A90DD8FC6E4726B7E7187C59 /* Pods_watchOS_WatchExtension_Watch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_watchOS_WatchExtension_Watch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ADC769271BB34C474C2D1E24 /* Pods-iOS-Shared-iOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Shared-iOS-metadata.plist"; path = "Pods/Pods-iOS-Shared-iOS-metadata.plist"; sourceTree = "<group>"; };
@@ -3354,11 +3368,12 @@
 		B6FD0573228411B200AC45BA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B6FD0574228411B200AC45BA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B9B49F9D3E32AD45659A0A41 /* Pods-iOS-Extensions-Matter.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Matter.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Matter/Pods-iOS-Extensions-Matter.beta.xcconfig"; sourceTree = "<group>"; };
-		BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseTableProtocol.test.swift; sourceTree = "<group>"; };
+		BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseTableProtocol.test.swift; sourceTree = "<group>"; };
 		BED1F3255FAD612BC4670B45 /* Pods-iOS-Extensions-Share.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Share.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Share/Pods-iOS-Extensions-Share.beta.xcconfig"; sourceTree = "<group>"; };
 		BEE6D44D86AC3F2F3E43950D /* Pods-watchOS-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-Shared-watchOS/Pods-watchOS-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C2563441A5A149C269C5F320 /* Pods-iOS-Shared-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS/Pods-iOS-Shared-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		C5FC0E87961345302D630E28 /* Pods-iOS-Extensions-Intents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Intents.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Intents/Pods-iOS-Extensions-Intents.debug.xcconfig"; sourceTree = "<group>"; };
+		C5FE582BB8B07ECA65EBC58F /* NotificationAction.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotificationAction.test.swift; path = Tests/Shared/NotificationAction.test.swift; sourceTree = "<group>"; };
 		C851CA22DDEEA359D12221C3 /* Pods_iOS_Extensions_Share.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_Share.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8896D3548ECEBD337889277 /* Pods-iOS-Extensions-Matter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Matter.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Matter/Pods-iOS-Extensions-Matter.debug.xcconfig"; sourceTree = "<group>"; };
 		CA1DE9B127B0A27EFB659904 /* Pods-iOS-Extensions-Intents.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Intents.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Intents/Pods-iOS-Extensions-Intents.beta.xcconfig"; sourceTree = "<group>"; };
@@ -4943,6 +4958,7 @@
 			isa = PBXGroup;
 			children = (
 				42755FF22CD913C700CB0032 /* MagicItemProviderTests.swift */,
+				83665C7787A368557ACE467E /* MagicItemAddViewModelTests.swift */,
 			);
 			path = MagicItem;
 			sourceTree = "<group>";
@@ -5799,6 +5815,11 @@
 		42ACC2A62E9F9B1E0045A3FD /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				42D5B1A52F3233380027DE70 /* Bool+HA.test.swift */,
+				42D5B1A62F3233380027DE70 /* ColorExtensions.test.swift */,
+				42D5B1A72F3233380027DE70 /* DictionaryExtensions.test.swift */,
+				42D5B1A82F3233380027DE70 /* Float+HA.test.swift */,
+				42D5B1A92F3233380027DE70 /* String+HA.test.swift */,
 				42D4574A2EF1835D007934BC /* StringExtensions.test.swift */,
 				42ACC2A32E9F9AEA0045A3FD /* URLExtensions.test.swift */,
 			);
@@ -7145,10 +7166,10 @@
 				11CB98CC249E637300B05222 /* Version+HA.test.swift */,
 				11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */,
 				11883CC624C131EE0036A6C6 /* RealmZone.test.swift */,
-				892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */,
-				BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */,
-				5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */,
-				9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */,
+				892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */,
+				BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */,
+				5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */,
+				9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */,
 				11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */,
 				11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */,
 				1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */,
@@ -7168,6 +7189,10 @@
 				114CBAEA2839FC2500A9BAFF /* SecurityExceptions.test.swift */,
 				114CBAEC283AB92D00A9BAFF /* SecTrust+TestAdditions.swift */,
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
+				480076B98486FF79EE49B24F /* NotificationCategory.test.swift */,
+				C5FE582BB8B07ECA65EBC58F /* NotificationAction.test.swift */,
+				00DB08A32260CCBDB77F6DE4 /* ActionTests.swift */,
+				A249501CBC93DEAB21ECB236 /* LocationHistoryTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -7999,7 +8024,7 @@
 			packageReferences = (
 				420E64BB2D676B2400A31E86 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				42B89EA62E05CC54000224A2 /* XCRemoteSwiftPackageReference "WebRTC" */,
-				42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */,
+				42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */,
 				4237E6372E5333370023B673 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			productRefGroup = B657A8E71CA646EB00121384 /* Products */;
@@ -10212,6 +10237,11 @@
 			files = (
 				11B38EDF275BE29F00205C7B /* ConnectionInfo.test.swift in Sources */,
 				11883CC524C12C8A0036A6C6 /* CLLocation+Extensions.test.swift in Sources */,
+				42D5B1AA2F3233380027DE70 /* ColorExtensions.test.swift in Sources */,
+				42D5B1AB2F3233380027DE70 /* Float+HA.test.swift in Sources */,
+				42D5B1AC2F3233380027DE70 /* Bool+HA.test.swift in Sources */,
+				42D5B1AD2F3233380027DE70 /* DictionaryExtensions.test.swift in Sources */,
+				42D5B1AE2F3233380027DE70 /* String+HA.test.swift in Sources */,
 				1109F82424A25A41002590F2 /* SensorContainer.test.swift in Sources */,
 				119385A7249E9F930097F497 /* StorageSensor.test.swift in Sources */,
 				11CD94B724B2CC7400BA801D /* WebhookResponseLocation.test.swift in Sources */,
@@ -10221,10 +10251,10 @@
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11F2F2B8258728B200F61F7C /* NotificationAttachmentParserURL.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
-				DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */,
-				A2F3A140CDD1EF1AEA6DFAB9 /* Database/DatabaseTableProtocol.test.swift in Sources */,
-				692BCBBA4EEEABCC76DBBECA /* Database/GRDB+Initialization.test.swift in Sources */,
-				BECCC152A4E3F69A8EF5A6F3 /* Database/TableSchemaTests.test.swift in Sources */,
+				DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */,
+				A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */,
+				692BCBBA4EEEABCC76DBBECA /* GRDB+Initialization.test.swift in Sources */,
+				BECCC152A4E3F69A8EF5A6F3 /* TableSchemaTests.test.swift in Sources */,
 				11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */,
 				11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */,
 				42FDCA272F0C7EB900C92958 /* EntityRegistry.test.swift in Sources */,
@@ -12105,7 +12135,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */ = {
+		42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Sources/SharedPush;
 		};
@@ -12161,7 +12191,7 @@
 		};
 		4273F7DF2E258827000629F7 /* SharedPush */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */;
+			package = 42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */;
 			productName = SharedPush;
 		};
 		427692E22B98B82500F24321 /* SharedPush */ = {

--- a/Tests/Shared/ActionTests.swift
+++ b/Tests/Shared/ActionTests.swift
@@ -1,0 +1,422 @@
+import CoreLocation
+import Foundation
+import ObjectMapper
+import RealmSwift
+@testable import Shared
+import UIKit
+import XCTest
+
+class ActionTests: XCTestCase {
+    private var realm: Realm!
+    private var server: Server!
+
+    override func setUp() {
+        super.setUp()
+
+        let executionIdentifier = UUID().uuidString
+        realm = try! Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
+        server = Server.fake(identifier: "test_server")
+
+        Current.realm = { self.realm }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Current.realm = Realm.live
+    }
+
+    // MARK: - Initialization Tests
+
+    func testDefaultInitialization() {
+        let action = Action()
+
+        XCTAssertFalse(action.ID.isEmpty, "ID should not be empty")
+        XCTAssertEqual(action.Name, "", "Name should be empty string by default")
+        XCTAssertEqual(action.Text, "", "Text should be empty string by default")
+        XCTAssertFalse(action.IconName.isEmpty, "IconName should have a default value")
+        XCTAssertFalse(action.BackgroundColor.isEmpty, "BackgroundColor should be set")
+        XCTAssertFalse(action.IconColor.isEmpty, "IconColor should be set")
+        XCTAssertFalse(action.TextColor.isEmpty, "TextColor should be set")
+        XCTAssertEqual(action.Position, 0, "Position should be 0 by default")
+        XCTAssertFalse(action.isServerControlled, "isServerControlled should be false by default")
+        XCTAssertEqual(action.serverIdentifier, "", "serverIdentifier should be empty by default")
+        XCTAssertTrue(action.showInCarPlay, "showInCarPlay should be true by default")
+        XCTAssertTrue(action.showInWatch, "showInWatch should be true by default")
+        XCTAssertFalse(action.useCustomColors, "useCustomColors should be false by default")
+    }
+
+    func testDefaultInitializationSetsAppropriateColors() {
+        let action = Action()
+
+        // Verify that colors are valid hex strings
+        XCTAssertTrue(action.BackgroundColor.hasPrefix("#") || UIColor(hex: action.BackgroundColor) != nil)
+        XCTAssertTrue(action.IconColor.hasPrefix("#") || UIColor(hex: action.IconColor) != nil)
+        XCTAssertTrue(action.TextColor.hasPrefix("#") || UIColor(hex: action.TextColor) != nil)
+
+        // Verify that text and icon colors are either black or white (contrasting with background)
+        XCTAssertTrue(
+            action.TextColor == UIColor.black.hexString() || action.TextColor == UIColor.white.hexString(),
+            "TextColor should be either black or white"
+        )
+        XCTAssertTrue(
+            action.IconColor == UIColor.black.hexString() || action.IconColor == UIColor.white.hexString(),
+            "IconColor should be either black or white"
+        )
+    }
+
+    // MARK: - ObjectMapper Tests
+
+    func testMappingFromJSON() throws {
+        let json: [String: Any] = [
+            "ID": "test_action_id",
+            "Name": "Test Action",
+            "Text": "Test Text",
+            "Position": 10,
+            "BackgroundColor": "#FF5733",
+            "IconName": "mdi:home",
+            "IconColor": "#FFFFFF",
+            "TextColor": "#000000",
+            "CreatedAt": Date().timeIntervalSince1970,
+            "isServerControlled": true,
+            "serverIdentifier": "server_1",
+            "showInCarPlay": false,
+            "showInWatch": false,
+            "useCustomColors": true,
+        ]
+
+        let action = try Action(JSON: json)
+
+        XCTAssertEqual(action.ID, "test_action_id")
+        XCTAssertEqual(action.Name, "Test Action")
+        XCTAssertEqual(action.Text, "Test Text")
+        XCTAssertEqual(action.Position, 10)
+        XCTAssertEqual(action.BackgroundColor, "#FF5733")
+        XCTAssertEqual(action.IconName, "mdi:home")
+        XCTAssertEqual(action.IconColor, "#FFFFFF")
+        XCTAssertEqual(action.TextColor, "#000000")
+        XCTAssertTrue(action.isServerControlled)
+        XCTAssertEqual(action.serverIdentifier, "server_1")
+        XCTAssertFalse(action.showInCarPlay)
+        XCTAssertFalse(action.showInWatch)
+        XCTAssertTrue(action.useCustomColors)
+    }
+
+    func testMappingToJSON() {
+        let action = Action()
+        action.ID = "test_id"
+        action.Name = "Test"
+        action.Text = "Test Text"
+        action.Position = 5
+        action.BackgroundColor = "#123456"
+        action.IconName = "mdi:test"
+        action.IconColor = "#FFFFFF"
+        action.TextColor = "#000000"
+        action.isServerControlled = false
+        action.serverIdentifier = "server_test"
+        action.showInCarPlay = true
+        action.showInWatch = true
+        action.useCustomColors = false
+
+        let json = action.toJSON()
+
+        XCTAssertEqual(json["ID"] as? String, "test_id")
+        XCTAssertEqual(json["Name"] as? String, "Test")
+        XCTAssertEqual(json["Text"] as? String, "Test Text")
+        XCTAssertEqual(json["Position"] as? Int, 5)
+        XCTAssertEqual(json["BackgroundColor"] as? String, "#123456")
+        XCTAssertEqual(json["IconName"] as? String, "mdi:test")
+        XCTAssertEqual(json["IconColor"] as? String, "#FFFFFF")
+        XCTAssertEqual(json["TextColor"] as? String, "#000000")
+        XCTAssertEqual(json["isServerControlled"] as? Bool, false)
+        XCTAssertEqual(json["serverIdentifier"] as? String, "server_test")
+        XCTAssertEqual(json["showInCarPlay"] as? Bool, true)
+        XCTAssertEqual(json["showInWatch"] as? Bool, true)
+        XCTAssertEqual(json["useCustomColors"] as? Bool, false)
+    }
+
+    func testMappingRoundTrip() throws {
+        let originalAction = Action()
+        originalAction.ID = "roundtrip_id"
+        originalAction.Name = "Roundtrip Action"
+        originalAction.Text = "Roundtrip Text"
+        originalAction.Position = 99
+        originalAction.BackgroundColor = "#ABCDEF"
+        originalAction.IconName = "mdi:roundtrip"
+        originalAction.IconColor = "#111111"
+        originalAction.TextColor = "#222222"
+        originalAction.isServerControlled = true
+        originalAction.serverIdentifier = "roundtrip_server"
+        originalAction.showInCarPlay = false
+        originalAction.showInWatch = true
+        originalAction.useCustomColors = true
+
+        let json = originalAction.toJSON()
+        let reconstructedAction = try Action(JSON: json)
+
+        XCTAssertEqual(reconstructedAction.ID, originalAction.ID)
+        XCTAssertEqual(reconstructedAction.Name, originalAction.Name)
+        XCTAssertEqual(reconstructedAction.Text, originalAction.Text)
+        XCTAssertEqual(reconstructedAction.Position, originalAction.Position)
+        XCTAssertEqual(reconstructedAction.BackgroundColor, originalAction.BackgroundColor)
+        XCTAssertEqual(reconstructedAction.IconName, originalAction.IconName)
+        XCTAssertEqual(reconstructedAction.IconColor, originalAction.IconColor)
+        XCTAssertEqual(reconstructedAction.TextColor, originalAction.TextColor)
+        XCTAssertEqual(reconstructedAction.isServerControlled, originalAction.isServerControlled)
+        XCTAssertEqual(reconstructedAction.serverIdentifier, originalAction.serverIdentifier)
+        XCTAssertEqual(reconstructedAction.showInCarPlay, originalAction.showInCarPlay)
+        XCTAssertEqual(reconstructedAction.showInWatch, originalAction.showInWatch)
+        XCTAssertEqual(reconstructedAction.useCustomColors, originalAction.useCustomColors)
+    }
+
+    // MARK: - CanConfigure Tests
+
+    func testCanConfigureWhenNotServerControlled() {
+        let action = Action()
+        action.isServerControlled = false
+
+        XCTAssertTrue(action.canConfigure(\Action.BackgroundColor))
+        XCTAssertTrue(action.canConfigure(\Action.TextColor))
+        XCTAssertTrue(action.canConfigure(\Action.IconColor))
+        XCTAssertTrue(action.canConfigure(\Action.IconName))
+        XCTAssertTrue(action.canConfigure(\Action.Name))
+        XCTAssertTrue(action.canConfigure(\Action.Text))
+        XCTAssertTrue(action.canConfigure(\Action.serverIdentifier))
+        XCTAssertTrue(action.canConfigure(\Action.showInCarPlay))
+        XCTAssertTrue(action.canConfigure(\Action.showInWatch))
+        XCTAssertTrue(action.canConfigure(\Action.useCustomColors))
+        XCTAssertTrue(action.canConfigure(\Action.Position))
+    }
+
+    func testCannotConfigureWhenServerControlled() {
+        let action = Action()
+        action.isServerControlled = true
+
+        XCTAssertFalse(action.canConfigure(\Action.BackgroundColor))
+        XCTAssertFalse(action.canConfigure(\Action.TextColor))
+        XCTAssertFalse(action.canConfigure(\Action.IconColor))
+        XCTAssertFalse(action.canConfigure(\Action.IconName))
+        XCTAssertFalse(action.canConfigure(\Action.Name))
+        XCTAssertFalse(action.canConfigure(\Action.Text))
+        XCTAssertFalse(action.canConfigure(\Action.serverIdentifier))
+        XCTAssertFalse(action.canConfigure(\Action.showInCarPlay))
+        XCTAssertFalse(action.canConfigure(\Action.showInWatch))
+        XCTAssertFalse(action.canConfigure(\Action.useCustomColors))
+        XCTAssertTrue(action.canConfigure(\Action.Position))
+    }
+
+    func testCanConfigureWithScene() throws {
+        let scene = RLMScene()
+        scene.identifier = "scene.test"
+        scene.serverIdentifier = "server_1"
+        scene.backgroundColor = "#FF0000"
+        scene.textColor = "#00FF00"
+        scene.iconColor = "#0000FF"
+
+        try realm.write {
+            realm.add(scene)
+        }
+
+        let action = Action()
+        action.ID = "scene.test"
+        action.isServerControlled = false
+
+        try realm.write {
+            action.Scene = scene
+            realm.add(action)
+        }
+
+        // When scene has colors set, cannot configure those colors
+        XCTAssertFalse(action.canConfigure(\Action.BackgroundColor))
+        XCTAssertFalse(action.canConfigure(\Action.TextColor))
+        XCTAssertFalse(action.canConfigure(\Action.IconColor))
+
+        // When scene exists, cannot configure these
+        XCTAssertFalse(action.canConfigure(\Action.IconName))
+        XCTAssertFalse(action.canConfigure(\Action.Name))
+        XCTAssertFalse(action.canConfigure(\Action.Text))
+        XCTAssertFalse(action.canConfigure(\Action.serverIdentifier))
+        XCTAssertFalse(action.canConfigure(\Action.showInCarPlay))
+        XCTAssertFalse(action.canConfigure(\Action.showInWatch))
+        XCTAssertFalse(action.canConfigure(\Action.useCustomColors))
+    }
+
+    func testCanConfigureWithSceneWithoutColors() throws {
+        let scene = RLMScene()
+        scene.identifier = "scene.test"
+        scene.serverIdentifier = "server_1"
+        scene.backgroundColor = nil
+        scene.textColor = nil
+        scene.iconColor = nil
+
+        try realm.write {
+            realm.add(scene)
+        }
+
+        let action = Action()
+        action.ID = "scene.test"
+        action.isServerControlled = false
+
+        try realm.write {
+            action.Scene = scene
+            realm.add(action)
+        }
+
+        // When scene doesn't have colors, can configure them
+        XCTAssertTrue(action.canConfigure(\Action.BackgroundColor))
+        XCTAssertTrue(action.canConfigure(\Action.TextColor))
+        XCTAssertTrue(action.canConfigure(\Action.IconColor))
+
+        // When scene exists, still cannot configure these
+        XCTAssertFalse(action.canConfigure(\Action.IconName))
+        XCTAssertFalse(action.canConfigure(\Action.Name))
+        XCTAssertFalse(action.canConfigure(\Action.Text))
+    }
+
+    // MARK: - TriggerType Tests
+
+    func testTriggerTypeForEvent() {
+        let action = Action()
+        action.ID = "custom_action"
+
+        XCTAssertEqual(action.triggerType, .event)
+    }
+
+    func testTriggerTypeForScene() {
+        let action = Action()
+        action.ID = "scene.living_room"
+
+        XCTAssertEqual(action.triggerType, .scene)
+    }
+
+    func testTriggerTypeForSceneWithDifferentFormat() {
+        let action = Action()
+        action.ID = "scene.bedroom_lights"
+
+        XCTAssertEqual(action.triggerType, .scene)
+    }
+
+    // MARK: - Update with MobileAppConfigAction Tests
+
+    func testUpdateWithMobileAppConfigAction() throws {
+        let configAction = try MobileAppConfigAction(JSON: [
+            "name": "test_action",
+            "background_color": "#FF0000",
+            "label": ["text": "Test Label", "color": "#00FF00"],
+            "icon": ["icon": "mdi:test", "color": "#0000FF"],
+            "show_in_carplay": true,
+            "show_in_watch": false,
+            "use_custom_colors": true,
+        ])
+
+        let action = Action()
+
+        try realm.write {
+            let result = action.update(with: configAction, server: server, using: realm)
+            XCTAssertTrue(result)
+        }
+
+        XCTAssertEqual(action.ID, "test_action")
+        XCTAssertEqual(action.Name, "test_action")
+        XCTAssertEqual(action.BackgroundColor, "#FF0000")
+        XCTAssertEqual(action.Text, "Test Label")
+        XCTAssertEqual(action.TextColor, "#00FF00")
+        XCTAssertEqual(action.IconName, "mdi:test")
+        XCTAssertEqual(action.IconColor, "#0000FF")
+        XCTAssertTrue(action.isServerControlled)
+        XCTAssertEqual(action.serverIdentifier, server.identifier.rawValue)
+        XCTAssertTrue(action.showInCarPlay)
+        XCTAssertFalse(action.showInWatch)
+        XCTAssertTrue(action.useCustomColors)
+    }
+
+    func testUpdateWithMobileAppConfigActionMinimalFields() throws {
+        let configAction = try MobileAppConfigAction(JSON: [
+            "name": "minimal_action",
+        ])
+
+        let action = Action()
+
+        try realm.write {
+            let result = action.update(with: configAction, server: server, using: realm)
+            XCTAssertTrue(result)
+        }
+
+        XCTAssertEqual(action.ID, "minimal_action")
+        XCTAssertEqual(action.Name, "minimal_action")
+        XCTAssertEqual(action.Text, "Minimal Action") // Should be formatted name
+        XCTAssertFalse(action.IconName.isEmpty) // Should have generated icon
+        XCTAssertTrue(action.isServerControlled)
+    }
+
+    func testUpdateWithMobileAppConfigActionPreservesIDAndName() throws {
+        let configAction = try MobileAppConfigAction(JSON: [
+            "name": "existing_action",
+            "label": ["text": "New Text"],
+        ])
+
+        let action = Action()
+        action.ID = "existing_action"
+        action.Name = "existing_action"
+
+        try realm.write {
+            realm.add(action)
+        }
+
+        try realm.write {
+            let result = action.update(with: configAction, server: server, using: realm)
+            XCTAssertTrue(result)
+        }
+
+        XCTAssertEqual(action.ID, "existing_action")
+        XCTAssertEqual(action.Name, "existing_action")
+        XCTAssertEqual(action.Text, "New Text")
+    }
+
+    // MARK: - DidUpdate Tests
+
+    func testDidUpdateSetsPositions() throws {
+        let action1 = Action()
+        action1.ID = "action1"
+        let action2 = Action()
+        action2.ID = "action2"
+        let action3 = Action()
+        action3.ID = "action3"
+
+        let actions = [action1, action2, action3]
+
+        try realm.write {
+            Action.didUpdate(objects: actions, server: server, realm: realm)
+        }
+
+        XCTAssertEqual(action1.Position, Action.PositionOffset.synced.rawValue + server.info.sortOrder)
+        XCTAssertEqual(action2.Position, Action.PositionOffset.synced.rawValue + server.info.sortOrder + 1)
+        XCTAssertEqual(action3.Position, Action.PositionOffset.synced.rawValue + server.info.sortOrder + 2)
+    }
+
+    // MARK: - UIColor Random Background Tests
+
+    func testRandomBackgroundColorProperties() {
+        for _ in 0 ..< 100 {
+            let color = UIColor.randomBackgroundColor()
+            var hue: CGFloat = 0
+            var saturation: CGFloat = 0
+            var brightness: CGFloat = 0
+            var alpha: CGFloat = 0
+
+            color.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+
+            XCTAssertGreaterThanOrEqual(saturation, 0.5, "Saturation should be >= 0.5")
+            XCTAssertLessThanOrEqual(saturation, 1.0, "Saturation should be <= 1.0")
+            XCTAssertGreaterThanOrEqual(brightness, 0.25, "Brightness should be >= 0.25")
+            XCTAssertLessThanOrEqual(brightness, 0.75, "Brightness should be <= 0.75")
+            XCTAssertEqual(alpha, 1.0, "Alpha should be 1.0")
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmptyJSONMapping() {
+        let json: [String: Any] = [:]
+        XCTAssertThrowsError(try Action(JSON: json))
+    }
+}

--- a/Tests/Shared/LocationHistoryTests.swift
+++ b/Tests/Shared/LocationHistoryTests.swift
@@ -1,0 +1,404 @@
+import CoreLocation
+import Foundation
+import RealmSwift
+@testable import Shared
+import XCTest
+
+class LocationHistoryTests: XCTestCase {
+    private var realm: Realm!
+
+    override func setUp() {
+        super.setUp()
+
+        let executionIdentifier = UUID().uuidString
+        realm = try! Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
+
+        Current.realm = { self.realm }
+        Current.date = Date.init
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Current.realm = Realm.live
+        Current.date = Date.init
+    }
+
+    // MARK: - LocationHistoryEntry Tests
+
+    func testLocationHistoryEntryConvenienceInitWithLocation() {
+        let testDate = Date()
+        Current.date = { testDate }
+
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            altitude: 10.0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 3.0,
+            timestamp: testDate
+        )
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "test_payload"
+        )
+
+        XCTAssertEqual(entry.Trigger, "Manual")
+        XCTAssertNil(entry.Zone)
+        XCTAssertEqual(entry.Latitude, 37.7749, accuracy: 0.0001)
+        XCTAssertEqual(entry.Longitude, -122.4194, accuracy: 0.0001)
+        XCTAssertEqual(entry.Accuracy, 5.0)
+        XCTAssertEqual(entry.Payload, "test_payload")
+        XCTAssertEqual(entry.accuracyAuthorization, .fullAccuracy)
+    }
+
+    func testLocationHistoryEntryConvenienceInitWithZone() throws {
+        let testDate = Date()
+        Current.date = { testDate }
+
+        let zone = RLMZone()
+        zone.entityId = "home"
+        zone.serverIdentifier = "server1"
+        zone.Latitude = 40.7128
+        zone.Longitude = -74.0060
+        zone.Radius = 100.0
+
+        try realm.write {
+            realm.add(zone)
+        }
+
+        let entry = LocationHistoryEntry(
+            updateType: .RegionEnter,
+            location: nil,
+            zone: zone,
+            accuracyAuthorization: .reducedAccuracy,
+            payload: "zone_payload"
+        )
+
+        XCTAssertEqual(entry.Trigger, "Region Entered")
+        XCTAssertNotNil(entry.Zone)
+        XCTAssertEqual(entry.Zone?.entityId, "home")
+        XCTAssertEqual(entry.Latitude, 40.7128, accuracy: 0.0001)
+        XCTAssertEqual(entry.Longitude, -74.0060, accuracy: 0.0001)
+        XCTAssertEqual(entry.Payload, "zone_payload")
+        XCTAssertEqual(entry.accuracyAuthorization, .reducedAccuracy)
+    }
+
+    func testLocationHistoryEntryConvenienceInitWithLocationAndZone() throws {
+        let testDate = Date()
+        Current.date = { testDate }
+
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            altitude: 10.0,
+            horizontalAccuracy: 15.0,
+            verticalAccuracy: 5.0,
+            timestamp: testDate
+        )
+
+        let zone = RLMZone()
+        zone.entityId = "work"
+        zone.serverIdentifier = "server1"
+        zone.Latitude = 40.0
+        zone.Longitude = -75.0
+        zone.Radius = 200.0
+
+        try realm.write {
+            realm.add(zone)
+        }
+
+        let entry = LocationHistoryEntry(
+            updateType: .GPSRegionEnter,
+            location: location,
+            zone: zone,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "combined_payload"
+        )
+
+        XCTAssertEqual(entry.Trigger, "Geographic Region Entered")
+        XCTAssertNotNil(entry.Zone)
+        // When location is provided, it should be used over zone location
+        XCTAssertEqual(entry.Latitude, 37.7749, accuracy: 0.0001)
+        XCTAssertEqual(entry.Longitude, -122.4194, accuracy: 0.0001)
+        XCTAssertEqual(entry.Accuracy, 15.0)
+        XCTAssertEqual(entry.Payload, "combined_payload")
+    }
+
+    func testLocationHistoryEntryConvenienceInitWithoutLocationOrZone() {
+        let entry = LocationHistoryEntry(
+            updateType: .BackgroundFetch,
+            location: nil,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "no_location_payload"
+        )
+
+        XCTAssertEqual(entry.Trigger, "Background Fetch")
+        XCTAssertNil(entry.Zone)
+        // Should have default CLLocation values
+        XCTAssertEqual(entry.Latitude, 0.0)
+        XCTAssertEqual(entry.Longitude, 0.0)
+        XCTAssertEqual(entry.Payload, "no_location_payload")
+    }
+
+    func testLocationHistoryEntryWithAllTriggerTypes() {
+        let triggerTypes: [LocationUpdateTrigger] = [
+            .RegionEnter,
+            .RegionExit,
+            .GPSRegionEnter,
+            .GPSRegionExit,
+            .BeaconRegionEnter,
+            .BeaconRegionExit,
+            .Manual,
+            .SignificantLocationUpdate,
+            .BackgroundFetch,
+            .PushNotification,
+            .URLScheme,
+            .XCallbackURL,
+            .Siri,
+        ]
+
+        for triggerType in triggerTypes {
+            let entry = LocationHistoryEntry(
+                updateType: triggerType,
+                location: nil,
+                zone: nil,
+                accuracyAuthorization: .fullAccuracy,
+                payload: ""
+            )
+            XCTAssertEqual(entry.Trigger, triggerType.rawValue)
+        }
+    }
+
+    func testLocationHistoryEntryPersistence() throws {
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: CLLocation(latitude: 35.0, longitude: -118.0),
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "persistence_test"
+        )
+
+        try realm.write {
+            realm.add(entry)
+        }
+
+        let retrievedEntry = realm.objects(LocationHistoryEntry.self).first
+        XCTAssertNotNil(retrievedEntry)
+        XCTAssertEqual(retrievedEntry?.Trigger, "Manual")
+        XCTAssertEqual(retrievedEntry?.Latitude, 35.0, accuracy: 0.0001)
+        XCTAssertEqual(retrievedEntry?.Longitude, -118.0, accuracy: 0.0001)
+        XCTAssertEqual(retrievedEntry?.Payload, "persistence_test")
+        XCTAssertEqual(retrievedEntry?.accuracyAuthorization, .fullAccuracy)
+    }
+
+    // MARK: - LocationError Tests
+
+    func testLocationErrorConvenienceInitWithCLError() {
+        let testDate = Date()
+        Current.date = { testDate }
+
+        let clError = CLError(.denied)
+        let locationError = LocationError(err: clError)
+
+        XCTAssertEqual(locationError.Code, CLError.denied.rawValue)
+        XCTAssertFalse(locationError.Description.isEmpty)
+        XCTAssertEqual(locationError.CreatedAt.timeIntervalSince1970, testDate.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    func testLocationErrorWithDifferentErrorCodes() {
+        let errorCodes: [CLError.Code] = [
+            .locationUnknown,
+            .denied,
+            .network,
+            .headingFailure,
+            .regionMonitoringDenied,
+            .regionMonitoringFailure,
+            .regionMonitoringSetupDelayed,
+            .regionMonitoringResponseDelayed,
+        ]
+
+        for errorCode in errorCodes {
+            let clError = CLError(errorCode)
+            let locationError = LocationError(err: clError)
+
+            XCTAssertEqual(locationError.Code, errorCode.rawValue)
+            XCTAssertFalse(locationError.Description.isEmpty)
+        }
+    }
+
+    func testLocationErrorPersistence() throws {
+        let clError = CLError(.network)
+        let locationError = LocationError(err: clError)
+
+        try realm.write {
+            realm.add(locationError)
+        }
+
+        let retrievedError = realm.objects(LocationError.self).first
+        XCTAssertNotNil(retrievedError)
+        XCTAssertEqual(retrievedError?.Code, CLError.network.rawValue)
+        XCTAssertFalse(retrievedError?.Description.isEmpty ?? true)
+    }
+
+    func testLocationErrorMultipleEntries() throws {
+        let error1 = LocationError(err: CLError(.denied))
+        let error2 = LocationError(err: CLError(.network))
+        let error3 = LocationError(err: CLError(.locationUnknown))
+
+        try realm.write {
+            realm.add([error1, error2, error3])
+        }
+
+        let retrievedErrors = realm.objects(LocationError.self)
+        XCTAssertEqual(retrievedErrors.count, 3)
+    }
+
+    // MARK: - Edge Cases
+
+    func testLocationHistoryEntryWithZeroAccuracy() {
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0),
+            altitude: 0.0,
+            horizontalAccuracy: 0.0,
+            verticalAccuracy: 0.0,
+            timestamp: Date()
+        )
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: ""
+        )
+
+        XCTAssertEqual(entry.Accuracy, 0.0)
+        XCTAssertEqual(entry.Latitude, 0.0)
+        XCTAssertEqual(entry.Longitude, 0.0)
+    }
+
+    func testLocationHistoryEntryWithNegativeAccuracy() {
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 45.0, longitude: 90.0),
+            altitude: 0.0,
+            horizontalAccuracy: -1.0,
+            verticalAccuracy: 0.0,
+            timestamp: Date()
+        )
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: ""
+        )
+
+        XCTAssertEqual(entry.Accuracy, -1.0)
+    }
+
+    func testLocationHistoryEntryWithExtremeCoordinates() {
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 90.0, longitude: 180.0),
+            altitude: 0.0,
+            horizontalAccuracy: 1.0,
+            verticalAccuracy: 0.0,
+            timestamp: Date()
+        )
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: ""
+        )
+
+        XCTAssertEqual(entry.Latitude, 90.0)
+        XCTAssertEqual(entry.Longitude, 180.0)
+    }
+
+    func testLocationHistoryEntryWithLargePayload() {
+        let largePayload = String(repeating: "A", count: 10000)
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: CLLocation(latitude: 0.0, longitude: 0.0),
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: largePayload
+        )
+
+        XCTAssertEqual(entry.Payload.count, 10000)
+        XCTAssertEqual(entry.Payload, largePayload)
+    }
+
+    func testLocationHistoryEntryWithSpecialCharactersInPayload() {
+        let specialPayload = "Test 特殊字符 🏠 emoji @#$%^&*(){}[]"
+
+        let entry = LocationHistoryEntry(
+            updateType: .Manual,
+            location: CLLocation(latitude: 0.0, longitude: 0.0),
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: specialPayload
+        )
+
+        XCTAssertEqual(entry.Payload, specialPayload)
+    }
+
+    func testLocationHistoryEntryCLLocationWithExtremeDates() {
+        // Test with a date far in the past
+        let pastDate = Date(timeIntervalSince1970: 0)
+        Current.date = { pastDate }
+
+        let entry = LocationHistoryEntry()
+        entry.Latitude = 0.0
+        entry.Longitude = 0.0
+        entry.Accuracy = 5.0
+
+        let clLocation = entry.clLocation
+        XCTAssertEqual(clLocation.timestamp.timeIntervalSince1970, pastDate.timeIntervalSince1970, accuracy: 1.0)
+
+        // Test with a date far in the future
+        let futureDate = Date(timeIntervalSince1970: 2_000_000_000)
+        Current.date = { futureDate }
+
+        let entry2 = LocationHistoryEntry()
+        entry2.Latitude = 0.0
+        entry2.Longitude = 0.0
+
+        let clLocation2 = entry2.clLocation
+        XCTAssertEqual(clLocation2.timestamp.timeIntervalSince1970, futureDate.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    func testMultipleLocationHistoryEntriesWithSameData() throws {
+        let location = CLLocation(latitude: 37.0, longitude: -122.0)
+
+        let entry1 = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "duplicate"
+        )
+
+        let entry2 = LocationHistoryEntry(
+            updateType: .Manual,
+            location: location,
+            zone: nil,
+            accuracyAuthorization: .fullAccuracy,
+            payload: "duplicate"
+        )
+
+        try realm.write {
+            realm.add([entry1, entry2])
+        }
+
+        let entries = realm.objects(LocationHistoryEntry.self)
+        XCTAssertEqual(entries.count, 2)
+    }
+}

--- a/Tests/Shared/NotificationAction.test.swift
+++ b/Tests/Shared/NotificationAction.test.swift
@@ -467,15 +467,17 @@ private extension MobileAppConfigPushCategory.Action {
         url: String?,
         icon: String?
     ) {
-        self.title = title
-        self.identifier = identifier
-        self.authenticationRequired = authenticationRequired
-        self.behavior = behavior
-        self.activationMode = activationMode
-        self.destructive = destructive
-        self.textInputButtonTitle = textInputButtonTitle
-        self.textInputPlaceholder = textInputPlaceholder
-        self.url = url
-        self.icon = icon
+        self = createMockPushAction(
+            title: title,
+            identifier: identifier,
+            authenticationRequired: authenticationRequired,
+            behavior: behavior,
+            activationMode: activationMode,
+            destructive: destructive,
+            textInputButtonTitle: textInputButtonTitle,
+            textInputPlaceholder: textInputPlaceholder,
+            url: url,
+            icon: icon
+        )
     }
 }

--- a/Tests/Shared/NotificationAction.test.swift
+++ b/Tests/Shared/NotificationAction.test.swift
@@ -1,0 +1,481 @@
+import Foundation
+import RealmSwift
+@testable import Shared
+import UserNotifications
+import XCTest
+
+class NotificationActionTests: XCTestCase {
+    private var realm: Realm!
+    private var testQueue: DispatchQueue!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        testQueue = DispatchQueue(label: #file)
+        let executionIdentifier = UUID().uuidString
+        try testQueue.sync {
+            realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier), queue: testQueue)
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func testDefaultInitialization() {
+        let action = NotificationAction()
+
+        XCTAssertFalse(action.uuid.isEmpty)
+        XCTAssertEqual(action.Identifier, "")
+        XCTAssertEqual(action.Title, "")
+        XCTAssertFalse(action.TextInput)
+        XCTAssertFalse(action.isServerControlled)
+        XCTAssertNil(action.icon)
+        XCTAssertFalse(action.Foreground)
+        XCTAssertFalse(action.Destructive)
+        XCTAssertFalse(action.AuthenticationRequired)
+    }
+
+    func testUUIDIsUnique() {
+        let action1 = NotificationAction()
+        let action2 = NotificationAction()
+
+        XCTAssertNotEqual(action1.uuid, action2.uuid)
+    }
+
+    // MARK: - Convenience Initializer Tests
+
+    func testInitWithMobileAppConfigPushCategoryAction() {
+        let pushAction = createMockPushAction(
+            title: "Reply",
+            identifier: "reply_action",
+            authenticationRequired: true,
+            behavior: "textinput",
+            activationMode: "foreground",
+            destructive: false,
+            textInputButtonTitle: "Send",
+            textInputPlaceholder: "Type here",
+            url: nil,
+            icon: "sfsymbols:message"
+        )
+
+        let action = NotificationAction(action: pushAction)
+
+        XCTAssertTrue(action.isServerControlled)
+        XCTAssertEqual(action.Title, "Reply")
+        XCTAssertEqual(action.Identifier, "reply_action")
+        XCTAssertTrue(action.AuthenticationRequired)
+        XCTAssertTrue(action.Foreground)
+        XCTAssertFalse(action.Destructive)
+        XCTAssertTrue(action.TextInput)
+        XCTAssertEqual(action.icon, "sfsymbols:message")
+        XCTAssertEqual(action.TextInputButtonTitle, "Send")
+        XCTAssertEqual(action.TextInputPlaceholder, "Type here")
+    }
+
+    func testInitWithMobileAppConfigActionBackgroundMode() {
+        let pushAction = createMockPushAction(
+            title: "Dismiss",
+            identifier: "dismiss_action",
+            authenticationRequired: false,
+            behavior: "default",
+            activationMode: "background",
+            destructive: true,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action = NotificationAction(action: pushAction)
+
+        XCTAssertEqual(action.Title, "Dismiss")
+        XCTAssertFalse(action.Foreground)
+        XCTAssertTrue(action.Destructive)
+        XCTAssertFalse(action.TextInput)
+    }
+
+    func testInitWithMobileAppConfigActionForegroundMode() {
+        let pushAction = createMockPushAction(
+            title: "Open",
+            identifier: "open_action",
+            authenticationRequired: false,
+            behavior: "default",
+            activationMode: "foreground",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action = NotificationAction(action: pushAction)
+
+        XCTAssertTrue(action.Foreground)
+    }
+
+    func testInitWithMobileAppConfigActionTextInput() {
+        let pushAction = createMockPushAction(
+            title: "Reply",
+            identifier: "reply",
+            authenticationRequired: false,
+            behavior: "textinput",
+            activationMode: "background",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action = NotificationAction(action: pushAction)
+
+        XCTAssertTrue(action.TextInput)
+    }
+
+    func testInitWithMobileAppConfigActionDefaultTextInputValues() {
+        let pushAction = createMockPushAction(
+            title: "Reply",
+            identifier: "reply",
+            authenticationRequired: false,
+            behavior: "textinput",
+            activationMode: "background",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action = NotificationAction(action: pushAction)
+
+        XCTAssertEqual(
+            action.TextInputButtonTitle,
+            L10n.NotificationsConfigurator.Action.Rows.TextInputButtonTitle.title
+        )
+        XCTAssertEqual(
+            action.TextInputPlaceholder,
+            L10n.NotificationsConfigurator.Action.Rows.TextInputPlaceholder.title
+        )
+    }
+
+    // MARK: - Options Tests
+
+    func testOptionsWithAllEnabled() {
+        let action = NotificationAction()
+        action.AuthenticationRequired = true
+        action.Destructive = true
+        action.Foreground = true
+
+        let options = action.options
+        XCTAssertTrue(options.contains(.authenticationRequired))
+        XCTAssertTrue(options.contains(.destructive))
+        XCTAssertTrue(options.contains(.foreground))
+    }
+
+    // MARK: - Action Property Tests
+
+    func testActionPropertyWithTextInput() {
+        let action = NotificationAction()
+        action.Identifier = "reply_action"
+        action.Title = "Reply"
+        action.TextInput = true
+        action.TextInputButtonTitle = "Send"
+        action.TextInputPlaceholder = "Type here"
+
+        let unAction = action.action
+        XCTAssertTrue(unAction is UNTextInputNotificationAction)
+
+        if let textInputAction = unAction as? UNTextInputNotificationAction {
+            XCTAssertEqual(textInputAction.textInputButtonTitle, "Send")
+            XCTAssertEqual(textInputAction.textInputPlaceholder, "Type here")
+        } else {
+            XCTFail("Action should be UNTextInputNotificationAction")
+        }
+    }
+
+    func testActionPropertyWithOptions() {
+        let action = NotificationAction()
+        action.Identifier = "delete_action"
+        action.Title = "Delete"
+        action.Destructive = true
+        action.Foreground = true
+
+        let unAction = action.action
+        XCTAssertTrue(unAction.options.contains(.destructive))
+        XCTAssertTrue(unAction.options.contains(.foreground))
+    }
+
+    func testActionPropertyWithSFSymbolIcon() {
+        let action = NotificationAction()
+        action.Identifier = "star_action"
+        action.Title = "Star"
+        action.icon = "sfsymbols:star"
+
+        let unAction = action.action
+        XCTAssertNotNil(unAction.icon)
+    }
+
+    // MARK: - Example Trigger Tests
+
+    func testExampleTriggerWithoutTextInput() {
+        let api = FakeHomeAssistantAPI(server: .fake())
+
+        let trigger = NotificationAction.exampleTrigger(
+            api: api,
+            identifier: "test_action",
+            category: "test_category",
+            textInput: false
+        )
+
+        XCTAssertTrue(trigger.contains("platform: event"))
+        XCTAssertTrue(trigger.contains("event_type:"))
+        XCTAssertTrue(trigger.contains("event_data:"))
+        XCTAssertFalse(trigger.contains("# text you input"))
+    }
+
+    func testExampleTriggerWithTextInput() {
+        let api = FakeHomeAssistantAPI(server: .fake())
+
+        let trigger = NotificationAction.exampleTrigger(
+            api: api,
+            identifier: "reply_action",
+            category: "message_category",
+            textInput: true
+        )
+
+        XCTAssertTrue(trigger.contains("platform: event"))
+        XCTAssertTrue(trigger.contains("event_type:"))
+        XCTAssertTrue(trigger.contains("event_data:"))
+        XCTAssertTrue(trigger.contains("# text you input"))
+    }
+
+    func testExampleTriggerWithoutCategory() {
+        let api = FakeHomeAssistantAPI(server: .fake())
+
+        let trigger = NotificationAction.exampleTrigger(
+            api: api,
+            identifier: "test_action",
+            category: nil,
+            textInput: false
+        )
+
+        XCTAssertTrue(trigger.contains("platform: event"))
+    }
+
+    // MARK: - Persistence Tests
+
+    func testPersistenceWithRealm() throws {
+        try testQueue.sync {
+            try realm.write {
+                let action = NotificationAction()
+                action.Identifier = "persisted_action"
+                action.Title = "Persisted Action"
+                realm.add(action)
+            }
+
+            let retrieved = realm.object(ofType: NotificationAction.self, forPrimaryKey: action.uuid)
+            XCTAssertNotNil(retrieved)
+            XCTAssertEqual(retrieved?.Title, "Persisted Action")
+        }
+
+        func action() -> NotificationAction {
+            let action = NotificationAction()
+            try! realm.write {
+                realm.add(action)
+            }
+            return action
+        }
+    }
+
+    func testPersistenceWithCategory() throws {
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "test_category"
+                category.Name = "Test Category"
+
+                let action = NotificationAction()
+                action.Identifier = "action_in_category"
+                action.Title = "Action"
+
+                category.Actions.append(action)
+                realm.add(category)
+            }
+
+            let retrievedCategory = realm.object(
+                ofType: NotificationCategory.self,
+                forPrimaryKey: "test_category"
+            )
+            XCTAssertNotNil(retrievedCategory)
+            XCTAssertEqual(retrievedCategory?.Actions.count, 1)
+
+            let retrievedAction = retrievedCategory?.Actions.first
+            XCTAssertNotNil(retrievedAction)
+            XCTAssertEqual(retrievedAction?.Identifier, "action_in_category")
+            XCTAssertEqual(retrievedAction?.categories.count, 1)
+        }
+    }
+
+    // MARK: - Edge Cases Tests
+
+    func testTextInputWithEmptyButtonTitle() {
+        let action = NotificationAction()
+        action.TextInput = true
+        action.TextInputButtonTitle = ""
+        action.TextInputPlaceholder = ""
+
+        let unAction = action.action
+        XCTAssertTrue(unAction is UNTextInputNotificationAction)
+
+        if let textInputAction = unAction as? UNTextInputNotificationAction {
+            XCTAssertEqual(textInputAction.textInputButtonTitle, "")
+            XCTAssertEqual(textInputAction.textInputPlaceholder, "")
+        }
+    }
+
+    func testCaseInsensitiveActivationMode() {
+        let pushAction1 = createMockPushAction(
+            title: "Test",
+            identifier: "test1",
+            authenticationRequired: false,
+            behavior: "default",
+            activationMode: "FOREGROUND",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action1 = NotificationAction(action: pushAction1)
+        XCTAssertTrue(action1.Foreground)
+
+        let pushAction2 = createMockPushAction(
+            title: "Test",
+            identifier: "test2",
+            authenticationRequired: false,
+            behavior: "default",
+            activationMode: "Background",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action2 = NotificationAction(action: pushAction2)
+        XCTAssertFalse(action2.Foreground)
+    }
+
+    func testCaseInsensitiveBehavior() {
+        let pushAction1 = createMockPushAction(
+            title: "Test",
+            identifier: "test1",
+            authenticationRequired: false,
+            behavior: "TEXTINPUT",
+            activationMode: "background",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action1 = NotificationAction(action: pushAction1)
+        XCTAssertTrue(action1.TextInput)
+
+        let pushAction2 = createMockPushAction(
+            title: "Test",
+            identifier: "test2",
+            authenticationRequired: false,
+            behavior: "TextInput",
+            activationMode: "background",
+            destructive: false,
+            textInputButtonTitle: nil,
+            textInputPlaceholder: nil,
+            url: nil,
+            icon: nil
+        )
+
+        let action2 = NotificationAction(action: pushAction2)
+        XCTAssertTrue(action2.TextInput)
+    }
+
+    func testMultipleActionsWithSameIdentifier() throws {
+        try testQueue.sync {
+            try realm.write {
+                let action1 = NotificationAction()
+                action1.Identifier = "same_identifier"
+                action1.Title = "Action 1"
+
+                let action2 = NotificationAction()
+                action2.Identifier = "same_identifier"
+                action2.Title = "Action 2"
+
+                realm.add(action1)
+                realm.add(action2)
+
+                XCTAssertNotEqual(action1.uuid, action2.uuid)
+            }
+        }
+    }
+}
+
+// MARK: - Helper Functions
+
+private func createMockPushAction(
+    title: String,
+    identifier: String,
+    authenticationRequired: Bool,
+    behavior: String,
+    activationMode: String,
+    destructive: Bool,
+    textInputButtonTitle: String?,
+    textInputPlaceholder: String?,
+    url: String?,
+    icon: String?
+) -> MobileAppConfigPushCategory.Action {
+    MobileAppConfigPushCategory.Action(
+        title: title,
+        identifier: identifier,
+        authenticationRequired: authenticationRequired,
+        behavior: behavior,
+        activationMode: activationMode,
+        destructive: destructive,
+        textInputButtonTitle: textInputButtonTitle,
+        textInputPlaceholder: textInputPlaceholder,
+        url: url,
+        icon: icon
+    )
+}
+
+// MARK: - Helper Extensions
+
+private extension MobileAppConfigPushCategory.Action {
+    init(
+        title: String,
+        identifier: String,
+        authenticationRequired: Bool,
+        behavior: String,
+        activationMode: String,
+        destructive: Bool,
+        textInputButtonTitle: String?,
+        textInputPlaceholder: String?,
+        url: String?,
+        icon: String?
+    ) {
+        self.title = title
+        self.identifier = identifier
+        self.authenticationRequired = authenticationRequired
+        self.behavior = behavior
+        self.activationMode = activationMode
+        self.destructive = destructive
+        self.textInputButtonTitle = textInputButtonTitle
+        self.textInputPlaceholder = textInputPlaceholder
+        self.url = url
+        self.icon = icon
+    }
+}

--- a/Tests/Shared/NotificationCategory.test.swift
+++ b/Tests/Shared/NotificationCategory.test.swift
@@ -19,6 +19,7 @@ class NotificationCategoryTests: XCTestCase {
     }
 
     override func tearDown() {
+        Current.realm = Realm.live
         super.tearDown()
     }
 

--- a/Tests/Shared/NotificationCategory.test.swift
+++ b/Tests/Shared/NotificationCategory.test.swift
@@ -1,0 +1,344 @@
+import Foundation
+import RealmSwift
+@testable import Shared
+import UserNotifications
+import XCTest
+
+class NotificationCategoryTests: XCTestCase {
+    private var realm: Realm!
+    private var testQueue: DispatchQueue!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        testQueue = DispatchQueue(label: #file)
+        let executionIdentifier = UUID().uuidString
+        try testQueue.sync {
+            realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier), queue: testQueue)
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func testDefaultInitialization() {
+        let category = NotificationCategory()
+
+        XCTAssertFalse(category.isServerControlled)
+        XCTAssertEqual(category.serverIdentifier, "")
+        XCTAssertEqual(category.Name, "")
+        XCTAssertEqual(category.Identifier, "")
+        XCTAssertNil(category.HiddenPreviewsBodyPlaceholder)
+        XCTAssertNil(category.CategorySummaryFormat)
+        XCTAssertTrue(category.SendDismissActions)
+        XCTAssertFalse(category.HiddenPreviewsShowTitle)
+        XCTAssertFalse(category.HiddenPreviewsShowSubtitle)
+        XCTAssertEqual(category.Actions.count, 0)
+    }
+
+    // MARK: - Options Tests
+
+    #if os(iOS)
+    func testOptionsWithAllEnabled() {
+        let category = NotificationCategory()
+        category.SendDismissActions = true
+        category.HiddenPreviewsShowTitle = true
+        category.HiddenPreviewsShowSubtitle = true
+
+        let options = category.options
+        XCTAssertTrue(options.contains(.customDismissAction))
+        XCTAssertTrue(options.contains(.hiddenPreviewsShowTitle))
+        XCTAssertTrue(options.contains(.hiddenPreviewsShowSubtitle))
+    }
+    #endif
+
+    // MARK: - Categories Tests
+
+    #if os(iOS)
+    func testCategoriesProperty() {
+        let category = NotificationCategory()
+        category.Identifier = "test_category"
+        category.Name = "Test Category"
+        category.HiddenPreviewsBodyPlaceholder = "Hidden"
+        category.CategorySummaryFormat = "%u messages"
+
+        let categories = category.categories
+        XCTAssertEqual(categories.count, 1)
+
+        let unCategory = categories.first
+        XCTAssertNotNil(unCategory)
+        XCTAssertEqual(unCategory?.identifier, "TEST_CATEGORY")
+    }
+
+    func testCategoriesWithActions() throws {
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "test_category"
+                category.Name = "Test Category"
+
+                let action1 = NotificationAction()
+                action1.Identifier = "action1"
+                action1.Title = "Action 1"
+
+                let action2 = NotificationAction()
+                action2.Identifier = "action2"
+                action2.Title = "Action 2"
+
+                category.Actions.append(objectsIn: [action1, action2])
+                realm.add(category)
+
+                let categories = category.categories
+                XCTAssertEqual(categories.count, 1)
+                XCTAssertEqual(categories.first?.actions.count, 2)
+            }
+        }
+    }
+    #endif
+
+    // MARK: - Example Service Call Tests
+
+    func testExampleServiceCallWithActions() throws {
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "test_category"
+
+                let action1 = NotificationAction()
+                action1.Identifier = "action1"
+                action1.Title = "Action 1"
+
+                category.Actions.append(action1)
+                realm.add(category)
+
+                let serviceCall = category.exampleServiceCall
+                XCTAssertTrue(serviceCall.contains("category: TEST_CATEGORY"))
+                XCTAssertTrue(serviceCall.contains("\"action1\": \"http://example.com/url\""))
+            }
+        }
+    }
+
+    func testExampleServiceCallContainsFallbackActionIdentifier() {
+        let category = NotificationCategory()
+        category.Identifier = "test"
+
+        let serviceCall = category.exampleServiceCall
+        XCTAssertTrue(serviceCall.contains("\"_\": \"http://example.com/fallback\""))
+    }
+
+    // MARK: - Update Tests
+
+    func testUpdateWithMobileAppConfigPushCategory() throws {
+        let servers = FakeServerManager(initial: 1)
+        let server = servers.server(forServerIdentifier: servers.all.first!.identifier)!
+
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+
+                let action = MobileAppConfigPushCategory.Action(
+                    title: "Reply",
+                    identifier: "reply_action",
+                    authenticationRequired: true,
+                    behavior: "textinput",
+                    activationMode: "foreground",
+                    destructive: false,
+                    textInputButtonTitle: "Send",
+                    textInputPlaceholder: "Type here",
+                    url: nil,
+                    icon: "sfsymbols:message"
+                )
+
+                let pushCategory = MobileAppConfigPushCategory(
+                    name: "Test Category",
+                    identifier: "test_category",
+                    actions: [action]
+                )
+
+                let updated = category.update(with: pushCategory, server: server, using: realm)
+
+                XCTAssertTrue(updated)
+                XCTAssertTrue(category.isServerControlled)
+                XCTAssertEqual(category.serverIdentifier, server.identifier.rawValue)
+                XCTAssertEqual(category.Name, "Test Category")
+                XCTAssertEqual(category.Identifier, "TEST_CATEGORY")
+                XCTAssertEqual(category.Actions.count, 1)
+
+                let updatedAction = category.Actions.first
+                XCTAssertNotNil(updatedAction)
+                XCTAssertEqual(updatedAction?.Title, "Reply")
+                XCTAssertEqual(updatedAction?.Identifier, "reply_action")
+                XCTAssertTrue(updatedAction?.AuthenticationRequired ?? false)
+                XCTAssertTrue(updatedAction?.TextInput ?? false)
+                XCTAssertTrue(updatedAction?.Foreground ?? false)
+            }
+        }
+    }
+
+    func testUpdatePreservesIdentifier() throws {
+        let servers = FakeServerManager(initial: 1)
+        let server = servers.server(forServerIdentifier: servers.all.first!.identifier)!
+
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "EXISTING_CATEGORY"
+                realm.add(category)
+
+                let pushCategory = MobileAppConfigPushCategory(
+                    name: "Updated Category",
+                    identifier: "existing_category",
+                    actions: []
+                )
+
+                let updated = category.update(with: pushCategory, server: server, using: realm)
+
+                XCTAssertTrue(updated)
+                XCTAssertEqual(category.Identifier, "EXISTING_CATEGORY")
+            }
+        }
+    }
+
+    func testUpdateReplacesActions() throws {
+        let servers = FakeServerManager(initial: 1)
+        let server = servers.server(forServerIdentifier: servers.all.first!.identifier)!
+
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "TEST_CATEGORY"
+
+                let oldAction = NotificationAction()
+                oldAction.Identifier = "old_action"
+                oldAction.Title = "Old Action"
+                category.Actions.append(oldAction)
+                realm.add(category)
+
+                XCTAssertEqual(category.Actions.count, 1)
+
+                let newAction = MobileAppConfigPushCategory.Action(
+                    title: "New Action",
+                    identifier: "new_action",
+                    authenticationRequired: false,
+                    behavior: "default",
+                    activationMode: "background",
+                    destructive: false,
+                    textInputButtonTitle: nil,
+                    textInputPlaceholder: nil,
+                    url: nil,
+                    icon: nil
+                )
+
+                let pushCategory = MobileAppConfigPushCategory(
+                    name: "Test Category",
+                    identifier: "test_category",
+                    actions: [newAction]
+                )
+
+                let updated = category.update(with: pushCategory, server: server, using: realm)
+
+                XCTAssertTrue(updated)
+                XCTAssertEqual(category.Actions.count, 1)
+                XCTAssertEqual(category.Actions.first?.Identifier, "new_action")
+                XCTAssertEqual(category.Actions.first?.Title, "New Action")
+            }
+        }
+    }
+
+    // MARK: - Persistence Tests
+
+    func testPersistenceWithRealm() throws {
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "persisted_category"
+                category.Name = "Persisted Category"
+                category.isServerControlled = true
+                category.serverIdentifier = "server_1"
+                realm.add(category)
+            }
+
+            let retrieved = realm.object(ofType: NotificationCategory.self, forPrimaryKey: "persisted_category")
+            XCTAssertNotNil(retrieved)
+            XCTAssertEqual(retrieved?.Name, "Persisted Category")
+            XCTAssertTrue(retrieved?.isServerControlled ?? false)
+            XCTAssertEqual(retrieved?.serverIdentifier, "server_1")
+        }
+    }
+
+    func testPersistenceWithActions() throws {
+        try testQueue.sync {
+            try realm.write {
+                let category = NotificationCategory()
+                category.Identifier = "category_with_actions"
+                category.Name = "Category With Actions"
+
+                let action = NotificationAction()
+                action.Identifier = "action_1"
+                action.Title = "Action 1"
+                category.Actions.append(action)
+
+                realm.add(category)
+            }
+
+            let retrieved = realm.object(ofType: NotificationCategory.self, forPrimaryKey: "category_with_actions")
+            XCTAssertNotNil(retrieved)
+            XCTAssertEqual(retrieved?.Actions.count, 1)
+            XCTAssertEqual(retrieved?.Actions.first?.Title, "Action 1")
+        }
+    }
+
+    // MARK: - Edge Cases Tests
+
+    func testCaseInsensitiveIdentifier() {
+        let category = NotificationCategory()
+        category.Identifier = "lowercase"
+
+        #if os(iOS)
+        let categories = category.categories
+        XCTAssertEqual(categories.first?.identifier, "LOWERCASE")
+        #endif
+
+        let serviceCall = category.exampleServiceCall
+        XCTAssertTrue(serviceCall.contains("category: LOWERCASE"))
+    }
+}
+
+// MARK: - Helper Extensions
+
+private extension MobileAppConfigPushCategory {
+    init(name: String, identifier: String, actions: [Action]) {
+        self.name = name
+        self.identifier = identifier
+        self.actions = actions
+    }
+}
+
+private extension MobileAppConfigPushCategory.Action {
+    init(
+        title: String,
+        identifier: String,
+        authenticationRequired: Bool,
+        behavior: String,
+        activationMode: String,
+        destructive: Bool,
+        textInputButtonTitle: String?,
+        textInputPlaceholder: String?,
+        url: String?,
+        icon: String?
+    ) {
+        self.title = title
+        self.identifier = identifier
+        self.authenticationRequired = authenticationRequired
+        self.behavior = behavior
+        self.activationMode = activationMode
+        self.destructive = destructive
+        self.textInputButtonTitle = textInputButtonTitle
+        self.textInputPlaceholder = textInputPlaceholder
+        self.url = url
+        self.icon = icon
+    }
+}


### PR DESCRIPTION
## Summary

Add unit tests for API models: NotificationCategory, NotificationAction, Action, and LocationHistory.

## Screenshots

N/A - Test code only

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Adds 45 tests covering data models, Codable compliance, and Realm persistence.