### PR TITLE
Move scripts and sensors widgets to the end of the widget picker

### DIFF
--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -46,11 +46,11 @@ struct WidgetsBundle17: WidgetBundle {
         WidgetCommonlyUsedEntities()
         WidgetCustom()
         WidgetAssist()
-        WidgetScripts()
         WidgetTodoList()
         WidgetGauge()
         WidgetDetails()
         WidgetOpenPage()
+        WidgetScripts()
         WidgetSensors()
     }
 }
@@ -89,11 +89,11 @@ struct WidgetsBundle18: WidgetBundle {
         WidgetCommonlyUsedEntities()
         WidgetCustom()
         WidgetAssist()
-        WidgetScripts()
         WidgetTodoList()
         WidgetGauge()
         WidgetDetails()
-        WidgetSensors()
         WidgetOpenPage()
+        WidgetScripts()
+        WidgetSensors()
     }
 }

--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -47,9 +47,9 @@ struct WidgetsBundle17: WidgetBundle {
         WidgetCustom()
         WidgetAssist()
         WidgetTodoList()
+        WidgetOpenPage()
         WidgetGauge()
         WidgetDetails()
-        WidgetOpenPage()
         WidgetScripts()
         WidgetSensors()
     }
@@ -90,9 +90,9 @@ struct WidgetsBundle18: WidgetBundle {
         WidgetCustom()
         WidgetAssist()
         WidgetTodoList()
+        WidgetOpenPage()
         WidgetGauge()
         WidgetDetails()
-        WidgetOpenPage()
         WidgetScripts()
         WidgetSensors()
     }

--- a/Sources/Extensions/Widgets/Widgets.swift
+++ b/Sources/Extensions/Widgets/Widgets.swift
@@ -50,8 +50,8 @@ struct WidgetsBundle17: WidgetBundle {
         WidgetOpenPage()
         WidgetGauge()
         WidgetDetails()
-        WidgetScripts()
         WidgetSensors()
+        WidgetScripts()
     }
 }
 
@@ -93,7 +93,7 @@ struct WidgetsBundle18: WidgetBundle {
         WidgetOpenPage()
         WidgetGauge()
         WidgetDetails()
-        WidgetScripts()
         WidgetSensors()
+        WidgetScripts()
     }
 }


### PR DESCRIPTION
## Summary
Reorders the widget options in the iOS widget picker so that the **Scripts** and **Sensors** widgets appear as the last two options.

The picker order is determined solely by the declaration order of the widgets in the `WidgetBundle` `body`. This change moves `WidgetScripts()` and `WidgetSensors()` to the end of the widget list in both `WidgetsBundle17` (iOS 17) and `WidgetsBundle18` (iOS 18+), so they no longer appear in the middle of the list. No functional behavior changes — only presentation order in the picker.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
_N/A — this only reorders entries in the system widget picker; the widgets themselves are unchanged._

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`WidgetsBundleLegacy` (iOS < 17) does not include the scripts or sensors widgets, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
