### PR TITLE
Add unit tests for extension utilities

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1224,18 +1224,20 @@
 		46F103262D721516002BC586 /* LocationHistoryListViewSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F103252D721504002BC586 /* LocationHistoryListViewSnapshot.test.swift */; };
 		491E98FF25D543560077BBE3 /* LogbookEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491E98FE25D543560077BBE3 /* LogbookEntry.swift */; };
 		491E990025D543560077BBE3 /* LogbookEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491E98FE25D543560077BBE3 /* LogbookEntry.swift */; };
+		52B17D27B321FB4F15CFAE2B /* ColorExtensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEAAD0943C42868B05E2AF4 /* ColorExtensions.test.swift */; };
 		539AA1653F4BCDB61FE7C696 /* Pods_iOS_Shared_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 213EF66D14F92AF8BF2E9E98 /* Pods_iOS_Shared_iOS.framework */; };
 		5B715903CB3450FE351399BC /* Pods-iOS-Extensions-Share-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 207E35C8F1554A9AD616FFA2 /* Pods-iOS-Extensions-Share-metadata.plist */; };
 		5FFBC80F835393915C4748CF /* Pods_iOS_Extensions_PushProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A370326321B07E5ACE0BCB65 /* Pods_iOS_Extensions_PushProvider.framework */; };
 		65286F3B745551AD4090EE6B /* Pods-iOS-SharedTesting-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4053903E4C54A6803204286E /* Pods-iOS-SharedTesting-metadata.plist */; };
-		692BCBBA4EEEABCC76DBBECA /* Database/GRDB+Initialization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */; };
+		692BCBBA4EEEABCC76DBBECA /* GRDB+Initialization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */; };
 		6FCEBAA2C8E9C5403055E73D /* IntentFanEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5E2F9F8F008EEA30C533FD /* IntentFanEntity.swift */; };
 		78BE7D5D003D9F8C7486DD69 /* Pods_iOS_Shared_iOS_Tests_Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F4DFB087A3A43F9A526B851 /* Pods_iOS_Shared_iOS_Tests_Shared.framework */; };
 		81A0C1BBDEFF4F8C5FC314BE /* Pods_iOS_Extensions_NotificationContent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F356D0219C7F8A24234511B /* Pods_iOS_Extensions_NotificationContent.framework */; };
 		84F7755EFB03C3F463292ABF /* Pods-watchOS-Shared-watchOS-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */; };
 		8E5FA96C740F1D671966CEA9 /* Pods-iOS-Extensions-NotificationContent-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B613440AEDD4209862503F5D /* Pods-iOS-Extensions-NotificationContent-metadata.plist */; };
-		A2F3A140CDD1EF1AEA6DFAB9 /* Database/DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */; };
+		A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */; };
 		A5A3C1932BE1F4A40EA78754 /* Pods-iOS-Extensions-Matter-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392B0C44197C98E2653932A5 /* Pods-iOS-Extensions-Matter-metadata.plist */; };
+		B09FECA8FCD1B506E37DA3A1 /* String+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27878A8A33BB63302DD6573 /* String+HA.test.swift */; };
 		B6022213226DAC9D00E8DBFE /* ScaledFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6022212226DAC9D00E8DBFE /* ScaledFont.swift */; };
 		B60248001FBD343000998205 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B60247FE1FBD343000998205 /* InfoPlist.strings */; };
 		B605C891226E9DAC00EF46DD /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B605C890226E9DAC00EF46DD /* Permissions.swift */; };
@@ -1488,11 +1490,13 @@
 		B6E2D4D52270706300446DFA /* ha-loading.json in Resources */ = {isa = PBXBuildFile; fileRef = B6E2D4D42270706200446DFA /* ha-loading.json */; };
 		B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D03D891720E0A85200D4F28D /* Shared.framework */; };
 		B9820AF29664869FD0B25CDF /* Pods_iOS_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD90A8F251D0671EFAC931ED /* Pods_iOS_App.framework */; };
-		BECCC152A4E3F69A8EF5A6F3 /* Database/TableSchemaTests.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */; };
+		BECCC152A4E3F69A8EF5A6F3 /* TableSchemaTests.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */; };
 		C10D762EFE08D347D0538339 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B2F5238669D8A7416FBD2B55 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist */; };
 		C6478E5ADCB3EB7EC959EB53 /* Pods_iOS_Extensions_Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29FC93E25AB875716E2F35D4 /* Pods_iOS_Extensions_Intents.framework */; };
+		C8885A0F274E06FBE629CE6C /* DictionaryExtensions.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE0704A278B3F876C306B5B /* DictionaryExtensions.test.swift */; };
 		CA6886D02384DA18A91F37DD /* Pods-iOS-Extensions-Intents-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = E41A4AAEF642A72ACDB6C006 /* Pods-iOS-Extensions-Intents-metadata.plist */; };
 		CB1983AFBFED0A03533DBE85 /* Pods_iOS_Extensions_Share.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C851CA22DDEEA359D12221C3 /* Pods_iOS_Extensions_Share.framework */; };
