### PR TITLE
Add Assist VAD timing settings

### DIFF
--- a/Sources/App/Assist/AssistConfiguration.swift
+++ b/Sources/App/Assist/AssistConfiguration.swift
@@ -25,6 +25,14 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
         vadSilenceSeconds != nil || vadTimeoutSeconds != nil
     }
 
+    var vadAudioOptions: AssistPipelineAudioOptions {
+        guard isCustomVadSettingsEnabled else { return .init() }
+        return .init(
+            vadSilenceSeconds: vadSilenceSeconds ?? Self.defaultVadSilenceSeconds,
+            vadTimeoutSeconds: vadTimeoutSeconds ?? Self.defaultVadTimeoutSeconds
+        )
+    }
+
     /// Custom row initializer to handle NULL values from migrated columns.
     init(row: Row) throws {
         self.id = row[DatabaseTables.AssistConfiguration.id.rawValue]

--- a/Sources/App/Assist/AssistConfiguration.swift
+++ b/Sources/App/Assist/AssistConfiguration.swift
@@ -7,12 +7,23 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
     /// Singleton ID for the configuration (only one row in the database)
     static let singletonID = "assist_config"
 
+    static let defaultVadSilenceSeconds = 0.7
+    static let defaultVadTimeoutSeconds = 15.0
+    static let vadSilenceSecondsRange = 0.1...5.0
+    static let vadTimeoutSecondsRange = 1.0...120.0
+
     var id: String = AssistConfiguration.singletonID
     var enableOnDeviceSTT: Bool = false
     var onDeviceSTTLocaleIdentifier: String? = nil
     var muteTTS: Bool = false
     var enableOnDeviceTTS: Bool = false
     var onDeviceTTSVoiceIdentifier: String? = nil
+    var vadSilenceSeconds: Double? = nil
+    var vadTimeoutSeconds: Double? = nil
+
+    var isCustomVadSettingsEnabled: Bool {
+        vadSilenceSeconds != nil || vadTimeoutSeconds != nil
+    }
 
     /// Custom row initializer to handle NULL values from migrated columns.
     init(row: Row) throws {
@@ -22,6 +33,8 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
         self.muteTTS = row[DatabaseTables.AssistConfiguration.muteTTS.rawValue] ?? false
         self.enableOnDeviceTTS = row[DatabaseTables.AssistConfiguration.enableOnDeviceTTS.rawValue] ?? false
         self.onDeviceTTSVoiceIdentifier = row[DatabaseTables.AssistConfiguration.onDeviceTTSVoiceIdentifier.rawValue]
+        self.vadSilenceSeconds = row[DatabaseTables.AssistConfiguration.vadSilenceSeconds.rawValue]
+        self.vadTimeoutSeconds = row[DatabaseTables.AssistConfiguration.vadTimeoutSeconds.rawValue]
     }
 
     init(
@@ -30,7 +43,9 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
         onDeviceSTTLocaleIdentifier: String? = nil,
         muteTTS: Bool = false,
         enableOnDeviceTTS: Bool = false,
-        onDeviceTTSVoiceIdentifier: String? = nil
+        onDeviceTTSVoiceIdentifier: String? = nil,
+        vadSilenceSeconds: Double? = nil,
+        vadTimeoutSeconds: Double? = nil
     ) {
         self.id = id
         self.enableOnDeviceSTT = enableOnDeviceSTT
@@ -38,6 +53,8 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
         self.muteTTS = muteTTS
         self.enableOnDeviceTTS = enableOnDeviceTTS
         self.onDeviceTTSVoiceIdentifier = onDeviceTTSVoiceIdentifier
+        self.vadSilenceSeconds = vadSilenceSeconds
+        self.vadTimeoutSeconds = vadTimeoutSeconds
     }
 
     static var config: AssistConfiguration {
@@ -54,6 +71,16 @@ struct AssistConfiguration: Codable, Identifiable, Equatable, PersistableRecord,
             Current.Log.error("Failed to fetch AssistConfiguration: \(error)")
             assertionFailure("Failed to fetch AssistConfiguration: \(error)")
             return AssistConfiguration()
+        }
+    }
+
+    mutating func setCustomVadSettingsEnabled(_ enabled: Bool) {
+        if enabled {
+            vadSilenceSeconds = vadSilenceSeconds ?? Self.defaultVadSilenceSeconds
+            vadTimeoutSeconds = vadTimeoutSeconds ?? Self.defaultVadTimeoutSeconds
+        } else {
+            vadSilenceSeconds = nil
+            vadTimeoutSeconds = nil
         }
     }
 

