### PR TITLE
Add push commands to open or hide full screen camera view

### DIFF
--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'Sources/PushServer/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -14,11 +14,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Import Swift signing keys
-        run: curl -sSL https://www.swift.org/keys/all-keys.asc | gpg --import -
       - uses: fwal/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9  # v3
         with:
           swift-version: "5.8"
+          skip-verify-signature: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run Tests
         run: swift test

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -14,11 +14,6 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: fwal/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9  # v3
-        with:
-          swift-version: "5.8"
-          skip-verify-signature: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run Tests
-        run: swift test
-        working-directory: Sources/PushServer
+        run: docker run --rm -v "$PWD:/workspace" -w /workspace/Sources/PushServer swift:5.8-jammy swift test

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Import Swift signing keys
+        run: curl -sSL https://www.swift.org/keys/all-keys.asc | gpg --import -
       - uses: fwal/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9  # v3
         with:
           swift-version: "5.8"

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: fwal/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9  # v3
         with:

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -274,6 +274,8 @@
 		11ADB13E24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADB13D24C29E6900FF5EB2 /* ZoneManagerRegionFilter.swift */; };
 		11ADF940267D34B10040A7E3 /* NotificationsCommandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADF93E267D34AD0040A7E3 /* NotificationsCommandManager.swift */; };
 		11ADF941267D34B20040A7E3 /* NotificationsCommandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADF93E267D34AD0040A7E3 /* NotificationsCommandManager.swift */; };
+		11ADF942267D34B20040A7E3 /* HandlerShowCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADF93F267D34AD0040A7E3 /* HandlerShowCamera.swift */; };
+		11ADF943267D34B20040A7E3 /* HandlerHideCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11ADF944267D34AD0040A7E3 /* HandlerHideCamera.swift */; };
 		11AF4D13249C7E08006C74C0 /* ActivitySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */; };
 		11AF4D14249C7E09006C74C0 /* ActivitySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */; };
 		11AF4D16249C8083006C74C0 /* With.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF4D15249C8082006C74C0 /* With.swift */; };
@@ -3145,6 +3147,8 @@
 		A95FDD092F6B89C6008EF72F /* HALiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HALiveActivityAttributes.swift; sourceTree = "<group>"; };
 		A95FDD0A2F6B89C6008EF72F /* LiveActivityRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityRegistry.swift; sourceTree = "<group>"; };
 		A95FDD0E2F6B8A19008EF72F /* HandlerLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlerLiveActivity.swift; sourceTree = "<group>"; };
+		11ADF93F267D34AD0040A7E3 /* HandlerShowCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlerShowCamera.swift; sourceTree = "<group>"; };
+		11ADF944267D34AD0040A7E3 /* HandlerHideCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlerHideCamera.swift; sourceTree = "<group>"; };
 		A95FDD102F6B8A3E008EF72F /* HADynamicIslandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HADynamicIslandView.swift; sourceTree = "<group>"; };
 		A95FDD112F6B8A3E008EF72F /* HALiveActivityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HALiveActivityConfiguration.swift; sourceTree = "<group>"; };
 		A95FDD122F6B8A3E008EF72F /* HALockScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HALockScreenView.swift; sourceTree = "<group>"; };
@@ -4211,6 +4215,8 @@
 			isa = PBXGroup;
 			children = (
 				A95FDD0E2F6B8A19008EF72F /* HandlerLiveActivity.swift */,
+				11ADF93F267D34AD0040A7E3 /* HandlerShowCamera.swift */,
+				11ADF944267D34AD0040A7E3 /* HandlerHideCamera.swift */,
 				11ADF93E267D34AD0040A7E3 /* NotificationsCommandManager.swift */,
 			);
 			path = NotificationCommands;
@@ -10288,6 +10294,8 @@
 				B6B74CBD228399AB00D58A68 /* Action.swift in Sources */,
 				428DC00A2F0CAAE7003B08D5 /* EntityProvider+Details.swift in Sources */,
 				A95FDD0F2F6B8A19008EF72F /* HandlerLiveActivity.swift in Sources */,