+		CCFE958C52425990E37E7754 /* Bool+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54A3AA95E71D55F8F9A78E4 /* Bool+HA.test.swift */; };
 		CF58E969432B36CC112701AC /* Pods_watchOS_Shared_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F1D92E4B7A5CD1007EB0782 /* Pods_watchOS_Shared_watchOS.framework */; };
 		D014EEA92128E192008EA6F5 /* ConnectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D014EEA82128E192008EA6F5 /* ConnectionInfo.swift */; };
 		D03D892920E0A85300D4F28D /* Shared.h in Headers */ = {isa = PBXBuildFile; fileRef = D03D891920E0A85300D4F28D /* Shared.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1530,7 +1534,8 @@
 		D0EEF322214DE56B00D1D360 /* LocationTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EEF321214DE56B00D1D360 /* LocationTrigger.swift */; };
 		D0EEF324214DF2B700D1D360 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E857A11CB1CCCC00F96925 /* Utils.swift */; };
 		D0EEF335214EB77100D1D360 /* CLLocation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2C17E20D1F64D00BD810B /* CLLocation+Extensions.swift */; };
-		DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */; };
+		D20FFDD9D9F18990BEDDE07C /* Float+HA.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CDCCF5A17F4217A21EDF69 /* Float+HA.test.swift */; };
+		DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */; };
 		FC8E9421FDB864726918B612 /* Pods-watchOS-WatchExtension-Watch-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9249824D575933DFA1530BB2 /* Pods-watchOS-WatchExtension-Watch-metadata.plist */; };
 		FD3BC66329B9FF8F00B19FBE /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */; };
 		FD3BC66C29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */; };
@@ -3005,7 +3010,8 @@
 		574F428FD5AD613411644AE4 /* Pods-iOS-Extensions-PushProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-PushProvider.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-PushProvider/Pods-iOS-Extensions-PushProvider.release.xcconfig"; sourceTree = "<group>"; };
 		57B9C3C07B5A002D749B5CDA /* Pods_Tests_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		592EED7A6C2444872F11C17B /* Pods-iOS-Extensions-NotificationService-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-NotificationService-metadata.plist"; path = "Pods/Pods-iOS-Extensions-NotificationService-metadata.plist"; sourceTree = "<group>"; };
-		5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
+		5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
+		66CDCCF5A17F4217A21EDF69 /* Float+HA.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Float+HA.test.swift"; path = "Tests/Shared/Extensions/Float+HA.test.swift"; sourceTree = "<group>"; };
 		6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Widgets-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Widgets-metadata.plist"; sourceTree = "<group>"; };
 		675CE4281FE5F1920B13D553 /* Pods-iOS-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.debug.xcconfig"; sourceTree = "<group>"; };
 		6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-Shared-watchOS-metadata.plist"; path = "Pods/Pods-watchOS-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
@@ -3016,8 +3022,9 @@
 		755DF7AFFAA21F6CE428E998 /* Pods-watchOS-WatchExtension-Watch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-WatchExtension-Watch.release.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-WatchExtension-Watch/Pods-watchOS-WatchExtension-Watch.release.xcconfig"; sourceTree = "<group>"; };
 		7A6E8DF7DED57BAD4EF47D11 /* Pods_iOS_Extensions_Today.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_Today.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D94AB7BD65F15C8FEE0912E /* Pods-iOS-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.release.xcconfig"; sourceTree = "<group>"; };
+		7DE0704A278B3F876C306B5B /* DictionaryExtensions.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DictionaryExtensions.test.swift; path = Tests/Shared/Extensions/DictionaryExtensions.test.swift; sourceTree = "<group>"; };
 		80854D28D2FCD1482E92ED31 /* Pods-Tests-App.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-App.beta.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-App/Pods-Tests-App.beta.xcconfig"; sourceTree = "<group>"; };
-		892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
+		892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
 		8965FD50AC78F092CEB5F076 /* Pods-iOS-Extensions-Widgets.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Widgets.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Widgets/Pods-iOS-Extensions-Widgets.beta.xcconfig"; sourceTree = "<group>"; };
 		89E1823CF2D12BD3161FCC86 /* Pods-iOS-SharedTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-SharedTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-SharedTesting/Pods-iOS-SharedTesting.debug.xcconfig"; sourceTree = "<group>"; };
 		8A34A5417D650BBBE9D2D7C0 /* ControlFanValueProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlFanValueProvider.swift; sourceTree = "<group>"; };
@@ -3031,8 +3038,9 @@
 		9C4E5E25229D986B0044C8EC /* HomeAssistant.beta.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = HomeAssistant.beta.xcconfig; sourceTree = "<group>"; };
 		9C4E5E27229D992A0044C8EC /* HomeAssistant.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = HomeAssistant.xcconfig; sourceTree = "<group>"; };
 		9C7970E308CFEAEAFA05E004 /* Pods-iOS-Extensions-NotificationContent.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationContent.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationContent/Pods-iOS-Extensions-NotificationContent.release.xcconfig"; sourceTree = "<group>"; };
-		9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/TableSchemaTests.test.swift; sourceTree = "<group>"; };
+		9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/TableSchemaTests.test.swift; sourceTree = "<group>"; };
 		A0CE1C12B4ACF0A6876B6F7F /* Pods-iOS-Extensions-Today.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Today.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Today/Pods-iOS-Extensions-Today.beta.xcconfig"; sourceTree = "<group>"; };
+		A27878A8A33BB63302DD6573 /* String+HA.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+HA.test.swift"; path = "Tests/Shared/Extensions/String+HA.test.swift"; sourceTree = "<group>"; };
 		A370326321B07E5ACE0BCB65 /* Pods_iOS_Extensions_PushProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_PushProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A90DD8FC6E4726B7E7187C59 /* Pods_watchOS_WatchExtension_Watch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_watchOS_WatchExtension_Watch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ADC769271BB34C474C2D1E24 /* Pods-iOS-Shared-iOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Shared-iOS-metadata.plist"; path = "Pods/Pods-iOS-Shared-iOS-metadata.plist"; sourceTree = "<group>"; };
@@ -3354,7 +3362,7 @@
 		B6FD0573228411B200AC45BA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B6FD0574228411B200AC45BA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B9B49F9D3E32AD45659A0A41 /* Pods-iOS-Extensions-Matter.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Matter.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Matter/Pods-iOS-Extensions-Matter.beta.xcconfig"; sourceTree = "<group>"; };
-		BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseTableProtocol.test.swift; sourceTree = "<group>"; };
+		BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseTableProtocol.test.swift; sourceTree = "<group>"; };
 		BED1F3255FAD612BC4670B45 /* Pods-iOS-Extensions-Share.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Share.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Share/Pods-iOS-Extensions-Share.beta.xcconfig"; sourceTree = "<group>"; };
 		BEE6D44D86AC3F2F3E43950D /* Pods-watchOS-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-Shared-watchOS/Pods-watchOS-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C2563441A5A149C269C5F320 /* Pods-iOS-Shared-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS/Pods-iOS-Shared-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -3396,10 +3404,12 @@
 		D0FF79CD20D85C3A0034574D /* ClientEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientEventStore.swift; sourceTree = "<group>"; };
 		D27653D385E4CEB58E52A350 /* Pods_iOS_Extensions_Widgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_Widgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D404CC38F07CE4476FCF69B4 /* Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS-Tests-Shared/Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig"; sourceTree = "<group>"; };
+		D54A3AA95E71D55F8F9A78E4 /* Bool+HA.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bool+HA.test.swift"; path = "Tests/Shared/Extensions/Bool+HA.test.swift"; sourceTree = "<group>"; };
 		D5E3CB71A877FCB1F0F5DE99 /* Pods-iOS-Extensions-Share.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Share.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Share/Pods-iOS-Extensions-Share.release.xcconfig"; sourceTree = "<group>"; };
 		D72C761F65606EF882E2A7B1 /* Pods-iOS-Extensions-Today-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Today-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Today-metadata.plist"; sourceTree = "<group>"; };
 		DA2CE827B2DBBDBFB11559DF /* Pods-iOS-App.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.beta.xcconfig"; sourceTree = "<group>"; };
 		DD90A8F251D0671EFAC931ED /* Pods_iOS_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDEAAD0943C42868B05E2AF4 /* ColorExtensions.test.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ColorExtensions.test.swift; path = Tests/Shared/Extensions/ColorExtensions.test.swift; sourceTree = "<group>"; };
 		DFE9B91096F09C0E2A124B76 /* Pods-iOS-Extensions-Widgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Widgets.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Widgets/Pods-iOS-Extensions-Widgets.release.xcconfig"; sourceTree = "<group>"; };
 		E1A08868E5F1AEA7C24FAAAE /* Pods-iOS-Extensions-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationService.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationService/Pods-iOS-Extensions-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		E3D5CF14402325076CA105EB /* Pods-iOS-Extensions-PushProvider-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-PushProvider-metadata.plist"; path = "Pods/Pods-iOS-Extensions-PushProvider-metadata.plist"; sourceTree = "<group>"; };
@@ -5801,6 +5811,11 @@
 			children = (
 				42D4574A2EF1835D007934BC /* StringExtensions.test.swift */,
 				42ACC2A32E9F9AEA0045A3FD /* URLExtensions.test.swift */,
