### PR TITLE
  Add TestFlight communication screen when app opens

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -27,6 +27,11 @@
 		01783C74005B40978CE7508B /* NotificationIdentifierField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99EC7EF1136575D0E7A17091 /* NotificationIdentifierField.swift */; };
 		072BACCC5B2509E4AF06BFED /* KioskSettingsTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14444A34DA125693568C7035 /* KioskSettingsTable.swift */; };
 		0907D6244565287ED4E46A3C /* WhatsNewCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09953104F4749B10268B7C61 /* WhatsNewCatalog.swift */; };
+		00345F0517E14EC186DFB25D /* TestFlightCommunicationEngine.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EE842480AD406D8305F377 /* TestFlightCommunicationEngine.test.swift */; };
+		14A4AE0E492F4BADB1E8A3CA /* TestFlightCommunicationCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666F733264F8449E8E7CB985 /* TestFlightCommunicationCatalog.swift */; };
+		639D841C8B7A4154956024A8 /* TestFlightCommunicationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0B01160F7B467E8FE2C7C7 /* TestFlightCommunicationEngine.swift */; };
+		E60778133EC44B10A61D551C /* TestFlightCommunicationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212E30CB76DE4ED1B6E317CD /* TestFlightCommunicationModels.swift */; };
+		027A90037B4049A1AFFF27E3 /* TestFlightCommunicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C389A0CF18C042F18FAD572C /* TestFlightCommunicationView.swift */; };
 		0C1F82B6DF9051F98A587352 /* ComplicationEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3995EF7323087AA35F01BDDF /* ComplicationEditView.swift */; };
 		1100D51F2496F63400B1073C /* ThemeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1100D51E2496F63400B1073C /* ThemeColors.swift */; };
 		1101568324D770B2009424C9 /* iOSTagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1161C01624D75BD500A0E3C4 /* iOSTagManager.swift */; };
