### PR TITLE
Ask iOS location permission popup for "less secure" connection level as well

### DIFF
--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationView.swift
@@ -77,12 +77,7 @@ struct OnboardingPermissionsNavigationView: View {
             case .mostSecure:
                 viewModel.requestLocationPermissionForSecureLocalConnection()
             case .lessSecure:
-                viewModel.setLessSecureLocalConnection()
-                if viewModel.steps.contains(.completion) {
-                    viewModel.navigateToStep(.completion)
-                } else if viewModel.steps.contains(.updatePreferencesSuccess) {
-                    viewModel.navigateToStep(.updatePreferencesSuccess)
-                }
+                viewModel.requestLocationPermissionForLessSecureLocalConnection()
             }
         }
     }

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
@@ -48,6 +48,8 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
         case shareWithHomeAssistant
         /// Location permission is being requested for secure local network connections
         case secureLocalConnection
+        /// Location permission is being requested so iOS records the user's less secure local connection decision
+        case lessSecureLocalConnection
     }
 
     // MARK: - Published Properties
@@ -184,6 +186,13 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
         requestLocationPermission()
     }
 
+    /// Requests location permission specifically for less secure local network connections
+    /// - Note: Sets context to lessSecureLocalConnection before requesting permission
+    func requestLocationPermissionForLessSecureLocalConnection() {
+        locationPermissionContext = .lessSecureLocalConnection
+        requestLocationPermission()
+    }
+
     /// Configures the server for less secure local connections (when location permission is denied)
     /// - Note: Sets security level to .lessSecure as fallback option
     func setLessSecureLocalConnection() {
@@ -212,6 +221,10 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
     private func requestLocationPermission() {
         switch Current.location.permissionStatus {
         case .denied, .restricted:
+            guard locationPermissionContext != .lessSecureLocalConnection else {
+                applyLocationPermissionNeeds()
+                return
+            }
             // Open iOS settings for user to manually enable location
             if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
                 URLOpener.shared.open(settingsUrl, options: [:], completionHandler: nil)
@@ -241,7 +254,23 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
             }
         }
 
+        if locationPermissionContext == .lessSecureLocalConnection {
+            setLessSecureLocalConnection()
+            navigatePastLocalAccessConfiguration()
+            return
+        }
+
         nextStep()
+    }
+
+    private func navigatePastLocalAccessConfiguration() {
+        if steps.contains(.completion) {
+            navigateToStep(.completion)
+        } else if steps.contains(.updatePreferencesSuccess) {
+            navigateToStep(.updatePreferencesSuccess)
+        } else {
+            nextStep()
+        }
     }
 }
 
@@ -262,6 +291,9 @@ extension OnboardingPermissionsNavigationViewModel: CLLocationManagerDelegate {
         case .denied:
             // User explicitly denied location access - disable related sensors
             disableLocationSensor()
+            if locationPermissionContext == .lessSecureLocalConnection {
+                applyLocationPermissionNeeds()
+            }
         case .authorizedAlways:
             // Full location access granted - no additional action needed
             break

--- a/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
+++ b/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
@@ -244,6 +244,15 @@ struct OnboardingPermissionsNavigationViewModelTests {
         #expect(server.info.connection.connectionAccessSecurityLevel == .lessSecure)
     }
 
+    @Test("Request location permission for less secure local connection")
+    func requestLocationPermissionForLessSecureLocalConnection() async throws {
+        let server = ServerFixture.standard
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        viewModel.requestLocationPermissionForLessSecureLocalConnection()
+        #expect(viewModel.locationPermissionContext == .lessSecureLocalConnection)
+    }
+
     @Test("Disable location sensor")
     func disableLocationSensor() async throws {
         let server = ServerFixture.standard
@@ -308,6 +317,9 @@ struct OnboardingPermissionsNavigationViewModelTests {
         viewModel.locationPermissionContext = .secureLocalConnection
         #expect(viewModel.locationPermissionContext == .secureLocalConnection)
 
+        viewModel.locationPermissionContext = .lessSecureLocalConnection
+        #expect(viewModel.locationPermissionContext == .lessSecureLocalConnection)
+
         viewModel.locationPermissionContext = .notRequested
         #expect(viewModel.locationPermissionContext == .notRequested)
     }
@@ -352,6 +364,39 @@ struct OnboardingPermissionsNavigationViewModelLocationDelegateTests {
         // Should disable location sensor
         let locationPrivacy = server.info.setting(for: .locationPrivacy)
         #expect(locationPrivacy == .never)
+    }
+
+    @Test("Location manager authorization change - denied after less secure selection advances")
+    func locationManagerAuthorizationChangeDeniedAfterLessSecureSelectionAdvances() async throws {
+        let server = ServerFixture.standard
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+        viewModel.navigateToStep(.localAccess)
+        viewModel.locationPermissionContext = .lessSecureLocalConnection
+
+        let mockLocationManager = MockCLLocationManager()
+        mockLocationManager.authorizationStatus = .denied
+
+        viewModel.locationManagerDidChangeAuthorization(mockLocationManager)
+
+        #expect(server.info.setting(for: .locationPrivacy) == .never)
+        #expect(server.info.connection.connectionAccessSecurityLevel == .lessSecure)
+        #expect(viewModel.currentStep == .completion)
+    }
+
+    @Test("Location manager authorization change - when in use after less secure selection advances")
+    func locationManagerAuthorizationChangeWhenInUseAfterLessSecureSelectionAdvances() async throws {
+        let server = ServerFixture.standard
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+        viewModel.navigateToStep(.localAccess)
+        viewModel.locationPermissionContext = .lessSecureLocalConnection
+
+        let mockLocationManager = MockCLLocationManager()
+        mockLocationManager.authorizationStatus = .authorizedWhenInUse
+
+        viewModel.locationManagerDidChangeAuthorization(mockLocationManager)
+
+        #expect(server.info.connection.connectionAccessSecurityLevel == .lessSecure)
+        #expect(viewModel.currentStep == .completion)
     }
 
     @Test("Location manager authorization change - not determined")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When the user chooses to not share location with Home Assistant + Less secure connection security level, they never see the iOS native location permission popup, which keeps their location permission state as ".notDetermined" entering in loop until selected "Most secure" and choosing an option from the popup.

This PR triggers the popup for both connection security level options, therefore avoiding the non determined state after the user makes its decision.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