+				A27878A8A33BB63302DD6573 /* String+HA.test.swift */,
+				66CDCCF5A17F4217A21EDF69 /* Float+HA.test.swift */,
+				D54A3AA95E71D55F8F9A78E4 /* Bool+HA.test.swift */,
+				DDEAAD0943C42868B05E2AF4 /* ColorExtensions.test.swift */,
+				7DE0704A278B3F876C306B5B /* DictionaryExtensions.test.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7145,10 +7160,10 @@
 				11CB98CC249E637300B05222 /* Version+HA.test.swift */,
 				11883CC424C12C8A0036A6C6 /* CLLocation+Extensions.test.swift */,
 				11883CC624C131EE0036A6C6 /* RealmZone.test.swift */,
-				892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */,
-				BC31518EE9DC9E065AC508D9 /* Database/DatabaseTableProtocol.test.swift */,
-				5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */,
-				9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */,
+				892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */,
+				BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */,
+				5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */,
+				9EE9A0E08E6FEBDDE425D0D4 /* TableSchemaTests.test.swift */,
 				11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */,
 				11BC9E5424FDB88200B9FBF7 /* ActiveStateManager.test.swift */,
 				1104FCCE253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift */,
@@ -7999,7 +8014,7 @@
 			packageReferences = (
 				420E64BB2D676B2400A31E86 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				42B89EA62E05CC54000224A2 /* XCRemoteSwiftPackageReference "WebRTC" */,
-				42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */,
+				42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */,
 				4237E6372E5333370023B673 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			productRefGroup = B657A8E71CA646EB00121384 /* Products */;
@@ -10221,10 +10236,10 @@
 				11AF4D2C249D965C006C74C0 /* BatterySensor.test.swift in Sources */,
 				11F2F2B8258728B200F61F7C /* NotificationAttachmentParserURL.test.swift in Sources */,
 				11883CC724C131EE0036A6C6 /* RealmZone.test.swift in Sources */,
-				DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */,
-				A2F3A140CDD1EF1AEA6DFAB9 /* Database/DatabaseTableProtocol.test.swift in Sources */,
-				692BCBBA4EEEABCC76DBBECA /* Database/GRDB+Initialization.test.swift in Sources */,
-				BECCC152A4E3F69A8EF5A6F3 /* Database/TableSchemaTests.test.swift in Sources */,
+				DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */,
+				A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */,
+				692BCBBA4EEEABCC76DBBECA /* GRDB+Initialization.test.swift in Sources */,
+				BECCC152A4E3F69A8EF5A6F3 /* TableSchemaTests.test.swift in Sources */,
 				11267D0925BBA9FE00F28E5C /* Updater.test.swift in Sources */,
 				11A3F08C24ECE88C0018D84F /* WebhookUpdateLocation.test.swift in Sources */,
 				42FDCA272F0C7EB900C92958 /* EntityRegistry.test.swift in Sources */,
@@ -10266,6 +10281,11 @@
 				11764A6C26817FC3007D47F3 /* UserDefaultsValueSync.test.swift in Sources */,
 				114CBAED283AB92D00A9BAFF /* SecTrust+TestAdditions.swift in Sources */,
 				110ED58025A570F100489AF7 /* DisplaySensor.test.swift in Sources */,
+				B09FECA8FCD1B506E37DA3A1 /* String+HA.test.swift in Sources */,
+				D20FFDD9D9F18990BEDDE07C /* Float+HA.test.swift in Sources */,
+				CCFE958C52425990E37E7754 /* Bool+HA.test.swift in Sources */,
+				52B17D27B321FB4F15CFAE2B /* ColorExtensions.test.swift in Sources */,
+				C8885A0F274E06FBE629CE6C /* DictionaryExtensions.test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12105,7 +12125,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */ = {
+		42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Sources/SharedPush;
 		};
@@ -12161,7 +12181,7 @@
 		};
 		4273F7DF2E258827000629F7 /* SharedPush */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "Sources/SharedPush" */;