--- a/Sources/App/Assist/AssistSettingsView.swift
+++ b/Sources/App/Assist/AssistSettingsView.swift
@@ -31,6 +31,39 @@ struct AssistSettingsView: View {
         )
     }
 
+    private var customVadSettingsBinding: Binding<Bool> {
+        Binding(
+            get: {
+                viewModel.configuration.isCustomVadSettingsEnabled
+            },
+            set: { isEnabled in
+                viewModel.configuration.setCustomVadSettingsEnabled(isEnabled)
+            }
+        )
+    }
+
+    private var vadSilenceSecondsBinding: Binding<Double> {
+        Binding(
+            get: {
+                viewModel.configuration.vadSilenceSeconds ?? AssistConfiguration.defaultVadSilenceSeconds
+            },
+            set: { newValue in
+                viewModel.configuration.vadSilenceSeconds = newValue
+            }
+        )
+    }
+
+    private var vadTimeoutSecondsBinding: Binding<Double> {
+        Binding(
+            get: {
+                viewModel.configuration.vadTimeoutSeconds ?? AssistConfiguration.defaultVadTimeoutSeconds
+            },
+            set: { newValue in
+                viewModel.configuration.vadTimeoutSeconds = newValue
+            }
+        )
+    }
+
     private var selectedVoiceDisplayName: String {
         guard let id = viewModel.configuration.onDeviceTTSVoiceIdentifier,
               let voice = AVSpeechSynthesisVoice(identifier: id) else {
@@ -47,6 +80,7 @@ struct AssistSettingsView: View {
         NavigationView {
             Form {
                 muteToggle
+                voiceDetection
                 experimental
             }
             .onChange(of: viewModel.configuration.enableOnDeviceSTT) { isEnabled in
@@ -76,6 +110,42 @@ struct AssistSettingsView: View {
             })
         } footer: {
             Text(L10n.Assist.Settings.TtsMute.footer)
+        }
+    }
+
+    private var voiceDetection: some View {
+        Section {
+            Toggle(isOn: customVadSettingsBinding) {
+                toggleLabel(symbol: .micFill, text: L10n.Assist.Settings.VoiceDetection.customToggle)
+            }
+
+            if viewModel.configuration.isCustomVadSettingsEnabled {
+                Stepper(
+                    value: vadSilenceSecondsBinding,
+                    in: AssistConfiguration.vadSilenceSecondsRange,
+                    step: 0.1
+                ) {
+                    valueLabel(
+                        title: L10n.Assist.Settings.VoiceDetection.silenceSeconds,
+                        value: formattedSeconds(vadSilenceSecondsBinding.wrappedValue, fractionDigits: 1)
+                    )
+                }
+
+                Stepper(
+                    value: vadTimeoutSecondsBinding,
+                    in: AssistConfiguration.vadTimeoutSecondsRange,
+                    step: 1
+                ) {
+                    valueLabel(
+                        title: L10n.Assist.Settings.VoiceDetection.timeoutSeconds,
+                        value: formattedSeconds(vadTimeoutSecondsBinding.wrappedValue, fractionDigits: 0)
+                    )
+                }
+            }
+        } header: {
+            Text(L10n.Assist.Settings.VoiceDetection.title)
+        } footer: {
+            Text(L10n.Assist.Settings.VoiceDetection.footer)
         }
     }
 
@@ -120,6 +190,22 @@ struct AssistSettingsView: View {
                 }
             }
         }
