### PR TITLE
Feature/custom request headers

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -951,7 +951,6 @@
 		42A47A872C452D5400C9B43D /* WebViewExternalMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A862C452D5400C9B43D /* WebViewExternalMessageHandlerTests.swift */; };
 		42A47A8A2C452DB500C9B43D /* MockWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A892C452DB500C9B43D /* MockWebViewController.swift */; };
 		42A47A902C4548E100C9B43D /* ImprovDiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A8F2C4548E100C9B43D /* ImprovDiscoverView.swift */; };
-		42A7F1012FBC000100BEEF01 /* AllowedTag.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1002FBC000100BEEF01 /* AllowedTag.test.swift */; };
 		42A7F1012FBC000100BEEF01 /* Database/AllowedTag.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1002FBC000100BEEF01 /* Database/AllowedTag.test.swift */; };
 		42A7F1212FBC000100BEEF01 /* NFCTagApproval.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1202FBC000100BEEF01 /* NFCTagApproval.test.swift */; };
 		42A818E02BBEA8150083D045 /* AssistViewModel.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A818DF2BBEA8150083D045 /* AssistViewModel.test.swift */; };
@@ -1588,7 +1587,6 @@
 		D8B4F2A61E9C73058AF2D49E /* KioskSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A3E91F5B8D42A6E0F13B74 /* KioskSettingsViewModel.swift */; };
 		D9A6697AF4D05BB8DE822A54 /* Pods_iOS_Extensions_Share.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CA7FF55788E7084DA5E4B3 /* Pods_iOS_Extensions_Share.framework */; };
 		D9BF1EFF40733A4A1D03B9C8 /* CustomWidgetIntentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7FF77B68D19A4AD68F8FE3 /* CustomWidgetIntentHelper.swift */; };
-		DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */; };
 		DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */; };
 		DB54626ADCE0C32094C8C0B9 /* LoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFD0D30836C69840AB63A8A /* LoadingButton.swift */; };
 		DEFBE1A5E9A005B0A5392D27 /* KioskLocalization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4593A60DBF019E6C91AAA7 /* KioskLocalization.test.swift */; };
@@ -2842,7 +2840,6 @@
 		42A747492E832FB8005E0332 /* report.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = report.xml; sourceTree = "<group>"; };
 		42A7474A2E832FB8005E0332 /* Snapfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Snapfile; sourceTree = "<group>"; };
 		42A7474B2E832FB8005E0332 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
-		42A7F1002FBC000100BEEF01 /* AllowedTag.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/AllowedTag.test.swift; sourceTree = "<group>"; };
 		42A7F1002FBC000100BEEF01 /* Database/AllowedTag.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/AllowedTag.test.swift; sourceTree = "<group>"; };
 		42A7F1202FBC000100BEEF01 /* NFCTagApproval.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCTagApproval.test.swift; sourceTree = "<group>"; };
 		42A818DF2BBEA8150083D045 /* AssistViewModel.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistViewModel.test.swift; sourceTree = "<group>"; };

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -951,6 +951,7 @@
 		42A47A872C452D5400C9B43D /* WebViewExternalMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A862C452D5400C9B43D /* WebViewExternalMessageHandlerTests.swift */; };
 		42A47A8A2C452DB500C9B43D /* MockWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A892C452DB500C9B43D /* MockWebViewController.swift */; };
 		42A47A902C4548E100C9B43D /* ImprovDiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47A8F2C4548E100C9B43D /* ImprovDiscoverView.swift */; };
+		42A7F1012FBC000100BEEF01 /* AllowedTag.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1002FBC000100BEEF01 /* AllowedTag.test.swift */; };
 		42A7F1012FBC000100BEEF01 /* Database/AllowedTag.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1002FBC000100BEEF01 /* Database/AllowedTag.test.swift */; };
 		42A7F1212FBC000100BEEF01 /* NFCTagApproval.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F1202FBC000100BEEF01 /* NFCTagApproval.test.swift */; };
 		42A818E02BBEA8150083D045 /* AssistViewModel.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A818DF2BBEA8150083D045 /* AssistViewModel.test.swift */; };