+			package = 42E00D0F2E1E7487006D140D /* XCLocalSwiftPackageReference "SharedPush" */;
 			productName = SharedPush;
 		};
 		427692E22B98B82500F24321 /* SharedPush */ = {

--- a/Tests/Shared/Extensions/Bool+HA.test.swift
+++ b/Tests/Shared/Extensions/Bool+HA.test.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("Bool+HA Extensions Tests")
+struct BoolHAExtensionsTests {
+    // MARK: - Bool? orFalse Tests
+
+    @Test("Given nil bool when getting orFalse then returns false")
+    func orFalseWithNil() async throws {
+        let nilBool: Bool? = nil
+        #expect(nilBool.orFalse == false, "nil bool should return false")
+    }
+
+    @Test("Given true bool when getting orFalse then returns true")
+    func orFalseWithTrue() async throws {
+        let trueBool: Bool? = true
+        #expect(trueBool.orFalse == true, "true bool should return true")
+    }
+
+    @Test("Given false bool when getting orFalse then returns false")
+    func orFalseWithFalse() async throws {
+        let falseBool: Bool? = false
+        #expect(falseBool.orFalse == false, "false bool should return false")
+    }
+}

--- a/Tests/Shared/Extensions/ColorExtensions.test.swift
+++ b/Tests/Shared/Extensions/ColorExtensions.test.swift
@@ -1,0 +1,133 @@
+import Foundation
+@testable import Shared
+import SwiftUI
+import Testing
+
+@Suite("Color+hex Extensions Tests")
+struct ColorHexExtensionsTests {
+    @Test(
+        "Given valid 6-character hex strings when initializing Color then creates correct color",
+        arguments: [
+            ("FF0000", 1.0, 0.0, 0.0, 1.0), // Red
+            ("00FF00", 0.0, 1.0, 0.0, 1.0), // Green
+            ("0000FF", 0.0, 0.0, 1.0, 1.0), // Blue
+            ("FFFFFF", 1.0, 1.0, 1.0, 1.0), // White
+            ("000000", 0.0, 0.0, 0.0, 1.0), // Black
+            ("FF5733", 1.0, 0.341, 0.2, 1.0), // Orange
+            ("3498DB", 0.204, 0.596, 0.859, 1.0), // Blue
+            ("2ECC71", 0.180, 0.8, 0.443, 1.0), // Green
+        ]
+    )
+    func validSixCharHexCreatesColor(hex: String, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) async throws {
+        let color = Color(hex: hex)
+        let uiColor = UIColor(color)
+
+        guard let components = uiColor.cgColor.components, components.count >= 3 else {
+            Issue.record("Failed to get color components")
+            return
+        }
+
+        let tolerance: CGFloat = 0.01
+        #expect(abs(components[0] - r) < tolerance, "Red component should match")
+        #expect(abs(components[1] - g) < tolerance, "Green component should match")
+        #expect(abs(components[2] - b) < tolerance, "Blue component should match")
+
+        if components.count >= 4 {
+            #expect(abs(components[3] - a) < tolerance, "Alpha component should match")
+        }
+    }
+
+    @Test(
+        "Given valid 8-character hex strings with alpha when initializing Color then creates color with opacity",
+        arguments: [
+            ("FF0000FF", 1.0, 0.0, 0.0, 1.0), // Red, full opacity
+            ("00FF0080", 0.0, 1.0, 0.0, 0.502), // Green, half opacity
+            ("0000FF00", 0.0, 0.0, 1.0, 0.0), // Blue, transparent
+            ("FFFFFF7F", 1.0, 1.0, 1.0, 0.498), // White, ~half opacity
+        ]
+    )
+    func validEightCharHexWithAlphaCreatesColor(
+        hex: String,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat
+    ) async throws {
+        let color = Color(hex: hex)
+        let uiColor = UIColor(color)
+
+        guard let components = uiColor.cgColor.components, components.count >= 4 else {
+            Issue.record("Failed to get color components with alpha")
+            return
+        }
+
+        let tolerance: CGFloat = 0.01
+        #expect(abs(components[0] - r) < tolerance, "Red component should match")
+        #expect(abs(components[1] - g) < tolerance, "Green component should match")
+        #expect(abs(components[2] - b) < tolerance, "Blue component should match")
+        #expect(abs(components[3] - a) < tolerance, "Alpha component should match for \(hex)")
+    }
+
+    @Test(
+        "Given invalid hex strings when initializing Color then falls back to default color",
+        arguments: [
+            "invalid",
+            "GGGGGG",
+            "12345", // Wrong length
+            "1234567", // Wrong length
+            "FFFFFFFFF", // Too long
+            "ZZZ",
+            "",
+        ]
+    )
+    func invalidHexFallsBackToDefault(hex: String) async throws {
+        let color = Color(hex: hex)
+        // Should not crash and should create some color (fallback to haPrimary)
+        let uiColor = UIColor(color)
+        #expect(uiColor.cgColor.components != nil, "Should create a valid fallback color")
+    }
+
+    @Test("Given nil hex when initializing Color then falls back to default color")
+    func nilHexFallsBackToDefault() async throws {
+        let color = Color(hex: nil)
+        let uiColor = UIColor(color)
+        #expect(uiColor.cgColor.components != nil, "Should create a valid fallback color")
+    }
+
+    @Test("Given Color when converting to hex then returns correct hex string")
+    func colorToHexConversion() async throws {
+        let redColor = Color(red: 1.0, green: 0.0, blue: 0.0)
+        let hex = redColor.hex()
+        #expect(hex == "FF0000", "Red color should convert to FF0000")
+
+        let blackColor = Color(red: 0.0, green: 0.0, blue: 0.0)
+        let blackHex = blackColor.hex()
+        #expect(blackHex == "000000", "Black color should convert to 000000")
+    }
+
+    @Test("Given Color with opacity when converting to hex then returns 8-character hex string")
+    func colorWithOpacityToHexConversion() async throws {
+        let redWithOpacity = Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 0.5)
+        let hex = redWithOpacity.hex()
+        #expect(hex?.count == 8, "Color with opacity should return 8-character hex")
+        #expect(hex?.hasPrefix("FF0000") == true, "Should start with red color code")
+    }
+
+    @Test("Given hex string when round-trip converting then preserves color")
+    func hexRoundTripConversion() async throws {
+        let originalHex = "3498DB"
+        let color = Color(hex: originalHex)
+        let convertedHex = color.hex()
+
+        #expect(convertedHex == originalHex, "Round-trip conversion should preserve hex value")
+    }
+
+    @Test("Given hex string with alpha when round-trip converting then preserves color and opacity")
+    func hexWithAlphaRoundTripConversion() async throws {
+        let originalHex = "FF000080"
+        let color = Color(hex: originalHex)
+        let convertedHex = color.hex()
+
+        #expect(convertedHex == originalHex, "Round-trip conversion with alpha should preserve hex value")
+    }
+}

