### PR TITLE
Handle malformed device registry entries

### DIFF
--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -362,11 +362,30 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                     continuation.resume(returning: nil)
                     return
                 }
-                api.connection.send(.configDeviceRegistryList()) { result in
+                api.connection.send(HARequest(type: "config/device_registry/list")) { result in
                     switch result {
-                    case let .success(entries):
-                        Current.Log.verbose("Successfully fetched device registry for server \(server.info.name)")
-                        continuation.resume(returning: entries)
+                    case let .success(data):
+                        do {
+                            let entries = try DeviceRegistryEntry.decodeLossyArray(data: data) { skippedEntry in
+                                Current.Log.error(
+                                    "Skipped malformed device registry entry for server \(server.info.name), \(skippedEntry.logDescription)"
+                                )
+                            }
+                            Current.Log.verbose(
+                                "Successfully fetched device registry for server \(server.info.name), entries: \(entries.count)"
+                            )
+                            continuation.resume(returning: entries)
+                        } catch {
+                            Current.Log.error("Failed to decode device registry response: \(error)")
+                            Current.clientEventStore.addEvent(.init(
+                                text: "Failed to decode device registry response on server \(server.info.name)",
+                                type: .networkRequest,
+                                payload: [
+                                    "error": error.localizedDescription,
+                                ]
+                            ))
+                            continuation.resume(returning: nil)
+                        }
                     case let .failure(error):
                         Current.Log.error("Failed to fetch device registry: \(error)")
                         Current.clientEventStore.addEvent(.init(

--- a/Sources/Shared/Environment/DeviceRegistryEntry.swift
+++ b/Sources/Shared/Environment/DeviceRegistryEntry.swift
@@ -51,6 +51,56 @@ public struct DeviceRegistryEntry: Codable, HADataDecodable {
         self.viaDeviceID = try? data.decode("via_device_id")
     }
 
+    static func decodeLossyArray(
+        data: HAData,
+        onSkippedEntry: (SkippedDecode) -> Void
+    ) throws -> [DeviceRegistryEntry] {
+        guard case let .array(entries) = data else {
+            throw HADataError.couldntTransform(key: "root")
+        }
+
+        return entries.enumerated().compactMap { index, entryData in
+            do {
+                return try DeviceRegistryEntry(data: entryData)
+            } catch {
+                onSkippedEntry(.init(index: index, data: entryData, error: error))
+                return nil
+            }
+        }
+    }
+
+    struct SkippedDecode: Equatable {
+        let index: Int
+        let id: String?
+        let name: String?
+        let nameByUser: String?
+        let manufacturer: String?
+        let model: String?
+        let errorDescription: String
+
+        init(index: Int, data: HAData, error: Error) {
+            self.index = index
+            self.id = data.stringValue(for: "id")
+            self.name = data.stringValue(for: "name")
+            self.nameByUser = data.stringValue(for: "name_by_user")
+            self.manufacturer = data.stringValue(for: "manufacturer")
+            self.model = data.stringValue(for: "model")
+            self.errorDescription = String(describing: error)
+        }
+
+        var logDescription: String {
+            [
+                "index: \(index)",
+                "id: \(id ?? "unknown")",
+                "name: \(name ?? "unknown")",
+                "nameByUser: \(nameByUser ?? "unknown")",
+                "manufacturer: \(manufacturer ?? "unknown")",
+                "model: \(model ?? "unknown")",
+                "error: \(errorDescription)",
+            ].joined(separator: ", ")
+        }
+    }
+
     // Computed helpers
     var displayName: String {
         nameByUser ?? name ?? model ?? id
@@ -108,6 +158,22 @@ public struct DeviceRegistryEntry: Codable, HADataDecodable {
         self.viaDeviceID = viaDeviceID
     }
     #endif
+}
+
+private extension HAData {
+    func stringValue(for key: String) -> String? {
+        guard case let .dictionary(dictionary) = self,
+              let value = dictionary[key],
+              !(value is NSNull) else {
+            return nil
+        }
+
+        if let value = value as? String {
+            return value
+        } else {
+            return String(describing: value)
+        }
+    }
 }
 
 // MARK: - Database Model

--- a/Tests/Shared/Models/DeviceRegistry.test.swift
+++ b/Tests/Shared/Models/DeviceRegistry.test.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HAKit
 @testable import Shared
 import Testing
 
@@ -57,5 +58,38 @@ struct DeviceRegistryTests {
         // Validate computed properties
         #expect(firstEntry.displayName == "Home Assistant Core")
         #expect(firstEntry.isDisabled == false)
+    }
+
+    @Test("Lossy decode skips malformed entries and keeps valid devices")
+    func lossyDecodeSkipsMalformedEntries() throws {
+        let data = HAData.array([
+            deviceData(id: "valid-1", name: "Valid One", identifiers: [["mobile_app", "valid-1"]]),
+            deviceData(id: "bad-identifiers", name: "Bad Device", identifiers: ["mobile_app", "bad-identifiers"]),
+            deviceData(id: "valid-2", name: "Valid Two", identifiers: [["mobile_app", "valid-2"]]),
+        ])
+        var skippedEntries: [DeviceRegistryEntry.SkippedDecode] = []
+
+        let entries = try DeviceRegistryEntry.decodeLossyArray(data: data) { skippedEntries.append($0) }
+
+        #expect(entries.map(\.id) == ["valid-1", "valid-2"])
+        #expect(skippedEntries.count == 1)
+        #expect(skippedEntries.first?.index == 1)
+        #expect(skippedEntries.first?.id == "bad-identifiers")
+        #expect(skippedEntries.first?.name == "Bad Device")
+        #expect(skippedEntries.first?.errorDescription.contains("identifiers") == true)
+    }
+
+    private func deviceData(id: String, name: String, identifiers: Any) -> HAData {
+        .dictionary([
+            "config_entries": [],
+            "config_entries_subentries": [:],
+            "connections": [],
+            "created_at": 0.0,
+            "id": id,
+            "identifiers": identifiers,
+            "labels": [],
+            "modified_at": 1.0,
+            "name": name,
+        ])
     }
 }


### PR DESCRIPTION
## Summary

- Fetch the Home Assistant device registry as raw `HAData` and decode entries lossily.
- Skip malformed device entries instead of failing the entire device registry update.
- Log the skipped entry index, id, name, user name, manufacturer, model, and decode error so support can identify the bad device.

## Context

User logs showed device registry updates failing with:

`HADataError.incorrectType(key: "identifiers", expected: "Optional<Array<Array<String>>>", actual: "__NSSingleObjectArrayI")`

Because the registry response was decoded as a typed array, one malformed device blocked persistence for every valid device. This keeps valid devices flowing while still surfacing the malformed entry clearly.