+    }
+
+    private func valueLabel(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formattedSeconds(_ value: Double, fractionDigits: Int) -> String {
+        if fractionDigits == 0 {
+            return String(format: "%.0f s", value)
+        }
+        return String(format: "%.1f s", value)
     }
 
     private func toggleLabel(symbol: SFSymbol, text: String) -> some View {

--- a/Sources/App/Assist/AssistSettingsView.swift
+++ b/Sources/App/Assist/AssistSettingsView.swift
@@ -202,10 +202,7 @@ struct AssistSettingsView: View {
     }
 
     private func formattedSeconds(_ value: Double, fractionDigits: Int) -> String {
-        if fractionDigits == 0 {
-            return String(format: "%.0f s", value)
-        }
-        return String(format: "%.1f s", value)
+        String(format: "%.\(fractionDigits)f s", value)
     }
 
     private func toggleLabel(symbol: SFSymbol, text: String) -> some View {

--- a/Sources/App/Assist/AssistViewModel.swift
+++ b/Sources/App/Assist/AssistViewModel.swift
@@ -168,7 +168,11 @@ final class AssistViewModel: NSObject, ObservableObject {
             source: .audio(
                 pipelineId: preferredPipelineId.isEmpty ? pipelines.first?.id : preferredPipelineId,
                 audioSampleRate: audioSampleRate,
-                tts: !configuration.muteTTS && !configuration.enableOnDeviceTTS
+                tts: !configuration.muteTTS && !configuration.enableOnDeviceTTS,
+                options: .init(
+                    vadSilenceSeconds: configuration.vadSilenceSeconds,
+                    vadTimeoutSeconds: configuration.vadTimeoutSeconds
+                )
             )
         )
     }

--- a/Sources/App/Assist/AssistViewModel.swift
+++ b/Sources/App/Assist/AssistViewModel.swift
@@ -169,10 +169,7 @@ final class AssistViewModel: NSObject, ObservableObject {
                 pipelineId: preferredPipelineId.isEmpty ? pipelines.first?.id : preferredPipelineId,
                 audioSampleRate: audioSampleRate,
                 tts: !configuration.muteTTS && !configuration.enableOnDeviceTTS,
-                options: .init(
-                    vadSilenceSeconds: configuration.vadSilenceSeconds,
-                    vadTimeoutSeconds: configuration.vadTimeoutSeconds
-                )
+                options: configuration.vadAudioOptions
             )
         )
     }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -151,6 +151,11 @@
 "assist.settings.title" = "Assist Settings";
 "assist.settings.tts_mute.footer" = "When enabled, Assist will not play audio responses even if the pipeline has text-to-speech configured. You will still see text responses.";
 "assist.settings.tts_mute.toggle" = "Mute voice responses";
+"assist.settings.voice_detection.custom_toggle" = "Customize voice detection";
+"assist.settings.voice_detection.footer" = "Applies when Assist sends microphone audio to Home Assistant. Leave this off to use Home Assistant defaults.";
+"assist.settings.voice_detection.silence_seconds" = "End-of-speech silence";
+"assist.settings.voice_detection.timeout_seconds" = "Command timeout";
+"assist.settings.voice_detection.title" = "Voice detection";
 "assist.watch.mic_button.title" = "Tap to";
 "assist.watch.not_reachable.title" = "Assist requires iPhone connectivity. Your iPhone is currently unreachable.";
 "assist.watch.volume.title" = "Volume control";

--- a/Sources/Shared/Database/DatabaseTables.swift
+++ b/Sources/Shared/Database/DatabaseTables.swift
@@ -190,6 +190,8 @@ public enum DatabaseTables {
         case muteTTS
         case enableOnDeviceTTS
         case onDeviceTTSVoiceIdentifier
+        case vadSilenceSeconds
+        case vadTimeoutSeconds
     }
 
     // Kiosk mode settings (stored as JSON blob)

