### PR TITLE
Fix widget extension crashes causing blank widgets

### DIFF
--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -53,7 +53,7 @@ class OnboardingAuth {
                 // somewhat necessary so it points to the keychain-persisted version
                 api.server = server
                 // not super necessary but prevents making a duplicate connection during this session
-                Current.cachedApis[api.server.identifier] = api
+                Current.setCachedApi(api, for: api.server.identifier)
             }.then { server in
                 steps(.complete).map { server }
             }.recover(policy: .allErrors) { [self] error -> Promise<Server> in

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -102,7 +102,12 @@ private struct ServerCache {
 
     var info: [Identifier<Server>: ServerInfo] = [:] {
         didSet {
-            precondition(deletedServers.isDisjoint(with: info.keys))
+            if !deletedServers.isDisjoint(with: info.keys) {
+                Current.Log
+                    .error(
+                        "Stale server(s) in info cache overlapping with deleted servers, info keys: \(info.keys), deleted servers: \(deletedServers)"
+                    )
+            }
         }
     }
 

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -5,35 +5,39 @@ public extension DatabaseQueue {
     // Following GRDB cocnurrency rules, we have just one database instance
     // https://swiftpackageindex.com/groue/grdb.swift/v6.29.3/documentation/grdb/concurrency#Concurrency-Rules
     static var appDatabase: DatabaseQueue = {
+        let database: DatabaseQueue
         do {
-            let database = try DatabaseQueue(path: databasePath())
-
-            // Create tables if needed
-            for table in DatabaseQueue.tables() {
-                do {
-                    try table.createIfNeeded(database: database)
-                } catch {
-                    let className = String(describing: type(of: table))
-                    let errorMessage = "Failed create GRDB table \(className), error: \(error.localizedDescription)"
-                    Current.clientEventStore.addEvent(ClientEvent(text: errorMessage, type: .database))
-                }
-            }
-            DatabaseQueue.deleteOldTables(database: database)
-
+            database = try DatabaseQueue(path: databasePath())
             #if targetEnvironment(simulator)
             print("GRDB App database is stored at \(AppConstants.appGRDBFile.description)")
             #endif
-            return database
         } catch {
             Current.Log.error("Failed to initialize GRDB, error: \(error.localizedDescription)")
             // Fallback to in-memory database so extensions don't crash
             do {
-                return try DatabaseQueue()
+                database = try DatabaseQueue()
+                Current.Log.error("Using in-memory GRDB database as fallback")
             } catch {
                 fatalError("Failed to create even an in-memory GRDB database: \(error.localizedDescription)")
             }
         }
+
+        setupSchema(database: database)
+        return database
     }()
+
+    private static func setupSchema(database: DatabaseQueue) {
+        for table in DatabaseQueue.tables() {
+            do {
+                try table.createIfNeeded(database: database)
+            } catch {
+                let className = String(describing: type(of: table))
+                let errorMessage = "Failed create GRDB table \(className), error: \(error.localizedDescription)"
+                Current.clientEventStore.addEvent(ClientEvent(text: errorMessage, type: .database))
+            }
+        }
+        DatabaseQueue.deleteOldTables(database: database)
+    }
 
     static func databasePath() -> String {
         // Path for tests

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -25,9 +25,13 @@ public extension DatabaseQueue {
             #endif
             return database
         } catch {
-            let errorMessage = "Failed to initialize GRDB, error: \(error.localizedDescription)"
-            Current.Log.error(errorMessage)
-            fatalError(errorMessage)
+            Current.Log.error("Failed to initialize GRDB, error: \(error.localizedDescription)")
+            // Fallback to in-memory database so extensions don't crash
+            do {
+                return try DatabaseQueue()
+            } catch {
+                fatalError("Failed to create even an in-memory GRDB database: \(error.localizedDescription)")
+            }
         }
     }()
 

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -175,7 +175,23 @@ public class AppEnvironment {
 
     public var servers: ServerManager = ServerManagerImpl()
 
-    public var cachedApis = [Identifier<Server>: HomeAssistantAPI]()
+    // Thread-safe wrapper for the API cache. AppIntents (e.g. ScriptAppIntent,
+    // SwitchIntent) run on arbitrary threads and can call api(for:) concurrently,
+    // so unprotected dictionary access causes memory corruption in extensions.
+    private var cachedApisLock = NSLock()
+    private var _cachedApis = [Identifier<Server>: HomeAssistantAPI]()
+    public var cachedApis: [Identifier<Server>: HomeAssistantAPI] {
+        get {
+            cachedApisLock.lock()
+            defer { cachedApisLock.unlock() }
+            return _cachedApis
+        }
+        set {
+            cachedApisLock.lock()
+            defer { cachedApisLock.unlock() }
+            _cachedApis = newValue
+        }
+    }
 
     public var apis: [HomeAssistantAPI] { servers.all.compactMap(api(for:)) }
 
@@ -185,11 +201,15 @@ public class AppEnvironment {
             return nil
         }
 
-        if let existing = cachedApis[server.identifier] {
+        // Use the same lock to make the read-check-write atomic
+        cachedApisLock.lock()
+        defer { cachedApisLock.unlock() }
+
+        if let existing = _cachedApis[server.identifier] {
             return existing
         } else {
             let api = HomeAssistantAPI(server: server, urlConfig: .default)
-            cachedApis[server.identifier] = api
+            _cachedApis[server.identifier] = api
             return api
         }
     }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -193,6 +193,15 @@ public class AppEnvironment {
         }
     }
 
+    /// Thread-safe single-key insertion into the API cache.
+    /// Prefer this over `cachedApis[id] = api` which involves a
+    /// non-atomic get→mutate→set cycle on the computed property.
+    public func setCachedApi(_ api: HomeAssistantAPI, for identifier: Identifier<Server>) {
+        cachedApisLock.lock()
+        defer { cachedApisLock.unlock() }
+        _cachedApis[identifier] = api
+    }
+
     public var apis: [HomeAssistantAPI] { servers.all.compactMap(api(for:)) }
 
     private var lastActiveURLForServer = [Identifier<Server>: URL?]()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes three distinct crashes in the widget extension process that cause
widgets to go blank and not recover until the app is reinstalled.

- **ServerCache precondition crash** — `ServerCache.info.didSet` uses a
  `precondition` that reads `deletedServers` from shared UserDefaults on
  every check. When the main app deletes a server, the widget's cached
  `info` dict still contains it, causing the precondition to fail on the
  next mutation. Replaced with an error log, matching the existing pattern
  for the `server` dict. This was the most common crash (4 of 10 logs)
  and created a permanent crash loop only fixable by reinstalling.

- **Thread-unsafe `cachedApis` dictionary** — `AppEnvironment.cachedApis`
  is a plain dictionary accessed concurrently from multiple AppIntent
  threads (`ScriptAppIntent`, `SwitchIntent`), causing memory corruption.
  Added `NSLock` synchronization around all access.

- **`fatalError` in GRDB initialization** — When `DatabaseQueue` fails to
  open the on-disk database (locked file, corruption, file protection),
  the widget extension calls `fatalError`. Replaced with a fallback to an
  in-memory database, matching Realm's existing pattern.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
