### PR TITLE
Fix iOS 15 safe-area inflation breaking WebView layout and taps

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
@@ -28,7 +28,15 @@ extension WebViewController {
             }
         )
 
-        addChild(emptyState.hostingViewController)
+        // On iOS 16+, parenting the empty state's UIHostingController as a child of self lets the
+        // SwiftUI safe-area plumbing reflect the real layout (#4572). On iOS 15 the same call
+        // triggers a UIKit safe-area-inflation bug that oversizes the native statusBarView and
+        // breaks WKWebView hit-testing for the entire WebViewController (#4499). Skip the
+        // child-VC parenting on iOS 15 — the empty state still renders, it just doesn't get the
+        // iOS-16-specific SwiftUI safe-area propagation #4572 added.
+        if #available(iOS 16.0, *) {
+            addChild(emptyState.hostingViewController)
+        }
         view.addSubview(emptyState)
 
         emptyState.translatesAutoresizingMaskIntoConstraints = false
@@ -42,7 +50,9 @@ extension WebViewController {
 
         emptyState.alpha = 0
         emptyStateView = emptyState
-        emptyState.hostingViewController.didMove(toParent: self)
+        if #available(iOS 16.0, *) {
+            emptyState.hostingViewController.didMove(toParent: self)
+        }
     }
 
     func emptyStateStyle(for connectionState: FrontEndConnectionState) -> WebViewEmptyStateStyle {

--- a/Sources/App/Kiosk/KioskModeManager.swift
+++ b/Sources/App/Kiosk/KioskModeManager.swift
@@ -172,11 +172,15 @@ public final class KioskModeManager: ObservableObject {
 
         guard let viewController = webViewController as? UIViewController else { return }
 
-        // Setup secret exit gesture overlay (always available when kiosk mode is active)
-        setupSecretExitGesture(in: viewController)
-
-        // Apply initial state if already in kiosk mode
+        // The secret-exit gesture overlay is only installed while kiosk mode is actually active —
+        // see enableKioskMode(). Installing it unconditionally regressed iOS 15: adding a full-screen
+        // child UIViewController whose subtree contains a UIHostingController to a WebViewController
+        // hosted in a UINavigationController with hidden nav bar triggers a UIKit safe-area
+        // inflation bug that oversizes the native statusBarView and breaks WKWebView hit-testing
+        // (issue #4499).
         if isKioskModeActive {
+            tearDownSecretExitGesture()
+            setupSecretExitGesture(in: viewController)
             updateKioskModeLockdown(enabled: true)
         }
     }
@@ -222,6 +226,12 @@ public final class KioskModeManager: ObservableObject {
         applyBrightness()
         startIdleTimer()
 
+        // Install the secret-exit gesture overlay only while kiosk mode is active so it doesn't
+        // affect WebView safe-area / hit-testing during normal use.
+        if let viewController = webViewController as? UIViewController {
+            setupSecretExitGesture(in: viewController)
+        }
+
         updateKioskModeLockdown(enabled: true)
         notifyObserversOfModeChange()
     }
@@ -257,6 +267,10 @@ public final class KioskModeManager: ObservableObject {
 
         // Hide screensaver if active
         hideScreensaver(source: "kiosk_disabled")
+
+        // Tear down the secret-exit gesture overlay so its child VC + UIHostingController stop
+        // covering the WebView.
+        tearDownSecretExitGesture()
 
         updateKioskModeLockdown(enabled: false)
         notifyObserversOfModeChange()
@@ -488,6 +502,8 @@ public final class KioskModeManager: ObservableObject {
     // MARK: - Secret Exit Gesture
 
     private func setupSecretExitGesture(in parentController: UIViewController) {
+        guard secretExitGestureController == nil else { return }
+
         let controller = KioskSecretExitGestureViewController()
         secretExitGestureController = controller
 
@@ -507,6 +523,14 @@ public final class KioskModeManager: ObservableObject {
         ])
 
         controller.didMove(toParent: parentController)
+    }
+
+    private func tearDownSecretExitGesture() {
+        guard let controller = secretExitGestureController else { return }
+        controller.willMove(toParent: nil)
+        controller.view.removeFromSuperview()
+        controller.removeFromParent()
+        secretExitGestureController = nil
     }
 
     // MARK: - UI Lockdown

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -117,7 +117,10 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.emptyStateView?.showsErrorDetailsButton, true)
     }
 
-    func testSetupEmptyStateAddsHostingControllerAsChild() {
+    func testSetupEmptyStateAddsHostingControllerAsChild() throws {
+        // The parent-child relationship is intentionally only established on iOS 16+ — on iOS 15 it
+        // triggers a UIKit safe-area-inflation bug that breaks WKWebView hit-testing (#4499).
+        guard #available(iOS 16.0, *) else { throw XCTSkip("iOS 16+ only by design (#4499)") }
         let sut = makeSUT()
 
         sut.setupEmptyState()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On iOS 15, when a WebViewController is hosted in a UINavigationController with the navigation bar hidden, adding a full-screen child UIViewController whose subtree contains a UIHostingController triggers a UIKit safe-area inflation bug: view.safeAreaInsets.top becomes roughly twice the real status-bar height, the native statusBarView (pinned to view.safeAreaLayoutGuide.topAnchor) oversizes, and WKWebView caches a hit-test region from the inflated value — so taps near the top of the page (e.g. the dashboard hamburger menu) land at the wrong content coordinates until the device is rotated. iOS 16+ is unaffected.

Two callsites on main triggered this independently:

1. KioskSecretExitGestureViewController was installed unconditionally from KioskModeManager.setup(using:) — even when kiosk mode wasn't active. Now installed in enableKioskMode() and torn down in disableKioskMode(); setup() only re-anchors it for an already-active kiosk session.

2. WebViewController+EmptyState.setupEmptyState() called addChild(emptyState.hostingViewController) unconditionally (added in #4572 for iOS-16 SwiftUI safe-area propagation). The addChild + didMove(toParent:) calls are now guarded with #available(iOS 16.0, *). The empty state still renders on iOS 15; it just skips the parenting that iOS 15 doesn't honor the same way anyway.

Updated the related test to XCTSkip on iOS 15 with a comment pointing at this commit.

Fixes #4499.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
