### PR TITLE
Fix iOS 15 WebView top bar safe area

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+WebViewSetup.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebViewSetup.swift
@@ -31,6 +31,12 @@ extension WebViewController {
         if edgeToEdge {
             webViewTopConstraint = webView.topAnchor.constraint(equalTo: view.topAnchor)
             statusBarView.isHidden = true
+        } else if #unavailable(iOS 16.0), !Current.isCatalyst {
+            webViewTopConstraint = webView.topAnchor.constraint(
+                equalTo: view.topAnchor,
+                constant: DesignSystem.Spaces.two
+            )
+            statusBarView.isHidden = false
         } else {
             webViewTopConstraint = webView.topAnchor.constraint(equalTo: statusBarView.bottomAnchor)
             statusBarView.isHidden = false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Fix oversized Home Assistant dashboard top spacing on iOS 15 WebViews by avoiding the inflated safe-area spacer in the normal WebView layout.

On iOS 15 only, when the app is not in edge-to-edge/fullscreen mode and not running as Catalyst, the WebView is now pinned to the top of the screen with a fixed `DesignSystem.Spaces.two` offset. iOS 16+, Catalyst, edge-to-edge, and fullscreen keep their existing behavior.

## Screenshots
Not available. This targets iOS 15 devices that are not available locally.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Root cause: affected iOS 15 devices can report an oversized top safe-area inset, which makes the existing native status spacer too tall and pushes the WebView content down.

Related issues: #4499 and #4631.

Validation:
- `git diff --check`
- Attempted `bundle exec fastlane autocorrect`, but this checkout is missing `../Pods/SwiftFormat/CommandLineTool/swiftformat`
- Attempted `xcodebuild build-for-testing -workspace HomeAssistant.xcworkspace -scheme Tests-Unit -destination 'generic/platform=iOS Simulator'`, but the local checkout is missing CocoaPods artifacts/modules such as `HAKit`, `PromiseKit`, `RealmSwift`, `GRDB`, `SFSafeSymbols`, and Pods metadata plist files