### PR TITLE
Omit empty PKCS#12 passphrase and add tests

### DIFF
--- a/Sources/Shared/API/mTLS/ClientCertificate.swift
+++ b/Sources/Shared/API/mTLS/ClientCertificate.swift
@@ -58,6 +58,18 @@ public final class ClientCertificateManager {
 
     private init() {}
 
+    static func pkcs12ImportOptions(password: String) -> [String: Any] {
+        // On macOS, passwordless PKCS#12 imports fail when an explicit empty-string passphrase
+        // is supplied. Omitting the option lets Security treat the bundle as unprotected.
+        guard !password.isEmpty else {
+            return [:]
+        }
+
+        return [
+            kSecImportExportPassphrase as String: password,
+        ]
+    }
+
     /// Import a PKCS#12 file into the Keychain
     /// - Parameters:
     ///   - p12Data: The raw .p12 file data
@@ -65,10 +77,7 @@ public final class ClientCertificateManager {
     ///   - identifier: A unique identifier for storing in Keychain
     /// - Returns: A ClientCertificate reference
     public func importP12(data p12Data: Data, password: String, identifier: String) throws -> ClientCertificate {
-        // Import options
-        let options: [String: Any] = [
-            kSecImportExportPassphrase as String: password,
-        ]
+        let options = Self.pkcs12ImportOptions(password: password)
 
         var items: CFArray?
         let status = SecPKCS12Import(p12Data as CFData, options as CFDictionary, &items)

--- a/Tests/Shared/ClientCertificate.test.swift
+++ b/Tests/Shared/ClientCertificate.test.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 @testable import Shared
 import Testing
 
@@ -244,6 +245,24 @@ struct ClientCertificateErrorTests {
     func keychainErrorStatusCodes(status: Int32, expectedDescription: String) {
         let error = ClientCertificateError.keychainError(OSStatus(status))
         #expect(error.errorDescription == expectedDescription)
+    }
+}
+
+@Suite("ClientCertificateManager Import Tests")
+struct ClientCertificateManagerImportTests {
+    @Test("Given empty password when creating PKCS#12 import options then passphrase is omitted")
+    func emptyPasswordOmitsPassphraseOption() {
+        let options = ClientCertificateManager.pkcs12ImportOptions(password: "")
+
+        #expect(options.isEmpty)
+        #expect(options[kSecImportExportPassphrase as String] == nil)
+    }
+
+    @Test("Given non-empty password when creating PKCS#12 import options then passphrase is included")
+    func nonEmptyPasswordIncludesPassphraseOption() {
+        let options = ClientCertificateManager.pkcs12ImportOptions(password: "secret")
+
+        #expect(options[kSecImportExportPassphrase as String] as? String == "secret")
     }
 }
 #endif


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Avoid passing an explicit empty passphrase to SecPKCS12Import on macOS by introducing ClientCertificateManager.pkcs12ImportOptions(password:). importP12 now uses this helper so an empty password results in no passphrase option being supplied. Added unit tests verifying both empty and non-empty password behavior and imported Security in the test file.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
