### PR TITLE
Communicate to frontend when matter commissioning finishes

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
@@ -71,4 +71,5 @@ enum WebViewExternalBusOutgoingMessage: String, CaseIterable {
     case improvDiscoveredDevice = "improv/discovered_device"
     case improvDiscoveredDeviceSetupDone = "improv/device_setup_done"
     case navigate = "navigate"
+    case matterCommissionFinish = "matter/commission/finish"
 }

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
@@ -35,6 +35,7 @@ enum WebViewExternalBusMessage: String, CaseIterable {
             "hasSettingsScreen": !Current.isCatalyst,
             "canWriteTag": Current.tags.isNFCAvailable,
             "canCommissionMatter": Current.matter.isAvailable,
+            "hasMatterStatusReport": Current.matter.isAvailable,
             "canImportThreadCredentials": Current.matter.threadCredentialsSharingEnabled,
             "hasBarCodeScanner": true,
             "canTransferThreadCredentialsToKeychain": Current.matter

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -471,8 +471,16 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             Current.Log.error("WebViewController not available while commissioning matter device")
             return
         }
-        Current.matter.commission(webViewController.server).done {
-            Current.Log.info("Commission call completed")
+        Current.matter.commission(webViewController.server).done { [weak self] deviceName in
+            Current.Log.info("Commission call completed with device name: \(String(describing: deviceName))")
+            guard let deviceName else {
+                Current.Log.error("Matter commission completed without a device name")
+                return
+            }
+            self?.sendExternalBus(message: .init(
+                command: WebViewExternalBusOutgoingMessage.matterCommissionFinish.rawValue,
+                payload: ["name": deviceName]
+            ))
         }.catch { [weak self] error in
             // we don't show a user-visible error because even a successful operation will return 'cancelled'
             // but the errors aren't public, so we can't compare -- the apple ui shows errors visually though

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -473,14 +473,8 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
         }
         Current.matter.commission(webViewController.server).done { [weak self] deviceName in
             Current.Log.info("Commission call completed with device name: \(String(describing: deviceName))")
-            guard let deviceName else {
-                Current.Log.error("Matter commission completed without a device name")
-                return
-            }
             self?.communicateMatterCommissioningFinished(deviceName: deviceName, success: true)
         }.catch { [weak self] error in
-            // we don't show a user-visible error because even a successful operation will return 'cancelled'
-            // but the errors aren't public, so we can't compare -- the apple ui shows errors visually though
             Current.Log.error(error)
             self?.communicateMatterCommissioningFinished(deviceName: nil, success: false)
         }

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -477,16 +477,23 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
                 Current.Log.error("Matter commission completed without a device name")
                 return
             }
-            self?.sendExternalBus(message: .init(
-                command: WebViewExternalBusOutgoingMessage.matterCommissionFinish.rawValue,
-                payload: ["name": deviceName]
-            ))
+            self?.communicateMatterCommissioningFinished(deviceName: deviceName, success: true)
         }.catch { [weak self] error in
             // we don't show a user-visible error because even a successful operation will return 'cancelled'
             // but the errors aren't public, so we can't compare -- the apple ui shows errors visually though
             Current.Log.error(error)
-            self?.webViewController?.refresh()
+            self?.communicateMatterCommissioningFinished(deviceName: nil, success: false)
         }
+    }
+
+    private func communicateMatterCommissioningFinished(deviceName: String?, success: Bool) {
+        sendExternalBus(message: .init(
+            command: WebViewExternalBusOutgoingMessage.matterCommissionFinish.rawValue,
+            payload: [
+                "name": deviceName,
+                "success": success,
+            ]
+        ))
     }
 
     func showAssist(server: Server, pipeline: String = "", autoStartRecording: Bool = false) {

--- a/Sources/Extensions/Matter/MatterRequestHandler.swift
+++ b/Sources/Extensions/Matter/MatterRequestHandler.swift
@@ -83,6 +83,6 @@ class MatterRequestHandler: MatterAddDeviceExtensionRequestHandler {
     }
 
     override func configureDevice(named name: String, in room: MatterAddDeviceRequest.Room?) async {
-        // Use this function to configure the (now) commissioned device with the given name and room.
+        Current.settingsStore.matterLastCommissionedDeviceName = name
     }
 }

