### PR TITLE
Migrate Apple Watch complications to SwiftUI

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 /* Begin PBXBuildFile section */
 		00C267608DCC88B783816CBF /* FanIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6888525DCF492642BA7EA3 /* FanIntent.swift */; };
 		072BACCC5B2509E4AF06BFED /* KioskSettingsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14444A34DA125693568C7035 /* KioskSettingsTable.swift */; };
+		0C1F82B6DF9051F98A587352 /* ComplicationEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3995EF7323087AA35F01BDDF /* ComplicationEditView.swift */; };
+		1100D51D2496AECE00B1073C /* PermissionStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100D51C2496AECE00B1073C /* PermissionStatusRow.swift */; };
 		1100D51F2496F63400B1073C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100D51E2496F63400B1073C /* ThemeColors.swift */; };
 		1101568324D770B2009424C9 /* iOSTagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161C01624D75BD500A0E3C4 /* iOSTagManager.swift */; };
 		1101568424D770B2009424C9 /* NFCWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D04E324D76CDB003CE877 /* NFCWriter.swift */; };
@@ -1242,6 +1244,7 @@
 		46F9A1012F0A000100ABCD01 /* StatusItemTitleRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F9A1002F0A000100ABCD01 /* StatusItemTitleRendererTests.swift */; };
 		491E98FF25D543560077BBE3 /* LogbookEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491E98FE25D543560077BBE3 /* LogbookEntry.swift */; };
 		491E990025D543560077BBE3 /* LogbookEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491E98FE25D543560077BBE3 /* LogbookEntry.swift */; };
+		498C0EF747C141F3E3204BBE /* ComplicationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862436CFE6E3F4B31500EFB2 /* ComplicationListViewModel.swift */; };
 		504A2C862F8133E6002A3C0E /* CarPlayTabsSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A2C852F8133E6002A3C0E /* CarPlayTabsSelectionView.swift */; };
 		51B609B13F56C4F17CEF2BE4 /* KioskConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825E1E44BA9ABF1BF53733D3 /* KioskConstants.swift */; };
 		54B2C38995814098B677135A /* WidgetCommonlyUsedEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEEA3344F064DB183F46C47 /* WidgetCommonlyUsedEntities.swift */; };
@@ -1264,10 +1267,14 @@
 		897D7538631C46D4BD849CF5 /* NotificationsCommandManagerLiveActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D790D5FA5DBB4B5B9DBB2334 /* NotificationsCommandManagerLiveActivityTests.swift */; };
 		8DFA3DEE4881E59961C3B5E2 /* BarometerSensor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A4CD40BADC119045547D77 /* BarometerSensor.test.swift */; };
 		8E5FA96C740F1D671966CEA9 /* Pods-iOS-Extensions-NotificationContent-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B613440AEDD4209862503F5D /* Pods-iOS-Extensions-NotificationContent-metadata.plist */; };
+		925D92FC9E2221189D67B22C /* ComplicationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF9C3A30E10A8E214623EBB /* ComplicationListView.swift */; };
 		999549244371450BC98C700E /* Pods_iOS_Extensions_PushProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 608CFDA223EBCDF01B946093 /* Pods_iOS_Extensions_PushProvider.framework */; };
 		A1619F1ED93FB8B0E7E53C38 /* KioskLifecycleBrightness.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AE72CB925F044BAE18B62 /* KioskLifecycleBrightness.test.swift */; };
 		A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */; };
+		A2F3A140CDD1EF1AEA6DFAB9 /* DatabaseTableProtocol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC31518EE9DC9E065AC508D9 /* DatabaseTableProtocol.test.swift */; };
+		A596C4D1E125E6863C7D2034 /* ComplicationEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512A72C5F1BCC979E74F7629 /* ComplicationEditViewModel.swift */; };
 		A5A3C1932BE1F4A40EA78754 /* Pods-iOS-Extensions-Matter-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 392B0C44197C98E2653932A5 /* Pods-iOS-Extensions-Matter-metadata.plist */; };
+		A60E917B401A6D456F1DB630 /* ComplicationFamilySelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1861EB0361816DC9260D1F5E /* ComplicationFamilySelectView.swift */; };
 		A95FDD0C2F6B89C6008EF72F /* LiveActivityRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FDD0A2F6B89C6008EF72F /* LiveActivityRegistry.swift */; };
 		A95FDD0D2F6B89C6008EF72F /* HALiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FDD092F6B89C6008EF72F /* HALiveActivityAttributes.swift */; };
 		A95FDD0F2F6B8A19008EF72F /* HandlerLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FDD0E2F6B8A19008EF72F /* HandlerLiveActivity.swift */; };
@@ -1582,8 +1589,11 @@
 		D8B4F2A61E9C73058AF2D49E /* KioskSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A3E91F5B8D42A6E0F13B74 /* KioskSettingsViewModel.swift */; };
 		D9A6697AF4D05BB8DE822A54 /* Pods_iOS_Extensions_Share.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CA7FF55788E7084DA5E4B3 /* Pods_iOS_Extensions_Share.framework */; };
 		DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */; };
+		DB54626ADCE0C32094C8C0B9 /* LoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFD0D30836C69840AB63A8A /* LoadingButton.swift */; };
 		DEFBE1A5E9A005B0A5392D27 /* KioskLocalization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4593A60DBF019E6C91AAA7 /* KioskLocalization.test.swift */; };
+		E3A02409794174F002C8BB4F /* IconSearchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC23DE131CA8813C2DBD657 /* IconSearchPicker.swift */; };
 		E92E09E3A93650D56E3C5093 /* KioskScreensaverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CDCFDB29D283A7902A3ABE /* KioskScreensaverViewController.swift */; };
+		F0D1DD41A8F55F6D767EBF37 /* TemplatePreviewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332C060487B468055C487070 /* TemplatePreviewSection.swift */; };
 		FC8E9421FDB864726918B612 /* Pods-watchOS-WatchExtension-Watch-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9249824D575933DFA1530BB2 /* Pods-watchOS-WatchExtension-Watch-metadata.plist */; };
 		FD3BC66329B9FF8F00B19FBE /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */; };
 		FD3BC66C29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */; };
