### PR TITLE
Use macOS release workflow token

### DIFF
--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -80,6 +80,7 @@ jobs:
           TARGET_COMMIT_SHA: ${{ steps.parse_tag.outputs.commit_sha }}
           DISTRIBUTE_RUN_ID: ${{ inputs.distribute_run_id || '' }}
         with:
+          github-token: ${{ secrets.MAC_RELEASE_WORKFLOW_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -250,6 +251,7 @@ jobs:
         env:
           DISTRIBUTE_RUN_ID: ${{ steps.find_run.outputs.run_id }}
         with:
+          github-token: ${{ secrets.MAC_RELEASE_WORKFLOW_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -280,7 +282,7 @@ jobs:
           run-id: ${{ steps.find_run.outputs.run_id }}
           name: ${{ steps.find_artifact.outputs.artifact_name }}
           path: release-artifact/extracted
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.MAC_RELEASE_WORKFLOW_TOKEN }}
 
       - name: Prepare release asset
         id: download_asset
@@ -308,6 +310,7 @@ jobs:
           RELEASE_NAME: ${{ steps.parse_tag.outputs.version }} (${{ steps.parse_tag.outputs.display_build }})
           TARGET_COMMIT_SHA: ${{ steps.parse_tag.outputs.commit_sha }}
         with:
+          github-token: ${{ secrets.MAC_RELEASE_WORKFLOW_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -375,6 +378,7 @@ jobs:
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
           UPLOAD_URL: ${{ steps.release.outputs.upload_url }}
         with:
+          github-token: ${{ secrets.MAC_RELEASE_WORKFLOW_TOKEN }}
           script: |
             const fs = require('fs');
             const owner = context.repo.owner;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Use the `MAC_RELEASE_WORKFLOW_TOKEN` secret for the macOS release workflow GitHub API calls.

The tag-triggered macOS release workflow can fail to discover Distribute workflow runs when using the default `GITHUB_TOKEN`, even though the run exists and can be fetched by a personal token. This updates the GitHub API and artifact download steps to use the dedicated release token secret for:

- finding the matching Distribute run
- resolving and downloading the macOS artifact
- creating or updating the GitHub Release
- replacing and uploading the macOS release asset

