### PR TITLE
Enable Live Activities on iPad (iPadOS 17+)

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -11436,7 +11436,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E25229D986B0044C8EC /* HomeAssistant.beta.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = QMQYCKL255;
+				DEVELOPMENT_TEAM = 4Q9RHLUX47;
 			};
 			name = Beta;
 		};
@@ -11649,7 +11649,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E21229D98220044C8EC /* HomeAssistant.debug.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = QMQYCKL255;
+				DEVELOPMENT_TEAM = 4Q9RHLUX47;
 			};
 			name = Debug;
 		};
@@ -11657,7 +11657,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E22229D98530044C8EC /* HomeAssistant.release.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = QMQYCKL255;
+				DEVELOPMENT_TEAM = 4Q9RHLUX47;
 			};
 			name = Release;
 		};

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -11436,7 +11436,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E25229D986B0044C8EC /* HomeAssistant.beta.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = 4Q9RHLUX47;
+				DEVELOPMENT_TEAM = QMQYCKL255;
 			};
 			name = Beta;
 		};
@@ -11649,7 +11649,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E21229D98220044C8EC /* HomeAssistant.debug.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = 4Q9RHLUX47;
+				DEVELOPMENT_TEAM = QMQYCKL255;
 			};
 			name = Debug;
 		};
@@ -11657,7 +11657,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C4E5E22229D98530044C8EC /* HomeAssistant.release.xcconfig */;
 			buildSettings = {
-				DEVELOPMENT_TEAM = 4Q9RHLUX47;
+				DEVELOPMENT_TEAM = QMQYCKL255;
 			};
 			name = Release;
 		};

--- a/Sources/App/Resources/bg.lproj/Localizable.strings
+++ b/Sources/App/Resources/bg.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/ca-ES.lproj/Localizable.strings
+++ b/Sources/App/Resources/ca-ES.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/cs.lproj/Localizable.strings
+++ b/Sources/App/Resources/cs.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Tento server vyžaduje klientský certifikát (mTLS), ale operace byla zrušena.
 "live_activity.section.privacy" = "Soukromí";
 "live_activity.section.status" = "Stav";
 "live_activity.status.enabled" = "Povoleno";
-"live_activity.status.not_supported" = "Není dostupné na iPadu";
 "live_activity.status.open_settings" = "Otevřít Nastavení";
 "live_activity.subtitle" = "Aktualizace Home Assistanta v reálném čase na zamykací obrazovce a v Dynamic Islandu.";
 "live_activity.title" = "Živé aktivity";

--- a/Sources/App/Resources/cy-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/cy-GB.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/da.lproj/Localizable.strings
+++ b/Sources/App/Resources/da.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privatliv";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Aktiveret";
-"live_activity.status.not_supported" = "Ikke tilgængelig på iPad";
 "live_activity.status.open_settings" = "Åbn indstillinger";
 "live_activity.subtitle" = "Home Assistant-opdateringer i realtid på din låseskærm og Dynamic Island.";
 "live_activity.title" = "Liveaktiviteter";

--- a/Sources/App/Resources/de.lproj/Localizable.strings
+++ b/Sources/App/Resources/de.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Dieser Server benötigt ein Clientzertifikat (mTLS), aber der Vorgang wurde abge
 "live_activity.section.privacy" = "Datenschutz";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Aktiviert";
-"live_activity.status.not_supported" = "Auf dem iPad nicht verfügbar";
 "live_activity.status.open_settings" = "Einstellungen öffnen";
 "live_activity.subtitle" = "Home Assistant-Updates in Echtzeit auf deinem Sperrbildschirm und Dynamic Island.";
 "live_activity.title" = "Live-Aktivitäten";

--- a/Sources/App/Resources/el.lproj/Localizable.strings
+++ b/Sources/App/Resources/el.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "Απόρρητο";
 "live_activity.section.status" = "Κατάσταση";
 "live_activity.status.enabled" = "Ενεργό";
-"live_activity.status.not_supported" = "Δεν είναι διαθέσιμο σε iPad";
 "live_activity.status.open_settings" = "Ανοιγμα ρυθμίσεων";
 "live_activity.subtitle" = "Ενημερώσεις του Home Assistant σε πραγματικό χρόνο στην οθόνη κλειδώματος και στο Dynamic Island.";
 "live_activity.title" = "Ζωντανές δραστηριότητες";