--- a/Tests/Shared/Extensions/DictionaryExtensions.test.swift
+++ b/Tests/Shared/Extensions/DictionaryExtensions.test.swift
@@ -1,0 +1,98 @@
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("Dictionary+Additions Extensions Tests")
+struct DictionaryExtensionsTests {
+    // MARK: - mapKeys Tests
+
+    @Test("Given dictionary with string keys when mapping to uppercase then transforms all keys")
+    func mapKeysTransformsAllKeys() async throws {
+        let dict = ["hello": 1, "world": 2, "test": 3]
+        let result = dict.mapKeys { $0.uppercased() }
+
+        #expect(result["HELLO"] == 1, "Should map 'hello' to 'HELLO'")
+        #expect(result["WORLD"] == 2, "Should map 'world' to 'WORLD'")
+        #expect(result["TEST"] == 3, "Should map 'test' to 'TEST'")
+        #expect(result.count == 3, "Should preserve all entries")
+    }
+
+    @Test("Given dictionary when mapping keys to different type then changes key type")
+    func mapKeysChangesKeyType() async throws {
+        let dict = ["1": "one", "2": "two", "3": "three"]
+        let result = dict.mapKeys { Int($0) ?? 0 }
+
+        #expect(result[1] == "one", "Should map '1' to 1")
+        #expect(result[2] == "two", "Should map '2' to 2")
+        #expect(result[3] == "three", "Should map '3' to 3")
+        #expect(result.count == 3, "Should preserve all entries")
+    }
+
+    @Test("Given dictionary with duplicate mapped keys when mapping then last value wins")
+    func mapKeysWithDuplicateKeysLastValueWins() async throws {
+        let dict = ["hello": 1, "HELLO": 2, "HeLLo": 3]
+        let result = dict.mapKeys { $0.uppercased() }
+
+        // Since all keys map to "HELLO", one of the values will be present
+        #expect(result["HELLO"] != nil, "Should have 'HELLO' key")
+        #expect(result.count == 1, "Should have only one entry due to duplicate keys")
+        #expect([1, 2, 3].contains(result["HELLO"]!), "Value should be one of the original values")
+    }
+
+    // MARK: - compactMapKeys Tests
+
+    @Test("Given dictionary when compact mapping keys then filters out nil results")
+    func compactMapKeysFiltersNilResults() async throws {
+        let dict = ["1": "one", "2": "two", "invalid": "three", "3": "four"]
+        let result = dict.compactMapKeys { Int($0) }
+
+        #expect(result[1] == "one", "Should map '1' to 1")
+        #expect(result[2] == "two", "Should map '2' to 2")
+        #expect(result[3] == "four", "Should map '3' to 3")
+        #expect(result.count == 3, "Should exclude 'invalid' key")
+    }
+
+    @Test("Given dictionary when all keys map to nil then returns empty dictionary")
+    func compactMapKeysAllNilReturnsEmpty() async throws {
+        let dict = ["a": 1, "b": 2, "c": 3]
+        let result = dict.compactMapKeys { _ -> Int? in nil }
+
+        #expect(result.isEmpty, "Should return empty dictionary when all keys map to nil")
+        #expect(result.count == 0, "Count should be 0")
+    }
+
+    @Test("Given dictionary with mixed valid and invalid keys when compact mapping then keeps only valid")
+    func compactMapKeysMixedValidInvalid() async throws {
+        let dict = [
+            "user_1": "Alice",
+            "user_2": "Bob",
+            "admin": "Charlie",
+            "user_3": "Dave",
+            "guest": "Eve",
+        ]
+        let result = dict.compactMapKeys { key -> Int? in
+            guard key.hasPrefix("user_") else { return nil }
+            return Int(key.replacingOccurrences(of: "user_", with: ""))
+        }
+
+        #expect(result.count == 3, "Should only keep user_ keys")
+        #expect(result[1] == "Alice", "Should map user_1")
+        #expect(result[2] == "Bob", "Should map user_2")
+        #expect(result[3] == "Dave", "Should map user_3")
+        #expect(result[4] == nil, "Should not include admin")
+        #expect(result[5] == nil, "Should not include guest")
+    }
+
+    @Test("Given dictionary with duplicate mapped keys when compact mapping then last value wins")
+    func compactMapKeysWithDuplicatesLastValueWins() async throws {
+        let dict = ["a1": 1, "a2": 2, "b1": 3]
+        let result = dict.compactMapKeys { key -> String? in
+            String(key.first!)
+        }
+
+        #expect(result.count == 2, "Should have 'a' and 'b' keys")
+        #expect(result["a"] != nil, "Should have 'a' key")
+        #expect(result["b"] == 3, "Should have 'b' key with value 3")
+        #expect([1, 2].contains(result["a"]!), "Value for 'a' should be one of the duplicates")
+    }
+}