+				11ADF942267D34B20040A7E3 /* HandlerShowCamera.swift in Sources */,
+				11ADF943267D34B20040A7E3 /* HandlerHideCamera.swift in Sources */,
 				11CB98CA249E62E700B05222 /* Version+HA.swift in Sources */,
 				420F53EA2C4E9D54003C8415 /* WidgetsKind.swift in Sources */,
 				11EE9B4924C5116F00404AF8 /* LegacyModelManager.swift in Sources */,

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -22,6 +22,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
     }()
 
     var commandManager = NotificationCommandManager()
+    private weak var cameraOverlayController: UIViewController?
 
     override init() {
         super.init()
@@ -29,6 +30,18 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
             self,
             selector: #selector(didBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showCameraFromNotification(_:)),
+            name: NotificationCommandManager.didReceiveShowCameraNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(hideCameraFromNotification),
+            name: NotificationCommandManager.didReceiveHideCameraNotification,
             object: nil
         )
     }
@@ -42,6 +55,106 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         if Current.settingsStore.clearBadgeAutomatically {
             UIApplication.shared.applicationIconBadgeNumber = 0
         }
+    }
+
+    @objc private func showCameraFromNotification(_ notification: Notification) {
+        guard UIApplication.shared.applicationState == .active else {
+            scheduleShowCameraFallbackNotification(userInfo: notification.userInfo)
+            return
+        }
+
+        openCamera(from: notification.userInfo)
+    }
+
+    private func openCamera(from userInfo: [AnyHashable: Any]?) {
+        guard #available(iOS 16.0, *) else {
+            Current.Log.info("Ignoring show_camera push command because camera player requires iOS 16")
+            return
+        }
+
+        guard let entityId = cameraEntityId(from: userInfo) else {
+            Current.Log.error("Received show_camera push command without a valid camera entity_id")
+            return
+        }
+
+        Current.sceneManager.webViewWindowControllerPromise.then(\.webViewControllerPromise)
+            .done { webViewController in
+                let view = CameraPlayerView(
+                    server: webViewController.server,
+                    cameraEntityId: entityId
+                ).embeddedInHostingController()
+                self.cameraOverlayController = view
+                view.modalPresentationStyle = .overFullScreen
+                webViewController.presentOverlayController(controller: view, animated: true)
+            }.catch { error in
+                Current.Log.error("Failed to show camera from push command: \(error)")
+            }
+    }
+
+    private func scheduleShowCameraFallbackNotification(userInfo: [AnyHashable: Any]?) {
+        guard let entityId = cameraEntityId(from: userInfo) else {
+            Current.Log.error("Received show_camera push command without a valid camera entity_id")
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.body = "Tap to open camera"
+        content.sound = .default
+        content.userInfo = [
+            "homeassistant": [
+                "command": "show_camera",
+                "entity_id": entityId,
+            ],
+        ]
+
+        Current.userNotificationCenter.add(UNNotificationRequest(
+            identifier: "show_camera.\(entityId)",
+            content: content,
+            trigger: nil
+        )) { error in
+            if let error {
+                Current.Log.error("Failed to schedule show_camera fallback notification: \(error)")
+            }
+        }
+    }
+
+    private func cameraEntityId(from userInfo: [AnyHashable: Any]?) -> String? {
+        guard let userInfo else { return nil }
+
+        if let entityId = userInfo["entity_id"] as? String, entityId.hasPrefix("camera.") {
+            return entityId
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [String: Any],
+           let entityId = homeassistant["entity_id"] as? String,
+           entityId.hasPrefix("camera.") {
+            return entityId
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [AnyHashable: Any],
+           let entityId = homeassistant["entity_id"] as? String,
+           entityId.hasPrefix("camera.") {
+            return entityId
+        }
+
+        return nil
+    }
+
+    @objc private func hideCameraFromNotification() {
+        Current.sceneManager.webViewWindowControllerPromise.then(\.webViewControllerPromise)
+            .done { webViewController in
+                guard let cameraOverlayController = self.cameraOverlayController,
+                      webViewController.overlayedController === cameraOverlayController else {
+                    Current.Log.info("Ignoring hide_camera push command because no camera is on display")
+                    return
+                }
+
+                webViewController.dismissOverlayController(animated: true) { [weak self] in
+                    self?.cameraOverlayController = nil
+                }
+            }.catch { error in
+                Current.Log.error("Failed to hide camera from push command: \(error)")
+            }
     }
 
     func resetPushID() -> Promise<String> {
@@ -238,6 +351,12 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
 
         Current.Log.verbose("User info in incoming notification \(userInfo) with response \(response)")
 
+        if isShowCameraCommand(userInfo: userInfo), cameraEntityId(from: userInfo) != nil {
+            openCamera(from: userInfo)
+            completionHandler()
+            return
+        }
+
         guard let server = Current.servers.server(for: response.notification.request.content) else {
             Current.Log.info("ignoring push when unable to find server")
             completionHandler()
@@ -276,6 +395,24 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
                 $0.present(carPlayView)
             }
         }
+    }
+
+    private func isShowCameraCommand(userInfo: [AnyHashable: Any]) -> Bool {
+        if userInfo["command"] as? String == "show_camera" {
+            return true
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [String: Any],
+           homeassistant["command"] as? String == "show_camera" {
+            return true
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [AnyHashable: Any],
+           homeassistant["command"] as? String == "show_camera" {
+            return true
+        }
+
+        return false
     }
 
     public func userNotificationCenter(

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -80,7 +80,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         Current.sceneManager.webViewWindowControllerPromise.then(\.webViewControllerPromise)
             .done { webViewController in
                 let view = CameraPlayerView(
-                    server: webViewController.server,
+                    server: self.cameraServer(from: userInfo, fallback: webViewController.server),
                     cameraEntityId: entityId
                 ).embeddedInHostingController()
                 self.cameraOverlayController = view
@@ -98,14 +98,18 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         }
 
         let content = UNMutableNotificationContent()
-        content.body = "Tap to open camera"
+        content.body = L10n.CameraPlayer.Notification.body
         content.sound = .default
-        content.userInfo = [
+        var fallbackUserInfo: [AnyHashable: Any] = [
             "homeassistant": [
                 "command": "show_camera",
                 "entity_id": entityId,
             ],
         ]
+        if let webhookId = webhookId(from: userInfo) {
+            fallbackUserInfo["webhook_id"] = webhookId
+        }
+        content.userInfo = fallbackUserInfo
 
         Current.userNotificationCenter.add(UNNotificationRequest(
             identifier: "show_camera.\(entityId)",
@@ -138,6 +142,33 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         }
 
         return nil
+    }
+
+    private func webhookId(from userInfo: [AnyHashable: Any]?) -> String? {
+        guard let userInfo else { return nil }
+
+        if let webhookId = userInfo["webhook_id"] as? String {
+            return webhookId
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [String: Any] {
+            return homeassistant["webhook_id"] as? String
+        }
+
+        if let homeassistant = userInfo["homeassistant"] as? [AnyHashable: Any] {
+            return homeassistant["webhook_id"] as? String
+        }
+
+        return nil
+    }
+
+    private func cameraServer(from userInfo: [AnyHashable: Any]?, fallback: Server) -> Server {
+        guard let webhookId = webhookId(from: userInfo),
+              let server = Current.servers.server(forWebhookID: webhookId) else {
+            return fallback
+        }
+
+        return server
     }
 
     @objc private func hideCameraFromNotification() {

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "camera_player.errors.no_stream_available" = "No stream available";
 "camera_player.errors.unable_to_connect_to_server" = "Unable to connect to Home Assistant";
 "camera_player.errors.unknown" = "Unknown error";
+"camera_player.notification.body" = "Tap to open camera";
 "cameras.drag_to_reorder" = "Drag and drop to reorder";
 "cameras.no_server_found" = "No server found for camera: %@";
 "cancel_label" = "Cancel";

--- a/Sources/PushServer/SharedPush/Sources/NotificationParserLegacy.swift
+++ b/Sources/PushServer/SharedPush/Sources/NotificationParserLegacy.swift
@@ -80,6 +80,16 @@ public struct LegacyNotificationParserImpl: LegacyNotificationParser {
                 return .init(LegacyNotificationCommandType.updateComplications.rawValue)
             case .updateWidgets:
                 return .init(LegacyNotificationCommandType.updateWidgets.rawValue)
+            case .showCamera:
+                var homeassistant = [String: Any]()
+
+                if let entityId = data["entity_id"] {
+                    homeassistant["entity_id"] = entityId
+                }
+
+                return .init(LegacyNotificationCommandType.showCamera.rawValue, homeassistant: homeassistant)
+            case .hideCamera:
+                return .init(LegacyNotificationCommandType.hideCamera.rawValue)
             default: return nil
             }
         }()
@@ -255,6 +265,8 @@ enum LegacyNotificationCommandType: String {
     case clearNotification = "clear_notification"
     case updateComplications = "update_complications"
     case updateWidgets = "update_widgets"
+    case showCamera = "show_camera"
+    case hideCamera = "hide_camera"
 }
 
 private extension Dictionary where Value == Any {

--- a/Sources/PushServer/Tests/SharedPushTests/notification_test_cases.bundle/command_hide_camera.json
+++ b/Sources/PushServer/Tests/SharedPushTests/notification_test_cases.bundle/command_hide_camera.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "title": "extra excluded title",
+        "message": "hide_camera",
+        "registration_info": {
+            "app_id": "io.robbie.HomeAssistant.dev",
+            "os_version": "10.15",
+            "app_version": "2026.1"
+        }
+    },
+    "rate_limit": false,
+    "headers": {
+        "apns-push-type": "background"
+    },
+    "payload": {
+        "aps": {
+            "contentAvailable": true
+        },
+        "homeassistant": {
+            "command": "hide_camera"
+        }
+    }
+}

--- a/Sources/PushServer/Tests/SharedPushTests/notification_test_cases.bundle/command_show_camera.json
+++ b/Sources/PushServer/Tests/SharedPushTests/notification_test_cases.bundle/command_show_camera.json
@@ -1,0 +1,27 @@
+{
+    "input": {
+        "title": "extra excluded title",
+        "message": "show_camera",
+        "data": {
+            "entity_id": "camera.front_door"
+        },
+        "registration_info": {
+            "app_id": "io.robbie.HomeAssistant.dev",
+            "os_version": "10.15",
+            "app_version": "2026.1"
+        }
+    },
+    "rate_limit": false,
+    "headers": {
+        "apns-push-type": "background"
+    },
+    "payload": {
+        "aps": {
+            "contentAvailable": true
+        },
+        "homeassistant": {
+            "command": "show_camera",
+            "entity_id": "camera.front_door"
+        }
+    }
+}

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerHideCamera.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerHideCamera.swift
@@ -1,0 +1,24 @@
+#if os(iOS)
+import Foundation
+import PromiseKit
+
+struct HandlerHideCamera: NotificationCommandHandler {
+    func handle(_ payload: [String: Any]) -> Promise<Void> {
+        Promise<Void> { seal in
+            let postNotification = {
+                NotificationCenter.default.post(
+                    name: NotificationCommandManager.didReceiveHideCameraNotification,
+                    object: nil
+                )
+                seal.fulfill(())
+            }
+
+            if Thread.isMainThread {
+                postNotification()
+            } else {
+                DispatchQueue.main.async(execute: postNotification)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerShowCamera.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerShowCamera.swift
@@ -1,0 +1,36 @@
+#if os(iOS)
+import Foundation
+import PromiseKit
+
+private enum ShowCameraError: Error {
+    case invalidEntityId
+}
+
+struct HandlerShowCamera: NotificationCommandHandler {
+    func handle(_ payload: [String: Any]) -> Promise<Void> {
+        guard let entityId = payload["entity_id"] as? String, entityId.hasPrefix("camera.") else {
+            Current.Log.error("Received show_camera push command without a valid camera entity_id")
+            return Promise(error: ShowCameraError.invalidEntityId)
+        }
+
+        return Promise<Void> { seal in
+            let postNotification = {
+                NotificationCenter.default.post(
+                    name: NotificationCommandManager.didReceiveShowCameraNotification,
+                    object: nil,
+                    userInfo: payload.reduce(into: [AnyHashable: Any]()) { result, element in
+                        result[element.key] = element.value
+                    }
+                )
+                seal.fulfill(())
+            }
+
+            if Thread.isMainThread {
+                postNotification()
+            } else {
+                DispatchQueue.main.async(execute: postNotification)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -1,4 +1,5 @@
 import Communicator
+import Foundation
 import PromiseKit
 import UserNotifications
 import WidgetKit
@@ -12,6 +13,14 @@ public class NotificationCommandManager {
         .init(rawValue: "didUpdateComplicationsNotification")
     }
 
+    public static var didReceiveShowCameraNotification: Notification.Name {
+        .init(rawValue: "didReceiveShowCameraNotification")
+    }
+
+    public static var didReceiveHideCameraNotification: Notification.Name {
+        .init(rawValue: "didReceiveHideCameraNotification")
+    }
+
     public enum CommandError: Error {
         case notCommand
         case unknownCommand
@@ -22,6 +31,8 @@ public class NotificationCommandManager {
         register(command: "clear_notification", handler: HandlerClearNotification())
         #if os(iOS)
         register(command: "update_complications", handler: HandlerUpdateComplications())
+        register(command: "show_camera", handler: HandlerShowCamera())
+        register(command: "hide_camera", handler: HandlerHideCamera())
         #if !targetEnvironment(macCatalyst)
         if #available(iOS 17.2, *) {
             register(command: "live_activity", handler: HandlerStartOrUpdateLiveActivity())

--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -52,8 +52,12 @@ public class NotificationCommandManager {
     }
 
     public func handle(_ payload: [AnyHashable: Any]) -> Promise<Void> {
-        guard let hadict = payload["homeassistant"] as? [String: Any] else {
+        guard var hadict = payload["homeassistant"] as? [String: Any] else {
             return .init(error: CommandError.notCommand)
+        }
+
+        if let webhookId = payload["webhook_id"] as? String {
+            hadict["webhook_id"] = webhookId
         }
 
         // Support data.live_update: true — the same field Android uses for Live Updates.

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -732,6 +732,10 @@ public enum L10n {
       /// Unknown error
       public static var unknown: String { return L10n.tr("Localizable", "camera_player.errors.unknown") }
     }
+    public enum Notification {
+      /// Tap to open camera
+      public static var body: String { return L10n.tr("Localizable", "camera_player.notification.body") }
+    }
   }
 
   public enum Cameras {

--- a/Sources/SharedPush/Sources/NotificationParserLegacy.swift
+++ b/Sources/SharedPush/Sources/NotificationParserLegacy.swift
@@ -80,6 +80,16 @@ public struct LegacyNotificationParserImpl: LegacyNotificationParser {
                 return .init(LegacyNotificationCommandType.updateComplications.rawValue)
             case .updateWidgets:
                 return .init(LegacyNotificationCommandType.updateWidgets.rawValue)
+            case .showCamera:
+                var homeassistant = [String: Any]()
+
+                if let entityId = data["entity_id"] {
+                    homeassistant["entity_id"] = entityId
+                }
+
+                return .init(LegacyNotificationCommandType.showCamera.rawValue, homeassistant: homeassistant)
+            case .hideCamera:
+                return .init(LegacyNotificationCommandType.hideCamera.rawValue)
             default: return nil
             }
         }()
@@ -279,6 +289,8 @@ enum LegacyNotificationCommandType: String {
     case clearNotification = "clear_notification"
     case updateComplications = "update_complications"
     case updateWidgets = "update_widgets"
+    case showCamera = "show_camera"
+    case hideCamera = "hide_camera"
 }
 
 private extension Dictionary where Value == Any {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds push notification commands to open camera in full screen as well as closing it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1338
FCM: https://github.com/home-assistant/mobile-apps-fcm-push/pull/308

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