@@ -2259,6 +2269,7 @@
 		11FA53F1251071D2008D9506 /* NSItemProvider+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+Additions.swift"; sourceTree = "<group>"; };
 		1396822195C7FF562AB891F2 /* BarometerSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarometerSensor.swift; sourceTree = "<group>"; };
 		14444A34DA125693568C7035 /* KioskSettingsTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSettingsTable.swift; sourceTree = "<group>"; };
+		1861EB0361816DC9260D1F5E /* ComplicationFamilySelectView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationFamilySelectView.swift; sourceTree = "<group>"; };
 		1945E8E386664E5A88668E77 /* WebViewController+ReAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewController+ReAuth.swift"; sourceTree = "<group>"; };
 		1BAC899D24EB43716158A4F8 /* Pods-iOS-Extensions-NotificationContent.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationContent.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationContent/Pods-iOS-Extensions-NotificationContent.beta.xcconfig"; sourceTree = "<group>"; };
 		1FAFCDC6866E158B337576C2 /* Pods-iOS-Extensions-Share.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Share.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Share/Pods-iOS-Extensions-Share.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2268,6 +2279,7 @@
 		273BF4150C522259C6183B32 /* Pods-watchOS-Shared-watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-Shared-watchOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-Shared-watchOS/Pods-watchOS-Shared-watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		2A674A3ACB31BFCEB70423FE /* Pods-watchOS-WatchExtension-Watch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-WatchExtension-Watch.release.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-WatchExtension-Watch/Pods-watchOS-WatchExtension-Watch.release.xcconfig"; sourceTree = "<group>"; };
 		2C50B9249EE482AF53672D36 /* Pods-iOS-SharedTesting.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-SharedTesting.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-SharedTesting/Pods-iOS-SharedTesting.beta.xcconfig"; sourceTree = "<group>"; };
+		332C060487B468055C487070 /* TemplatePreviewSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TemplatePreviewSection.swift; sourceTree = "<group>"; };
 		33CA7FF55788E7084DA5E4B3 /* Pods_iOS_Extensions_Share.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_Share.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		365F0937BF33147F29CE8F8B /* Pods-watchOS-Shared-watchOS.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-watchOS-Shared-watchOS.beta.xcconfig"; path = "Pods/Target Support Files/Pods-watchOS-Shared-watchOS/Pods-watchOS-Shared-watchOS.beta.xcconfig"; sourceTree = "<group>"; };
 		373AE72CB925F044BAE18B62 /* KioskLifecycleBrightness.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskLifecycleBrightness.test.swift; sourceTree = "<group>"; };
@@ -2275,6 +2287,7 @@
 		3847E9669693AB9672A3301D /* Pods-iOS-SharedTesting.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-SharedTesting.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-SharedTesting/Pods-iOS-SharedTesting.release.xcconfig"; sourceTree = "<group>"; };
 		38D793A057CBFD32530A7193 /* KioskClockScreensaverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskClockScreensaverView.swift; sourceTree = "<group>"; };
 		392B0C44197C98E2653932A5 /* Pods-iOS-Extensions-Matter-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Matter-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Matter-metadata.plist"; sourceTree = "<group>"; };
+		3995EF7323087AA35F01BDDF /* ComplicationEditView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationEditView.swift; sourceTree = "<group>"; };
 		399792692B7F904A00231B54 /* MobileAppConfigPushCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAppConfigPushCategory.swift; sourceTree = "<group>"; };
 		3997926D2B7F907B00231B54 /* MobileAppConfigPush.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAppConfigPush.swift; sourceTree = "<group>"; };
 		399792702B7F909900231B54 /* MobileAppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAppConfig.swift; sourceTree = "<group>"; };
@@ -3086,17 +3099,21 @@
 		4F4593A60DBF019E6C91AAA7 /* KioskLocalization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskLocalization.test.swift; sourceTree = "<group>"; };
 		504A2C852F8133E6002A3C0E /* CarPlayTabsSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayTabsSelectionView.swift; sourceTree = "<group>"; };
 		50D9C22ED2834EC9DAAC63AC /* Pods-iOS-Extensions-Intents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Intents.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Intents/Pods-iOS-Extensions-Intents.debug.xcconfig"; sourceTree = "<group>"; };
+		512A72C5F1BCC979E74F7629 /* ComplicationEditViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationEditViewModel.swift; sourceTree = "<group>"; };
 		553A33E097387AA44265DB13 /* Pods-iOS-App-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-App-metadata.plist"; path = "Pods/Pods-iOS-App-metadata.plist"; sourceTree = "<group>"; };
 		592EED7A6C2444872F11C17B /* Pods-iOS-Extensions-NotificationService-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-NotificationService-metadata.plist"; path = "Pods/Pods-iOS-Extensions-NotificationService-metadata.plist"; sourceTree = "<group>"; };
+		5BFD0D30836C69840AB63A8A /* LoadingButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoadingButton.swift; sourceTree = "<group>"; };
 		5C50FA39BF16AD0BD782D0D7 /* GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
 		5D4737412F241342009A70EA /* FolderDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderDetailView.swift; sourceTree = "<group>"; };
 		5E95733B72864AB3B9607B57 /* MockLiveActivityRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLiveActivityRegistry.swift; sourceTree = "<group>"; };
+		5FF9C3A30E10A8E214623EBB /* ComplicationListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationListView.swift; sourceTree = "<group>"; };
 		608CFDA223EBCDF01B946093 /* Pods_iOS_Extensions_PushProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_PushProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		62CDCFDB29D283A7902A3ABE /* KioskScreensaverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskScreensaverViewController.swift; sourceTree = "<group>"; };
 		6563AFB7BDAF57478CA18D9B /* Pods-iOS-Extensions-PushProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-PushProvider.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-PushProvider/Pods-iOS-Extensions-PushProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		65B4DC669522BB7A70C5EED0 /* Pods_iOS_SharedTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_SharedTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Widgets-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Widgets-metadata.plist"; sourceTree = "<group>"; };
 		6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-Shared-watchOS-metadata.plist"; path = "Pods/Pods-watchOS-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
+		6BC23DE131CA8813C2DBD657 /* IconSearchPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IconSearchPicker.swift; sourceTree = "<group>"; };
 		6BECEB2525564358A124F818 /* FolderEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderEditView.swift; sourceTree = "<group>"; };
 		6D00E1755885575FF8118933 /* ControlFan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlFan.swift; sourceTree = "<group>"; };
 		6D9F4B31C60E0D155CC6ECAA /* Pods-iOS-Extensions-Share.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Share.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Share/Pods-iOS-Extensions-Share.beta.xcconfig"; sourceTree = "<group>"; };
@@ -3108,6 +3125,7 @@
 		7C3CCF89D04DB409DDFC4A09 /* Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS-Tests-Shared/Pods-iOS-Shared-iOS-Tests-Shared.release.xcconfig"; sourceTree = "<group>"; };
 		7DC07BDAC69AD95BDEFD8AFF /* Pods-iOS-Extensions-NotificationService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationService.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationService/Pods-iOS-Extensions-NotificationService.release.xcconfig"; sourceTree = "<group>"; };
 		825E1E44BA9ABF1BF53733D3 /* KioskConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskConstants.swift; sourceTree = "<group>"; };
+		862436CFE6E3F4B31500EFB2 /* ComplicationListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationListViewModel.swift; sourceTree = "<group>"; };
 		86BFD63671D2D0A012DFE169 /* Pods-iOS-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-App/Pods-iOS-App.debug.xcconfig"; sourceTree = "<group>"; };
 		892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
 		8A34A5417D650BBBE9D2D7C0 /* ControlFanValueProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlFanValueProvider.swift; sourceTree = "<group>"; };
@@ -3786,6 +3804,7 @@
 				1130F531253A1E7400F371BE /* ComplicationListViewController.swift */,
 				1130F57D253A2ED500F371BE /* ComplicationFamilySelectViewController.swift */,
 				B6B6B149215B137C003DE2DD /* ComplicationEditViewController.swift */,
+				D398218A29D34C148D517E1E /* Complications */,
 			);
 			path = AppleWatch;
 			sourceTree = "<group>";
@@ -7508,6 +7527,22 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		D398218A29D34C148D517E1E /* Complications */ = {
+			isa = PBXGroup;
+			children = (
+				1861EB0361816DC9260D1F5E /* ComplicationFamilySelectView.swift */,
+				5FF9C3A30E10A8E214623EBB /* ComplicationListView.swift */,
+				862436CFE6E3F4B31500EFB2 /* ComplicationListViewModel.swift */,
+				3995EF7323087AA35F01BDDF /* ComplicationEditView.swift */,
+				512A72C5F1BCC979E74F7629 /* ComplicationEditViewModel.swift */,
+				332C060487B468055C487070 /* TemplatePreviewSection.swift */,
+				6BC23DE131CA8813C2DBD657 /* IconSearchPicker.swift */,
+				5BFD0D30836C69840AB63A8A /* LoadingButton.swift */,
+			);
+			name = Complications;
+			path = Complications;
+			sourceTree = "<group>";
+		};
 		D6500FB6C2035F49B7421ED9 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -9687,6 +9722,14 @@
 				19F4C1F65664780F4E721699 /* KioskClockScreensaverView.swift in Sources */,
 				CB4D44CC6DBA5176155E157E /* KioskSecretExitGestureView.swift in Sources */,
 				12FC58D695EB7AF41673476E /* WebViewController+Kiosk.swift in Sources */,