--- a/Tests/Shared/Extensions/DictionaryExtensions.test.swift
+++ b/Tests/Shared/Extensions/DictionaryExtensions.test.swift
@@ -7,7 +7,7 @@ struct DictionaryExtensionsTests {
     // MARK: - mapKeys Tests
 
     @Test("Given dictionary with string keys when mapping to uppercase then transforms all keys")
-    func mapKeysTransformsAllKeys() async throws {
+    func mapKeysTransformsAllKeys() {
         let dict = ["hello": 1, "world": 2, "test": 3]
         let result = dict.mapKeys { $0.uppercased() }
 
@@ -18,7 +18,7 @@ struct DictionaryExtensionsTests {
     }
 
     @Test("Given dictionary when mapping keys to different type then changes key type")
-    func mapKeysChangesKeyType() async throws {
+    func mapKeysChangesKeyType() {
         let dict = ["1": "one", "2": "two", "3": "three"]
         let result = dict.mapKeys { Int($0) ?? 0 }
 
@@ -29,7 +29,7 @@ struct DictionaryExtensionsTests {
     }
 
     @Test("Given dictionary with duplicate mapped keys when mapping then last value wins")
-    func mapKeysWithDuplicateKeysLastValueWins() async throws {
+    func mapKeysWithDuplicateKeysLastValueWins() {
         let dict = ["hello": 1, "HELLO": 2, "HeLLo": 3]
         let result = dict.mapKeys { $0.uppercased() }
 
@@ -42,7 +42,7 @@ struct DictionaryExtensionsTests {
     // MARK: - compactMapKeys Tests
 
     @Test("Given dictionary when compact mapping keys then filters out nil results")
-    func compactMapKeysFiltersNilResults() async throws {
+    func compactMapKeysFiltersNilResults() {
         let dict = ["1": "one", "2": "two", "invalid": "three", "3": "four"]
         let result = dict.compactMapKeys { Int($0) }
 
@@ -53,7 +53,7 @@ struct DictionaryExtensionsTests {
     }
 
     @Test("Given dictionary when all keys map to nil then returns empty dictionary")
-    func compactMapKeysAllNilReturnsEmpty() async throws {
+    func compactMapKeysAllNilReturnsEmpty() {
         let dict = ["a": 1, "b": 2, "c": 3]
         let result = dict.compactMapKeys { _ -> Int? in nil }
 
@@ -62,7 +62,7 @@ struct DictionaryExtensionsTests {
     }
 
     @Test("Given dictionary with mixed valid and invalid keys when compact mapping then keeps only valid")
-    func compactMapKeysMixedValidInvalid() async throws {
+    func compactMapKeysMixedValidInvalid() {
         let dict = [
             "user_1": "Alice",
             "user_2": "Bob",
@@ -84,7 +84,7 @@ struct DictionaryExtensionsTests {
     }
 
     @Test("Given dictionary with duplicate mapped keys when compact mapping then last value wins")
-    func compactMapKeysWithDuplicatesLastValueWins() async throws {
+    func compactMapKeysWithDuplicatesLastValueWins() {
         let dict = ["a1": 1, "a2": 2, "b1": 3]
         let result = dict.compactMapKeys { key -> String? in
             String(key.first!)

--- a/Tests/Shared/Extensions/Float+HA.test.swift
+++ b/Tests/Shared/Extensions/Float+HA.test.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("Float+HA Extensions Tests")
+struct FloatHAExtensionsTests {
+    // MARK: - Float? orZero Tests
+
+    @Test("Given nil float when getting orZero then returns zero")
+    func orZeroWithNil() async throws {
+        let nilFloat: Float? = nil
+        #expect(nilFloat.orZero == 0.0, "nil float should return 0.0")
+    }
+
+    @Test(
+        "Given non-nil float when getting orZero then returns original value",
+        arguments: [
+            Float(0.0),
+            Float(1.0),
+            Float(-1.0),
+            Float(42.5),
+            Float(-42.5),
+            Float(0.123456),
+            Float(-0.123456),
+        ]
+    )
+    func orZeroWithNonNil(input: Float) async throws {
+        let optionalFloat: Float? = input
+        #expect(optionalFloat.orZero == input, "Non-nil float should return original value")
+    }
+
+    @Test("Given special float values when getting orZero then handles correctly")
+    func orZeroWithSpecialValues() async throws {
+        // Infinity
+        let infinity: Float? = Float.infinity
+        #expect(infinity.orZero == Float.infinity, "Infinity should return infinity")
+
+        let negativeInfinity: Float? = -Float.infinity
+        #expect(negativeInfinity.orZero == -Float.infinity, "Negative infinity should return negative infinity")
+
+        // NaN
+        let nan: Float? = Float.nan
+        #expect(nan.orZero.isNaN, "NaN should return NaN")
+    }
+}

--- a/Tests/Shared/Extensions/String+HA.test.swift
+++ b/Tests/Shared/Extensions/String+HA.test.swift
@@ -1,0 +1,244 @@
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("String+HA Extensions Tests")
+struct StringHAExtensionsTests {
+    // MARK: - djb2hash Tests
+
+    @Test("Given empty string when getting djb2hash then returns base hash")
+    func djb2hashEmptyString() async throws {
+        let emptyString = ""
+        #expect(emptyString.djb2hash == 5381, "Empty string should return base hash value 5381")
+    }
+
+    @Test(
+        "Given identical strings when getting djb2hash then returns same hash",
+        arguments: [
+            "test",
+            "home_assistant",
+            "entity.light.living_room",
+            "Hello World!",
+            "🏠",
+        ]
+    )
+    func djb2hashConsistency(input: String) async throws {
+        let hash1 = input.djb2hash
+        let hash2 = input.djb2hash
+        #expect(hash1 == hash2, "Hash should be consistent for '\(input)'")
+    }
+
+    @Test("Given different strings when getting djb2hash then returns different hashes")
+    func djb2hashDifferentStrings() async throws {
+        let string1 = "test1"
+        let string2 = "test2"
+        let string3 = "completely different"
+
+        #expect(string1.djb2hash != string2.djb2hash, "Different strings should produce different hashes")
+        #expect(string1.djb2hash != string3.djb2hash, "Different strings should produce different hashes")
+        #expect(string2.djb2hash != string3.djb2hash, "Different strings should produce different hashes")
+    }
+
+    @Test("Given string with unicode characters when getting djb2hash then returns valid hash")
+    func djb2hashUnicodeCharacters() async throws {
+        let unicode1 = "Hello 世界"
+        let unicode2 = "🏠🔒🔑"
+        let unicode3 = "Café"
+
+        // Verify hashes are generated without crashing
+        let hash1 = unicode1.djb2hash
+        let hash2 = unicode2.djb2hash
+        let hash3 = unicode3.djb2hash
+
+        // Hashes should be different for different strings
+        #expect(hash1 != hash2, "Different unicode strings should produce different hashes")
+        #expect(hash2 != hash3, "Different unicode strings should produce different hashes")
+    }
+
+    @Test("Given very long string when getting djb2hash then returns valid hash")
+    func djb2hashLongString() async throws {
+        let longString = String(repeating: "a", count: 10000)
+        let hash = longString.djb2hash
+        #expect(hash != 5381, "Long string should produce hash different from base value")
+    }
+
+    // MARK: - containsJinjaTemplate Tests
+
+    @Test(
+        "Given strings with Jinja templates when checking containsJinjaTemplate then returns true",
+        arguments: [
+            "{{ state.temperature }}",
+            "Value: {{ sensor.value }}",
+            "{% if condition %}text{% endif %}",
+            "Start {% for item in items %} loop",
+            "{# This is a comment #}",
+            "Mixed {{ variable }} and {% statement %}",
+            "Multiple {{ var1 }} {{ var2 }} templates",
+            "{{no_space}}",
+            "{%no_space%}",
+            "{#no_space#}",
+        ]
+    )
+    func containsJinjaTemplateTrue(input: String) async throws {
+        #expect(input.containsJinjaTemplate == true, "'\(input)' should contain Jinja template")
+    }
+
+    @Test(
+        "Given strings without Jinja templates when checking containsJinjaTemplate then returns false",
+        arguments: [
+            "plain text",
+            "{ single brace }",
+            "% percent sign %",
+            "# hashtag",
+            "regular JSON {\"key\": \"value\"}",
+            "",
+            "{ { space between }}",
+            "{% space before",
+            "after space %}",
+            "{{",
+            "{%",
+            "{#",
+        ]
+    )
+    func containsJinjaTemplateFalse(input: String) async throws {
+        #expect(input.containsJinjaTemplate == false, "'\(input)' should not contain Jinja template")
+    }
+
+    @Test("Given string with incomplete Jinja syntax when checking containsJinjaTemplate")
+    func containsJinjaTemplateIncomplete() async throws {
+        // These have the opening but are still considered to contain Jinja templates
+        #expect("{{ unclosed".containsJinjaTemplate == true, "String with {{ should be detected")
+        #expect("{% unclosed".containsJinjaTemplate == true, "String with {% should be detected")
+        #expect("{# unclosed".containsJinjaTemplate == true, "String with {# should be detected")
+    }
+
+    // MARK: - capitalizedFirst Tests
+
+    @Test(
+        "Given string when getting capitalizedFirst then capitalizes first character",
+        arguments: [
+            ("hello", "Hello"),
+            ("world", "World"),
+            ("test", "Test"),
+            ("a", "A"),
+            ("already Capitalized", "Already Capitalized"),
+        ]
+    )
+    func capitalizedFirst(input: String, expected: String) async throws {
+        #expect(input.capitalizedFirst == expected, "'\(input)' should become '\(expected)'")
+    }
+
+    @Test("Given empty string when getting capitalizedFirst then returns empty string")
+    func capitalizedFirstEmptyString() async throws {
+        let empty = ""
+        #expect(empty.capitalizedFirst == "", "Empty string should remain empty")
+    }
+
+    @Test("Given string with special characters when getting capitalizedFirst then handles correctly")
+    func capitalizedFirstSpecialCharacters() async throws {
+        let unicode = "éllo"
+        #expect(unicode.capitalizedFirst == "Éllo", "Unicode character should be capitalized")
+    }
+
+    // MARK: - formattedBSSID Tests
+
+    @Test(
+        "Given BSSID with single-digit hex values when formatted then adds leading zeros",
+        arguments: [
+            ("18:e8:29:a7:e9:b", "18:e8:29:a7:e9:0b"),
+            ("a:b:c:d:e:f", "0a:0b:0c:0d:0e:0f"),
+            ("1:2:3:4:5:6", "01:02:03:04:05:06"),
+            ("aa:bb:cc:dd:ee:f", "aa:bb:cc:dd:ee:0f"),
+            ("1:bb:c:dd:e:ff", "01:bb:0c:dd:0e:ff"),
+        ]
+    )
+    func bssidFormattingAddsLeadingZeros(input: String, expected: String) async throws {
+        #expect(input.formattedBSSID == expected, "BSSID \(input) should be formatted as \(expected)")
+    }
+
+    @Test(
+        "Given BSSID with all two-digit hex values when formatted then remains unchanged",
+        arguments: [
+            "18:e8:29:a7:e9:0b",
+            "ff:ee:dd:cc:bb:aa",
+            "aa:bb:cc:dd:ee:ff",
+            "12:34:56:78:9a:bc",
+        ]
+    )
+    func bssidFormattingPreservesFullValues(input: String) async throws {
+        #expect(input.formattedBSSID == input, "BSSID \(input) should remain unchanged")
+    }
+
+    @Test(
+        "Given invalid MAC address formats when formatted then returns unchanged",
+        arguments: [
+            "not-a-mac",
+            "18:e8:29:a7:e9", // Too few octets
+            "18:e8:29:a7:e9:0b:aa", // Too many octets
+            "", // Empty string
+            "invalid:format:here",
+            "no:colons:just:text",
+            "12:34", // Only 2 octets
+        ]
+    )
+    func bssidFormattingHandlesInvalidFormats(input: String) async throws {
+        #expect(
+            input.formattedBSSID == input,
+            "Invalid MAC address \(input) should be returned unchanged"
+        )
+    }
+
+    @Test("Given uppercase BSSID when formatted then preserves case")
+    func bssidFormattingPreservesCase() async throws {
+        let uppercase = "AA:BB:CC:DD:EE:F"
+        let expectedUppercase = "AA:BB:CC:DD:EE:0F"
+        #expect(
+            uppercase.formattedBSSID == expectedUppercase,
+            "Uppercase BSSID should be formatted with preserved case"
+        )
+
+        let lowercase = "aa:bb:cc:dd:ee:f"
+        let expectedLowercase = "aa:bb:cc:dd:ee:0f"
+        #expect(
+            lowercase.formattedBSSID == expectedLowercase,
+            "Lowercase BSSID should be formatted with preserved case"
+        )
+
+        let mixed = "aA:bB:cC:dD:eE:Ff"
+        let expectedMixed = "aA:bB:cC:dD:eE:Ff"
+        #expect(mixed.formattedBSSID == expectedMixed, "Mixed case BSSID should be formatted with preserved case")
+    }
+
+    @Test("Given BSSID with three-character octets when formatted then preserves as-is")
+    func bssidFormattingWithThreeCharacterOctets() async throws {
+        let invalid = "111:222:333:444:555:666"
+        #expect(
+            invalid.formattedBSSID == "111:222:333:444:555:666",
+            "BSSID with 3-character octets should be returned unchanged"
+        )
+    }
+
+    // MARK: - String? orEmpty Tests
+
+    @Test("Given nil string when getting orEmpty then returns empty string")
+    func orEmptyWithNil() async throws {
+        let nilString: String? = nil
+        #expect(nilString.orEmpty == "", "nil string should return empty string")
+    }
+
+    @Test(
+        "Given non-nil string when getting orEmpty then returns original string",
+        arguments: [
+            "hello",
+            "world",
+            "",
+            "   ",
+            "test string",
+            "🏠",
+        ]
+    )
+    func orEmptyWithNonNil(input: String) async throws {
+        let optionalString: String? = input
+        #expect(optionalString.orEmpty == input, "Non-nil string should return original value")
+    }
+}


### PR DESCRIPTION
## Summary

Add unit tests for extension utilities: String+HA, Float+HA, Bool+HA, Color+hex, and Dictionary+Additions.

## Screenshots

N/A - Test code only

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Adds 31 tests covering string formatting, color parsing, and dictionary operations.