### PR TITLE
Support styled empty states and preserve auth-invalid

### DIFF
--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -46,7 +46,6 @@ enum WebViewEmptyStateStyle: Equatable {
 struct WebViewEmptyStateView: View {
     @Environment(\.safeAreaInsets) private var safeAreaInsets
 
-    @State private var showCloseButton = false
     let style: WebViewEmptyStateStyle
     let server: Server
     let retryAction: (() -> Void)?

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -2,10 +2,52 @@ import Shared
 import SwiftUI
 import UIKit
 
+enum WebViewEmptyStateStyle: Equatable {
+    case disconnected
+    case unauthenticated
+
+    var title: String {
+        switch self {
+        case .disconnected:
+            L10n.WebView.EmptyState.title
+        case .unauthenticated:
+            L10n.Unauthenticated.Message.title
+        }
+    }
+
+    var body: String {
+        switch self {
+        case .disconnected:
+            L10n.WebView.EmptyState.body
+        case .unauthenticated:
+            L10n.Unauthenticated.Message.body
+        }
+    }
+
+    var primaryButtonTitle: String {
+        switch self {
+        case .disconnected:
+            L10n.WebView.EmptyState.retryButton
+        case .unauthenticated:
+            L10n.WebView.EmptyState.openSettingsButton
+        }
+    }
+
+    var secondaryButtonTitle: String {
+        switch self {
+        case .disconnected:
+            L10n.WebView.EmptyState.openSettingsButton
+        case .unauthenticated:
+            L10n.WebView.EmptyState.retryButton
+        }
+    }
+}
+
 struct WebViewEmptyStateView: View {
     @Environment(\.safeAreaInsets) private var safeAreaInsets
 
     @State private var showCloseButton = false
+    let style: WebViewEmptyStateStyle
     let server: Server
     let retryAction: (() -> Void)?
     let settingsAction: (() -> Void)?
@@ -40,27 +82,19 @@ struct WebViewEmptyStateView: View {
                 .scaledToFit()
                 .frame(width: 80, height: 80)
                 .foregroundColor(.accentColor)
-            Text(L10n.WebView.EmptyState.title)
+            Text(style.title)
                 .font(.title2)
                 .fontWeight(.semibold)
-            Text(L10n.WebView.EmptyState.body)
+            Text(style.body)
                 .font(.callout)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DesignSystem.Spaces.two)
             VStack(spacing: DesignSystem.Spaces.one) {
-                Button(action: {
-                    retryAction?()
-                }) {
-                    Text(L10n.WebView.EmptyState.retryButton)
-                }
-                .buttonStyle(.primaryButton)
-                Button(action: {
-                    settingsAction?()
-                }) {
-                    Text(L10n.WebView.EmptyState.openSettingsButton)
-                }
-                .buttonStyle(.secondaryButton)
+                primaryButton
+                    .buttonStyle(.primaryButton)
+                secondaryButton
+                    .buttonStyle(.secondaryButton)
             }
             .frame(maxWidth: Sizes.maxWidthForLargerScreens)
             .padding(.horizontal, DesignSystem.Spaces.two)
@@ -87,24 +121,60 @@ struct WebViewEmptyStateView: View {
             }
         }
     }
+
+    private var primaryButton: some View {
+        Button(action: {
+            switch style {
+            case .disconnected:
+                retryAction?()
+            case .unauthenticated:
+                settingsAction?()
+            }
+        }) {
+            Text(style.primaryButtonTitle)
+        }
+    }
+
+    private var secondaryButton: some View {
+        Button(action: {
+            switch style {
+            case .disconnected:
+                settingsAction?()
+            case .unauthenticated:
+                retryAction?()
+            }
+        }) {
+            Text(style.secondaryButtonTitle)
+        }
+    }
 }
 
 #Preview {
