### PR TITLE
Rename live activity webhook types to drop mobile_app_ prefix

### DIFF
--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -36,12 +36,12 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     // MARK: - Webhook Constants (wire-format frozen — tested in LiveActivityContractTests)
 
     /// Webhook type for reporting a new per-activity push token to HA.
-    static let webhookTypeToken = "mobile_app_live_activity_token"
+    static let webhookTypeToken = "live_activity_token"
     /// Keys in the token webhook request data dictionary.
     static let tokenWebhookKeys: Set<String> = ["activity_id", "push_token", "apns_environment"]
 
     /// Webhook type for reporting that a Live Activity was dismissed.
-    static let webhookTypeDismissed = "mobile_app_live_activity_dismissed"
+    static let webhookTypeDismissed = "live_activity_dismissed"
     /// Keys in the dismissed webhook request data dictionary.
     static let dismissedWebhookKeys: Set<String> = ["activity_id", "live_activity_tag", "reason"]
 

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -90,7 +90,7 @@ final class LiveActivityContractTests: XCTestCase {
     func testWebhookTypeToken_isFrozen() {
         XCTAssertEqual(
             LiveActivityRegistry.webhookTypeToken,
-            "mobile_app_live_activity_token"
+            "live_activity_token"
         )
     }
 
@@ -108,7 +108,7 @@ final class LiveActivityContractTests: XCTestCase {
     func testWebhookTypeDismissed_isFrozen() {
         XCTAssertEqual(
             LiveActivityRegistry.webhookTypeDismissed,
-            "mobile_app_live_activity_dismissed"
+            "live_activity_dismissed"
         )
     }
 


### PR DESCRIPTION
## Summary

- Renames `webhookTypeToken` from `"mobile_app_live_activity_token"` → `"live_activity_token"`
- Renames `webhookTypeDismissed` from `"mobile_app_live_activity_dismissed"` → `"live_activity_dismissed"`

Requested in home-assistant/core#166072 — all other webhooks in the mobile_app integration use short names without the `mobile_app_` prefix (e.g. `scan_tag`, `update_location`). This aligns our new webhook types with that convention.

## Related

- home-assistant/core#166072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of epic: https://github.com/home-assistant/epics/issues/61
Fixes: https://github.com/home-assistant/iOS/issues/4623