### PR TITLE
Extract helper for entity intent collections

### DIFF
--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenCamera/ControlOpenCameraValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenCamera/ControlOpenCameraValueProvider.swift
@@ -83,21 +83,9 @@ struct ControlOpenCameraConfiguration: ControlConfigurationIntent {
 struct CameraEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.camera]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.video.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.video.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenCoverEntity/ControlOpenCoverEntityValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenCoverEntity/ControlOpenCoverEntityValueProvider.swift
@@ -83,21 +83,9 @@ struct ControlOpenCoverEntityConfiguration: ControlConfigurationIntent {
 struct CoverEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.cover]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.curtainsClosed.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.curtainsClosed.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenInputBoolean/ControlOpenInputBooleanValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenInputBoolean/ControlOpenInputBooleanValueProvider.swift
@@ -86,21 +86,9 @@ struct ControlOpenInputBooleanConfiguration: ControlConfigurationIntent {
 struct InputBooleanEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.inputBoolean]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.switchProgrammable.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.switchProgrammable.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenLight/ControlOpenLightValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenLight/ControlOpenLightValueProvider.swift
@@ -83,21 +83,9 @@ struct ControlOpenLightConfiguration: ControlConfigurationIntent {
 struct LightEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.light]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.lightbulb.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.lightbulb.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenLock/ControlOpenLockValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenLock/ControlOpenLockValueProvider.swift
@@ -83,21 +83,9 @@ struct ControlOpenLockConfiguration: ControlConfigurationIntent {
 struct LockEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.lock]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.lock.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.lock.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenSensor/ControlOpenSensorValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenSensor/ControlOpenSensorValueProvider.swift
@@ -82,21 +82,9 @@ struct ControlOpenSensorConfiguration: ControlConfigurationIntent {
 struct SensorEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.sensor, .binarySensor]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.eye.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.eye.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenSwitch/ControlOpenSwitchValueProvider.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenSwitch/ControlOpenSwitchValueProvider.swift
@@ -83,21 +83,9 @@ struct ControlOpenSwitchConfiguration: ControlConfigurationIntent {
 struct SwitchEntityOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> IntentItemCollection<HAAppEntityAppIntentEntity> {
         let entities = ControlEntityProvider(domains: [.switch]).getEntities()
-
-        return .init(sections: entities.map { (key: Server, value: [HAAppEntity]) in
-            .init(
-                .init(stringLiteral: key.info.name),
-                items: value.map { entity in
-                    HAAppEntityAppIntentEntity(
-                        id: entity.id,
-                        entityId: entity.entityId,
-                        serverId: entity.serverId,
-                        serverName: key.info.name,
-                        displayString: entity.name,
-                        iconName: entity.icon ?? SFSymbol.lightswitchOn.rawValue
-                    )
-                }
-            )
-        })
+        return makeHAEntityIntentItemCollection(
+            entities: entities,
+            defaultIconName: SFSymbol.lightswitchOn.rawValue
+        )
     }
 }

--- a/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
+++ b/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
@@ -111,3 +111,27 @@ struct HAAppEntityAppIntentEntityQuery: EntityQuery, EntityStringQuery {
         return allEntities
     }
 }
+
+@available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
+func makeHAEntityIntentItemCollection(
+    entities: [(Server, [HAAppEntity])],
+    defaultIconName: String
+) -> IntentItemCollection<HAAppEntityAppIntentEntity> {
+    .init(sections: entities.map { (server: Server, values: [HAAppEntity]) in
+        let areasMap = values.areasMap(for: server.identifier.rawValue)
+        return .init(
+            .init(stringLiteral: server.info.name),
+            items: values.map { entity in
+                HAAppEntityAppIntentEntity(
+                    id: entity.id,
+                    entityId: entity.entityId,
+                    serverId: entity.serverId,
+                    serverName: server.info.name,
+                    areaName: areasMap[entity.entityId]?.name,
+                    displayString: entity.name,
+                    iconName: entity.icon ?? defaultIconName
+                )
+            }
+        )
+    })
+}


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Introduce makeHAEntityIntentItemCollection to centralize building IntentItemCollection<HAAppEntityAppIntentEntity> with a default icon and areaName mapping. Replace duplicated mapping logic in multiple ControlOpen* entity option providers (Camera, Cover, InputBoolean, Light, Lock, Sensor, Switch) to call the new helper, reducing duplication and adding consistent areaName support. The helper is added to HAAppEntityAppIntentEntity.swift and used by the various ControlOpen*ValueProvider files.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
