### PR TITLE
Add pre-commit hook that runs fastlane autocorrect

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 #
 # pre-commit: run `bundle exec fastlane autocorrect` so SwiftFormat / Rubocop
-# fixes are applied automatically before each commit, and re-stage any
-# modifications it introduces to files that were already part of this commit.
+# fixes are applied automatically before each commit, then re-stage only the
+# changes autocorrect introduced — without touching unstaged hunks the
+# developer left in the working tree.
 #
-# Install once with:
-#     git config core.hooksPath .githooks
-#
-# Bypass for a single commit:
-#     SKIP_AUTOCORRECT=1 git commit ...
+# Bypass: SKIP_AUTOCORRECT=1 git commit ...
 
 set -euo pipefail
 
@@ -21,19 +18,47 @@ if git diff --cached --quiet; then
     exit 0
 fi
 
+# Snapshot the staged file list BEFORE running autocorrect, so we only ever
+# re-stage files that were already part of the commit.
+already_staged=$(git diff --cached --name-only)
+
+# Stash unstaged work and untracked files with `--keep-index` so the working
+# tree exactly matches what's about to be committed. This means:
+#   - Partial-staged commits (`git add -p`) keep their unstaged hunks.
+#   - Autocorrect runs against the staged content, not against in-progress edits.
+#   - The only diffs left after autocorrect are autocorrect's own changes,
+#     which we can safely re-stage without sweeping in unrelated work.
+stash_msg="pre-commit-autocorrect-$$"
+need_unstash=0
+if ! git diff --quiet HEAD -- 2>/dev/null \
+    || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    if git stash push --keep-index --include-untracked --quiet \
+            --message "$stash_msg" 2>/dev/null; then
+        need_unstash=1
+    fi
+fi
+
+# Restore the stash on exit (covers autocorrect failures + interrupts).
+restore_stash() {
+    if [[ "$need_unstash" == "1" ]]; then
+        if ! git stash pop --quiet 2>/dev/null; then
+            echo "pre-commit: WARNING — could not pop the autosave stash."
+            echo "  Run 'git stash list' to locate '$stash_msg' and pop it manually."
+        fi
+    fi
+}
+trap restore_stash EXIT
+
 echo "pre-commit: running 'bundle exec fastlane autocorrect'..."
 bundle exec fastlane autocorrect
 
-# Re-stage anything autocorrect modified, but only for files that were already
-# part of the commit. Files outside the staged set are left in the working
-# tree as unstaged changes for the developer to review.
-already_staged=$(git diff --cached --name-only)
-if [[ -n "$already_staged" ]]; then
-    echo "$already_staged" | while IFS= read -r f; do
-        [[ -n "$f" ]] || continue
-        [[ -f "$f" ]] || continue
-        if ! git diff --quiet -- "$f"; then
-            git add -- "$f"
-        fi
-    done
-fi
+# After autocorrect runs, the only unstaged differences are its modifications
+# (because we stashed everything else above with --keep-index). Re-stage those
+# changes, but only for files that were already part of the commit.
+while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    [[ -f "$f" ]] || continue
+    if ! git diff --quiet -- "$f"; then
+        git add -- "$f"
+    fi
+done <<< "$already_staged"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# pre-commit: run `bundle exec fastlane autocorrect` so SwiftFormat / Rubocop
+# fixes are applied automatically before each commit, and re-stage any
+# modifications it introduces to files that were already part of this commit.
+#
+# Install once with:
+#     git config core.hooksPath .githooks
+#
+# Bypass for a single commit:
+#     SKIP_AUTOCORRECT=1 git commit ...
+
+set -euo pipefail
+
+if [[ "${SKIP_AUTOCORRECT:-0}" == "1" ]]; then
+    exit 0
+fi
+
+# Nothing staged → nothing to do (covers `git commit --amend` no-ops).
+if git diff --cached --quiet; then
+    exit 0
+fi
+
+echo "pre-commit: running 'bundle exec fastlane autocorrect'..."
+bundle exec fastlane autocorrect
+
+# Re-stage anything autocorrect modified, but only for files that were already
+# part of the commit. Files outside the staged set are left in the working
+# tree as unstaged changes for the developer to review.
+already_staged=$(git diff --cached --name-only)
+if [[ -n "$already_staged" ]]; then
+    echo "$already_staged" | while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        [[ -f "$f" ]] || continue
+        if ! git diff --quiet -- "$f"; then
+            git add -- "$f"
+        fi
+    done
+fi

--- a/Podfile
+++ b/Podfile
@@ -106,6 +106,16 @@ abstract_target 'watchOS' do
 end
 
 post_install do |installer|
+  # Wire up the checked-in pre-commit hook so every developer gets autocorrect
+  # on commit. Idempotent — safe to re-run on every `pod install`.
+  if Dir.exist?('.git') && Dir.exist?('.githooks')
+    current = `git config --get core.hooksPath`.strip
+    if current != '.githooks'
+      system('git', 'config', 'core.hooksPath', '.githooks')
+      Pod::UI.puts 'Configured git core.hooksPath = .githooks (pre-commit autocorrect)'.green
+    end
+  end
+
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['WATCHOS_DEPLOYMENT_TARGET'] = '8.0'

