### PR TITLE
Bind delayed instruction hide to SwiftUI view lifecycle

### DIFF
--- a/Sources/App/Cameras/CameraList/CamerasRoomView.swift
+++ b/Sources/App/Cameras/CameraList/CamerasRoomView.swift
@@ -76,10 +76,11 @@ struct CamerasRoomView: View {
                     }
                 }
             }
-            .onAppear {
-                // Hide instructions after 3 seconds
-                Task {
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+            .task {
+                // Hide instructions after 3 seconds, cancel if view disappears
+                guard showInstructions else { return }
+                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                await MainActor.run {
                     withAnimation {
                         showInstructions = false
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Problem
CamerasRoomView hides instructions with a delayed Task started from onAppear. The task is not lifecycle-bound and can still mutate showInstructions after the view disappears.

Change
Move the delayed hide logic to SwiftUI .task so it is automatically cancelled when the view leaves the hierarchy. Keep behavior unchanged (instructions still hide after ~3s).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Verification
Built the app target locally. Relying on CI (GitHub Actions) to run tests/build.