### PR TITLE
Avoid displaying connection security level config when not needed

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsView.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsView.swift
@@ -325,16 +325,18 @@ struct ConnectionSettingsView: View {
                 .buttonStyle(.plain)
             }
 
-            Button {
-                showSecurityLevelPicker = true
-            } label: {
-                NavigationRow(
-                    title: L10n.Settings.ConnectionSection.ConnectionAccessSecurityLevel.title,
-                    value: viewModel.securityLevel.description
-                )
-                .contentShape(Rectangle())
+            if viewModel.shouldShowSecurityLevelPicker {
+                Button {
+                    showSecurityLevelPicker = true
+                } label: {
+                    NavigationRow(
+                        title: L10n.Settings.ConnectionSection.ConnectionAccessSecurityLevel.title,
+                        value: viewModel.securityLevel.description
+                    )
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             Button {
                 viewModel.updateAppDatabase()

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -50,6 +50,14 @@ final class ConnectionSettingsViewModel: ObservableObject {
         server.info.version <= .updateLocationGPSOptional
     }
 
+    var shouldShowSecurityLevelPicker: Bool {
+        guard let internalURL = server.info.connection.address(for: .internal) else {
+            return false
+        }
+
+        return internalURL.scheme?.lowercased() == "http"
+    }
+
     // MARK: - Initialization
 
     init(server: Server) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Hide connection security level config when user has no internal URL set or has one that is already HTTPS
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