--- a/Sources/Shared/Environment/MatterWrapper.swift
+++ b/Sources/Shared/Environment/MatterWrapper.swift
@@ -49,25 +49,30 @@ public class MatterWrapper {
         set { Current.settingsStore.prefs.set(newValue?.rawValue, forKey: "lastCommissionServerID") }
     }
 
-    public lazy var commission: (_ server: Server) -> Promise<Void> = { [self] server in
+    public lazy var commission: (_ server: Server) -> Promise<String?> = { [self] server in
         #if canImport(MatterSupport)
         guard #available(iOS 16.4, *) else {
-            return .value(())
+            return .value(nil)
         }
 
         lastCommissionServerIdentifier = server.identifier
+        Current.settingsStore.matterLastCommissionedDeviceName = nil
 
         let request = MatterAddDeviceRequest(
             topology: .init(ecosystemName: "Home Assistant", homes: []),
             shouldScanNetworks: true
         )
 
-        return Promise<Void> { seal in
+        return Promise<String?> { seal in
             Task {
                 do {
                     try await request.perform()
+                    let deviceName = Current.settingsStore.matterLastCommissionedDeviceName
+                    // Reset device name after reading it, so that if the user tries to pair another device without
+                    // going through the flow again, we won't have a stale name hanging around
+                    Current.settingsStore.matterLastCommissionedDeviceName = nil
                     Current.Log.info("Matter pairing finished (native flow manually closed or pairing succeeded)")
-                    seal.fulfill(())
+                    seal.fulfill(deviceName)
                 } catch {
                     Current.Log.error("Matter pairing failed: \(error)")
                     seal.reject(error)
@@ -75,7 +80,7 @@ public class MatterWrapper {
             }
         }
         #else
-        return .value(())
+        return .value(nil)
         #endif
     }
     #endif

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -78,6 +78,15 @@ public class SettingsStore {
         }
     }
 
+    public var matterLastCommissionedDeviceName: String? {
+        get {
+            keychain["matterLastCommissionedDeviceName"]
+        }
+        set {
+            keychain["matterLastCommissionedDeviceName"] = newValue
+        }
+    }
+
     public func isLocationEnabled(for state: UIApplication.State) -> Bool {
         let authorizationStatus: CLAuthorizationStatus
 

--- a/Tests/App/WebView/Mocks/MockWebViewController.swift
+++ b/Tests/App/WebView/Mocks/MockWebViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import HomeAssistant
 import Shared
 import UIKit
+import XCTest
 
 final class MockWebViewController: WebViewControllerProtocol {
     var webViewExternalMessageHandler: WebViewExternalMessageHandlerProtocol
@@ -17,6 +18,7 @@ final class MockWebViewController: WebViewControllerProtocol {
     var evaluateJavaScriptCalled = false
     var lastEvaluatedJavaScriptScript: String?
     var lastEvaluatedJavaScriptCompletion: ((Any?, (any Error)?) -> Void)?
+    var evaluateJavaScriptExpectation: XCTestExpectation?
     var dismissControllerAboveOverlayControllerCalled = false
     var dismissOverlayControllerCalled = false
     var dismissOverlayControllerLastAnimated = false
@@ -69,6 +71,7 @@ final class MockWebViewController: WebViewControllerProtocol {
         evaluateJavaScriptCalled = true
         lastEvaluatedJavaScriptScript = script
         lastEvaluatedJavaScriptCompletion = completion
+        evaluateJavaScriptExpectation?.fulfill()
     }
 
     func dismissOverlayController(animated: Bool, completion: (() -> Void)?) {

--- a/Tests/App/WebView/WebViewExternalBusMessageTests.swift
+++ b/Tests/App/WebView/WebViewExternalBusMessageTests.swift
@@ -53,8 +53,12 @@ final class WebViewExternalBusMessageTests: XCTestCase {
             WebViewExternalBusOutgoingMessage.navigate.rawValue,
             "navigate"
         )
+        XCTAssertEqual(
+            WebViewExternalBusOutgoingMessage.matterCommissionFinish.rawValue,
+            "matter/commission/finish"
+        )
 
-        XCTAssertEqual(WebViewExternalBusOutgoingMessage.allCases.count, 7)
+        XCTAssertEqual(WebViewExternalBusOutgoingMessage.allCases.count, 8)
     }
 
     @MainActor func testConfigResultIncludesAllExpectedKeys() {

--- a/Tests/App/WebView/WebViewExternalBusMessageTests.swift
+++ b/Tests/App/WebView/WebViewExternalBusMessageTests.swift
@@ -69,6 +69,7 @@ final class WebViewExternalBusMessageTests: XCTestCase {
             "hasSettingsScreen",
             "canWriteTag",
             "canCommissionMatter",
+            "hasMatterStatusReport",
             "canImportThreadCredentials",
             "hasBarCodeScanner",
             "canTransferThreadCredentialsToKeychain",

--- a/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
@@ -1,18 +1,29 @@
 @testable import HomeAssistant
 import Improv_iOS
+import PromiseKit
+@testable import Shared
 import SwiftUI
 import XCTest
 
 final class WebViewExternalMessageHandlerTests: XCTestCase {
     private var sut: WebViewExternalMessageHandler!
     private var mockWebViewController: MockWebViewController!
+    private var originalMatterCommission: ((Server) -> Promise<String?>)!
 
     override func setUp() async throws {
+        originalMatterCommission = Current.matter.commission
         mockWebViewController = MockWebViewController()
         sut = WebViewExternalMessageHandler(
             improvManager: ImprovManager.shared
         )
         sut.webViewController = mockWebViewController
+    }
+
+    override func tearDown() async throws {
+        Current.matter.commission = originalMatterCommission
+        originalMatterCommission = nil
+        sut = nil
+        mockWebViewController = nil
     }
 
     @MainActor func testHandleExternalMessageConfigScreenShowShowSettings() {
@@ -157,6 +168,31 @@ final class WebViewExternalMessageHandlerTests: XCTestCase {
         XCTAssertEqual(mockWebViewController.overlayedController?.view.backgroundColor, .clear)
     }
 
+    @MainActor func testHandleExternalMessageMatterCommissionSendsFinishMessageWithDeviceName() throws {
+        let deviceName = "Kitchen Plug"
+        let expectation = expectation(description: "Matter commission finish message sent")
+        mockWebViewController.evaluateJavaScriptExpectation = expectation
+        Current.matter.commission = { _ in .value(deviceName) }
+
+        let dictionary: [String: Any] = [
+            "id": 1,
+            "message": "",
+            "command": "",
+            "type": "matter/commission",
+        ]
+
+        sut.handleExternalMessage(dictionary)
+
+        wait(for: [expectation], timeout: 1)
+        let script = try XCTUnwrap(mockWebViewController.lastEvaluatedJavaScriptScript)
+        let message = try externalBusMessage(from: script)
+        let payload = try XCTUnwrap(message["payload"] as? [String: Any])
+
+        XCTAssertEqual(message["type"] as? String, "command")
+        XCTAssertEqual(message["command"] as? String, WebViewExternalBusOutgoingMessage.matterCommissionFinish.rawValue)
+        XCTAssertEqual(payload["name"] as? String, deviceName)
+    }
+
     @MainActor func testHandleExternalMessageShowAssistShowsAssist() {
         let dictionary: [String: Any] = [
             "id": 1,
@@ -182,6 +218,16 @@ final class WebViewExternalMessageHandlerTests: XCTestCase {
 
         XCTAssertNotNil(mockWebViewController.overlayedController)
         XCTAssertEqual(mockWebViewController.overlayedController?.modalPresentationStyle, .overFullScreen)
+    }
+
+    private func externalBusMessage(from script: String) throws -> [String: Any] {
+        let prefix = "window.externalBus("
+        XCTAssertTrue(script.hasPrefix(prefix))
+        XCTAssertTrue(script.hasSuffix(")"))
+
+        let jsonString = String(script.dropFirst(prefix.count).dropLast())
+        let jsonObject = try JSONSerialization.jsonObject(with: Data(jsonString.utf8))
+        return try XCTUnwrap(jsonObject as? [String: Any])
     }
 
     @MainActor func testHandleExternalMessageCameraPlayerShowPresentsCameraPlayer() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
- This PR adds a frontend bus command to communicate when matter commissioning finishes and also provides the device name chosen by the user during the Apple matter flow
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
