### PR TITLE
Normalize ipv6 URL for host comparison in WKSecurityOrigin

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
@@ -61,7 +61,7 @@ final class SafeScriptMessageHandler: NSObject, WKScriptMessageHandler {
             return nil
         }
 
-        return "\(scheme.lowercased())://\(host.lowercased()):\(normalizedPort)"
+        return "\(scheme.lowercased())://\(normalizedHost(host)):\(normalizedPort)"
     }
 
     private func normalizedPort(for scheme: String, port: Int?) -> Int? {
@@ -74,5 +74,14 @@ final class SafeScriptMessageHandler: NSObject, WKScriptMessageHandler {
         case "https": return 443
         default: return port
         }
+    }
+
+    private func normalizedHost(_ host: String) -> String {
+        let lowercasedHost = host.lowercased()
+        if lowercasedHost.hasPrefix("["), lowercasedHost.hasSuffix("]") {
+            return String(lowercasedHost.dropFirst().dropLast())
+        }
+
+        return lowercasedHost
     }
 }

--- a/Tests/App/WebView/SafeScriptMessageHandlerTests.swift
+++ b/Tests/App/WebView/SafeScriptMessageHandlerTests.swift
@@ -28,6 +28,16 @@ struct SafeScriptMessageHandlerTests {
         #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "https", host: "ui.nabu.casa", port: 0))
     }
 
+    @Test func allowsMainFrameMessageFromBracketedIPv6Host() {
+        let handler = SafeScriptMessageHandler(
+            server: server(internalURL: URL(string: "http://[fd00::abcd]:8123")!),
+            delegate: NoOpScriptMessageHandler()
+        )
+
+        #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "http", host: "[fd00::abcd]", port: 8123))
+        #expect(handler.shouldAllowMessage(isMainFrame: true, scheme: "http", host: "fd00::abcd", port: 8123))
+    }
+
     @Test func rejectsMessageFromOriginOutsideConfiguredServerOrigins() {
         ServerFixture.reset()
         let handler = SafeScriptMessageHandler(
@@ -59,6 +69,38 @@ struct SafeScriptMessageHandlerTests {
             port: 443
         ))
     }
+}
+
+private func server(internalURL: URL) -> Server {
+    var info = ServerInfo(
+        name: "IPv6 Server",
+        connection: .init(
+            externalURL: nil,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook-id",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(exceptions: []),
+            connectionAccessSecurityLevel: .undefined
+        ),
+        token: .init(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            expiration: Date()
+        ),
+        version: "2026.4.1"
+    )
+
+    return Server(identifier: "ipv6", getter: {
+        info
+    }, setter: { newInfo in
+        info = newInfo
+        return true
+    })
 }
 
 private final class NoOpScriptMessageHandler: NSObject, WKScriptMessageHandler {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The issue is the new WebView bridge origin check. It compares configured URL hosts with WKSecurityOrigin.host and IPv6 can appear as fd00::abcd in one API and [fd00::abcd] in another, so the bridge rejects valid frontend messages. That blocks external auth and leaves the frontend loading, while widgets still work.

This PR normalizes the url
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
