### PR TITLE
Fix CarPlay configuration not saving for new users

### DIFF
--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationViewModel.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationViewModel.swift
@@ -63,7 +63,8 @@ final class CarPlayConfigurationViewModel: ObservableObject {
                 setConfig(config)
                 Current.Log.info("CarPlay configuration exists")
             } else {
-                Current.Log.error("No CarPlay config found")
+                Current.Log.info("No CarPlay config found, initializing default configuration")
+                setConfig(CarPlayConfig())
             }
         } catch {
             Current.Log.error("Failed to access database (GRDB), error: \(error.localizedDescription)")


### PR DESCRIPTION
When loadDatabase() doesn't find an existing CarPlay configuration, it was only logging an error without initializing a default config. This caused isInitialLoad to remain true, which blocked the auto-save mechanism in setupAutoSave().

Changes:
- Initialize default CarPlayConfig when none exists
- Change log level from error to info (first-time setup isn't an error)

Fixes issue where users could configure CarPlay settings but changes were never persisted to the database.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
