### PR TITLE
Fix typo in NSLocationAlwaysAndWhenInUseUsageDescription string

### DIFF
--- a/Sources/App/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -3,7 +3,7 @@
 "NSCrossWebsiteTrackingUsageDescription" = "如果您的配置需要，可以选择启用跨网站跟踪。";
 "NSFocusStatusUsageDescription" = "以传感器形式报告您的专注模式状态。";
 "NSLocalNetworkUsageDescription" = "定位并与您的 Home Assistant 实例通信。";
-"NSLocationAlwaysAndWhenInUseUsageDescription" = "\n 🔵  我们还需要”始终“访问位置信息的权限，以便应用可以执行后台操作。\n\n ⚠️ 没有此权限，应用将无法决定在后台时食用哪种连接（本地或远程），并将一直使用远程连接。";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "\n 🔵  我们还需要”始终“访问位置信息的权限，以便应用可以执行后台操作。\n\n ⚠️ 没有此权限，应用将无法决定在后台时使用哪种连接（本地或远程），并将一直使用远程连接。";
 "NSLocationAlwaysUsageDescription" = "我们需要持续获取您的位置用于 iBeacons、地理围栏、后台位置更新和准确性报告等功能。";
 "NSLocationUsageDescription" = "启用后，您的设备位置信息将作为设备跟踪器发送到 Home Assistant 服务器。";
 "NSLocationWhenInUseUsageDescription" = "此应用需要访问您的位置信息才能直接连接到您的 Home Assistant 系统。\n\n 1️⃣ 您的位置信息仅用于检查您是否已连接到本地网络。\n\n 2️⃣ 您的位置信息不会与任何人共享。\n\n 3️⃣ 如果您不允许访问位置信息，应用将始终通过互联网连接。如果未进行配置，应用将保护您的数据并拒绝连接。";


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fix a typo in NSLocationAlwaysAndWhenInUseUsageDescription (zh-hans) string:

食用(eat) -> 使用(use)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
