### PR TITLE
Include leaf cert in URLCredential when available

### DIFF
--- a/Sources/Shared/API/mTLS/ClientCertificate.swift
+++ b/Sources/Shared/API/mTLS/ClientCertificate.swift
@@ -191,7 +191,10 @@ public final class ClientCertificateManager {
             return URLCredential(identity: identity, certificates: [leafCertificate], persistence: .forSession)
         }
 
-        Current.Log.warning("Failed to copy client certificate from identity (\(status)); falling back to identity-only credential")
+        Current.Log
+            .warning(
+                "Failed to copy client certificate from identity (\(status)); falling back to identity-only credential"
+            )
         return URLCredential(identity: identity, certificates: nil, persistence: .forSession)
     }
 


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Attempt to copy the leaf certificate from the SecIdentity using SecIdentityCopyCertificate and include it in the URLCredential certificates array when successful. This ensures TLS client-auth sends a non-empty certificate list; if copying fails we log a warning and fall back to an identity-only credential.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
