### PR TITLE
Fix using elementId in handleElementFocus script

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -243,7 +243,7 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
 
                 // Search through all elements with shadow roots
                 const allElements = root.querySelectorAll('*');
-                for (let el of allElements) {
+                for (const el of allElements) {
                     if (el.shadowRoot) {
                         element = findElementInShadowDOM(elementId, el.shadowRoot);
                         if (element) return element;
@@ -253,14 +253,15 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             }
 
             // Search for the element
-            var element = findElementInShadowDOM('\(elementId)');
+            const elementId = '\(elementId)';
+            const element = findElementInShadowDOM(elementId);
 
             if (element) {
                 element.focus();
                 return 'Element found and focused: ' + elementId;
-            } else {
-                return 'Element not found: ' + elementId;
             }
+
+            return 'Element not found: ' + elementId;
         })();
         """
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
- Fix home-assistant/frontend#30048
- elementId inside the JS was used in the return string, but not escaped so JS fails.
  -  I am actually not sure if this return string is even needed. Does it have any sense?

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- when this is releases we activate again the functionality in the frontend: home-assistant/frontend#30226
