### PR TITLE
Remove unused Live Activity registration fields

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -602,13 +602,6 @@ public class HomeAssistantAPI {
 
                 #if os(iOS) && !targetEnvironment(macCatalyst)
                 if #available(iOS 17.2, *) {
-                    // Advertise Live Activity support so HA can send activity push tokens
-                    // to the relay server. areActivitiesEnabled reflects the user's Settings
-                    // toggle and returns true on both iPhone and iPad (iPadOS 17+).
-                    appData["supports_live_activities"] = ActivityAuthorizationInfo().areActivitiesEnabled
-                    appData["supports_live_activities_frequent_updates"] =
-                        ActivityAuthorizationInfo().frequentPushesEnabled
-
                     // Push-to-start token (stored in Keychain at launch, updated via stream).
                     // The relay server uses this token to start a Live Activity entirely via APNs.
                     if let pushToStartToken = LiveActivityRegistry.storedPushToStartToken {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -11,9 +11,6 @@ import Version
 #if os(iOS)
 import Reachability
 #endif
-#if os(iOS) && !targetEnvironment(macCatalyst)
-import ActivityKit
-#endif
 
 public class HomeAssistantAPI {
     public enum APIError: Error, Equatable {


### PR DESCRIPTION
## Summary

- Removes `supports_live_activities` and `supports_live_activities_frequent_updates` from the app registration payload sent to HA

These fields were removed from the HA core side in home-assistant/core#166072 (the `SCHEMA_APP_DATA` schema no longer accepts them). Sending data that the server doesn't read wastes bandwidth on every registration.

## Related

- home-assistant/core#166072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of epic: https://github.com/home-assistant/epics/issues/61
Fixes: https://github.com/home-assistant/iOS/issues/4623