--- a/Sources/Shared/Database/Tables/AssistConfigurationTable.swift
+++ b/Sources/Shared/Database/Tables/AssistConfigurationTable.swift
@@ -20,6 +20,8 @@ struct AssistConfigurationTable: DatabaseTableProtocol {
                     table.column(DatabaseTables.AssistConfiguration.muteTTS.rawValue, .boolean)
                     table.column(DatabaseTables.AssistConfiguration.enableOnDeviceTTS.rawValue, .boolean)
                     table.column(DatabaseTables.AssistConfiguration.onDeviceTTSVoiceIdentifier.rawValue, .text)
+                    table.column(DatabaseTables.AssistConfiguration.vadSilenceSeconds.rawValue, .double)
+                    table.column(DatabaseTables.AssistConfiguration.vadTimeoutSeconds.rawValue, .double)
                 }
             }
         } else {

--- a/Sources/Shared/Intents/AppIntent/AssistInApp/AssistRequests.swift
+++ b/Sources/Shared/Intents/AppIntent/AssistInApp/AssistRequests.swift
@@ -8,14 +8,23 @@ public enum AssistRequests {
         audioSampleRate: Double,
         conversationId: String?,
         hassDeviceId: String?,
-        tts: Bool
+        tts: Bool,
+        options: AssistPipelineAudioOptions = .init()
     ) -> HATypedSubscription<AssistResponse> {
+        var input: [String: Any] = [
+            "sample_rate": audioSampleRate,
+        ]
+        if let vadSilenceSeconds = options.vadSilenceSeconds {
+            input["vad_silence_seconds"] = vadSilenceSeconds
+        }
+        if let vadTimeoutSeconds = options.vadTimeoutSeconds {
+            input["vad_timeout_seconds"] = vadTimeoutSeconds
+        }
+
         var data: [String: Any] = [
             "start_stage": "stt",
             "end_stage": tts ? "tts" : "intent",
-            "input": [
-                "sample_rate": audioSampleRate,
-            ],
+            "input": input,
         ]
         if let preferredPipelineId {
             data["pipeline"] = preferredPipelineId

--- a/Sources/Shared/Intents/AppIntent/AssistInApp/AssistService.swift
+++ b/Sources/Shared/Intents/AppIntent/AssistInApp/AssistService.swift
@@ -24,16 +24,35 @@ public protocol AssistServiceDelegate: AnyObject {
     func didReceiveError(code: String, message: String)
 }
 
+public struct AssistPipelineAudioOptions: Equatable {
+    public let vadSilenceSeconds: Double?
+    public let vadTimeoutSeconds: Double?
+
+    public init(vadSilenceSeconds: Double? = nil, vadTimeoutSeconds: Double? = nil) {
+        self.vadSilenceSeconds = vadSilenceSeconds
+        self.vadTimeoutSeconds = vadTimeoutSeconds
+    }
+}
+
 public enum AssistSource: Equatable {
     case text(input: String, pipelineId: String?, expectTTS: Bool)
-    case audio(pipelineId: String?, audioSampleRate: Double, tts: Bool)
+    case audio(
+        pipelineId: String?,
+        audioSampleRate: Double,
+        tts: Bool,
+        options: AssistPipelineAudioOptions = .init()
+    )
 
     public static func == (lhs: AssistSource, rhs: AssistSource) -> Bool {
         switch (lhs, rhs) {
         case let (.text(lhsInput, lhsPipelineId, lhsExpectTTS), .text(rhsInput, rhsPipelineId, rhsExpectTTS)):
             return lhsInput == rhsInput && lhsPipelineId == rhsPipelineId && lhsExpectTTS == rhsExpectTTS
-        case let (.audio(lhsPipelineId, lhsSampleRate, lhsTTS), .audio(rhsPipelineId, rhsSampleRate, rhsTTS)):
+        case let (
+            .audio(lhsPipelineId, lhsSampleRate, lhsTTS, lhsOptions),
+            .audio(rhsPipelineId, rhsSampleRate, rhsTTS, rhsOptions)
+        ):
             return lhsPipelineId == rhsPipelineId && lhsSampleRate == rhsSampleRate && lhsTTS == rhsTTS
+                && lhsOptions == rhsOptions
         default:
             return false
         }
@@ -77,8 +96,8 @@ public final class AssistService: AssistServiceProtocol {
         switch source {
         case let .text(input, pipelineId, expectTTS):
             assistWithText(input: input, pipelineId: pipelineId, expectTTS: expectTTS)
-        case let .audio(pipelineId, audioSampleRate, tts):
-            assistWithAudio(pipelineId: pipelineId, audioSampleRate: audioSampleRate, tts: tts)
+        case let .audio(pipelineId, audioSampleRate, tts, options):
+            assistWithAudio(pipelineId: pipelineId, audioSampleRate: audioSampleRate, tts: tts, options: options)
         }
     }
 
@@ -122,14 +141,20 @@ public final class AssistService: AssistServiceProtocol {
         }
     }
 
-    private func assistWithAudio(pipelineId: String?, audioSampleRate: Double, tts: Bool) {
+    private func assistWithAudio(
+        pipelineId: String?,
+        audioSampleRate: Double,
+        tts: Bool,
+        options: AssistPipelineAudioOptions
+    ) {
         lastPipelineIdUsed = pipelineId
         Current.api(for: server)?.connection.subscribe(to: AssistRequests.assistByVoiceTypedSubscription(
             preferredPipelineId: pipelineId,
             audioSampleRate: audioSampleRate,
             conversationId: conversationId,
             hassDeviceId: server.info.hassDeviceId,
-            tts: tts
+            tts: tts,
+            options: options
         )) { [weak self] cancellable, data in
             guard let self else { return }
             self.cancellable = cancellable

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -649,6 +649,18 @@ public enum L10n {
         /// Mute voice responses
         public static var toggle: String { return L10n.tr("Localizable", "assist.settings.tts_mute.toggle") }
       }
+      public enum VoiceDetection {
+        /// Customize voice detection
+        public static var customToggle: String { return L10n.tr("Localizable", "assist.settings.voice_detection.custom_toggle") }
+        /// Applies when Assist sends microphone audio to Home Assistant. Leave this off to use Home Assistant defaults.
+        public static var footer: String { return L10n.tr("Localizable", "assist.settings.voice_detection.footer") }
+        /// End-of-speech silence
+        public static var silenceSeconds: String { return L10n.tr("Localizable", "assist.settings.voice_detection.silence_seconds") }
+        /// Command timeout
+        public static var timeoutSeconds: String { return L10n.tr("Localizable", "assist.settings.voice_detection.timeout_seconds") }
+        /// Voice detection
+        public static var title: String { return L10n.tr("Localizable", "assist.settings.voice_detection.title") }
+      }
     }
     public enum Watch {
       public enum MicButton {

--- a/Tests/App/Assist/AssistViewModel.test.swift
+++ b/Tests/App/Assist/AssistViewModel.test.swift
@@ -90,7 +90,28 @@ final class AssistViewModelTests: XCTestCase {
     func testDidStartRecording() {
         sut.preferredPipelineId = "2"
         sut.didStartRecording(with: 16000)
-        XCTAssertEqual(mockAssistService.assistSource, .audio(pipelineId: "2", audioSampleRate: 16000.0, tts: true))
+        XCTAssertEqual(
+            mockAssistService.assistSource,
+            .audio(pipelineId: "2", audioSampleRate: 16000.0, tts: true, options: .init())
+        )
+    }
+
+    func testDidStartRecordingUsesCustomVadSettings() {
+        sut.preferredPipelineId = "2"
+        sut.configuration.vadSilenceSeconds = 1.2
+        sut.configuration.vadTimeoutSeconds = 45
+
+        sut.didStartRecording(with: 16000)
+
+        XCTAssertEqual(
+            mockAssistService.assistSource,
+            .audio(
+                pipelineId: "2",
+                audioSampleRate: 16000.0,
+                tts: true,
+                options: .init(vadSilenceSeconds: 1.2, vadTimeoutSeconds: 45)
+            )
+        )
     }
 
     func testDidStopRecording() {

--- a/Tests/App/Assist/AssistViewModel.test.swift
+++ b/Tests/App/Assist/AssistViewModel.test.swift
@@ -114,6 +114,56 @@ final class AssistViewModelTests: XCTestCase {
         )
     }
 
+    func testDidStartRecordingNormalizesPartialVadSettings() {
+        sut.preferredPipelineId = "2"
+        sut.configuration.vadSilenceSeconds = 1.2
+
+        sut.didStartRecording(with: 16000)
+
+        XCTAssertEqual(
+            mockAssistService.assistSource,
+            .audio(
+                pipelineId: "2",
+                audioSampleRate: 16000.0,
+                tts: true,
+                options: .init(
+                    vadSilenceSeconds: 1.2,
+                    vadTimeoutSeconds: AssistConfiguration.defaultVadTimeoutSeconds
+                )
+            )
+        )
+    }
+
+    func testVoiceSubscriptionOmitsVadSettingsByDefault() throws {
+        let subscription = AssistRequests.assistByVoiceTypedSubscription(
+            preferredPipelineId: nil,
+            audioSampleRate: 16000,
+            conversationId: nil,
+            hassDeviceId: nil,
+            tts: true
+        )
+
+        let input = try XCTUnwrap(subscription.request.data["input"] as? [String: Any])
+        XCTAssertEqual(input["sample_rate"] as? Double, 16000)
+        XCTAssertNil(input["vad_silence_seconds"])
+        XCTAssertNil(input["vad_timeout_seconds"])
+    }
+
+    func testVoiceSubscriptionIncludesVadSettings() throws {
+        let subscription = AssistRequests.assistByVoiceTypedSubscription(
+            preferredPipelineId: nil,
+            audioSampleRate: 16000,
+            conversationId: nil,
+            hassDeviceId: nil,
+            tts: true,
+            options: .init(vadSilenceSeconds: 1.2, vadTimeoutSeconds: 45)
+        )
+
+        let input = try XCTUnwrap(subscription.request.data["input"] as? [String: Any])
+        XCTAssertEqual(input["vad_silence_seconds"] as? Double, 1.2)
+        XCTAssertEqual(input["vad_timeout_seconds"] as? Double, 45)
+    }
+
     func testDidStopRecording() {
         sut.didStopRecording()
         XCTAssertFalse(sut.isRecording)


### PR DESCRIPTION
Adds optional VAD silence and timeout settings for iOS Assist voice input.

Pairs with home-assistant/core#122177.