-    WebViewEmptyStateView(server: ServerFixture.standard) {} settingsAction: {} dismissAction: {}
+    WebViewEmptyStateView(style: .disconnected, server: ServerFixture.standard) {} settingsAction: {} dismissAction: {}
 }
 
 final class WebViewEmptyStateWrapperView: UIView {
     private let hostingController: UIHostingController<WebViewEmptyStateView>
     private let server: Server
+    private let retryAction: (() -> Void)?
+    private let settingsAction: (() -> Void)?
+    private let dismissAction: (() -> Void)?
+    private(set) var style: WebViewEmptyStateStyle
 
     init(
+        style: WebViewEmptyStateStyle = .disconnected,
         server: Server,
         retryAction: (() -> Void)? = nil,
         settingsAction: (() -> Void)? = nil,
         dismissAction: (() -> Void)? = nil
     ) {
+        self.style = style
         self.server = server
+        self.retryAction = retryAction
+        self.settingsAction = settingsAction
+        self.dismissAction = dismissAction
         let swiftUIView = WebViewEmptyStateView(
+            style: style,
             server: server,
             retryAction: retryAction,
             settingsAction: settingsAction,
@@ -130,5 +200,17 @@ final class WebViewEmptyStateWrapperView: UIView {
             hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
         backgroundColor = .clear
+    }
+
+    func updateStyle(_ style: WebViewEmptyStateStyle) {
+        guard self.style != style else { return }
+        self.style = style
+        hostingController.rootView = WebViewEmptyStateView(
+            style: style,
+            server: server,
+            retryAction: retryAction,
+            settingsAction: settingsAction,
+            dismissAction: dismissAction
+        )
     }
 }

--- a/Sources/App/Frontend/WebView/WebViewController+Alerts.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+Alerts.swift
@@ -504,29 +504,9 @@ extension WebViewController {
         }
 
         // Avoid retrying from Home Assistant UI since this is a dead end
+        connectionState = .authInvalid
         load(request: URLRequest(url: URL(string: "about:blank")!))
         showEmptyState()
-        showBanner(request: .init(
-            id: "reauth-\(serverId)",
-            title: L10n.Unauthenticated.Message.title,
-            message: L10n.Unauthenticated.Message.body,
-            duration: .forever,
-            dimming: .gray(interactive: true),
-            style: .warning,
-            action: .init(
-                image: MaterialDesignIcons.cogIcon.image(
-                    ofSize: CGSize(width: 24, height: 24),
-                    color: .haPrimary
-                ),
-                tintColor: .haPrimary,
-                accessibilityLabel: L10n.ConnectionError.OpenSettings.title,
-                dismissOnTap: false,
-                handler: { [weak self] in
-                    self?.showSettingsViewController()
-                }
-            ),
-            dimmingAccessibilityLabel: L10n.cancelLabel
-        ))
     }
 
     func showActionAutomationEditorNotAvailable() {

--- a/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
@@ -5,7 +5,10 @@ import UIKit
 
 extension WebViewController {
     func setupEmptyState() {
-        let emptyState = WebViewEmptyStateWrapperView(server: server) { [weak self] in
+        let emptyState = WebViewEmptyStateWrapperView(
+            style: emptyStateStyle(for: connectionState),
+            server: server
+        ) { [weak self] in
             self?.hideEmptyState()
             self?.refresh()
         } settingsAction: { [weak self] in
@@ -29,7 +32,17 @@ extension WebViewController {
         emptyStateView = emptyState
     }
 
+    func emptyStateStyle(for connectionState: FrontEndConnectionState) -> WebViewEmptyStateStyle {
+        switch connectionState {
+        case .authInvalid:
+            .unauthenticated
+        case .connected, .disconnected, .unknown:
+            .disconnected
+        }
+    }
+
     func showEmptyState() {
+        emptyStateView?.updateStyle(emptyStateStyle(for: connectionState))
         UIView.animate(withDuration: emptyStateTransitionDuration, delay: 0, options: .curveEaseInOut, animations: {
             self.emptyStateView?.alpha = 1
         }, completion: nil)
@@ -44,7 +57,11 @@ extension WebViewController {
     // To avoid keeping the empty state on screen when user is disconnected in background
     // due to inactivity, we reset the empty state timer
     @objc func resetEmptyStateTimerWithLatestConnectedState() {
-        let state: FrontEndConnectionState = isConnected ? .connected : .disconnected
+        let state: FrontEndConnectionState = if connectionState == .authInvalid {
+            .authInvalid
+        } else {
+            isConnected ? .connected : .disconnected
+        }
         updateFrontendConnectionState(state: state.rawValue)
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -59,14 +59,22 @@ extension WebViewController: WebViewControllerProtocol {
         emptyStateTimer?.invalidate()
         emptyStateTimer = nil
 
-        let state = FrontEndConnectionState(rawValue: state) ?? .unknown
-        isConnected = state == .connected
-        connectionState = state
+        let requestedState = FrontEndConnectionState(rawValue: state) ?? .unknown
+        let resolvedState: FrontEndConnectionState = if connectionState == .authInvalid, requestedState != .connected {
+            .authInvalid
+        } else {
+            requestedState
+        }
+        isConnected = resolvedState == .connected
+        connectionState = resolvedState
 
         // Possible values: connected, disconnected, auth-invalid
-        if state == .connected {
+        switch resolvedState {
+        case .connected:
             hideEmptyState()
-        } else {
+        case .authInvalid:
+            showEmptyState()
+        case .disconnected, .unknown:
             // Start a 10-second timer. If not interrupted by a 'connected' state, set alpha to 1.
             emptyStateTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { [weak self] _ in
                 self?.showEmptyState()

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -23,7 +23,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     let leftEdgePanGestureRecognizer: UIScreenEdgePanGestureRecognizer
     let rightEdgeGestureRecognizer: UIScreenEdgePanGestureRecognizer
 
-    var emptyStateView: UIView?
+    var emptyStateView: WebViewEmptyStateWrapperView?
     let emptyStateTransitionDuration: TimeInterval = 0.3
 
     var statusBarView: UIView?

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -60,6 +60,51 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertNil(sut.keyboardFocusedElementScrollWorkItem)
     }
 
+    func testEmptyStateStyleUsesUnauthenticatedVariantForAuthInvalidConnectionState() {
+        let sut = makeSUT()
+
+        let style = sut.emptyStateStyle(for: .authInvalid)
+
+        XCTAssertEqual(style, .unauthenticated)
+    }
+
+    func testEmptyStateStyleUsesDisconnectedVariantForDisconnectedConnectionState() {
+        let sut = makeSUT()
+
+        let style = sut.emptyStateStyle(for: .disconnected)
+
+        XCTAssertEqual(style, .disconnected)
+    }
+
+    func testResetEmptyStateTimerKeepsAuthInvalidConnectionState() {
+        let sut = makeSUT()
+        sut.connectionState = .authInvalid
+        sut.isConnected = false
+
+        sut.resetEmptyStateTimerWithLatestConnectedState()
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+    }
+
+    func testUpdateFrontendConnectionStateDoesNotDowngradeAuthInvalidToDisconnected() {
+        let sut = makeSUT()
+        sut.connectionState = .authInvalid
+
+        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertNil(sut.emptyStateTimer)
+    }
+
+    func testUpdateFrontendConnectionStateSchedulesTimerForDisconnectedState() {
+        let sut = makeSUT()
+
+        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+
+        XCTAssertEqual(sut.connectionState, .disconnected)
+        XCTAssertNotNil(sut.emptyStateTimer)
+    }
+
     private func makeSUT() -> WebViewController {
         let sut = WebViewController(server: .fake())
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Display unauthenticated state in the same UI style as the current empty state, so we dont have the duplicated popup coming over it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="1206" height="2622" alt="Simulator Screenshot - Daily tester 2 - 2026-04-14 at 11 55 17" src="https://github.com/user-attachments/assets/e94caddc-ceae-4edf-9e95-4953b81a71cc" />

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
