### PR TITLE
Instruct AI agents to prefer Swift concurrency over PromiseKit

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -28,6 +28,7 @@ bundle exec fastlane test
 3. **SF Symbols**: Use `SFSafeSymbols` (`Image(systemSymbol: .house)`) not string-based APIs.
 4. **CocoaPods only**: No Swift Package Manager. Dependencies via `Podfile`.
 5. **Workspace**: Always use `HomeAssistant.xcworkspace`.
+6. **Concurrency**: Prefer Swift Concurrency (`async/await`, `Task`, actors) for new async code. Do not introduce new **PromiseKit** code — it's a legacy dependency being phased out (some of `HomeAssistantAPI` still uses it). Migrate PromiseKit to `async/await` where practical when you touch it.
 
 ### Architecture
 
@@ -44,6 +45,7 @@ bundle exec fastlane test
 - No `force_cast` or `force_try`
 - Use `guard` for early returns
 - SwiftUI preferred for new UI, `@MainActor` on view models
+- Prefer `async/await` over PromiseKit for asynchronous code
 
 ### Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,7 +77,7 @@ When adding a new persistent model, prefer GRDB. Implement `DatabaseTableProtoco
 
 ### HAKit (WebSocket + REST)
 
-`HAKit` is the library for all Home Assistant server communication. Use `HATypedRequest` for typed WebSocket/REST calls. Network requests in `HomeAssistantAPI` (`HAAPI.swift`) still use **PromiseKit** for some flows alongside newer `async/await`. Don't assume the codebase is fully migrated to async/await.
+`HAKit` is the library for all Home Assistant server communication. Use `HATypedRequest` for typed WebSocket/REST calls. Network requests in `HomeAssistantAPI` (`HAAPI.swift`) still use **PromiseKit** for some flows alongside newer `async/await`. Don't assume the codebase is fully migrated to async/await — but **prefer `async/await` for new request flows and avoid introducing new PromiseKit usage** (see [Concurrency](#concurrency)).
 
 ### MagicItem — Cross-Platform Action Abstraction
 
@@ -85,7 +85,11 @@ When adding a new persistent model, prefer GRDB. Implement `DatabaseTableProtoco
 
 ## Swift Conventions
 
-- Use Swift's modern language features (async/await, Combine where appropriate). Note: parts of `HomeAssistantAPI` still use **PromiseKit** — don't assume a full async/await migration.
+### Concurrency
+
+**Prefer Swift Concurrency (`async/await`, `Task`, actors, structured concurrency) for all new asynchronous code. Do not introduce new PromiseKit code.** PromiseKit is a legacy dependency the codebase is moving away from — parts of `HomeAssistantAPI` (`HAAPI.swift`) still use it, so don't assume a full migration, but new work should use `async/await` instead of `Promise`/`Guarantee`. When editing existing PromiseKit code, migrate it to `async/await` where practical rather than extending the PromiseKit usage. Use `Combine` only where an existing reactive pattern already requires it.
+
+- Use Swift's modern language features (`async/await`, structured concurrency, `Combine` where appropriate). Avoid PromiseKit in new code — see [Concurrency](#concurrency) above.
 - SwiftUI preferred for new UI; UIKit where existing patterns require it.
 - Prefer value types (structs) over reference types (classes) when appropriate.
 - Use proper access control (`private`, `fileprivate`, `internal`, `public`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,12 +205,22 @@ All lint checks and tests must pass before a PR can be merged.
 
 ## Common Patterns
 
+### Concurrency
+
+**Prefer Swift Concurrency (`async`/`await`, `Task`, actors, structured concurrency) for all new asynchronous code.**
+
+- **Do not introduce new [PromiseKit](https://github.com/mxcl/PromiseKit) code.** PromiseKit is a legacy dependency that the codebase is gradually moving away from. Parts of `HomeAssistantAPI` (`HAAPI.swift`) still use it, so don't assume a full migration — but new work should use `async`/`await` instead of `Promise`/`Guarantee`.
+- When touching existing PromiseKit code, migrate it to `async`/`await` where practical rather than extending the PromiseKit usage.
+- Use `Combine` only where an existing reactive pattern already requires it; otherwise prefer `async`/`await` and `AsyncStream`/`AsyncSequence`.
+- Annotate SwiftUI-facing view models with `@MainActor`.
+
 ### Networking
 
 Use `HAKit` (the Home Assistant Swift SDK) for server communication:
 - REST API calls via `HAConnection`
 - WebSocket subscriptions for real-time updates
 - Connection info managed through `Current.servers`
+- Prefer `async`/`await` for new request flows (see [Concurrency](#concurrency)); avoid adding new PromiseKit-based calls.
 
 ### Data Persistence
 


### PR DESCRIPTION
## Summary
Updates the AI agent instruction files so that AI coding assistants prefer **Swift Concurrency** (`async/await`, `Task`, actors, structured concurrency) for new asynchronous code and **avoid introducing new PromiseKit usage**.

PromiseKit remains a legacy dependency in parts of `HomeAssistantAPI` (`HAAPI.swift`), so the guidance also tells agents not to assume a full migration and to convert PromiseKit to `async/await` where practical when they touch that code.

Files updated:
- `AGENTS.md` — added a **Concurrency** subsection under Common Patterns and a note in the Networking section.
- `.github/copilot-instructions.md` — added a **Concurrency** subsection under Swift Conventions and clarified the existing PromiseKit/HAKit notes. (`CLAUDE.md` is a symlink to this file, so it's covered too.)
- `.cursorrules` — added a concurrency key rule and a code-style bullet.

These are documentation-only changes to AI agent guidance; no app code is affected.

## Screenshots
N/A — documentation/instruction files only, no user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No-op for the build/tests — only Markdown instruction files for AI agents changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)