@@ -1587,6 +1588,7 @@
 		D8B4F2A61E9C73058AF2D49E /* KioskSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A3E91F5B8D42A6E0F13B74 /* KioskSettingsViewModel.swift */; };
 		D9A6697AF4D05BB8DE822A54 /* Pods_iOS_Extensions_Share.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CA7FF55788E7084DA5E4B3 /* Pods_iOS_Extensions_Share.framework */; };
 		D9BF1EFF40733A4A1D03B9C8 /* CustomWidgetIntentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7FF77B68D19A4AD68F8FE3 /* CustomWidgetIntentHelper.swift */; };
+		DA6F4C18D66EDBA5DCEAE833 /* DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* DatabaseMigration.test.swift */; };
 		DA6F4C18D66EDBA5DCEAE833 /* Database/DatabaseMigration.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */; };
 		DB54626ADCE0C32094C8C0B9 /* LoadingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFD0D30836C69840AB63A8A /* LoadingButton.swift */; };
 		DEFBE1A5E9A005B0A5392D27 /* KioskLocalization.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4593A60DBF019E6C91AAA7 /* KioskLocalization.test.swift */; };
@@ -2840,6 +2842,7 @@
 		42A747492E832FB8005E0332 /* report.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = report.xml; sourceTree = "<group>"; };
 		42A7474A2E832FB8005E0332 /* Snapfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Snapfile; sourceTree = "<group>"; };
 		42A7474B2E832FB8005E0332 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		42A7F1002FBC000100BEEF01 /* AllowedTag.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/AllowedTag.test.swift; sourceTree = "<group>"; };
 		42A7F1002FBC000100BEEF01 /* Database/AllowedTag.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/AllowedTag.test.swift; sourceTree = "<group>"; };
 		42A7F1202FBC000100BEEF01 /* NFCTagApproval.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCTagApproval.test.swift; sourceTree = "<group>"; };
 		42A818DF2BBEA8150083D045 /* AssistViewModel.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistViewModel.test.swift; sourceTree = "<group>"; };

--- a/Sources/App/Frontend/WebView/WebViewController+Navigation.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+Navigation.swift
@@ -28,7 +28,7 @@ extension WebViewController {
                     )
                 return
             }
-            load(request: URLRequest(url: url))
+            load(request: urlRequest(for: url))
         } else {
             openURLInBrowser(url, self)
         }
@@ -40,7 +40,7 @@ extension WebViewController {
 
         guard url.queryItems?[AppConstants.QueryItems.openMoreInfoDialog.rawValue] == nil || server.info
             .version >= .canNavigateMoreInfoDialogThroughFrontend else {
-            load(request: URLRequest(url: url))
+            load(request: urlRequest(for: url))
             Current.Log.verbose("Opening more-info dialog for URL: \(url)")
             return
         }
@@ -57,7 +57,7 @@ extension WebViewController {
             if !success {
                 Current.Log.warning("Failed to navigate through frontend for URL: \(url)")
                 // Fallback to loading the URL directly if navigation fails
-                self?.load(request: URLRequest(url: url))
+                self?.load(request: self?.urlRequest(for: url) ?? URLRequest(url: url))
             }
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -85,7 +85,7 @@ extension WebViewController: WebViewControllerProtocol {
 
     func navigateToPath(path: String) {
         if let activeURL = server.info.connection.activeURL(), let url = URL(string: activeURL.absoluteString + path) {
-            load(request: URLRequest(url: url))
+            load(request: urlRequest(for: url))
         }
     }
 
@@ -110,7 +110,7 @@ extension WebViewController: WebViewControllerProtocol {
                 if webView.url?.baseIsEqual(to: webviewURL) == true, !lastNavigationWasServerError {
                     reload()
                 } else {
-                    load(request: URLRequest(url: webviewURL))
+                    load(request: urlRequest(for: webviewURL))
                 }
                 hideNoActiveURLError()
             } else {

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -38,6 +38,15 @@ extension WebViewController {
         }
     }
 
+    /// Builds a URLRequest for the given URL with any configured custom headers applied.
+    func urlRequest(for url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        server.info.connection.customHeaders?.forEach { name, value in
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        return request
+    }
+
     @objc func loadActiveURLIfNeeded() {
         guard !loadActiveURLIfNeededInProgress else {
             Current.Log.info("loadActiveURLIfNeeded already in progress, skipping")
@@ -78,7 +87,7 @@ extension WebViewController {
             if Current.settingsStore.restoreLastURL,
                let initialURL, initialURL.baseIsEqual(to: webviewURL) {
                 Current.Log.info("restoring initial url path: \(initialURL.path)")
-                request = URLRequest(url: initialURL)
+                request = urlRequest(for: initialURL)
             } else if let currentURL = webView.url, currentURL.path.count > 1 {
                 // Preserve the current path when the base URL changes (e.g., switching between internal/external)
                 var components = URLComponents(url: webviewURL, resolvingAgainstBaseURL: true)
@@ -96,10 +105,10 @@ extension WebViewController {
                 components?.fragment = currentURL.fragment
                 let newURL = components?.url ?? webviewURL
                 Current.Log.info("preserving current path on base URL change: \(newURL.path)")
-                request = URLRequest(url: newURL)
+                request = urlRequest(for: newURL)
             } else {
                 Current.Log.info("loading default url path: \(webviewURL.path)")
-                request = URLRequest(url: webviewURL)
+                request = urlRequest(for: webviewURL)
             }
 
             load(request: request)

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -133,7 +133,7 @@ extension WebViewController {
 
             if let webviewURL = server.info.connection.webviewURL() {
                 decisionHandler(.cancel)
-                load(request: URLRequest(url: webviewURL))
+                load(request: urlRequest(for: webviewURL))
             } else {
                 // we don't have anything we can do about this
                 decisionHandler(.allow)

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -883,6 +883,12 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.connection_section.always_fallback_internal.confirmation.title" = "Are you sure?";
 "settings.connection_section.always_fallback_internal.footer" = "Enabling this with an unsecure URL (http) may compromise your security on public networks.";
 "settings.connection_section.always_fallback_internal.title" = "Always fallback to internal URL";
+"settings.connection_section.custom_headers.add" = "Add Header";
+"settings.connection_section.custom_headers.edit_title" = "Edit Header";
+"settings.connection_section.custom_headers.footer" = "Headers added to every request sent to this server. Useful for proxy authentication (e.g. Cloudflare Access service tokens).";
+"settings.connection_section.custom_headers.header" = "Custom Request Headers";
+"settings.connection_section.custom_headers.name_placeholder" = "Header Name";
+"settings.connection_section.custom_headers.value_placeholder" = "Value";
 "settings.connection_section.client_certificate.expired" = "Certificate expired";
 "settings.connection_section.client_certificate.expires_at" = "Expires %@";
 "settings.connection_section.client_certificate.footer" = "Import a PKCS#12 (.p12) certificate for mutual TLS authentication. Required when your Home Assistant server requires client certificates.";

--- a/Sources/App/Settings/Connection/ConnectionSettingsView.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsView.swift
@@ -23,6 +23,10 @@ struct ConnectionSettingsView: View {
     @State private var certificatePassword = ""
     @State private var pendingCertificateURL: URL?
     @State private var showRemoveCertificateConfirmation = false
+    @State private var showAddHeaderSheet = false
+    @State private var newHeaderName = ""
+    @State private var newHeaderValue = ""
+    @State private var editingHeaderName: String?
 
     let onDismiss: (() -> Void)?
 
@@ -35,6 +39,7 @@ struct ConnectionSettingsView: View {
         List {
             detailsSection
             clientCertificateSection
+            customHeadersSection
             privacySection
             statusSection
             deleteSection
@@ -210,6 +215,9 @@ struct ConnectionSettingsView: View {
             Button(L10n.okLabel, role: .cancel) {}
         } message: { error in
             Text(error.localizedDescription)
+        }
+        .sheet(isPresented: $showAddHeaderSheet) {
+            addHeaderSheet
         }
         .onDisappear {
             onDismiss?()
@@ -420,6 +428,121 @@ struct ConnectionSettingsView: View {
         } footer: {
             Text(L10n.Settings.ConnectionSection.ClientCertificate.footer)
         }
+    }
+
+    // MARK: - Custom Headers Section
+
+    private var customHeadersSection: some View {
+        Section {
+            ForEach(viewModel.customHeaders, id: \.name) { header in
+                Button {
+                    editingHeaderName = header.name
+                    newHeaderName = header.name
+                    newHeaderValue = header.value
+                    showAddHeaderSheet = true
+                } label: {
+                    HStack {
+                        Text(header.name)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(header.value)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .onDelete { offsets in
+                viewModel.deleteCustomHeaders(at: offsets)
+            }
+
+            Button {
+                editingHeaderName = nil
+                newHeaderName = ""
+                newHeaderValue = ""
+                showAddHeaderSheet = true
+            } label: {
+                Label(L10n.Settings.ConnectionSection.CustomHeaders.add, systemSymbol: .plus)
+            }
+        } header: {
+            Text(L10n.Settings.ConnectionSection.CustomHeaders.header)
+        } footer: {
+            Text(L10n.Settings.ConnectionSection.CustomHeaders.footer)
+        }
+    }
+
+    private var addHeaderSheet: some View {
+        NavigationView {
+            Form {
+                Section {
+                    TextField(
+                        L10n.Settings.ConnectionSection.CustomHeaders.namePlaceholder,
+                        text: $newHeaderName
+                    )
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    TextField(
+                        L10n.Settings.ConnectionSection.CustomHeaders.valuePlaceholder,
+                        text: $newHeaderValue
+                    )
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                } footer: {
+                    let trimmedName = newHeaderName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let trimmedValue = newHeaderValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmedName.isEmpty, !trimmedValue.isEmpty {
+                        Text("\(trimmedName): \(trimmedValue)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let oldName = editingHeaderName {
+                    Section {
+                        Button(role: .destructive) {
+                            viewModel.deleteCustomHeader(name: oldName)
+                            showAddHeaderSheet = false
+                        } label: {
+                            HStack {
+                                Spacer()
+                                Text(L10n.delete)
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(
+                editingHeaderName != nil
+                    ? L10n.Settings.ConnectionSection.CustomHeaders.editTitle
+                    : L10n.Settings.ConnectionSection.CustomHeaders.add
+            )
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(L10n.cancelLabel) {
+                        showAddHeaderSheet = false
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(L10n.doneLabel) {
+                        if let oldName = editingHeaderName {
+                            viewModel.updateCustomHeader(
+                                oldName: oldName,
+                                newName: newHeaderName,
+                                value: newHeaderValue
+                            )
+                        } else {
+                            viewModel.addCustomHeader(name: newHeaderName, value: newHeaderValue)
+                        }
+                        showAddHeaderSheet = false
+                    }
+                    .disabled(newHeaderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
     }
 
     // MARK: - Privacy Section

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -363,6 +363,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
         customHeaders = server.info.connection.customHeaders.map { dict in
             dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
         } ?? []
+        reconnectForSettingsChange()
     }
 
     func updateCustomHeader(oldName: String, newName: String, value: String) {
@@ -378,6 +379,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
         customHeaders = server.info.connection.customHeaders.map { dict in
             dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
         } ?? []
+        reconnectForSettingsChange()
     }
 
     func deleteCustomHeader(name: String) {
@@ -389,6 +391,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
         customHeaders = server.info.connection.customHeaders.map { dict in
             dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
         } ?? []
+        reconnectForSettingsChange()
     }
 
     func deleteCustomHeaders(at offsets: IndexSet) {
@@ -401,5 +404,13 @@ final class ConnectionSettingsViewModel: ObservableObject {
             info.connection.customHeaders = headers.isEmpty ? nil : headers
         }
         customHeaders = headers.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        reconnectForSettingsChange()
+    }
+
+    private func reconnectForSettingsChange() {
+        Current.api(for: server)?.connection.disconnect()
+        let freshAPI = HomeAssistantAPI(server: server, urlConfig: .default)
+        Current.setCachedApi(freshAPI, for: server.identifier)
+        freshAPI.connection.connect()
     }
 }

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -28,6 +28,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
     @Published var clientCertificate: ClientCertificate?
     @Published var isImportingCertificate = false
     @Published var certificateError: Error?
+    @Published var customHeaders: [(name: String, value: String)] = []
 
     // MARK: - Properties
 
@@ -124,6 +125,9 @@ final class ConnectionSettingsViewModel: ObservableObject {
         updateFromServerInfo(server.info)
         updateURLs()
         clientCertificate = server.info.connection.clientCertificate
+        customHeaders = server.info.connection.customHeaders.map { dict in
+            dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        } ?? []
         Current.api(for: server)?.currentUser { [weak self] user in
             Task { @MainActor [weak self] in
                 self?.loggedInUser = user?.name ?? ""
@@ -343,5 +347,59 @@ final class ConnectionSettingsViewModel: ObservableObject {
         Current.servers.all.contains { server in
             server.info.connection.clientCertificate?.keychainIdentifier == certificate.keychainIdentifier
         }
+    }
+
+    // MARK: - Custom Headers
+
+    func addCustomHeader(name: String, value: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        server.update { info in
+            var headers = info.connection.customHeaders ?? [:]
+            headers[trimmedName] = trimmedValue
+            info.connection.customHeaders = headers
+        }
+        customHeaders = server.info.connection.customHeaders.map { dict in
+            dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        } ?? []
+    }
+
+    func updateCustomHeader(oldName: String, newName: String, value: String) {
+        let trimmedName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        server.update { info in
+            var headers = info.connection.customHeaders ?? [:]
+            headers.removeValue(forKey: oldName)
+            headers[trimmedName] = trimmedValue
+            info.connection.customHeaders = headers
+        }
+        customHeaders = server.info.connection.customHeaders.map { dict in
+            dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        } ?? []
+    }
+
+    func deleteCustomHeader(name: String) {
+        server.update { info in
+            var headers = info.connection.customHeaders ?? [:]
+            headers.removeValue(forKey: name)
+            info.connection.customHeaders = headers.isEmpty ? nil : headers
+        }
+        customHeaders = server.info.connection.customHeaders.map { dict in
+            dict.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        } ?? []
+    }
+
+    func deleteCustomHeaders(at offsets: IndexSet) {
+        var headers = server.info.connection.customHeaders ?? [:]
+        let sortedHeaders = headers.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
+        for index in offsets {
+            headers.removeValue(forKey: sortedHeaders[index].name)
+        }
+        server.update { info in
+            info.connection.customHeaders = headers.isEmpty ? nil : headers
+        }
+        customHeaders = headers.map { (name: $0.key, value: $0.value) }.sorted { $0.name < $1.name }
     }
 }

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -36,6 +36,8 @@ public struct ConnectionInfo: Codable, Equatable {
     public var connectionAccessSecurityLevel: ConnectionSecurityLevel = .undefined
     /// Client certificate for mTLS authentication (optional, iOS only)
     public var clientCertificate: ClientCertificate?
+    /// Custom HTTP headers sent on every request to this server (e.g. Cloudflare Access service tokens)
+    public var customHeaders: [String: String]?
     public var internalSSIDs: [String]? {
         didSet {
             overrideActiveURLType = nil
@@ -120,7 +122,8 @@ public struct ConnectionInfo: Codable, Equatable {
         isLocalPushEnabled: Bool,
         securityExceptions: SecurityExceptions,
         connectionAccessSecurityLevel: ConnectionSecurityLevel,
-        clientCertificate: ClientCertificate? = nil
+        clientCertificate: ClientCertificate? = nil,
+        customHeaders: [String: String]? = nil
     ) {
         self.externalURL = externalURL
         self.internalURL = internalURL
@@ -134,6 +137,7 @@ public struct ConnectionInfo: Codable, Equatable {
         self.securityExceptions = securityExceptions
         self.connectionAccessSecurityLevel = connectionAccessSecurityLevel
         self.clientCertificate = clientCertificate
+        self.customHeaders = customHeaders
     }
 
     public init(from decoder: Decoder) throws {
@@ -161,6 +165,7 @@ public struct ConnectionInfo: Codable, Equatable {
             ClientCertificate.self,
             forKey: .clientCertificate
         )
+        self.customHeaders = try container.decodeIfPresent([String: String].self, forKey: .customHeaders)
     }
 
     public enum URLType: Int, Codable, CaseIterable, CustomStringConvertible, CustomDebugStringConvertible {
@@ -404,6 +409,16 @@ public struct ConnectionInfo: Codable, Equatable {
     }
 }
 
+extension URLSessionConfiguration {
+    /// Merges custom server headers into the session's additional headers.
+    func apply(customHeaders: [String: String]?) {
+        guard let customHeaders, !customHeaders.isEmpty else { return }
+        var headers = httpAdditionalHeaders ?? [:]
+        customHeaders.forEach { headers[$0.key] = $0.value }
+        httpAdditionalHeaders = headers
+    }
+}
+
 class ServerRequestAdapter: RequestAdapter {
     let server: Server
 
@@ -429,6 +444,10 @@ class ServerRequestAdapter: RequestAdapter {
                 Current.Log.error("ActiveURL was not avaiable when ServerRequestAdapter adapt was called")
                 completion(.failure(ServerConnectionError.noActiveURL(server.info.name)))
             }
+        }
+
+        server.info.connection.customHeaders?.forEach { name, value in
+            updatedRequest.setValue(value, forHTTPHeaderField: name)
         }
 
         completion(.success(updatedRequest))

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -103,13 +103,18 @@ public class HomeAssistantAPI {
             let certificateProvider = HomeAssistantCertificateProvider(server: server)
             let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
             let configuration = URLSessionConfiguration.ephemeral
+            configuration.apply(customHeaders: server.info.connection.customHeaders)
             hakitURLSession = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
         } else {
             Current.Log.info("[mTLS] Using default URLSession for HAKit")
-            hakitURLSession = URLSession(configuration: .ephemeral)
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.apply(customHeaders: server.info.connection.customHeaders)
+            hakitURLSession = URLSession(configuration: configuration)
         }
         #else
-        let hakitURLSession = URLSession(configuration: .ephemeral)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.apply(customHeaders: server.info.connection.customHeaders)
+        let hakitURLSession = URLSession(configuration: configuration)
         #endif
 
         let underlyingConnection = HAKit.connection(

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -245,6 +245,7 @@ extension ServerInfo {
         info.connection.webhookSecret = nil
         info.connection.securityExceptions = .init()
         info.connection.clientCertificate = nil
+        info.connection.customHeaders = nil
         return info
     }
 

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -551,6 +551,9 @@ public class WebhookManager: NSObject {
 
             var urlRequest = try URLRequest(url: webhookURL, method: .post)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            server.info.connection.customHeaders?.forEach { name, value in
+                urlRequest.setValue(value, forHTTPHeaderField: name)
+            }
 
             let jsonObject = Mapper<WebhookRequest>(context: WebhookRequestContext.server(server)).toJSON(request)
             let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.sortedKeys])

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3222,6 +3222,20 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "settings.connection_section.connection_access_security_level.undefined.title") }
         }
       }
+      public enum CustomHeaders {
+        /// Add Header
+        public static var add: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.add") }
+        /// Edit Header
+        public static var editTitle: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.edit_title") }
+        /// Headers added to every request sent to this server. Useful for proxy authentication (e.g. Cloudflare Access service tokens).
+        public static var footer: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.footer") }
+        /// Custom Request Headers
+        public static var header: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.header") }
+        /// Header Name
+        public static var namePlaceholder: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.name_placeholder") }
+        /// Value
+        public static var valuePlaceholder: String { return L10n.tr("Localizable", "settings.connection_section.custom_headers.value_placeholder") }
+      }
       public enum DeleteServer {
         /// Are you sure you wish to delete this server?
         public static var message: String { return L10n.tr("Localizable", "settings.connection_section.delete_server.message") }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -701,6 +701,85 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(info.invitationURL(), remoteURL)
     }
 
+    // MARK: - Custom Headers
+
+    func testCustomHeadersCodableRoundTrip() throws {
+        var info = ConnectionInfo(
+            externalURL: URL(string: "http://example.com:8123"),
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined,
+            customHeaders: ["CF-Access-Client-Id": "abc123", "X-Custom": "value"]
+        )
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let data = try encoder.encode(info)
+        let decoded = try decoder.decode(ConnectionInfo.self, from: data)
+
+        XCTAssertEqual(decoded.customHeaders, info.customHeaders)
+    }
+
+    func testCustomHeadersNilByDefault() throws {
+        let info = ConnectionInfo(
+            externalURL: URL(string: "http://example.com:8123"),
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined
+        )
+
+        XCTAssertNil(info.customHeaders)
+
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(ConnectionInfo.self, from: data)
+        XCTAssertNil(decoded.customHeaders)
+    }
+
+    func testURLSessionConfigurationApplyCustomHeaders() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.apply(customHeaders: ["Foo": "Bar", "X-Token": "abc"])
+
+        let headers = configuration.httpAdditionalHeaders as? [String: String]
+        XCTAssertEqual(headers?["Foo"], "Bar")
+        XCTAssertEqual(headers?["X-Token"], "abc")
+    }
+
+    func testURLSessionConfigurationApplyNilCustomHeaders() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.apply(customHeaders: nil)
+        XCTAssertNil(configuration.httpAdditionalHeaders)
+    }
+
+    func testURLSessionConfigurationApplyEmptyCustomHeaders() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.apply(customHeaders: [:])
+        XCTAssertNil(configuration.httpAdditionalHeaders)
+    }
+
+    func testURLSessionConfigurationApplyDoesNotOverwriteExistingHeaders() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpAdditionalHeaders = ["User-Agent": "MyApp/1.0"]
+        configuration.apply(customHeaders: ["X-Token": "abc"])
+
+        let headers = configuration.httpAdditionalHeaders as? [String: String]
+        XCTAssertEqual(headers?["User-Agent"], "MyApp/1.0")
+        XCTAssertEqual(headers?["X-Token"], "abc")
+    }
+
     func testInvitationURLForInternal() {
         let internalURL = URL(string: "http://internal.com:8123")
         let info = ConnectionInfo(

--- a/Tests/Shared/Server.test.swift
+++ b/Tests/Shared/Server.test.swift
@@ -171,4 +171,14 @@ class ServerTests: XCTestCase {
         XCTAssertFalse(mirrored.connection.securityExceptions.hasExceptions)
         XCTAssertNil(mirrored.connection.clientCertificate)
     }
+
+    func testMirroredForPersistenceRemovesCustomHeaders() {
+        var info = ServerInfo.fake()
+        info.connection.customHeaders = ["CF-Access-Client-Id": "abc123", "CF-Access-Client-Secret": "secret"]
+
+        let mirrored = info.mirroredForPersistence
+
+        XCTAssertNil(mirrored.connection.customHeaders)
+        XCTAssertNotNil(info.connection.customHeaders, "original should be unmodified")
+    }
 }


### PR DESCRIPTION
Work In Progress: 

This change requires changes to HAKit before its ready.

https://github.com/home-assistant/HAKit/pull/104

## Summary

  Adds support for configuring custom HTTP headers per server connection. Headers are sent on every outbound request to that server across all transport layers: Alamofire REST calls, HAKit WebSocket
  upgrade handshake, WKWebView page loads, and webhook requests.

  The primary use case is proxy authentication in front of Home Assistant — for example, [Cloudflare Access service tokens](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/)
  (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) — but the implementation is general purpose and supports any header-based auth or telemetry proxy.

  Headers are configured per-server in **Settings → [Server] → Custom Request Headers** with add, edit, and delete support. They are stored alongside other server credentials and stripped from the GRDB
   persistence mirror alongside other secrets (webhook ID, client certificate, etc.).

  **Note:** Initial onboarding authentication (`/auth/token`) does not carry custom headers, as no server configuration exists at that point. The expected setup flow is to onboard on a local network
  first, then add headers for external access.

  ## Screenshots
  <!-- Screenshots of the Custom Request Headers UI in light and dark mode -->

  ## Link to pull request in Documentation repository

  Documentation: home-assistant/companion.home-assistant#

  ## Any other notes
  
  Headers are injected at four layers:
  - **Alamofire** — via the existing `ServerRequestAdapter` interceptor
  - **HAKit WebSocket** — via `URLSessionConfiguration.httpAdditionalHeaders` before session creation
  - **WKWebView** — via a new `urlRequest(for:)` helper on `WebViewController`
  - **Webhooks** — directly on the `URLRequest` in `WebhookManager`