--- a/README.md
+++ b/README.md
@@ -95,13 +95,7 @@ bundle exec fastlane lint
 bundle exec fastlane autocorrect
 ```
 
-To run `fastlane autocorrect` automatically before every commit, point Git at the checked-in `.githooks/` directory once:
-
-```bash
-git config core.hooksPath .githooks
-```
-
-The hook re-stages any files it modifies that were already part of the commit. Bypass for a single commit with `SKIP_AUTOCORRECT=1 git commit ...`.
+A checked-in pre-commit hook at `.githooks/pre-commit` runs `fastlane autocorrect` before every commit and re-stages any files it modifies that were already part of the commit. `bundle exec pod install` wires it up automatically by setting `core.hooksPath = .githooks`. Bypass for a single commit with `SKIP_AUTOCORRECT=1 git commit ...`.
 
 In the Xcode project, the autocorrectable linters will not modify your source code but will provide warnings. This project uses several linters:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ bundle exec fastlane lint
 bundle exec fastlane autocorrect
 ```
 
+To run `fastlane autocorrect` automatically before every commit, point Git at the checked-in `.githooks/` directory once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook re-stages any files it modifies that were already part of the commit. Bypass for a single commit with `SKIP_AUTOCORRECT=1 git commit ...`.
+
 In the Xcode project, the autocorrectable linters will not modify your source code but will provide warnings. This project uses several linters:
 
 - [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ bundle exec fastlane lint
 bundle exec fastlane autocorrect
 ```
 
-A checked-in pre-commit hook at `.githooks/pre-commit` runs `fastlane autocorrect` before every commit and re-stages any files it modifies that were already part of the commit. `bundle exec pod install` wires it up automatically by setting `core.hooksPath = .githooks`. Bypass for a single commit with `SKIP_AUTOCORRECT=1 git commit ...`.
+A checked-in pre-commit hook at `.githooks/pre-commit` runs `fastlane autocorrect` before every commit. It stashes unstaged work with `--keep-index` first, so autocorrect runs against the exact tree about to be committed, then re-stages only the changes autocorrect itself introduced — partial-staged hunks (`git add -p`) and unstaged edits are preserved. `bundle exec pod install` wires it up automatically by setting `core.hooksPath = .githooks`. Bypass for a single commit with `SKIP_AUTOCORRECT=1 git commit ...`.
 
 In the Xcode project, the autocorrectable linters will not modify your source code but will provide warnings. This project uses several linters:
 


### PR DESCRIPTION
## Summary

Adds a checked-in pre-commit hook at `.githooks/pre-commit` that runs `bundle exec fastlane autocorrect` before every commit. The existing `Podfile` `post_install` block wires it up automatically (`git config core.hooksPath .githooks`), so every contributor running `bundle exec pod install` — already part of project setup — gets autocorrect on commit without any extra step.

## How the hook behaves

1. Skip if `SKIP_AUTOCORRECT=1` is set in the environment.
2. Skip if there are no staged changes (covers `git commit --amend` no-ops).
3. Snapshot the staged file list **before** doing anything, so the re-stage step can only ever touch files that were already part of the commit.
4. `git stash push --keep-index --include-untracked` so the working tree exactly matches the staged content. This means autocorrect runs against the tree being committed, not against in-progress edits.
5. Run `bundle exec fastlane autocorrect`.
6. Re-stage anything autocorrect modified — but only for files in the snapshot from step 3. Because step 4 left the working tree clean of unstaged work, the only diffs at this point are autocorrect's own changes. Partial-staged hunks (`git add -p`) are preserved.
7. A trap pops the stash on any exit path (success, autocorrect failure, interrupt). If `git stash pop` conflicts, the hook surfaces a warning pointing at the named stash so it can be resolved manually.

## Setup

Automatic, via `bundle exec pod install` — the existing `post_install` block sets `core.hooksPath = .githooks` once. Idempotent and silent on subsequent runs. No extra step for new contributors.

## Bypass

```bash
SKIP_AUTOCORRECT=1 git commit ...
```

For mid-rebase, machines without Pods installed, or any other escape hatch.

## Files

- `.githooks/pre-commit` (new, executable)
- `Podfile` — add the `core.hooksPath` setup at the top of the existing `post_install` block
- `README.md` — one paragraph next to the existing `fastlane autocorrect` documentation

## Addressed in review

- **Snapshot staged files before autocorrect runs** (was captured after — fixed)
- **Don't break partial staging or sweep unrelated unstaged edits** — the `--keep-index` stash dance now genuinely guarantees only autocorrect's changes are re-staged
- **README wording matches the new behaviour** precisely

## Test plan

- [ ] `bundle exec pod install` configures `core.hooksPath = .githooks` on first run, silent on subsequent runs
- [ ] Commit a Swift file with intentional formatting issues — hook fixes and re-stages
- [ ] `git add -p` to stage partial hunks, then commit — hook preserves the unstaged hunks
- [ ] Commit while there are unstaged edits to *other* files — hook leaves those edits alone
- [ ] `SKIP_AUTOCORRECT=1 git commit ...` — bypasses without running autocorrect
- [ ] Commit a non-Swift, non-Ruby file — hook runs cleanly with no diff to re-stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)