+				A60E917B401A6D456F1DB630 /* ComplicationFamilySelectView.swift in Sources */,
+				925D92FC9E2221189D67B22C /* ComplicationListView.swift in Sources */,
+				498C0EF747C141F3E3204BBE /* ComplicationListViewModel.swift in Sources */,
+				0C1F82B6DF9051F98A587352 /* ComplicationEditView.swift in Sources */,
+				A596C4D1E125E6863C7D2034 /* ComplicationEditViewModel.swift in Sources */,
+				F0D1DD41A8F55F6D767EBF37 /* TemplatePreviewSection.swift in Sources */,
+				E3A02409794174F002C8BB4F /* IconSearchPicker.swift in Sources */,
+				DB54626ADCE0C32094C8C0B9 /* LoadingButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationEditView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationEditView.swift
@@ -1,0 +1,384 @@
+import Shared
+import SwiftUI
+
+/// SwiftUI replacement for `ComplicationEditViewController`.
+struct ComplicationEditView: View {
+    @StateObject private var viewModel: ComplicationEditViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    // The editor currently only renders its sections once the server selection
+    // is resolved, so we need a single source of truth for the active server
+    // passed to the live template renderers below.
+    @State private var showDeleteConfirmation = false
+
+    /// Called after a successful save for newly-created complications, used to
+    /// dismiss the containing modal sheet in the list view.
+    private let onSaved: (() -> Void)?
+
+    init(config: WatchComplication, isNew: Bool, onSaved: (() -> Void)?) {
+        self._viewModel = StateObject(wrappedValue: ComplicationEditViewModel(
+            config: config,
+            isNew: isNew
+        ))
+        self.onSaved = onSaved
+    }
+
+    var body: some View {
+        Form {
+            templateSection
+            ComplicationEditTextAreas(viewModel: viewModel)
+            column2AlignmentSection
+            ComplicationEditGaugeSection(viewModel: viewModel)
+            ComplicationEditRingSection(viewModel: viewModel)
+            iconSection
+            if !viewModel.isNew {
+                deleteSection
+            }
+        }
+        .navigationTitle(viewModel.family.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(L10n.cancelLabel) { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button(L10n.saveLabel) {
+                    viewModel.save()
+                    if let onSaved {
+                        onSaved()
+                    } else {
+                        dismiss()
+                    }
+                }
+                .disabled(!viewModel.isValid)
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Link(destination: URL(string: "https://companion.home-assistant.io/app/ios/apple-watch")!) {
+                    Image(systemSymbol: .questionmarkCircle)
+                }
+            }
+        }
+        .confirmationDialog(
+            L10n.Watch.Configurator.Delete.title,
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.Watch.Configurator.Delete.button, role: .destructive) {
+                viewModel.delete()
+                dismiss()
+            }
+            Button(L10n.cancelLabel, role: .cancel) {}
+        } message: {
+            Text(L10n.Watch.Configurator.Delete.message)
+        }
+        .interactiveDismissDisabled()
+    }
+
+    // MARK: - Sections
+
+    private var templateSection: some View {
+        Section {
+            TextField(
+                L10n.Watch.Configurator.Rows.DisplayName.title,
+                text: $viewModel.name,
+                prompt: Text(viewModel.family.name)
+            )
+
+            serverPicker
+
+            NavigationLink {
+                TemplateStylePicker(selected: $viewModel.displayTemplate, options: viewModel.family.templates)
+                    .onDisappear { viewModel.onDisplayTemplateChange() }
+            } label: {
+                HStack {
+                    Text(L10n.Watch.Configurator.Rows.Template.title)
+                    Spacer()
+                    Text(viewModel.displayTemplate.style)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Toggle(L10n.Watch.Configurator.Rows.IsPublic.title, isOn: $viewModel.isPublic)
+        }
+    }
+
+    @ViewBuilder
+    private var serverPicker: some View {
+        let allServers = Current.servers.all
+        if allServers.count > 1 {
+            Picker(L10n.Settings.ConnectionSection.servers, selection: $viewModel.serverIdentifier) {
+                ForEach(allServers, id: \.identifier.rawValue) { server in
+                    Text(server.info.name).tag(Optional(server.identifier.rawValue))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var column2AlignmentSection: some View {
+        if viewModel.supportsColumn2Alignment {
+            Section {
+                Picker(
+                    L10n.Watch.Configurator.Rows.Column2Alignment.title,
+                    selection: $viewModel.column2Alignment
+                ) {
+                    ForEach(ComplicationEditViewModel.Column2Alignment.allCases) { option in
+                        Text(option.localizedName).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var iconSection: some View {
+        if viewModel.hasImage {
+            Section {
+                IconSearchPicker(
+                    selectedIcon: $viewModel.icon,
+                    tintColor: viewModel.iconColor,
+                    title: L10n.Watch.Configurator.Rows.Icon.Choose.title
+                )
+                ColorPicker(
+                    L10n.Watch.Configurator.Rows.Icon.Color.title,
+                    selection: $viewModel.iconColor,
+                    supportsOpacity: false
+                )
+            } header: {
+                Text(L10n.Watch.Configurator.Sections.Icon.header)
+            } footer: {
+                Text(L10n.Watch.Configurator.Sections.Icon.footer)
+            }
+        }
+    }
+
+    private var deleteSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showDeleteConfirmation = true
+            } label: {
+                Text(L10n.Watch.Configurator.Delete.button)
+                    .foregroundColor(Color(.systemRed))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}
+
+// MARK: - Template picker
+
+private struct TemplateStylePicker: View {
+    @Binding var selected: ComplicationTemplate
+    let options: [ComplicationTemplate]
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List(options, id: \.rawValue) { option in
+            Button {
+                selected = option
+                dismiss()
+            } label: {
+                HStack(alignment: .top, spacing: DesignSystem.Spaces.one) {
+                    VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+                        Text(option.style)
+                            .foregroundColor(.primary)
+                        Text(option.description)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    if option == selected {
+                        Image(systemSymbol: .checkmark)
+                            .foregroundColor(.accentColor)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+        }
+        .navigationTitle(L10n.Watch.Configurator.Rows.Template.selectorTitle)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Gauge section
+
+private struct ComplicationEditGaugeSection: View {
+    @ObservedObject var viewModel: ComplicationEditViewModel
+    @StateObject private var renderer: TemplateRenderer
+
+    init(viewModel: ComplicationEditViewModel) {
+        self.viewModel = viewModel
+        let server = viewModel.server ?? Current.servers.all.first!
+        _renderer = StateObject(wrappedValue: TemplateRenderer(server: server, displayResult: {
+            try ComplicationEditViewModel.validatePercentile($0)
+        }))
+    }
+
+    var body: some View {
+        if viewModel.hasGauge {
+            TemplatePreviewSection(
+                header: L10n.Watch.Configurator.Sections.Gauge.header,
+                footer: L10n.Watch.Configurator.Sections.Gauge.footer,
+                title: L10n.Watch.Configurator.Rows.Gauge.title,
+                placeholder: "{{ range(1, 100) | random / 100.0 }}",
+                template: $viewModel.gaugeTemplate,
+                renderer: renderer
+            )
+            .onChange(of: viewModel.serverIdentifier) { _ in
+                if let server = viewModel.server {
+                    renderer.updateServer(server)
+                }
+            }
+
+            Section {
+                ColorPicker(
+                    L10n.Watch.Configurator.Rows.Gauge.Color.title,
+                    selection: $viewModel.gaugeColor,
+                    supportsOpacity: false
+                )
+                Picker(
+                    L10n.Watch.Configurator.Rows.Gauge.GaugeType.title,
+                    selection: $viewModel.gaugeType
+                ) {
+                    ForEach(ComplicationEditViewModel.GaugeType.allCases) { option in
+                        Text(option.localizedName).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .disabled(viewModel.isGaugeTypeForced)
+
+                Picker(
+                    L10n.Watch.Configurator.Rows.Gauge.Style.title,
+                    selection: $viewModel.gaugeStyle
+                ) {
+                    ForEach(ComplicationEditViewModel.GaugeStyle.allCases) { option in
+                        Text(option.localizedName).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+    }
+}
+
+// MARK: - Ring section
+
+private struct ComplicationEditRingSection: View {
+    @ObservedObject var viewModel: ComplicationEditViewModel
+    @StateObject private var renderer: TemplateRenderer
+
+    init(viewModel: ComplicationEditViewModel) {
+        self.viewModel = viewModel
+        let server = viewModel.server ?? Current.servers.all.first!
+        _renderer = StateObject(wrappedValue: TemplateRenderer(server: server, displayResult: {
+            try ComplicationEditViewModel.validatePercentile($0)
+        }))
+    }
+
+    var body: some View {
+        if viewModel.hasRing {
+            TemplatePreviewSection(
+                header: L10n.Watch.Configurator.Sections.Ring.header,
+                footer: L10n.Watch.Configurator.Sections.Ring.footer,
+                title: L10n.Watch.Configurator.Rows.Ring.Value.title,
+                placeholder: "{{ range(1, 100) | random / 100.0 }}",
+                template: $viewModel.ringTemplate,
+                renderer: renderer
+            )
+            .onChange(of: viewModel.serverIdentifier) { _ in
+                if let server = viewModel.server {
+                    renderer.updateServer(server)
+                }
+            }
+
+            Section {
+                Picker(
+                    L10n.Watch.Configurator.Rows.Ring.RingType.title,
+                    selection: $viewModel.ringType
+                ) {
+                    ForEach(ComplicationEditViewModel.RingType.allCases) { option in
+                        Text(option.localizedName).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                ColorPicker(
+                    L10n.Watch.Configurator.Rows.Ring.Color.title,
+                    selection: $viewModel.ringColor,
+                    supportsOpacity: false
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Text area sections
+
+private struct ComplicationEditTextAreas: View {
+    @ObservedObject var viewModel: ComplicationEditViewModel
+
+    var body: some View {
+        ForEach(viewModel.activeTextAreas, id: \.slug) { area in
+            TextAreaEditor(viewModel: viewModel, area: area)
+        }
+    }
+}
+
+private struct TextAreaEditor: View {
+    @ObservedObject var viewModel: ComplicationEditViewModel
+    let area: ComplicationTextAreas
+
+    @StateObject private var renderer: TemplateRenderer
+
+    init(viewModel: ComplicationEditViewModel, area: ComplicationTextAreas) {
+        self.viewModel = viewModel
+        self.area = area
+        let server = viewModel.server ?? Current.servers.all.first!
+        _renderer = StateObject(wrappedValue: TemplateRenderer(server: server, displayResult: {
+            try ComplicationEditViewModel.validateText($0)
+        }))
+    }
+
+    var body: some View {
+        // Bindings driven through a helper to avoid default-value churn.
+        let textBinding = Binding<String>(
+            get: { viewModel.textAreaValues[area.slug]?.text ?? "" },
+            set: { newValue in
+                var current = viewModel.textAreaValues[area.slug] ?? .init(text: "", color: .green)
+                current.text = newValue
+                viewModel.textAreaValues[area.slug] = current
+            }
+        )
+        let colorBinding = Binding<Color>(
+            get: { viewModel.textAreaValues[area.slug]?.color ?? .green },
+            set: { newValue in
+                var current = viewModel.textAreaValues[area.slug] ?? .init(text: "", color: .green)
+                current.color = newValue
+                viewModel.textAreaValues[area.slug] = current
+            }
+        )
+
+        TemplatePreviewSection(
+            header: area.label,
+            footer: area.description,
+            title: area.label,
+            placeholder: "{{ states(\"weather.temperature\") }}",
+            template: textBinding,
+            renderer: renderer
+        )
+        .onChange(of: viewModel.serverIdentifier) { _ in
+            if let server = viewModel.server {
+                renderer.updateServer(server)
+            }
+        }
+
+        Section {
+            ColorPicker(
+                L10n.Watch.Configurator.Rows.Color.title,
+                selection: colorBinding,
+                supportsOpacity: false
+            )
+        }
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationEditViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationEditViewModel.swift
@@ -1,0 +1,361 @@
+import Foundation
+import PromiseKit
+import RealmSwift
+import Shared
+import SwiftUI
+import UIKit
+
+/// Holds the mutable state displayed by `ComplicationEditView`. Decoupled from
+/// the view so we can keep the editor readable despite its many inputs.
+final class ComplicationEditViewModel: ObservableObject {
+    // Mutable editor state
+    @Published var name: String
+    @Published var isPublic: Bool
+    @Published var serverIdentifier: String?
+    @Published var displayTemplate: ComplicationTemplate
+
+    @Published var column2Alignment: Column2Alignment
+
+    @Published var gaugeTemplate: String = ""
+    @Published var gaugeColor: Color = .green
+    @Published var gaugeType: GaugeType = .open
+    @Published var gaugeStyle: GaugeStyle = .fill
+
+    @Published var ringTemplate: String = ""
+    @Published var ringColor: Color = .green
+    @Published var ringType: RingType = .open
+
+    @Published var icon: MaterialDesignIcons = .init(named: "home-assistant")
+    @Published var iconColor: Color = .green
+
+    @Published var textAreaValues: [String: TextAreaState] = [:]
+
+    // Readonly
+    let config: WatchComplication
+    let isNew: Bool
+
+    var family: ComplicationGroupMember { config.Family }
+
+    // MARK: - Init
+
+    // swiftlint:disable:next cyclomatic_complexity
+    init(config: WatchComplication, isNew: Bool) {
+        self.config = config
+        self.isNew = isNew
+        self.displayTemplate = config.Template
+
+        self.name = config.name ?? ""
+        self.isPublic = config.IsPublic
+
+        if let existing = Current.servers.server(forServerIdentifier: config.serverIdentifier) {
+            self.serverIdentifier = existing.identifier.rawValue
+        } else {
+            self.serverIdentifier = Current.servers.all.first?.identifier.rawValue
+        }
+
+        let data = config.Data
+
+        // Column 2 alignment
+        if let dict = data["column2alignment"] as? [String: Any],
+           let value = dict["column2alignment"] as? String,
+           let parsed = Column2Alignment(rawValue: value.lowercased()) {
+            self.column2Alignment = parsed
+        } else {
+            self.column2Alignment = .leading
+        }
+
+        // Gauge
+        if let dict = data["gauge"] as? [String: Any] {
+            self.gaugeTemplate = (dict["gauge"] as? String) ?? ""
+            if let hex = dict["gauge_color"] as? String {
+                self.gaugeColor = Color(uiColor: UIColor(hex: hex))
+            }
+            if let value = dict["gauge_type"] as? String,
+               let parsed = GaugeType(rawValue: value.lowercased()) {
+                self.gaugeType = parsed
+            }
+            if let value = dict["gauge_style"] as? String,
+               let parsed = GaugeStyle(rawValue: value.lowercased()) {
+                self.gaugeStyle = parsed
+            }
+        }
+
+        // Ring
+        if let dict = data["ring"] as? [String: Any] {
+            self.ringTemplate = (dict["ring_value"] as? String) ?? ""
+            if let hex = dict["ring_color"] as? String {
+                self.ringColor = Color(uiColor: UIColor(hex: hex))
+            }
+            if let value = dict["ring_type"] as? String,
+               let parsed = RingType(rawValue: value.lowercased()) {
+                self.ringType = parsed
+            }
+        }
+
+        // Icon
+        if let dict = data["icon"] as? [String: Any] {
+            if let iconName = dict["icon"] as? String {
+                self.icon = MaterialDesignIcons(named: iconName)
+            }
+            if let hex = dict["icon_color"] as? String {
+                self.iconColor = Color(uiColor: UIColor(hex: hex))
+            }
+        }
+
+        // Text areas
+        let savedAreas = (data["textAreas"] as? [String: [String: Any]]) ?? [:]
+        var map: [String: TextAreaState] = [:]
+        for area in ComplicationTextAreas.allCases {
+            let raw = savedAreas[area.slug] ?? [:]
+            let text = (raw["text"] as? String) ?? ""
+            let color: Color
+            if let hex = raw["color"] as? String {
+                color = Color(uiColor: UIColor(hex: hex))
+            } else {
+                color = .green
+            }
+            map[area.slug] = TextAreaState(text: text, color: color)
+        }
+        self.textAreaValues = map
+
+        adjustGaugeTypeIfForced()
+    }
+
+    // MARK: - Derived helpers
+
+    var server: Server? {
+        guard let serverIdentifier else { return Current.servers.all.first }
+        return Current.servers.server(forServerIdentifier: serverIdentifier) ?? Current.servers.all.first
+    }
+
+    var activeTextAreas: [ComplicationTextAreas] { displayTemplate.textAreas }
+    var hasGauge: Bool { displayTemplate.hasGauge }
+    var hasRing: Bool { displayTemplate.hasRing }
+    var hasImage: Bool { displayTemplate.hasImage }
+    var supportsColumn2Alignment: Bool { displayTemplate.supportsColumn2Alignment }
+
+    /// Some templates force the gauge type to a specific value (open vs closed).
+    /// In that case we still show the control but disable it.
+    var isGaugeTypeForced: Bool {
+        displayTemplate.gaugeIsOpenStyle || displayTemplate.gaugeIsClosedStyle
+    }
+
+    func onDisplayTemplateChange() {
+        adjustGaugeTypeIfForced()
+    }
+
+    private func adjustGaugeTypeIfForced() {
+        guard displayTemplate.hasGauge else { return }
+        if displayTemplate.gaugeIsOpenStyle {
+            gaugeType = .open
+        } else if displayTemplate.gaugeIsClosedStyle {
+            gaugeType = .closed
+        }
+    }
+
+    // MARK: - Save / Delete
+
+    /// Persists to Realm then asks the API to push the change. Returns once
+    /// the Realm write is committed; the API update is fired-and-forget like
+    /// the original Eureka controller.
+    func save() {
+        let realm = Current.realm()
+        let server = server
+        let payload = serializedData()
+        let nameValue = name.isEmpty ? nil : name
+        let isPublicValue = isPublic
+        let template = displayTemplate
+        let serverIdentifierValue = server?.identifier.rawValue
+
+        realm.reentrantWrite {
+            config.name = nameValue
+            config.IsPublic = isPublicValue
+            config.serverIdentifier = serverIdentifierValue
+            config.Template = template
+            config.Data = payload
+            realm.add(config, update: .all)
+        }.then(on: nil) { () -> Promise<Void> in
+            if let server {
+                return Current.api(for: server)?
+                    .updateComplications(passively: false) ??
+                    .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
+            } else {
+                return .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
+            }
+        }.cauterize()
+    }
+
+    func delete() {
+        let realm = Current.realm()
+        let server = server
+        realm.reentrantWrite {
+            realm.delete(config)
+        }.then(on: nil) { () -> Promise<Void> in
+            if let server {
+                return Current.api(for: server)?
+                    .updateComplications(passively: false) ??
+                    .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
+            } else {
+                return .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
+            }
+        }.cauterize()
+    }
+
+    // MARK: - Serialization
+
+    private func serializedData() -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        if supportsColumn2Alignment {
+            result["column2alignment"] = ["column2alignment": column2Alignment.rawValue]
+        }
+
+        if hasGauge {
+            result["gauge"] = [
+                "gauge": gaugeTemplate,
+                "gauge_color": UIColor(gaugeColor).hexString(true),
+                "gauge_type": gaugeType.rawValue,
+                "gauge_style": gaugeStyle.rawValue,
+            ]
+        }
+
+        if hasRing {
+            result["ring"] = [
+                "ring_value": ringTemplate,
+                "ring_color": UIColor(ringColor).hexString(true),
+                "ring_type": ringType.rawValue,
+            ]
+        }
+
+        if hasImage {
+            result["icon"] = [
+                "icon": icon.name,
+                "icon_color": UIColor(iconColor).hexString(true),
+            ]
+        }
+
+        var textAreas: [String: [String: Any]] = [:]
+        for area in activeTextAreas {
+            guard let state = textAreaValues[area.slug] else { continue }
+            textAreas[area.slug] = [
+                "text": state.text,
+                "color": UIColor(state.color).hexString(true),
+            ]
+        }
+        result["textAreas"] = textAreas
+
+        return result
+    }
+
+    // MARK: - Validation
+
+    /// Returns true when required inputs are filled for the current template.
+    var isValid: Bool {
+        if hasGauge, gaugeTemplate.isEmpty { return false }
+        if hasRing, ringTemplate.isEmpty { return false }
+        for area in activeTextAreas where (textAreaValues[area.slug]?.text ?? "").isEmpty {
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Template preview validation
+
+    static func validatePercentile(_ value: Any) throws -> String {
+        if let number = WatchComplication.percentileNumber(from: value) {
+            if !(0 ... 1 ~= number) {
+                throw RenderValueError.outOfRange(value: number)
+            }
+        } else {
+            throw RenderValueError.expectedFloat(value: value)
+        }
+        return String(describing: value)
+    }
+
+    static func validateText(_ value: Any) throws -> String {
+        String(describing: value)
+    }
+}
+
+// MARK: - Nested types
+
+extension ComplicationEditViewModel {
+    struct TextAreaState: Equatable {
+        var text: String
+        var color: Color
+    }
+
+    enum Column2Alignment: String, CaseIterable, Identifiable {
+        case leading
+        case trailing
+
+        var id: String { rawValue }
+
+        var localizedName: String {
+            switch self {
+            case .leading: return L10n.Watch.Configurator.Rows.Column2Alignment.Options.leading
+            case .trailing: return L10n.Watch.Configurator.Rows.Column2Alignment.Options.trailing
+            }
+        }
+    }
+
+    enum GaugeType: String, CaseIterable, Identifiable {
+        case open
+        case closed
+
+        var id: String { rawValue }
+
+        var localizedName: String {
+            switch self {
+            case .open: return L10n.Watch.Configurator.Rows.Gauge.GaugeType.Options.open
+            case .closed: return L10n.Watch.Configurator.Rows.Gauge.GaugeType.Options.closed
+            }
+        }
+    }
+
+    enum GaugeStyle: String, CaseIterable, Identifiable {
+        case fill
+        case ring
+
+        var id: String { rawValue }
+
+        var localizedName: String {
+            switch self {
+            case .fill: return L10n.Watch.Configurator.Rows.Gauge.Style.Options.fill
+            case .ring: return L10n.Watch.Configurator.Rows.Gauge.Style.Options.ring
+            }
+        }
+    }
+
+    enum RingType: String, CaseIterable, Identifiable {
+        case open
+        case closed
+
+        var id: String { rawValue }
+
+        var localizedName: String {
+            switch self {
+            case .open: return L10n.Watch.Configurator.Rows.Ring.RingType.Options.open
+            case .closed: return L10n.Watch.Configurator.Rows.Ring.RingType.Options.closed
+            }
+        }
+    }
+
+    enum RenderValueError: LocalizedError {
+        case expectedFloat(value: Any)
+        case outOfRange(value: Float)
+
+        var errorDescription: String? {
+            switch self {
+            case let .expectedFloat(value):
+                var displayType = String(describing: type(of: value))
+                if displayType.lowercased().contains("string") {
+                    displayType = "string"
+                }
+                return L10n.Watch.Configurator.PreviewError.notNumber(displayType, value)
+            case let .outOfRange(value):
+                return L10n.Watch.Configurator.PreviewError.outOfRange(value)
+            }
+        }
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationFamilySelectView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationFamilySelectView.swift
@@ -60,7 +60,7 @@ struct ComplicationFamilySelectView: View {
             }
         }
         .disabled(disabled)
-        .accessibilityAddTraits(disabled ? .isButton : [])
+        .accessibilityAddTraits(disabled ? [] : .isButton)
     }
 
     private func makeNewComplication(for family: ComplicationGroupMember) -> WatchComplication {

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationFamilySelectView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationFamilySelectView.swift
@@ -1,0 +1,78 @@
+import Shared
+import SwiftUI
+
+/// SwiftUI replacement for `ComplicationFamilySelectViewController`.
+struct ComplicationFamilySelectView: View {
+    let allowMultiple: Bool
+    let currentFamilies: Set<ComplicationGroupMember>
+    /// Called after a new complication is saved so the presenting flow can dismiss.
+    let onSaved: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            if !allowMultiple, !currentFamilies.isEmpty {
+                Section {
+                    Text(L10n.Watch.Configurator.New.multipleComplicationInfo)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            ForEach(ComplicationGroup.allCases.sorted(), id: \.self) { group in
+                Section {
+                    ForEach(group.members.sorted(), id: \.self) { family in
+                        familyRow(family: family)
+                    }
+                } header: {
+                    Text(group.name)
+                } footer: {
+                    Text(group.description)
+                }
+            }
+        }
+        .navigationTitle(L10n.Watch.Configurator.New.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(L10n.cancelLabel) { dismiss() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func familyRow(family: ComplicationGroupMember) -> some View {
+        let disabled = !allowMultiple && currentFamilies.contains(family)
+
+        NavigationLink {
+            ComplicationEditView(
+                config: makeNewComplication(for: family),
+                isNew: true,
+                onSaved: onSaved
+            )
+        } label: {
+            VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+                Text(family.shortName)
+                    .foregroundColor(disabled ? .secondary : .primary)
+                Text(family.description)
+                    .font(.caption)
+                    .foregroundColor(disabled ? Color(.tertiaryLabel) : .secondary)
+            }
+        }
+        .disabled(disabled)
+        .accessibilityAddTraits(disabled ? .isButton : [])
+    }
+
+    private func makeNewComplication(for family: ComplicationGroupMember) -> WatchComplication {
+        let complication = WatchComplication()
+        complication.Family = family
+
+        if !allowMultiple {
+            // Preserve migration behaviour: watchOS 6 complications used a
+            // predictable, family-derived identifier.
+            complication.identifier = family.rawValue
+        }
+
+        return complication
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
@@ -1,0 +1,115 @@
+import Shared
+import SwiftUI
+
+/// SwiftUI replacement for `ComplicationListViewController`.
+struct ComplicationListView: View {
+    @StateObject private var viewModel = ComplicationListViewModel()
+    @State private var showFamilyPicker = false
+
+    var body: some View {
+        List {
+            introSection
+            manualUpdatesSection
+            groupSections
+            addSection
+        }
+        .navigationTitle(L10n.SettingsDetails.Watch.title)
+        .sheet(isPresented: $showFamilyPicker) {
+            NavigationView {
+                ComplicationFamilySelectView(
+                    allowMultiple: viewModel.supportsMultipleComplications,
+                    currentFamilies: viewModel.currentFamilies,
+                    onSaved: { showFamilyPicker = false }
+                )
+            }
+            .navigationViewStyle(.stack)
+        }
+        .alert(
+            L10n.errorLabel,
+            isPresented: $viewModel.showError,
+            presenting: viewModel.errorMessage
+        ) { _ in
+            Button(L10n.okLabel, role: .cancel) {}
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var introSection: some View {
+        Section {
+            Text(L10n.Watch.Configurator.List.description)
+                .foregroundColor(.primary)
+            Link(destination: URL(string: "https://companion.home-assistant.io/app/ios/apple-watch")!) {
+                HStack {
+                    Text(L10n.Nfc.List.learnMore)
+                    Spacer()
+                    Image(systemSymbol: .arrowUpForwardSquare)
+                        .font(.caption)
+                }
+            }
+            Text(L10n.Watch.Configurator.Warning.templatingAdmin)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var manualUpdatesSection: some View {
+        Section {
+            HStack {
+                Text(L10n.Watch.Configurator.List.ManualUpdates.remaining)
+                Spacer()
+                Text(viewModel.remainingUpdatesDescription)
+                    .foregroundColor(.secondary)
+            }
+            LoadingButton(
+                title: L10n.Watch.Configurator.List.ManualUpdates.manuallyUpdate,
+                isLoading: viewModel.isUpdatingComplications
+            ) {
+                viewModel.updateComplications()
+            }
+        } header: {
+            Text(L10n.Watch.Configurator.List.ManualUpdates.title)
+        } footer: {
+            Text(L10n.Watch.Configurator.List.ManualUpdates.footer)
+        }
+    }
+
+    @ViewBuilder
+    private var groupSections: some View {
+        ForEach(ComplicationGroup.allCases.sorted(), id: \.self) { group in
+            if let items = viewModel.complicationsByGroup[group], !items.isEmpty {
+                Section {
+                    ForEach(items, id: \.identifier) { complication in
+                        NavigationLink {
+                            ComplicationEditView(
+                                config: complication,
+                                isNew: false,
+                                onSaved: nil
+                            )
+                        } label: {
+                            HStack {
+                                Text(complication.Family.shortName)
+                                Spacer()
+                                Text(complication.displayName)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                } header: {
+                    Text(group.name)
+                } footer: {
+                    Text(group.description)
+                }
+            }
+        }
+    }
+
+    private var addSection: some View {
+        Section {
+            Button(L10n.addButtonLabel) {
+                showFamilyPicker = true
+            }
+        }
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationListViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationListViewModel.swift
@@ -1,0 +1,128 @@
+import Communicator
+import Foundation
+import PromiseKit
+import RealmSwift
+import Shared
+import Version
+
+/// Observable view model backing `ComplicationListView`. Wraps the Realm
+/// notification tokens used to drive the existing Eureka controller.
+final class ComplicationListViewModel: ObservableObject {
+    @Published private(set) var complicationsByGroup: [ComplicationGroup: [WatchComplication]] = [:]
+    @Published private(set) var watchState: WatchState = Communicator.shared.currentWatchState
+    @Published var isUpdatingComplications = false
+    @Published var errorMessage: String?
+    @Published var showError = false
+
+    private var realmToken: NotificationToken?
+    private var watchStateToken: Any?
+    private var updateNotificationToken: NSObjectProtocol?
+
+    init() {
+        observeRealm()
+        observeWatchState()
+        observeComplicationsUpdate()
+    }
+
+    deinit {
+        realmToken?.invalidate()
+        if let watchStateToken {
+            WatchState.unobserve(watchStateToken)
+        }
+        if let updateNotificationToken {
+            NotificationCenter.default.removeObserver(updateNotificationToken)
+        }
+    }
+
+    // MARK: - Capability
+
+    var supportsMultipleComplications: Bool {
+        guard let string = Communicator.shared.mostRecentlyReceievedContext.content["watchVersion"] as? String else {
+            return false
+        }
+        do {
+            let version = try Version(string)
+            return version >= Version(major: 7)
+        } catch {
+            Current.Log.error("failed to parse \(string), saying we're not 7+")
+            return false
+        }
+    }
+
+    var currentFamilies: Set<ComplicationGroupMember> {
+        Set(complicationsByGroup.values.flatMap { $0 }.map(\.Family))
+    }
+
+    // MARK: - Manual update
+
+    func updateComplications() {
+        isUpdatingComplications = true
+        Current.notificationManager.commandManager.updateComplications()
+            .ensure { [weak self] in
+                DispatchQueue.main.async {
+                    self?.isUpdatingComplications = false
+                }
+            }
+            .catch { [weak self] error in
+                DispatchQueue.main.async {
+                    self?.errorMessage = error.localizedDescription
+                    self?.showError = true
+                }
+            }
+    }
+
+    // MARK: - Realm observation
+
+    private func observeRealm() {
+        let results = Current.realm().objects(WatchComplication.self).sorted(byKeyPath: "rawFamily")
+        realmToken = results.observe { [weak self] _ in
+            self?.rebuildGroups(from: results)
+        }
+    }
+
+    private func rebuildGroups(from results: Results<WatchComplication>) {
+        var grouped: [ComplicationGroup: [WatchComplication]] = [:]
+        for complication in results {
+            for group in ComplicationGroup.allCases where group.members.contains(complication.Family) {
+                grouped[group, default: []].append(complication)
+                break
+            }
+        }
+        complicationsByGroup = grouped
+    }
+
+    // MARK: - Watch state observation
+
+    private func observeWatchState() {
+        watchStateToken = WatchState.observe { [weak self] state in
+            DispatchQueue.main.async {
+                self?.watchState = state
+            }
+        }
+    }
+
+    private func observeComplicationsUpdate() {
+        updateNotificationToken = NotificationCenter.default.addObserver(
+            forName: NotificationCommandManager.didUpdateComplicationsNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.watchState = Communicator.shared.currentWatchState
+        }
+    }
+}
+
+extension ComplicationListViewModel {
+    var remainingUpdatesDescription: String {
+        switch watchState {
+        case .notPaired:
+            return L10n.Watch.Configurator.List.ManualUpdates.State.notPaired
+        case .paired(.notInstalled):
+            return L10n.Watch.Configurator.List.ManualUpdates.State.notInstalled
+        case .paired(.installed(.notEnabled, _)):
+            return L10n.Watch.Configurator.List.ManualUpdates.State.notEnabled
+        case let .paired(.installed(.enabled(numberOfUpdatesAvailableToday: remaining), _)):
+            return NumberFormatter.localizedString(from: NSNumber(value: remaining), number: .none)
+        }
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationListViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationListViewModel.swift
@@ -15,7 +15,7 @@ final class ComplicationListViewModel: ObservableObject {
     @Published var showError = false
 
     private var realmToken: NotificationToken?
-    private var watchStateToken: Any?
+    private var watchStateToken: Observation?
     private var updateNotificationToken: NSObjectProtocol?
 
     init() {

--- a/Sources/App/Settings/AppleWatch/Complications/IconSearchPicker.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/IconSearchPicker.swift
@@ -1,0 +1,98 @@
+import Shared
+import SwiftUI
+
+/// A SwiftUI searchable picker for `MaterialDesignIcons`. Replaces the
+/// `SearchPushRow<MaterialDesignIcons>` usage in the complication editor.
+struct IconSearchPicker: View {
+    @Binding var selectedIcon: MaterialDesignIcons
+    let tintColor: Color
+    let title: String
+
+    @State private var isPresented = false
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            HStack {
+                Text(title)
+                    .foregroundColor(.primary)
+                Spacer()
+                HStack(spacing: DesignSystem.Spaces.one) {
+                    Image(uiImage: selectedIcon.image(
+                        ofSize: CGSize(width: 24, height: 24),
+                        color: UIColor(tintColor)
+                    ))
+                    .renderingMode(.template)
+                    Text(selectedIcon.name)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $isPresented) {
+            IconSearchSheet(
+                selectedIcon: $selectedIcon,
+                tintColor: tintColor,
+                isPresented: $isPresented
+            )
+        }
+    }
+}
+
+private struct IconSearchSheet: View {
+    @Binding var selectedIcon: MaterialDesignIcons
+    let tintColor: Color
+    @Binding var isPresented: Bool
+
+    @State private var searchTerm: String = ""
+
+    private static let allIcons: [MaterialDesignIcons] = MaterialDesignIcons.allCases
+        .sorted(by: { $0.name < $1.name })
+
+    private var filteredIcons: [MaterialDesignIcons] {
+        let query = searchTerm.lowercased()
+        guard query.count >= 2 else { return Self.allIcons }
+        return Self.allIcons.filter { $0.name.lowercased().contains(query) }
+    }
+
+    var body: some View {
+        NavigationView {
+            List(filteredIcons, id: \.self) { icon in
+                Button {
+                    selectedIcon = icon
+                    isPresented = false
+                } label: {
+                    HStack(spacing: DesignSystem.Spaces.two) {
+                        Image(uiImage: icon.image(
+                            ofSize: CGSize(width: 30, height: 30),
+                            color: UIColor(tintColor)
+                        ))
+                        .renderingMode(.template)
+                        Text(icon.name)
+                            .foregroundColor(.primary)
+                        Spacer()
+                        if icon == selectedIcon {
+                            Image(systemSymbol: .checkmark)
+                                .foregroundColor(.accentColor)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+            .searchable(text: $searchTerm)
+            .navigationTitle(L10n.Watch.Configurator.Rows.Icon.Choose.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.cancelLabel) { isPresented = false }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/IconSearchPicker.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/IconSearchPicker.swift
@@ -19,11 +19,12 @@ struct IconSearchPicker: View {
                     .foregroundColor(.primary)
                 Spacer()
                 HStack(spacing: DesignSystem.Spaces.one) {
+                    // The UIImage is rendered with the desired tint color baked in;
+                    // keep the original rendering mode so SwiftUI doesn't strip it.
                     Image(uiImage: selectedIcon.image(
                         ofSize: CGSize(width: 24, height: 24),
                         color: UIColor(tintColor)
                     ))
-                    .renderingMode(.template)
                     Text(selectedIcon.name)
                         .foregroundColor(.secondary)
                         .lineLimit(1)
@@ -67,11 +68,12 @@ private struct IconSearchSheet: View {
                     isPresented = false
                 } label: {
                     HStack(spacing: DesignSystem.Spaces.two) {
+                        // Keep the baked-in tint color rather than letting SwiftUI flatten
+                        // the template image to a single color (was discarding `tintColor`).
                         Image(uiImage: icon.image(
                             ofSize: CGSize(width: 30, height: 30),
                             color: UIColor(tintColor)
                         ))
-                        .renderingMode(.template)
                         Text(icon.name)
                             .foregroundColor(.primary)
                         Spacer()

--- a/Sources/App/Settings/AppleWatch/Complications/LoadingButton.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/LoadingButton.swift
@@ -16,8 +16,7 @@ struct LoadingButton: View {
     var body: some View {
         Button(action: action) {
             HStack {
-                Text(title)
-                    .foregroundColor(.accentColor)
+                LoadingButtonLabel(title: title)
                 Spacer()
                 if isLoading {
                     ProgressView()
@@ -26,5 +25,17 @@ struct LoadingButton: View {
             .contentShape(Rectangle())
         }
         .disabled(isLoading)
+    }
+}
+
+/// Reads `\.isEnabled` so the title color matches the system tint when enabled
+/// and dims to `.secondary` when disabled, mirroring the system Button look.
+private struct LoadingButtonLabel: View {
+    let title: String
+    @Environment(\.isEnabled) private var isEnabled
+
+    var body: some View {
+        Text(title)
+            .foregroundColor(isEnabled ? .accentColor : .secondary)
     }
 }

--- a/Sources/App/Settings/AppleWatch/Complications/LoadingButton.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/LoadingButton.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// A SwiftUI replacement for `ButtonRowWithLoading`. Shows a progress indicator
+/// while `isLoading` is true and disables user interaction while loading.
+struct LoadingButton: View {
+    let title: String
+    let isLoading: Bool
+    let action: () -> Void
+
+    init(title: String, isLoading: Bool, action: @escaping () -> Void) {
+        self.title = title
+        self.isLoading = isLoading
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .foregroundColor(.accentColor)
+                Spacer()
+                if isLoading {
+                    ProgressView()
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .disabled(isLoading)
+    }
+}

--- a/Sources/App/Settings/AppleWatch/Complications/TemplatePreviewSection.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/TemplatePreviewSection.swift
@@ -1,4 +1,3 @@
-import Combine
 import HAKit
 import Shared
 import SwiftUI
@@ -86,7 +85,12 @@ final class TemplateRenderer: ObservableObject {
     }
 
     private func startSubscription() {
-        guard let api = Current.api(for: server) else { return }
+        guard let api = Current.api(for: server) else {
+            // No API available for this server — surface that instead of leaving the
+            // preview stuck on the loading spinner that `refresh()` set.
+            handle(failure: HomeAssistantAPI.APIError.noAPIAvailable)
+            return
+        }
         subscriptionToken = api.connection.subscribe(
             to: .renderTemplate(template),
             initiated: { [weak self] result in

--- a/Sources/App/Settings/AppleWatch/Complications/TemplatePreviewSection.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/TemplatePreviewSection.swift
@@ -1,0 +1,189 @@
+import Combine
+import HAKit
+import Shared
+import SwiftUI
+
+/// Observable wrapper for the live template rendering subscription used by the
+/// complication editor. Replaces the Eureka `TemplateSection` rendering logic.
+final class TemplateRenderer: ObservableObject {
+    enum Output: Equatable {
+        case idle
+        case loading
+        case success(String)
+        case failure(String)
+
+        static func == (lhs: Output, rhs: Output) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle), (.loading, .loading):
+                return true
+            case let (.success(a), .success(b)):
+                return a == b
+            case let (.failure(a), .failure(b)):
+                return a == b
+            default:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var output: Output = .idle
+
+    private let displayResult: (Any) throws -> String
+    private var server: Server
+    private var subscriptionToken: HACancellable?
+    private var debounceTimer: Timer?
+    private var template: String = ""
+
+    init(server: Server, displayResult: @escaping (Any) throws -> String = { String(describing: $0) }) {
+        self.server = server
+        self.displayResult = displayResult
+    }
+
+    deinit {
+        subscriptionToken?.cancel()
+        debounceTimer?.invalidate()
+    }
+
+    func updateServer(_ server: Server) {
+        self.server = server
+        refresh(skipDelay: true)
+    }
+
+    func updateTemplate(_ template: String) {
+        guard template != self.template else { return }
+        self.template = template
+        refresh()
+    }
+
+    /// Force a re-render without changing the template text. Useful when the
+    /// view first appears and wants an immediate evaluation.
+    func refreshNow() {
+        refresh(skipDelay: true)
+    }
+
+    private func refresh(skipDelay: Bool = false) {
+        subscriptionToken?.cancel()
+        debounceTimer?.invalidate()
+
+        let trimmed = template
+
+        guard !trimmed.isEmpty else {
+            output = .success("")
+            return
+        }
+
+        guard trimmed.containsJinjaTemplate else {
+            handle(success: trimmed)
+            return
+        }
+
+        output = .loading
+
+        let delay: TimeInterval = skipDelay ? 0 : (Current.isCatalyst ? 0.5 : 1.0)
+        debounceTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            self?.startSubscription()
+        }
+    }
+
+    private func startSubscription() {
+        guard let api = Current.api(for: server) else { return }
+        subscriptionToken = api.connection.subscribe(
+            to: .renderTemplate(template),
+            initiated: { [weak self] result in
+                if case let .failure(error) = result {
+                    DispatchQueue.main.async {
+                        self?.handle(failure: error)
+                    }
+                }
+            },
+            handler: { [weak self] _, result in
+                DispatchQueue.main.async {
+                    self?.handle(any: result.result)
+                }
+            }
+        )
+    }
+
+    private func handle(any value: Any) {
+        do {
+            output = try .success(displayResult(value))
+        } catch {
+            output = .failure(error.localizedDescription)
+        }
+    }
+
+    private func handle(success value: String) {
+        output = .success(value)
+    }
+
+    private func handle(failure error: Error) {
+        output = .failure(error.localizedDescription)
+    }
+}
+
+/// A SwiftUI section that edits a Jinja template and renders a live preview.
+/// Replaces the Eureka `TemplateSection`.
+struct TemplatePreviewSection: View {
+    let header: String?
+    let footer: String?
+    let title: String
+    let placeholder: String
+    @Binding var template: String
+    @ObservedObject var renderer: TemplateRenderer
+
+    var body: some View {
+        Section {
+            TextEditor(text: $template)
+                .font(.system(.body, design: .monospaced))
+                .autocapitalization(.none)
+                .autocorrectionDisabled(true)
+                .frame(minHeight: 100)
+                .overlay(alignment: .topLeading) {
+                    if template.isEmpty {
+                        Text(placeholder)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundColor(.secondary.opacity(0.5))
+                            .padding(.top, 8)
+                            .padding(.leading, 4)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .accessibilityLabel(title)
+
+            previewRow
+        } header: {
+            if let header { Text(header) }
+        } footer: {
+            if let footer { Text(footer) }
+        }
+        .onChange(of: template) { newValue in
+            renderer.updateTemplate(newValue)
+        }
+        .onAppear {
+            renderer.updateTemplate(template)
+            renderer.refreshNow()
+        }
+    }
+
+    @ViewBuilder
+    private var previewRow: some View {
+        switch renderer.output {
+        case .idle:
+            EmptyView()
+        case .loading:
+            HStack(spacing: DesignSystem.Spaces.one) {
+                ProgressView()
+                Text(L10n.Settings.ConnectionSection.Websocket.Status.connecting)
+                    .foregroundColor(.secondary)
+            }
+        case let .success(value):
+            Text(value)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case let .failure(message):
+            Text(message)
+                .foregroundColor(Color(.systemRed))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -225,8 +225,7 @@ struct SettingsNotificationsView: View {
 
 struct SettingsComplicationsView: View {
     var body: some View {
-        embed(ComplicationListViewController())
-            .navigationTitle(L10n.Settings.DetailsSection.WatchRowComplications.title)
+        ComplicationListView()
     }
 }
 

--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -226,6 +226,7 @@ struct SettingsNotificationsView: View {
 struct SettingsComplicationsView: View {
     var body: some View {
         ComplicationListView()
+            .navigationTitle(L10n.Settings.DetailsSection.WatchRowComplications.title)
     }
 }
 


### PR DESCRIPTION
## Summary
Migrate the Apple Watch complications list, family picker, and editor to SwiftUI:
- `ComplicationListView` + `ComplicationListViewModel`: watchOS capability check, manual-update `LoadingButton` with remaining-count, Realm-observed complication family sections, add flow.
- `ComplicationFamilySelectView`: grouped family list, disabled existing families on watchOS versions without multi-complication support, cancel + navigation to the editor.
- `ComplicationEditView` + `ComplicationEditViewModel`: editor decomposed into `TemplateStylePicker`, `ComplicationEditGaugeSection`, `ComplicationEditRingSection`, `ComplicationEditTextAreas`, `TextAreaEditor`. The view model parses and serialises `config.Data`, validates inputs, and runs save/delete via `realm.reentrantWrite`.

Adds reusable SwiftUI components:
- `TemplateRenderer` + `TemplatePreviewSection` — debounced `ObservableObject` wrapping a `HACancellable` subscription to `.renderTemplate`.
- `IconSearchPicker` — `.searchable` sheet over `MaterialDesignIcons.allCases`.
- `LoadingButton` — replacement for `ButtonRowWithLoading`.

`SettingsItem.watch` is rewired to `ComplicationListView()` directly.

## Screenshots
_Pending — to be added before merge._

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Part of a five-PR Eureka → SwiftUI migration tracked in `UIKitToSwiftUIMigration.md` (siblings: #4560, #4561, #4562, #4563). The `Eureka`, `ColorPickerRow`, and `ViewRow` pods stay until all slices land.

Original Eureka view controllers and shared helpers (`TemplateSection`, `WebSocketStatusRow`, `SearchPushRow`, `ButtonRowWithLoading`, `MaterialDesignIcons+Eureka`) are **not deleted in this PR** — `SettingsRootDataSource` and other in-flight slices still reference them. They can be removed after all slices merge.

This is the largest slice — extra review attention on template rendering, color pickers, icon search, and `config.Data` serialization is appreciated.

`bundle exec fastlane lint` passes. Not build-verified locally yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
