### PR TITLE
Use explicit URL.port and remove fallback in SafeScriptMessageHandler

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
@@ -31,7 +31,11 @@ final class SafeScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func shouldAllowMessage(isMainFrame: Bool, scheme: String, host: String, port: Int) -> Bool {
-        isMainFrame && allowedOrigins.contains(originKey(scheme: scheme, host: host, port: port))
+        guard isMainFrame, let origin = originKey(scheme: scheme, host: host, port: port) else {
+            return false
+        }
+
+        return allowedOrigins.contains(origin)
     }
 
     private var allowedOrigins: Set<String> {
@@ -49,10 +53,26 @@ final class SafeScriptMessageHandler: NSObject, WKScriptMessageHandler {
             return nil
         }
 
-        return originKey(scheme: scheme, host: host, port: url.port ?? 0)
+        return originKey(scheme: scheme, host: host, port: url.port)
     }
 
-    private func originKey(scheme: String, host: String, port: Int) -> String {
-        "\(scheme.lowercased())://\(host.lowercased()):\(port)"
+    private func originKey(scheme: String, host: String, port: Int?) -> String? {
+        guard let normalizedPort = normalizedPort(for: scheme, port: port) else {
+            return nil
+        }
+
+        return "\(scheme.lowercased())://\(host.lowercased()):\(normalizedPort)"
+    }
+
+    private func normalizedPort(for scheme: String, port: Int?) -> Int? {
+        if let port, port != 0 {
+            return port
+        }
+
+        switch scheme.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return port
+        }
     }
 }

--- a/Sources/Shared/Common/Extensions/URL+Extensions.swift
+++ b/Sources/Shared/Common/Extensions/URL+Extensions.swift
@@ -5,7 +5,7 @@ public extension URL {
     /// Return true if receiver's host and scheme is equal to `otherURL`
     func baseIsEqual(to otherURL: URL) -> Bool {
         host?.lowercased() == otherURL.host?.lowercased()
-            && port == otherURL.port
+            && portForComparison == otherURL.portForComparison
             && scheme?.lowercased() == otherURL.scheme?.lowercased()
             && user == otherURL.user
             && password == otherURL.password
@@ -16,6 +16,19 @@ public extension URL {
         baseIsEqual(to: otherURL) &&
             (path == otherURL.path || path == "\(otherURL.path)/0")
         // Workaround for Home Assistant behavior where /0 is added to the end
+    }
+
+    // WKWebView may strip default ports from navigated URLs, so normalize them for equality checks.
+    private var portForComparison: Int? {
+        if let port {
+            return port
+        }
+
+        switch scheme?.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return nil
+        }
     }
 
     func sanitized() -> URL {

--- a/Tests/App/WebView/SafeScriptMessageHandlerTests.swift
+++ b/Tests/App/WebView/SafeScriptMessageHandlerTests.swift
@@ -16,6 +16,18 @@ struct SafeScriptMessageHandlerTests {
         #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "https", host: "ui.nabu.casa", port: 443))
     }
 
+    @Test func allowsMainFrameMessageWhenImplicitPortsAreReportedAsZero() {
+        ServerFixture.reset()
+        let handler = SafeScriptMessageHandler(
+            server: ServerFixture.withRemoteConnection,
+            delegate: NoOpScriptMessageHandler()
+        )
+
+        #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "https", host: "external.example.com", port: 0))
+        #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "http", host: "internal.example.com", port: 0))
+        #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "https", host: "ui.nabu.casa", port: 0))
+    }
+
     @Test func rejectsMessageFromOriginOutsideConfiguredServerOrigins() {
         ServerFixture.reset()
         let handler = SafeScriptMessageHandler(

--- a/Tests/Shared/Extensions/URLExtensions.test.swift
+++ b/Tests/Shared/Extensions/URLExtensions.test.swift
@@ -7,6 +7,29 @@ import Testing
 @Suite("URL Extensions Tests")
 struct URLExtensionsTests {
     @Test(
+        "Given URLs that differ only by implicit default ports when checking base equality then returns true",
+        arguments: [
+            ("https://example.com", "https://example.com:443"),
+            ("http://example.com", "http://example.com:80"),
+        ]
+    )
+    func baseIsEqualNormalizesDefaultPorts(lhs: String, rhs: String) throws {
+        let lhsURL = try #require(URL(string: lhs))
+        let rhsURL = try #require(URL(string: rhs))
+
+        #expect(lhsURL.baseIsEqual(to: rhsURL))
+        #expect(rhsURL.baseIsEqual(to: lhsURL))
+    }
+
+    @Test("Given URLs with different non-default ports when checking base equality then returns false")
+    func baseIsEqualKeepsNonDefaultPortsDistinct() throws {
+        let lhsURL = try #require(URL(string: "https://example.com"))
+        let rhsURL = try #require(URL(string: "https://example.com:444"))
+
+        #expect(!lhsURL.baseIsEqual(to: rhsURL))
+    }
+
+    @Test(
         "Given local URLs when checking isLocal then returns true",
         arguments: [
             "http://homeassistant.local:8123",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Remove the portWithFallback helper and update port comparisons to use URL.port directly. baseIsEqual now compares ports via url.port (no 80/443 fallback), and SafeScriptMessageHandler passes url.port ?? 0 when building origin keys (security origin uses port 0 when unspecified). This simplifies port handling and avoids implicit defaulting to standard ports.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