--- a/Sources/App/Resources/en-GB.lproj/Localizable.strings
+++ b/Sources/App/Resources/en-GB.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/es-ES.lproj/Localizable.strings
+++ b/Sources/App/Resources/es-ES.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/App/Resources/es-MX.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/es.lproj/Localizable.strings
+++ b/Sources/App/Resources/es.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/et.lproj/Localizable.strings
+++ b/Sources/App/Resources/et.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "Privaatsus";
 "live_activity.section.status" = "Olek";
 "live_activity.status.enabled" = "Lubatud";
-"live_activity.status.not_supported" = "Pole iPadis saadaval";
 "live_activity.status.open_settings" = "Ava seaded";
 "live_activity.subtitle" = "Reaalajas Home Assistant värskendused lukustuskuval ja dünaamilisel saarel.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/fi.lproj/Localizable.strings
+++ b/Sources/App/Resources/fi.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/fr.lproj/Localizable.strings
+++ b/Sources/App/Resources/fr.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/he.lproj/Localizable.strings
+++ b/Sources/App/Resources/he.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/hu.lproj/Localizable.strings
+++ b/Sources/App/Resources/hu.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Ez a szerver kliens tanúsítványt (mTLS) igényel, de a művelet megszakítva.
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/id.lproj/Localizable.strings
+++ b/Sources/App/Resources/id.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Server ini memerlukan sertifikat klien (mTLS) tetapi operasi dibatalkan.";
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/it.lproj/Localizable.strings
+++ b/Sources/App/Resources/it.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Questo server richiede un certificato client (mTLS), ma l'operazione è stata an
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/ja.lproj/Localizable.strings
+++ b/Sources/App/Resources/ja.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/ko-KR.lproj/Localizable.strings
+++ b/Sources/App/Resources/ko-KR.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/ml.lproj/Localizable.strings
+++ b/Sources/App/Resources/ml.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/nb.lproj/Localizable.strings
+++ b/Sources/App/Resources/nb.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/nl.lproj/Localizable.strings
+++ b/Sources/App/Resources/nl.lproj/Localizable.strings
@@ -514,7 +514,6 @@ Deze server vereist een clientcertificaat (mTLS), maar de bewerking is geannulee
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Ingeschakeld";
-"live_activity.status.not_supported" = "Niet beschikbaar op iPad";
 "live_activity.status.open_settings" = "Open instellingen";
 "live_activity.subtitle" = "Real-time updates van Home Assistant op je vergrendelscherm en Dynamic Island.";
 "live_activity.title" = "Live activiteiten";

--- a/Sources/App/Resources/pl-PL.lproj/Localizable.strings
+++ b/Sources/App/Resources/pl-PL.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/App/Resources/pt-BR.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/ru.lproj/Localizable.strings
+++ b/Sources/App/Resources/ru.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/sl.lproj/Localizable.strings
+++ b/Sources/App/Resources/sl.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/sv.lproj/Localizable.strings
+++ b/Sources/App/Resources/sv.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/tr.lproj/Localizable.strings
+++ b/Sources/App/Resources/tr.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "Gizlilik";
 "live_activity.section.status" = "Durum";
 "live_activity.status.enabled" = "Etkin";
-"live_activity.status.not_supported" = "iPad'de mevcut değil";
 "live_activity.status.open_settings" = "Ayarları Aç";
 "live_activity.subtitle" = "Kilit Ekranınızda ve Dinamik Ada' da gerçek zamanlı Home Assistant güncellemeleri.";
 "live_activity.title" = "Canlı Etkinlikler";

--- a/Sources/App/Resources/uk.lproj/Localizable.strings
+++ b/Sources/App/Resources/uk.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/vi.lproj/Localizable.strings
+++ b/Sources/App/Resources/vi.lproj/Localizable.strings
@@ -514,7 +514,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.section.privacy" = "Privacy";
 "live_activity.section.status" = "Status";
 "live_activity.status.enabled" = "Enabled";
-"live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
 "live_activity.title" = "Live Activities";

--- a/Sources/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "隐私";
 "live_activity.section.status" = "状况";
 "live_activity.status.enabled" = "已启用";
