### PR TITLE
Remove mirror entries when deleting servers

### DIFF
--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -300,16 +300,25 @@ final class ServerManagerImpl: ServerManager {
             cache.remove(identifier: identifier)
         }
 
+        mirrorStore.remove(identifier.keychainKey)
+        var restoredMirroredServers = restoredMirroredServers
+        if restoredMirroredServers.remove(identifier.keychainKey) != nil {
+            self.restoredMirroredServers = restoredMirroredServers
+        }
+
         notify()
     }
 
     public func removeAll() {
+        let allKeys = Set(keychain.allKeys() + mirrorStore.allKeys())
         cache.mutate { cache in
-            let allKeys = Set(keychain.allKeys() + mirrorStore.allKeys())
             cache.deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
             cache.reset()
             _ = try? keychain.removeAll()
         }
+
+        mirrorStore.removeAll()
+        restoredMirroredServers = []
 
         notify()
     }

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -137,6 +137,7 @@ class ServerManagerTests: XCTestCase {
             servers.remove(identifier: "fake1")
         }
         try XCTAssertNil(keychain.getData("fake1"))
+        XCTAssertNil(mirrorStore.data["fake1"])
 
         // grab it, which may also side-effect insert into cache, if buggy
         _ = server1.info
@@ -156,6 +157,7 @@ class ServerManagerTests: XCTestCase {
 
         XCTAssertNil(servers.server(for: "fake1"))
         XCTAssertEqual(servers.all, [server2])
+        XCTAssertNil(mirrorStore.data["fake1"])
 
         var server3: Server!
 
@@ -178,6 +180,7 @@ class ServerManagerTests: XCTestCase {
         XCTAssertNil(servers.server(for: "fake2"))
         XCTAssertNil(servers.server(for: "fake3"))
         XCTAssertTrue(keychain.data.isEmpty)
+        XCTAssertTrue(mirrorStore.data.isEmpty)
 
         expectingObserver {
             servers.restoreState(stateS2S3)
@@ -633,6 +636,10 @@ class ServerManagerTests: XCTestCase {
 
         XCTAssertNil(servers.server(for: "fake1"))
         XCTAssertEqual(server.info.remoteName, info.remoteName)
+        XCTAssertNil(mirrorStore.data["fake1"])
+        XCTAssertFalse(servers.isMirrorRestorePending)
+        XCTAssertFalse(servers.restoreKeychainFromMirrorIfNeeded())
+        XCTAssertNil(try keychain.getData("fake1"))
     }
 
     func testKeychainInfoWinsOverMirrorFallback() throws {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Ensure mirrorStore is kept in sync when servers are removed. ServerManagerImpl now removes per-server mirrorStore entries and updates restoredMirroredServers when removing an identifier, and clears mirrorStore and restoredMirroredServers when removeAll() is called. The allKeys set is captured before mutating the cache so mirror keys are included in deletedServers. Tests updated to assert mirrorStore is cleared and that mirror-restore state behaves as expected.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
