### PR TITLE
Skip sync on Catalyst for load/refresh 

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -85,7 +85,7 @@ extension WebViewController: WebViewControllerProtocol {
     }
 
     @objc func refresh() {
-        Current.connectivity.syncNetworkInformation { [weak self] in
+        let refreshBlock: () -> Void = { [weak self] in
             guard let self else { return }
             // called via menu/keyboard shortcut too
             if let webviewURL = server.info.connection.webviewURL() {
@@ -97,6 +97,14 @@ extension WebViewController: WebViewControllerProtocol {
                 hideNoActiveURLError()
             } else {
                 showNoActiveURLError()
+            }
+        }
+
+        if Current.isCatalyst {
+            refreshBlock()
+        } else {
+            Current.connectivity.syncNetworkInformation {
+                refreshBlock()
             }
         }
         updateDatabaseAndPanels()

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -854,7 +854,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         loadActiveURLIfNeededInProgress = true
         Current.Log.info("loadActiveURLIfNeeded called")
 
-        Current.connectivity.syncNetworkInformation { [weak self] in
+        let loadBlock: () -> Void = { [weak self] in
             defer {
                 self?.loadActiveURLIfNeededInProgress = false
             }
@@ -910,6 +910,14 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             }
 
             load(request: request)
+        }
+
+        if Current.isCatalyst {
+            loadBlock()
+        } else {
+            Current.connectivity.syncNetworkInformation {
+                loadBlock()
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Extracted load/refresh blocks and conditionally invoke Current.connectivity.syncNetworkInformation only on non-Catalyst targets. On Catalyst the closures are executed immediately to avoid unnecessary async network syncs and ensure immediate UI behavior. Applied to WebViewController and its protocol conformance refresh handling.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