-"live_activity.status.not_supported" = "iPad 版暂不可用";
 "live_activity.status.open_settings" = "打开设置";
 "live_activity.subtitle" = "在锁屏和动态岛屿上实时更新 Home Assistant 。";
 "live_activity.title" = "实时活动";

--- a/Sources/App/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/App/Resources/zh-Hant.lproj/Localizable.strings
@@ -514,7 +514,6 @@
 "live_activity.section.privacy" = "隱私權";
 "live_activity.section.status" = "狀態";
 "live_activity.status.enabled" = "已開啟";
-"live_activity.status.not_supported" = "iPad 版暫不可用";
 "live_activity.status.open_settings" = "開啟設定";
 "live_activity.subtitle" = "在鎖定畫面和動態島上即時更新 Home Assistant。";
 "live_activity.title" = "即時動態";

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -86,9 +86,6 @@ struct LiveActivitySettingsView: View {
                 if authorizationEnabled {
                     Text(L10n.LiveActivity.Status.enabled)
                         .foregroundStyle(.green)
-                } else if UIDevice.current.userInterfaceIdiom == .pad {
-                    Text(L10n.LiveActivity.Status.notSupported)
-                        .foregroundStyle(.secondary)
                 } else {
                     Button(L10n.LiveActivity.Status.openSettings) {
                         if let url = URL(string: UIApplication.openSettingsURLString) {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -602,10 +602,9 @@ public class HomeAssistantAPI {
 
                 #if os(iOS) && !targetEnvironment(macCatalyst)
                 if #available(iOS 17.2, *) {
-                    // Advertise Live Activity support so HA can gate the UI and send
-                    // activity push tokens back to the relay server.
-                    // Use areActivitiesEnabled so iPad and users who disabled Live Activities
-                    // in Settings correctly report false.
+                    // Advertise Live Activity support so HA can send activity push tokens
+                    // to the relay server. areActivitiesEnabled reflects the user's Settings
+                    // toggle and returns true on both iPhone and iPad (iPadOS 17+).
                     appData["supports_live_activities"] = ActivityAuthorizationInfo().areActivitiesEnabled
                     appData["supports_live_activities_frequent_updates"] =
                         ActivityAuthorizationInfo().frequentPushesEnabled

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1910,8 +1910,6 @@ public enum L10n {
     public enum Status {
       /// Enabled
       public static var enabled: String { return L10n.tr("Localizable", "live_activity.status.enabled") }
-      /// Not available on iPad
-      public static var notSupported: String { return L10n.tr("Localizable", "live_activity.status.not_supported") }
       /// Open Settings
       public static var openSettings: String { return L10n.tr("Localizable", "live_activity.status.open_settings") }
     }


### PR DESCRIPTION
## Summary

iPad has supported Live Activities since iPadOS 17 — the previous `userInterfaceIdiom == .pad` guard in `LiveActivitySettingsView` was incorrect. `areActivitiesEnabled` (the `ActivityAuthorizationInfo` API) already returns the correct value on iPad, so no platform-specific gate is needed.

Changes:

- Remove the `userInterfaceIdiom == .pad` branch from `LiveActivitySettingsView` that showed a static "Not available on iPad" label. iPad users now see the same enabled/open-settings states as iPhone.
- Drop the `live_activity.status.not_supported` localisation key from all 34 locale files and the generated `Strings.swift` accessor.
- Update a stale comment in `HAAPI.swift` that incorrectly stated iPads report `false` for `areActivitiesEnabled`.

ActivityKit handles Dynamic Island availability transparently — the island pill appears on iPhone 14 Pro/Pro Max and all iPhone 15 and later models; on iPad and older iPhones it simply doesn't render, and the activity shows on the Lock Screen only.

## References

- Apple docs confirming iPad support: [Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities)
- Companion docs PR: home-assistant/companion.home-assistant#1303

## Test plan

- [ ] On iPhone: Live Activities settings screen shows enabled/open-settings as before
- [ ] On iPad (iPadOS 17+): settings screen no longer shows "Not available on iPad"; shows enabled/open-settings
- [ ] On iPad (iPadOS 17+): Live Activities can be started and updated from Home Assistant
- [ ] On iPad (iPadOS 16 or earlier): `areActivitiesEnabled` returns `false`; open-settings button shown
- [ ] Verify `live_activity.status.not_supported` key is absent from all `.lproj` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)