@@ -1885,6 +1890,11 @@
 		07701F2786F6D45E945CC1AA /* AssistPipelineAddList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistPipelineAddList.swift; sourceTree = "<group>"; };
 		07A4CD40BADC119045547D77 /* BarometerSensor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarometerSensor.test.swift; sourceTree = "<group>"; };
 		09953104F4749B10268B7C61 /* WhatsNewCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewCatalog.swift; sourceTree = "<group>"; };
+		14EE842480AD406D8305F377 /* TestFlightCommunicationEngine.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFlightCommunicationEngine.test.swift; sourceTree = "<group>"; };
+		666F733264F8449E8E7CB985 /* TestFlightCommunicationCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFlightCommunicationCatalog.swift; sourceTree = "<group>"; };
+		7A0B01160F7B467E8FE2C7C7 /* TestFlightCommunicationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFlightCommunicationEngine.swift; sourceTree = "<group>"; };
+		212E30CB76DE4ED1B6E317CD /* TestFlightCommunicationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFlightCommunicationModels.swift; sourceTree = "<group>"; };
+		C389A0CF18C042F18FAD572C /* TestFlightCommunicationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFlightCommunicationView.swift; sourceTree = "<group>"; };
 		09A39058730A6B3E876D8848 /* WebViewController+Kiosk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebViewController+Kiosk.swift"; sourceTree = "<group>"; };
 		09DFDC1BD6D3E07060517D1D /* Pods-iOS-Extensions-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-NotificationService.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-NotificationService/Pods-iOS-Extensions-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		1100D51E2496F63400B1073C /* ThemeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColors.swift; sourceTree = "<group>"; };
@@ -6505,6 +6515,25 @@
 			path = WhatsNew;
 			sourceTree = "<group>";
 		};
+		FCEBF2FDD5304DACB114B80B /* TestFlightCommunication */ = {
+			isa = PBXGroup;
+			children = (
+				666F733264F8449E8E7CB985 /* TestFlightCommunicationCatalog.swift */,
+				7A0B01160F7B467E8FE2C7C7 /* TestFlightCommunicationEngine.swift */,
+				212E30CB76DE4ED1B6E317CD /* TestFlightCommunicationModels.swift */,
+				C389A0CF18C042F18FAD572C /* TestFlightCommunicationView.swift */,
+			);
+			path = TestFlightCommunication;
+			sourceTree = "<group>";
+		};
+		D910BE79257341FBB86BCCF2 /* TestFlightCommunication */ = {
+			isa = PBXGroup;
+			children = (
+				14EE842480AD406D8305F377 /* TestFlightCommunicationEngine.test.swift */,
+			);
+			path = TestFlightCommunication;
+			sourceTree = "<group>";
+		};
 		55DB5351C79B716F7A464A95 /* Fan */ = {
 			isa = PBXGroup;
 			children = (
@@ -6915,6 +6944,7 @@
 				D03D893720E0AF1B00D4F28D /* ClientEvents */,
 				117EB13E2569AD3000049541 /* Notifications */,
 				5002BDABA052EC20E1ECC92A /* WhatsNew */,
+				FCEBF2FDD5304DACB114B80B /* TestFlightCommunication */,
 				B661FB6B226BCC8500E541DD /* Settings */,
 				11B7ECD9274DA521009AD634 /* Servers */,
 				B679B1FA1E1F3D020071D366 /* Utilities */,
@@ -6949,6 +6979,7 @@
 				46C3EB192D721000009A893F /* Utilities */,
 				42D3E49F2C5BCCF600444BE6 /* Watch */,
 				5002BDB02FEE000100BEEF01 /* WhatsNew */,
+				D910BE79257341FBB86BCCF2 /* TestFlightCommunication */,
 				4286260C2DA5CD1B00D58D13 /* Webhook */,
 				39A32EE32C0E38A100985722 /* WebView */,
 				420F53EC2C4E9FF1003C8415 /* Widgets */,
@@ -9486,6 +9517,10 @@
 				42FCCFE22B9B1B610057783F /* BarcodeScannerCamera.swift in Sources */,
 				42B7BFEC2E97AF070056BADC /* LocalAccessPermissionViewModel.swift in Sources */,
 				78F6EC29BAE43C9BAAFBAB1A /* WhatsNewView.swift in Sources */,
+				14A4AE0E492F4BADB1E8A3CA /* TestFlightCommunicationCatalog.swift in Sources */,
+				639D841C8B7A4154956024A8 /* TestFlightCommunicationEngine.swift in Sources */,
+				E60778133EC44B10A61D551C /* TestFlightCommunicationModels.swift in Sources */,
+				027A90037B4049A1AFFF27E3 /* TestFlightCommunicationView.swift in Sources */,
 				42FA83412F47230D0050095A /* WebViewController+Navigation.swift in Sources */,
 				4080D5C42C319B0A00099C88 /* WidgetDetailsAppIntent.swift in Sources */,
 				11A71C7124A4648000D9565F /* ZoneManagerEquatableRegion.swift in Sources */,
@@ -9741,6 +9776,7 @@
 				428ED98E2E9E555D0019113B /* OnboardingPermissionsNavigationViewModelTests.swift in Sources */,
 				42A42A6C2DC37F09000ABBAF /* AboutView.test.swift in Sources */,
 				5002BDAF2FEE000100BEEF01 /* WhatsNewEngine.test.swift in Sources */,
+				00345F0517E14EC186DFB25D /* TestFlightCommunicationEngine.test.swift in Sources */,
 				42E000042FEE100100BEEF01 /* LocalPushRetryDiagnosticsTests.swift in Sources */,
 				4272B9A92CDCE15C008CC262 /* CarPlayConfig.test.swift in Sources */,
 				42D3E4A12C5BCD1100444BE6 /* WatchContext.test.swift in Sources */,

--- a/Sources/App/Frontend/WebView/WebViewWindowController.swift
+++ b/Sources/App/Frontend/WebView/WebViewWindowController.swift
@@ -31,6 +31,11 @@ final class WebViewWindowController {
         static let retryLimit = 10
     }
 
+    enum TestFlightCommunicationConstants {
+        static let retryDelay: TimeInterval = 0.5
+        static let retryLimit = 10
+    }
+
     private enum RecoveredServerReauthenticationError: LocalizedError {
         case missingPresenter
         case cancelled
@@ -60,6 +65,7 @@ final class WebViewWindowController {
     private var webViewControllerSeal: (WebViewController) -> Void
     private var onboardingPreloadWebViewController: WebViewController?
     private var didPresentWhatsNew = false
+    private var didPresentTestFlightMessage = false
 
     init(window: UIWindow, restorationActivity: NSUserActivity?) {
         self.window = window
@@ -139,6 +145,7 @@ final class WebViewWindowController {
                     type: .webView
                 )
                 presentWhatsNewIfNeeded(over: webViewController)
+                presentTestFlightMessageIfNeeded(over: webViewController)
             } else {
                 updateRootViewController(
                     to: OnboardingNavigationView(onboardingStyle: .initial).embeddedInHostingController(),
@@ -193,6 +200,37 @@ final class WebViewWindowController {
             didPresentWhatsNew = true
             let controller = WhatsNewView(release: release) {
                 engine.markSeen(release)
+            }.embeddedInHostingController()
+            controller.modalPresentationStyle = .formSheet
+            webViewController.presentOverlayController(controller: controller, animated: true)
+        }
+    }
+
+    private func presentTestFlightMessageIfNeeded(
+        over webViewController: WebViewController,
+        attempt: Int = 0
+    ) {
+        guard !didPresentTestFlightMessage else { return }
+        let engine = TestFlightCommunicationEngine()
+        guard let message = engine.messageToShow() else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + TestFlightCommunicationConstants.retryDelay) { [
+            weak self,
+            weak webViewController
+        ] in
+            guard let self, let webViewController, !didPresentTestFlightMessage else { return }
+
+            guard webViewController.viewIfLoaded?.window != nil,
+                  webViewController.overlayedController == nil else {
+                if attempt < TestFlightCommunicationConstants.retryLimit {
+                    presentTestFlightMessageIfNeeded(over: webViewController, attempt: attempt + 1)
+                }
+                return
+            }
+
+            didPresentTestFlightMessage = true
+            let controller = TestFlightCommunicationView(message: message) {
+                engine.markSeen(message)
             }.embeddedInHostingController()
             controller.modalPresentationStyle = .formSheet
             webViewController.presentOverlayController(controller: controller, animated: true)

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1054,6 +1054,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.status_section.version_row.placeholder" = "0.92.0";
 "settings.status_section.version_row.title" = "Version";
 "settings.template_edit.title" = "Edit Template";
+"settings.test_flight_communication.title" = "Beta Tester Updates";
 "settings.whats_new.title" = "What's new?";
 "settings.widgets.create.add_item.title" = "Add item";
 "settings.widgets.create.footer.title" = "While the widget preview only displays one widget size, your custom widget will be available on multiple sizes respecting the limit of items per size.";
@@ -1582,6 +1583,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "web_view.server_selection.title" = "Choose server";
 "web_view.unique_server_selection.title" = "Choose one server";
 "webrtc_player.known_issues.title" = "Known Issues";
+"test_flight_communication.badge_title" = "Beta Tester Update";
 "whats_new.title" = "What's New in The Companion App";
 "whats_new.version_format" = "Version %@";
 "widgets.action.name.assist" = "Assist";

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @State private var selectedItem: SettingsItem? = .general
     @State private var showAbout = false
     @State private var whatsNewRelease: WhatsNewRelease?
+    @State private var testFlightMessage: TestFlightMessage?
     @State private var isShowingTranslationKeys = prefs.bool(forKey: "showTranslationKeys")
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var viewControllerProvider: ViewControllerProvider
@@ -199,6 +200,21 @@ struct SettingsView: View {
                 }
             }
 
+            if let latestMessage = TestFlightCommunicationEngine().latestMessage() {
+                // Beta Tester Updates
+                Section {
+                    Button {
+                        testFlightMessage = latestMessage
+                    } label: {
+                        Label {
+                            Text("Beta Tester Updates")
+                        } icon: {
+                            Image(systemName: "testtube.2")
+                        }
+                    }
+                }
+            }
+
             // About
             Section {
                 Button {
@@ -243,6 +259,11 @@ struct SettingsView: View {
         .sheet(item: $whatsNewRelease) { release in
             WhatsNewView(release: release) {
                 WhatsNewEngine().markSeen(release)
+            }
+        }
+        .sheet(item: $testFlightMessage) { message in
+            TestFlightCommunicationView(message: message) {
+                TestFlightCommunicationEngine().markSeen(message)
             }
         }
     }

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -207,9 +207,9 @@ struct SettingsView: View {
                         testFlightMessage = latestMessage
                     } label: {
                         Label {
-                            Text("Beta Tester Updates")
+                            Text(L10n.Settings.TestFlightCommunication.title)
                         } icon: {
-                            Image(systemName: "testtube.2")
+                            Image(systemSymbol: .testtube2)
                         }
                     }
                 }

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
@@ -1,0 +1,31 @@
+import Shared
+
+/// Catalog of messages shown exclusively to TestFlight beta testers.
+///
+/// Messages are displayed in order — the first unseen message for the current platform is shown.
+/// Leave `messages` empty when there is nothing to communicate.
+///
+/// Example:
+/// ```swift
+/// static let messages: [TestFlightMessage] = [
+///     TestFlightMessage(
+///         id: .exampleMessage,
+///         title: "Thanks for testing!",
+///         items: [
+///             WhatsNewItem(
+///                 id: .whatsNewValidationIntro,
+///                 title: "New in this beta",
+///                 body: "Describe what you'd like testers to focus on.",
+///                 icon: .sfSymbol(.testtube2)
+///             ),
+///         ],
+///         callToAction: .init(
+///             title: "Fill out the feedback survey",
+///             url: URL(string: "https://forms.example.com/beta-feedback")!
+///         )
+///     ),
+/// ]
+/// ```
+enum TestFlightCommunicationCatalog {
+    static let messages: [TestFlightMessage] = []
+}

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationEngine.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationEngine.swift
@@ -1,0 +1,42 @@
+import Shared
+
+final class TestFlightCommunicationEngine {
+    private let messages: [TestFlightMessage]
+    private let isTestFlight: () -> Bool
+    private let currentPlatform: () -> WhatsNewTargetPlatform
+    private let hasSeenMessage: (String) -> Bool
+
+    init(
+        messages: [TestFlightMessage] = TestFlightCommunicationCatalog.messages,
+        isTestFlight: @escaping () -> Bool = { Current.isTestFlight },
+        currentPlatform: @escaping () -> WhatsNewTargetPlatform = { .current },
+        hasSeenMessage: @escaping (String) -> Bool = {
+            Current.settingsStore.hasSeenTestFlightMessage(messageID: $0)
+        }
+    ) {
+        self.messages = messages
+        self.isTestFlight = isTestFlight
+        self.currentPlatform = currentPlatform
+        self.hasSeenMessage = hasSeenMessage
+    }
+
+    /// Returns the first unseen message targeting the current platform, or nil if the user is not on TestFlight.
+    func messageToShow() -> TestFlightMessage? {
+        guard isTestFlight() else { return nil }
+        let platform = currentPlatform()
+        return messages.first(where: {
+            $0.targetPlatforms.contains(platform) && !hasSeenMessage($0.id.rawValue)
+        })
+    }
+
+    /// Returns the latest message for the current platform regardless of seen state, or nil if not on TestFlight.
+    func latestMessage() -> TestFlightMessage? {
+        guard isTestFlight() else { return nil }
+        let platform = currentPlatform()
+        return messages.last(where: { $0.targetPlatforms.contains(platform) })
+    }
+
+    func markSeen(_ message: TestFlightMessage) {
+        Current.settingsStore.markTestFlightMessageSeen(messageID: message.id.rawValue)
+    }
+}

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
@@ -15,10 +15,6 @@ struct TestFlightMessageId: RawRepresentable, Hashable {
     init(rawValue: String) { self.rawValue = rawValue }
 }
 
-extension TestFlightMessageId {
-    static let testFlightWelcome = TestFlightMessageId("testflight-welcome-2026-06")
-}
-
 struct TestFlightMessage: Identifiable, Equatable {
     struct CallToAction: Equatable {
         let title: String

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Shared
+
+/// Stable identifier for a TestFlight message used to track seen state.
+/// Define message IDs as static constants on this type:
+///
+/// ```swift
+/// extension TestFlightMessageId {
+///     static let betaFeedbackRequest = TestFlightMessageId("beta-feedback-request-2026-06")
+/// }
+/// ```
+struct TestFlightMessageId: RawRepresentable, Hashable {
+    let rawValue: String
+    init(_ rawValue: String) { self.rawValue = rawValue }
+    init(rawValue: String) { self.rawValue = rawValue }
+}
+
+extension TestFlightMessageId {
+    static let testFlightWelcome = TestFlightMessageId("testflight-welcome-2026-06")
+}
+
+struct TestFlightMessage: Identifiable, Equatable {
+    struct CallToAction: Equatable {
+        let title: String
+        let url: URL
+    }
+
+    let id: TestFlightMessageId
+    let title: String
+    let items: [WhatsNewItem]
+    let targetPlatforms: [WhatsNewTargetPlatform]
+    let callToAction: CallToAction?
+
+    init(
+        id: TestFlightMessageId,
+        title: String,
+        items: [WhatsNewItem],
+        targetPlatforms: [WhatsNewTargetPlatform] = [.iPhone, .iPad, .mac],
+        callToAction: CallToAction? = nil
+    ) {
+        precondition(!items.isEmpty)
+        precondition(!targetPlatforms.isEmpty)
+        self.id = id
+        self.title = title
+        self.items = items
+        self.targetPlatforms = targetPlatforms
+        self.callToAction = callToAction
+    }
+}

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationView.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationView.swift
@@ -1,0 +1,155 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+import UIKit
+
+struct TestFlightCommunicationView: View {
+    let message: TestFlightMessage
+    let onViewed: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var didRecordView = false
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spaces.five) {
+                    header
+                    items
+                }
+                .padding(.horizontal, DesignSystem.Spaces.four)
+                .padding(.top, DesignSystem.Spaces.two)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    CloseButton {
+                        dismiss()
+                    }
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                bottomButtons
+            }
+            .onAppear {
+                recordViewIfNeeded()
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    private var header: some View {
+        VStack(alignment: .center, spacing: DesignSystem.Spaces.one) {
+            Label("Beta Tester Update", systemImage: "testtube.2")
+                .font(.caption.bold())
+                .foregroundStyle(.orange)
+            Text(message.title)
+                .font(.title.bold())
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var items: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spaces.four) {
+            ForEach(Array(message.items.enumerated()), id: \.element.id) { offset, item in
+                TestFlightItemRow(item: item, iconColor: TestFlightColors.iconColor(for: offset))
+            }
+        }
+    }
+
+    private var bottomButtons: some View {
+        VStack(spacing: DesignSystem.Spaces.two) {
+            if let callToAction = message.callToAction {
+                Link(destination: callToAction.url) {
+                    Text(callToAction.title)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.primaryButton)
+            }
+            if message.callToAction != nil {
+                Button {
+                    dismiss()
+                } label: {
+                    Text(L10n.continueLabel)
+                }
+                .buttonStyle(.secondaryButton)
+            } else {
+                Button {
+                    dismiss()
+                } label: {
+                    Text(L10n.continueLabel)
+                }
+                .buttonStyle(.primaryButton)
+            }
+        }
+        .padding([.horizontal, .bottom])
+    }
+
+    private func recordViewIfNeeded() {
+        guard !didRecordView else { return }
+        didRecordView = true
+        onViewed()
+    }
+}
+
+private struct TestFlightItemRow: View {
+    let item: WhatsNewItem
+    let iconColor: UIColor
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spaces.three) {
+            TestFlightIconView(icon: item.icon, color: iconColor)
+                .frame(width: 48, height: 48)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+                Text(item.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(item.body)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct TestFlightIconView: View {
+    let icon: WhatsNewIcon
+    let color: UIColor
+
+    var body: some View {
+        switch icon {
+        case let .sfSymbol(symbol):
+            Image(systemSymbol: symbol)
+                .font(.system(size: 38, weight: .regular))
+                .foregroundStyle(Color(uiColor: color))
+        case let .materialDesign(icon):
+            Image(uiImage: icon.image(ofSize: CGSize(width: 38, height: 38), color: color))
+                .renderingMode(.template)
+                .foregroundStyle(Color(uiColor: color))
+        }
+    }
+}
+
+private enum TestFlightColors {
+    private static let colors: [UIColor] = [
+        .systemOrange,
+        .haPrimary,
+        .systemBlue,
+        .systemGreen,
+        .systemRed,
+    ]
+
+    static func iconColor(for index: Int) -> UIColor {
+        colors[index % colors.count]
+    }
+}

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationView.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationView.swift
@@ -40,7 +40,7 @@ struct TestFlightCommunicationView: View {
 
     private var header: some View {
         VStack(alignment: .center, spacing: DesignSystem.Spaces.one) {
-            Label("Beta Tester Update", systemImage: "testtube.2")
+            Label(L10n.TestFlightCommunication.badgeTitle, systemSymbol: .testtube2)
                 .font(.caption.bold())
                 .foregroundStyle(.orange)
             Text(message.title)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3671,6 +3671,10 @@ public enum L10n {
       /// Edit Template
       public static var title: String { return L10n.tr("Localizable", "settings.template_edit.title") }
     }
+    public enum TestFlightCommunication {
+      /// Beta Tester Updates
+      public static var title: String { return L10n.tr("Localizable", "settings.test_flight_communication.title") }
+    }
     public enum WhatsNew {
       /// What's new?
       public static var title: String { return L10n.tr("Localizable", "settings.whats_new.title") }
@@ -4436,6 +4440,11 @@ public enum L10n {
         }
       }
     }
+  }
+
+  public enum TestFlightCommunication {
+    /// Beta Tester Update
+    public static var badgeTitle: String { return L10n.tr("Localizable", "test_flight_communication.badge_title") }
   }
 
   public enum Thread {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -9,6 +9,7 @@ public class SettingsStore {
     let keychain = AppConstants.Keychain
     let prefs = UserDefaults(suiteName: AppConstants.AppGroupID)!
     private let seenWhatsNewReleaseIDsKey = "seenWhatsNewReleaseIDs"
+    private let seenTestFlightMessageIDsKey = "seenTestFlightMessageIDs"
 
     /// These will only be posted on the main thread
     public static let webViewRelatedSettingDidChange: Notification.Name = .init("webViewRelatedSettingDidChange")
@@ -48,6 +49,10 @@ public class SettingsStore {
 
     private var seenWhatsNewReleaseIDs: Set<String> {
         Set(prefs.stringArray(forKey: seenWhatsNewReleaseIDsKey) ?? [])
+    }
+
+    private var seenTestFlightMessageIDs: Set<String> {
+        Set(prefs.stringArray(forKey: seenTestFlightMessageIDsKey) ?? [])
     }
 
     #if os(iOS)
@@ -198,6 +203,14 @@ public class SettingsStore {
 
     public func markWhatsNewSeen(releaseID: String) {
         prefs.set(seenWhatsNewReleaseIDs.union([releaseID]).sorted(), forKey: seenWhatsNewReleaseIDsKey)
+    }
+
+    public func hasSeenTestFlightMessage(messageID: String) -> Bool {
+        seenTestFlightMessageIDs.contains(messageID)
+    }
+
+    public func markTestFlightMessageSeen(messageID: String) {
+        prefs.set(seenTestFlightMessageIDs.union([messageID]).sorted(), forKey: seenTestFlightMessageIDsKey)
     }
 
     public var fullScreen: Bool {

--- a/Tests/App/TestFlightCommunication/TestFlightCommunicationEngine.test.swift
+++ b/Tests/App/TestFlightCommunication/TestFlightCommunicationEngine.test.swift
@@ -1,0 +1,134 @@
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+@Suite(.serialized)
+struct TestFlightCommunicationEngineTests {
+    private let seenTestFlightMessageIDsKey = "seenTestFlightMessageIDs"
+
+    @Test func messageToShowReturnsFirstUnseenMessageForCurrentPlatform() {
+        let firstMessage = Self.message(id: .init("first"), targetPlatforms: [.iPhone, .iPad])
+        let secondMessage = Self.message(id: .init("second"), targetPlatforms: [.iPhone])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [firstMessage, secondMessage],
+            isTestFlight: { true },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { _ in false }
+        )
+
+        #expect(engine.messageToShow() == firstMessage)
+    }
+
+    @Test func messageToShowSkipsSeenMessagesAndReturnsNextUnseen() {
+        let seenMessage = Self.message(id: .init("seen"), targetPlatforms: [.iPhone])
+        let unseenMessage = Self.message(id: .init("unseen"), targetPlatforms: [.iPhone])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [seenMessage, unseenMessage],
+            isTestFlight: { true },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { $0 == "seen" }
+        )
+
+        #expect(engine.messageToShow() == unseenMessage)
+    }
+
+    @Test func messageToShowReturnsNilWhenNotOnTestFlight() {
+        let message = Self.message(id: .init("msg"), targetPlatforms: [.iPhone])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [message],
+            isTestFlight: { false },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { _ in false }
+        )
+
+        #expect(engine.messageToShow() == nil)
+    }
+
+    @Test func messageToShowReturnsNilWhenPlatformDoesNotMatch() {
+        let message = Self.message(id: .init("mac-only"), targetPlatforms: [.mac])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [message],
+            isTestFlight: { true },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { _ in false }
+        )
+
+        #expect(engine.messageToShow() == nil)
+    }
+
+    @Test func messageToShowReturnsNilWhenAllMessagesAreSeen() {
+        let message = Self.message(id: .init("seen"), targetPlatforms: [.iPhone])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [message],
+            isTestFlight: { true },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { _ in true }
+        )
+
+        #expect(engine.messageToShow() == nil)
+    }
+
+    @Test func latestMessageReturnsLastMessageForCurrentPlatform() {
+        let firstMessage = Self.message(id: .init("first"), targetPlatforms: [.iPhone])
+        let latestMessage = Self.message(id: .init("latest"), targetPlatforms: [.iPhone, .iPad])
+        let macOnlyMessage = Self.message(id: .init("mac"), targetPlatforms: [.mac])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [firstMessage, latestMessage, macOnlyMessage],
+            isTestFlight: { true },
+            currentPlatform: { .iPad },
+            hasSeenMessage: { _ in true }
+        )
+
+        #expect(engine.latestMessage() == latestMessage)
+    }
+
+    @Test func latestMessageReturnsNilWhenNotOnTestFlight() {
+        let message = Self.message(id: .init("msg"), targetPlatforms: [.iPhone])
+
+        let engine = TestFlightCommunicationEngine(
+            messages: [message],
+            isTestFlight: { false },
+            currentPlatform: { .iPhone },
+            hasSeenMessage: { _ in false }
+        )
+
+        #expect(engine.latestMessage() == nil)
+    }
+
+    @Test func settingsStorePersistsSeenMessageIDsWithoutDroppingExistingValues() {
+        Current.settingsStore.prefs.removeObject(forKey: seenTestFlightMessageIDsKey)
+        defer { Current.settingsStore.prefs.removeObject(forKey: seenTestFlightMessageIDsKey) }
+
+        Current.settingsStore.markTestFlightMessageSeen(messageID: "beta-v1")
+        Current.settingsStore.markTestFlightMessageSeen(messageID: "beta-v2")
+
+        #expect(Current.settingsStore.hasSeenTestFlightMessage(messageID: "beta-v1"))
+        #expect(Current.settingsStore.hasSeenTestFlightMessage(messageID: "beta-v2"))
+        #expect(!Current.settingsStore.hasSeenTestFlightMessage(messageID: "beta-v3"))
+    }
+
+    private static func message(
+        id: TestFlightMessageId,
+        targetPlatforms: [WhatsNewTargetPlatform]
+    ) -> TestFlightMessage {
+        TestFlightMessage(
+            id: id,
+            title: "Beta update",
+            items: [
+                WhatsNewItem(
+                    id: .whatsNewValidationIntro,
+                    title: "What to test",
+                    body: "Something new to validate.",
+                    icon: .sfSymbol(.checkmark)
+                ),
+            ],
+            targetPlatforms: targetPlatforms
+        )
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="1206" height="2622" alt="Simulator Screenshot - Daily tester 2 - 2026-06-08 at 11 49 31" src="https://github.com/user-attachments/assets/f4e5e291-2377-46d5-8ac5-bc0c6279bba7" />

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
