### PR TITLE
Fix Live Activity ContentState decoding and Direct push delegate

### DIFF
--- a/Sources/App/Notifications/NotificationManagerLocalPushInterfaceDirect.swift
+++ b/Sources/App/Notifications/NotificationManagerLocalPushInterfaceDirect.swift
@@ -14,6 +14,7 @@ class NotificationManagerLocalPushInterfaceDirect: NotificationManagerLocalPushI
         self.localPushDelegate = delegate
         self.localPushManagers = .init { [weak self] server in
             let manager = LocalPushManager(server: server)
+            manager.delegate = self?.localPushDelegate
             let token = NotificationCenter.default.addObserver(
                 forName: LocalPushManager.stateDidChange,
                 object: manager,

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -97,6 +97,42 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             self.icon = icon
             self.color = color
         }
+
+        // MARK: - Codable
+
+        // ActivityKit decodes content-state with the default JSONDecoder, which
+        // treats `Date` as seconds since 2001-01-01. HA core sends Unix epoch
+        // seconds, so map countdownEnd manually via timeIntervalSince1970 to
+        // avoid a ~31-year offset. The encoder is symmetric for round-tripping.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            message = try container.decode(String.self, forKey: .message)
+            criticalText = try container.decodeIfPresent(String.self, forKey: .criticalText)
+            progress = try container.decodeIfPresent(Int.self, forKey: .progress)
+            progressMax = try container.decodeIfPresent(Int.self, forKey: .progressMax)
+            chronometer = try container.decodeIfPresent(Bool.self, forKey: .chronometer)
+            if let timestamp = try container.decodeIfPresent(Double.self, forKey: .countdownEnd) {
+                countdownEnd = Date(timeIntervalSince1970: timestamp)
+            } else {
+                countdownEnd = nil
+            }
+            icon = try container.decodeIfPresent(String.self, forKey: .icon)
+            color = try container.decodeIfPresent(String.self, forKey: .color)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(message, forKey: .message)
+            try container.encodeIfPresent(criticalText, forKey: .criticalText)
+            try container.encodeIfPresent(progress, forKey: .progress)
+            try container.encodeIfPresent(progressMax, forKey: .progressMax)
+            try container.encodeIfPresent(chronometer, forKey: .chronometer)
+            if let countdownEnd {
+                try container.encode(countdownEnd.timeIntervalSince1970, forKey: .countdownEnd)
+            }
+            try container.encodeIfPresent(icon, forKey: .icon)
+            try container.encodeIfPresent(color, forKey: .color)
+        }
     }
 
     // MARK: - Init

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -106,18 +106,18 @@ public struct HALiveActivityAttributes: ActivityAttributes {
         // avoid a ~31-year offset. The encoder is symmetric for round-tripping.
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            message = try container.decode(String.self, forKey: .message)
-            criticalText = try container.decodeIfPresent(String.self, forKey: .criticalText)
-            progress = try container.decodeIfPresent(Int.self, forKey: .progress)
-            progressMax = try container.decodeIfPresent(Int.self, forKey: .progressMax)
-            chronometer = try container.decodeIfPresent(Bool.self, forKey: .chronometer)
+            self.message = try container.decode(String.self, forKey: .message)
+            self.criticalText = try container.decodeIfPresent(String.self, forKey: .criticalText)
+            self.progress = try container.decodeIfPresent(Int.self, forKey: .progress)
+            self.progressMax = try container.decodeIfPresent(Int.self, forKey: .progressMax)
+            self.chronometer = try container.decodeIfPresent(Bool.self, forKey: .chronometer)
             if let timestamp = try container.decodeIfPresent(Double.self, forKey: .countdownEnd) {
-                countdownEnd = Date(timeIntervalSince1970: timestamp)
+                self.countdownEnd = Date(timeIntervalSince1970: timestamp)
             } else {
-                countdownEnd = nil
+                self.countdownEnd = nil
             }
-            icon = try container.decodeIfPresent(String.self, forKey: .icon)
-            color = try container.decodeIfPresent(String.self, forKey: .color)
+            self.icon = try container.decodeIfPresent(String.self, forKey: .icon)
+            self.color = try container.decodeIfPresent(String.self, forKey: .color)
         }
 
         public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
## Summary

Follow-up fixes to two issues surfaced while testing #4671 end-to-end.

1. **`HALiveActivityAttributes.ContentState.countdownEnd` decoded via Unix epoch.** ActivityKit decodes the `content-state` JSON arriving via APNs with the default `JSONDecoder`, whose `Date` strategy is `.deferredToDate` (seconds since the 2001 reference date). HA core sends `countdown_end` as Unix epoch seconds, matching the documented `data.when` / `data.when_relative` user contract and the in-app handler that already does `Date(timeIntervalSince1970:)`. Without a manual decode the APNs push path renders countdowns ~31 years in the future. Adds explicit `init(from:)` and `encode(to:)` that map `countdownEnd` via `timeIntervalSince1970`. All other fields use `container.decodeIfPresent` so behavior is unchanged for them.

2. **`NotificationManagerLocalPushInterfaceDirect` assigns `LocalPushManager.delegate`.** The Extension path assigns the delegate at line 197; the Direct path (used on simulator and Mac Catalyst) never did. On those platforms that meant silent commands such as `clear_notification` (no alert title/body) were dropped: iOS doesn't fire `willPresent` for content-less notifications, and the delegate is the only fallback that routes into `commandManager`. One-line fix that brings the Direct factory into line with the Extension's behavior.

Real-device verification (iPhone 13 Mini, iOS 26.5, paid Developer account): chronometer countdown rendered correctly 60→0 with the Codable fix in place. Without it the timer rendered as if `Date` were seconds-since-2001.

## Screenshots

n/a — both fixes affect decode / message routing behavior, not UI rendering.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#1303

## Any other notes

Part of the Live Activities effort tracked in home-assistant/epics#61. Companion server PR: home-assistant/core#166072.