### PR TITLE
Auto-activate kiosk mode on launch when previously enabled

### DIFF
--- a/Sources/App/Kiosk/KioskModeManager.swift
+++ b/Sources/App/Kiosk/KioskModeManager.swift
@@ -175,6 +175,13 @@ public final class KioskModeManager: ObservableObject {
         // Setup secret exit gesture overlay (always available when kiosk mode is active)
         setupSecretExitGesture(in: viewController)
 
+        // Restore kiosk mode if it was enabled before the app was last closed
+        if settings.isKioskModeEnabled, !isKioskModeActive {
+            Current.Log.info("Restoring kiosk mode from persisted settings")
+            enableKioskMode()
+            return
+        }
+
         // Apply initial state if already in kiosk mode
         if isKioskModeActive {
             updateKioskModeLockdown(enabled: true)

--- a/Sources/App/Kiosk/KioskModeManager.swift
+++ b/Sources/App/Kiosk/KioskModeManager.swift
@@ -178,6 +178,15 @@ public final class KioskModeManager: ObservableObject {
         // hosted in a UINavigationController with hidden nav bar triggers a UIKit safe-area
         // inflation bug that oversizes the native statusBarView and breaks WKWebView hit-testing
         // (issue #4499).
+
+        // Restore kiosk mode if it was enabled before the app was last closed.
+        // enableKioskMode() installs the secret-exit gesture as part of its lockdown flow.
+        if settings.isKioskModeEnabled, !isKioskModeActive {
+            Current.Log.info("Restoring kiosk mode from persisted settings")
+            enableKioskMode()
+            return
+        }
+
         if isKioskModeActive {
             tearDownSecretExitGesture()
             setupSecretExitGesture(in: viewController)

--- a/Tests/App/Kiosk/KioskLifecycleBrightness.test.swift
+++ b/Tests/App/Kiosk/KioskLifecycleBrightness.test.swift
@@ -198,4 +198,86 @@ struct KioskLifecycleBrightnessTests {
         mgr.appDidBecomeActive()
         #expect(box.value == 0.65, "kiosk inactive: foreground must not touch brightness")
     }
+
+    // MARK: - Auto-Activation on Launch (#4608)
+
+    // Regression: when kiosk mode was enabled and the app was then force-quit, crashed,
+    // or the device rebooted, the persisted isKioskModeEnabled was loaded into memory
+    // but never acted on — the user had to manually re-toggle kiosk mode after every
+    // restart. setup(using:) now restores kiosk mode when settings.isKioskModeEnabled
+    // is true on launch.
+
+    @Test func setupRestoresKioskModeWhenPersistedEnabled() async throws {
+        let (_, cleanup) = setupTest(initialBrightness: 0.5)
+        defer { cleanup() }
+
+        let mgr = KioskModeManager.shared
+        #expect(mgr.isKioskModeActive == false)
+
+        // Simulate state after a previous session enabled kiosk mode and the app was killed.
+        var persisted = mgr.settings
+        persisted.isKioskModeEnabled = true
+        mgr.updateSettings(persisted)
+
+        // App relaunches — WebViewController.viewDidLoad calls setup(using:).
+        let stubVC = StubKioskWebViewController()
+        mgr.setup(using: stubVC)
+
+        #expect(
+            mgr.isKioskModeActive == true,
+            "kiosk mode should auto-activate on launch when settings.isKioskModeEnabled is true"
+        )
+    }
+
+    @Test func setupDoesNotActivateWhenPersistedDisabled() async throws {
+        let (_, cleanup) = setupTest(initialBrightness: 0.5)
+        defer { cleanup() }
+
+        let mgr = KioskModeManager.shared
+
+        var persisted = mgr.settings
+        persisted.isKioskModeEnabled = false
+        mgr.updateSettings(persisted)
+
+        let stubVC = StubKioskWebViewController()
+        mgr.setup(using: stubVC)
+
+        #expect(
+            mgr.isKioskModeActive == false,
+            "kiosk mode must not activate on launch when settings.isKioskModeEnabled is false"
+        )
+    }
+}
+
+// MARK: - Test Stub
+
+/// Minimal `WebViewControllerProtocol`-conforming `UIViewController` subclass used
+/// to exercise `KioskModeManager.setup(using:)` without spinning up a full WebView.
+/// `setup(using:)` guards on `webViewController as? UIViewController`, so a plain
+/// `MockWebViewController` (which is not a UIViewController) cannot drive the restore path.
+private final class StubKioskWebViewController: UIViewController, WebViewControllerProtocol {
+    let webViewExternalMessageHandler: any WebViewExternalMessageHandlerProtocol = MockWebViewExternalMessageHandler()
+    var canGoBack: Bool = false
+    var canGoForward: Bool = false
+    var server: Server = ServerFixture.standard
+    var connectionState: FrontEndConnectionState = .connected
+    var overlayedController: UIViewController?
+
+    func presentOverlayController(controller: UIViewController, animated: Bool) {}
+    func presentAlertController(controller: UIViewController, animated: Bool) {}
+    func evaluateJavaScript(_ script: String, completion: ((Any?, (any Error)?) -> Void)?) {}
+    func dismissOverlayController(animated: Bool, completion: (() -> Void)?) {}
+    func dismissControllerAboveOverlayController() {}
+    func updateFrontendConnectionState(state: String) {}
+    func navigateToPath(path: String) {}
+    func showBanner(request: BannerRequest) {}
+    func hideBanner(id: String) {}
+    func refresh() {}
+    func refreshIfDisconnected() {}
+    func load(request: URLRequest) {}
+    func showSettingsViewController() {}
+    func openDebug() {}
+    func goBack() {}
+    func goForward() {}
+    func styleUI() {}
 }


### PR DESCRIPTION
## Summary

Fixes #4608.

When kiosk mode is enabled and the Home Assistant app is then force-quit, crashes, or the device reboots, kiosk mode does not re-activate on the next launch. The persisted `settings.isKioskModeEnabled = true` is loaded into memory by `KioskModeManager.loadSettings()` but never acted on, so the user has to manually re-toggle kiosk mode from settings each time. For the wall-mounted iPad use case kiosk mode is designed for, this leaves an unattended dashboard silently falling back to the normal UI after any restart.

## What changed

In `KioskModeManager.setup(using:)` (called from `WebViewController.viewDidLoad`), if `settings.isKioskModeEnabled` is `true` and kiosk mode is not already active, call `enableKioskMode()` to restore it.

`enableKioskMode()` is idempotent — it guards on `!isKioskModeActive` — so this is safe to call from any path and existing flows are unaffected.

```swift
// Restore kiosk mode if it was enabled before the app was last closed
if settings.isKioskModeEnabled, !isKioskModeActive {
    Current.Log.info("Restoring kiosk mode from persisted settings")
    enableKioskMode()
    return
}
```

## Test plan

- [ ] Enable kiosk mode in the app
- [ ] Force-quit the app from the app switcher
- [ ] Re-launch
- [ ] Verify the screen comes back up in kiosk mode (status bar hidden, screensaver active, secret exit gesture working)
- [ ] Reboot the device — verify kiosk mode is still on after launch
- [ ] Disable kiosk mode, force-quit, re-launch — verify it stays disabled

## Notes

- `KioskModeManager` is a singleton with UIKit dependencies and no existing tests, so I haven't added a unit test here. Happy to add one if there's a preferred pattern for managers like this.
- Out of scope (per the issue): a "panic recovery" guard so a crash loop inside kiosk mode does not trap the user. Worth a follow-up.
- Local `xcodebuild` was blocked by an unrelated `BuildMaterialDesignIconsFont` script failure in my environment, but `swiftformat --lint` passes and the change uses existing APIs that mirror the adjacent code path.