### PR TITLE
Guard backgroundTimeRemaining on main thread

### DIFF
--- a/Sources/App/Utilities/Extensions/UIApplication+BackgroundTask.swift
+++ b/Sources/App/Utilities/Extensions/UIApplication+BackgroundTask.swift
@@ -21,13 +21,19 @@ private extension UIApplication {
             withName: name,
             beginBackgroundTask: { name, expirationHandler in
                 let identifier = beginBackgroundTask(withName: name, expirationHandler: expirationHandler)
-                let remaining: TimeInterval?
-                if Thread.isMainThread {
-                    let timeRemaining = backgroundTimeRemaining
-                    remaining = timeRemaining < 100 ? timeRemaining : nil
-                } else {
-                    remaining = nil
-                }
+                let remaining: TimeInterval? = {
+                    if Thread.isMainThread {
+                        let timeRemaining = self.backgroundTimeRemaining
+                        return timeRemaining < 100 ? timeRemaining : nil
+                    } else {
+                        var result: TimeInterval?
+                        DispatchQueue.main.sync {
+                            let timeRemaining = self.backgroundTimeRemaining
+                            result = timeRemaining < 100 ? timeRemaining : nil
+                        }
+                        return result
+                    }
+                }()
                 return (identifier == .invalid ? nil : identifier, remaining)
             }, endBackgroundTask: { identifier in
                 self.endBackgroundTask(identifier)


### PR DESCRIPTION
backgroundTimeRemaining is only safe to read from the main thread. Check Thread.isMainThread before accessing it and set remaining to nil when off the main thread. Keeps existing logic that maps values >= 100 to nil and leaves task identifier handling unchanged. This prevents unsafe background-thread access when beginning background tasks.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
