### PR TITLE
Disfavor non-essential widgets in CarPlay widget gallery

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -666,6 +666,7 @@
 		423B5E0B2D677B9B0000CB95 /* WidgetCustom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4223688A2D40F9B7005911E4 /* WidgetCustom.swift */; };
 		423B5E0C2D677BA70000CB95 /* WidgetCustomTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4223688D2D40FB00005911E4 /* WidgetCustomTimelineProvider.swift */; };
 		423B5E0D2D677BB90000CB95 /* WidgetContentMargin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424A7F472B188BF3008C8DF3 /* WidgetContentMargin.swift */; };
+		CA40A11000000000000000B1 /* WidgetCarPlayLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40A11000000000000000F1 /* WidgetCarPlayLocation.swift */; };
 		423F44F02C17238200766A99 /* ChatBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423F44EF2C17238200766A99 /* ChatBubbleView.swift */; };
 		423F44FF2C186E4500766A99 /* WatchCommunicatorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423F44FE2C186E4500766A99 /* WatchCommunicatorService.swift */; };
 		423F45212C19D89100766A99 /* AssistDefaultComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423F45202C19D89100766A99 /* AssistDefaultComplication.swift */; };
@@ -688,6 +689,7 @@
 		424A49E02EC5FD3E00524586 /* OpenInBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424A49DF2EC5FD3E00524586 /* OpenInBrowser.swift */; };
 		424A7F462B188946008C8DF3 /* WidgetBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424A7F452B188946008C8DF3 /* WidgetBackground.swift */; };
 		424A7F482B188BF3008C8DF3 /* WidgetContentMargin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424A7F472B188BF3008C8DF3 /* WidgetContentMargin.swift */; };
+		CA40A11000000000000000B2 /* WidgetCarPlayLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40A11000000000000000F1 /* WidgetCarPlayLocation.swift */; };
 		424D2D102C89DACE00C610F1 /* HAAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */; };
 		424DD05A2B3509170057E456 /* CarPlayQuickAccessTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424DD0592B3509170057E456 /* CarPlayQuickAccessTemplate.swift */; };
 		42514C1A2F3E217E008EB858 /* WidgetTodoListAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42514C192F3E217E008EB858 /* WidgetTodoListAppIntent.swift */; };
@@ -2468,6 +2470,7 @@
 		424A49DF2EC5FD3E00524586 /* OpenInBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInBrowser.swift; sourceTree = "<group>"; };
 		424A7F452B188946008C8DF3 /* WidgetBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBackground.swift; sourceTree = "<group>"; };
 		424A7F472B188BF3008C8DF3 /* WidgetContentMargin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetContentMargin.swift; sourceTree = "<group>"; };
+		CA40A11000000000000000F1 /* WidgetCarPlayLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCarPlayLocation.swift; sourceTree = "<group>"; };
 		424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAppEntity.swift; sourceTree = "<group>"; };
 		424DD0592B3509170057E456 /* CarPlayQuickAccessTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarPlayQuickAccessTemplate.swift; sourceTree = "<group>"; };
 		42514C192F3E217E008EB858 /* WidgetTodoListAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetTodoListAppIntent.swift; sourceTree = "<group>"; };
@@ -3825,6 +3828,7 @@
 				420E2AE22C4746BB004921D8 /* WidgetBasicViewModel.swift */,
 				424A7F452B188946008C8DF3 /* WidgetBackground.swift */,
 				424A7F472B188BF3008C8DF3 /* WidgetContentMargin.swift */,
+				CA40A11000000000000000F1 /* WidgetCarPlayLocation.swift */,
 				4008F0252C2D0A1A00E24001 /* WidgetCircularView.swift */,
 				42AC94A32CF872520050A62C /* TileCardStyleModifier.swift */,
 				422C95E62F45C5CD00650B46 /* WidgetTimelineProviderSupport.swift */,
@@ -9159,6 +9163,7 @@
 				42B74A632D36B08600C37304 /* WidgetBasicView.swift in Sources */,
 				422F88162D428E8300706A0A /* CustomWidgetActivateAppIntent.swift in Sources */,
 				424A7F482B188BF3008C8DF3 /* WidgetContentMargin.swift in Sources */,
+				CA40A11000000000000000B2 /* WidgetCarPlayLocation.swift in Sources */,
 				115560E127010D8400A8F818 /* WidgetBasicContainerView.swift in Sources */,
 				115560EE27012F7300A8F818 /* WidgetOpenPage.swift in Sources */,
 				427647202C8F36950027B21F /* ControlLightsValueProvider.swift in Sources */,
@@ -9359,6 +9364,7 @@
 				423178482FBB000100814230 /* AllowedTagsView.swift in Sources */,
 				42FCCFFE2B9B1C310057783F /* ThreadCredentialsSharing+build.swift in Sources */,
 				423B5E0D2D677BB90000CB95 /* WidgetContentMargin.swift in Sources */,
+				CA40A11000000000000000B1 /* WidgetCarPlayLocation.swift in Sources */,
 				42A32F382EEA393700B323F1 /* CarPlayLockConfirmation.swift in Sources */,
 				4240DF472E1D148F00FB0DE6 /* DeviceNameView.swift in Sources */,
 				4210CD032F155C4500B71FB9 /* AssistConfiguration.swift in Sources */,

--- a/Sources/Extensions/Widgets/Assist/WidgetAssist.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssist.swift
@@ -23,6 +23,7 @@ struct WidgetAssist: Widget {
         .configurationDisplayName(L10n.Widgets.Assist.title)
         .description(L10n.Widgets.Assist.description)
         .supportedFamilies(supportedFamilies)
+        .disfavoredInCarPlayIfAvailable(for: supportedFamilies)
     }
 
     private var supportedFamilies: [WidgetFamily] {

--- a/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
@@ -9,8 +9,11 @@ extension WidgetConfiguration {
         // `WidgetLocation.carPlay` is available on iOS, iPadOS and Mac Catalyst 26+, and unavailable on
         // macOS (CarPlay does not exist there). The `disfavoredLocations(_:for:)` modifier itself is
         // iOS 17+, but the `.carPlay` location requires iOS 26, so guard on the stricter requirement.
+        // Use the `iOS` availability domain (not `iOSApplicationExtension`): this file also compiles
+        // into the non-extension `App` target, where an `iOSApplicationExtension` check does not refine
+        // the `iOS`-only availability of these symbols.
         #if !os(macOS)
-        if #available(iOSApplicationExtension 26.0, *) {
+        if #available(iOS 26.0, *) {
             return self.disfavoredLocations([.carPlay], for: families)
         } else {
             return self

--- a/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
@@ -6,10 +6,11 @@ extension WidgetConfiguration {
     /// Marks the widget as disfavored in CarPlay for the given families, so it appears in the
     /// "Other" section of the CarPlay widget gallery rather than alongside the suggested widgets.
     func disfavoredInCarPlayIfAvailable(for families: [WidgetFamily]) -> some WidgetConfiguration {
-        // `disfavoredLocations(_:for:)` and `WidgetLocation.carPlay` are unavailable on macOS (CarPlay
-        // does not exist there); they are available on iOS, iPadOS and Mac Catalyst 17+.
+        // `WidgetLocation.carPlay` is available on iOS, iPadOS and Mac Catalyst 26+, and unavailable on
+        // macOS (CarPlay does not exist there). The `disfavoredLocations(_:for:)` modifier itself is
+        // iOS 17+, but the `.carPlay` location requires iOS 26, so guard on the stricter requirement.
         #if !os(macOS)
-        if #available(iOSApplicationExtension 17.0, *) {
+        if #available(iOSApplicationExtension 26.0, *) {
             return self.disfavoredLocations([.carPlay], for: families)
         } else {
             return self

--- a/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+import WidgetKit
+
+extension WidgetConfiguration {
+    /// Marks the widget as disfavored in CarPlay for the given families, so it appears in the
+    /// "Other" section of the CarPlay widget gallery rather than alongside the suggested widgets.
+    func disfavoredInCarPlayIfAvailable(for families: [WidgetFamily]) -> some WidgetConfiguration {
+        // `disfavoredLocations(_:for:)` and `WidgetLocation.carPlay` are unavailable on macOS (CarPlay
+        // does not exist there); they are available on iOS, iPadOS and Mac Catalyst 17+.
+        #if !os(macOS)
+        if #available(iOSApplicationExtension 17.0, *) {
+            return self.disfavoredLocations([.carPlay], for: families)
+        } else {
+            return self
+        }
+        #else
+        return self
+        #endif
+    }
+}

--- a/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
@@ -26,6 +26,7 @@ struct WidgetDetails: Widget {
         .configurationDisplayName(L10n.Widgets.Details.title)
         .description(L10n.Widgets.Details.descriptionWithWarning)
         .supportedFamilies(WidgetDetailsSupportedFamilies.families)
+        .disfavoredInCarPlayIfAvailable(for: WidgetDetailsSupportedFamilies.families)
     }
 
     private func intent(for entry: WidgetDetailsEntry) -> ScriptAppIntent? {

--- a/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
@@ -26,6 +26,7 @@ struct WidgetGauge: Widget {
         .configurationDisplayName(L10n.Widgets.Gauge.title)
         .description(L10n.Widgets.Gauge.descriptionWithWarning)
         .supportedFamilies(WidgetGaugeSupportedFamilies.families)
+        .disfavoredInCarPlayIfAvailable(for: WidgetGaugeSupportedFamilies.families)
     }
 
     private func intent(for entry: WidgetGaugeEntry) -> ScriptAppIntent? {

--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
@@ -36,6 +36,7 @@ struct WidgetOpenPage: Widget {
         .configurationDisplayName(L10n.Widgets.OpenPage.title)
         .description(L10n.Widgets.OpenPage.description)
         .supportedFamilies(WidgetOpenPageSupportedFamilies.families)
+        .disfavoredInCarPlayIfAvailable(for: WidgetOpenPageSupportedFamilies.families)
         .onBackgroundURLSessionEvents(matching: nil) { identifier, completion in
             Current.webhooks.handleBackground(for: identifier, completionHandler: completion)
         }

--- a/Sources/Extensions/Widgets/Script/WidgetScripts.swift
+++ b/Sources/Extensions/Widgets/Script/WidgetScripts.swift
@@ -41,6 +41,7 @@ struct WidgetScripts: Widget {
         .configurationDisplayName(L10n.Widgets.Scripts.title)
         .description(L10n.Widgets.Scripts.description)
         .supportedFamilies(WidgetScriptsSupportedFamilies.families)
+        .disfavoredInCarPlayIfAvailable(for: WidgetScriptsSupportedFamilies.families)
     }
 }
 

--- a/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
+++ b/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
@@ -36,6 +36,7 @@ struct WidgetSensors: Widget {
         .configurationDisplayName(L10n.Widgets.Sensors.title)
         .description(L10n.Widgets.Sensors.description)
         .supportedFamilies(WidgetDetailsTableSupportedFamilies.families)
+        .disfavoredInCarPlayIfAvailable(for: WidgetDetailsTableSupportedFamilies.families)
     }
 
     private func appendUnitOfMeasurementToValue(sensor: WidgetSensorsEntry.SensorData) -> String {


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Marks every widget **except** the most driving-relevant ones as disfavored in the CarPlay widget gallery, using SwiftUI's [`disfavoredLocations(_:for:)`](https://developer.apple.com/documentation/swiftui/widgetconfiguration/disfavoredlocations(_:for:)) with `WidgetLocation.carPlay`. Disfavored widgets are moved to the "Other" section of the CarPlay gallery instead of being suggested up front.

**Disfavored in CarPlay:** Assist, Scripts, Gauge, Details, Sensors, Open Page.

**Kept favored (unchanged):** Commonly Used Entities, Custom, and To-do List — the widgets most useful at a glance while driving.

Implementation notes:
- A small `disfavoredInCarPlayIfAvailable(for:)` helper (`Sources/Extensions/Widgets/Common/WidgetCarPlayLocation.swift`) wraps the API, following the existing `contentMarginsDisabledIfAvailable()` pattern. The new file is registered in `project.pbxproj` for both the `App` and `Extensions-Widgets` targets (the two targets that compile widget code).
- `WidgetLocation.carPlay` is `@available(iOS 26.0, *)` (iOS / iPadOS / Mac Catalyst 26.0+) and unavailable on native macOS. Although the `disfavoredLocations(_:for:)` modifier itself is iOS 17+, the `.carPlay` location requires iOS 26, so the helper guards on the stricter requirement (`#available(iOS 26.0, *)`) and on platform (`#if !os(macOS)`). The `iOS` availability domain is used rather than `iOSApplicationExtension`, because the file also compiles into the non-extension `App` target where an `iOSApplicationExtension` check would not refine these `iOS`-only symbols. On earlier OS versions the modifier is a no-op, which is correct since the CarPlay widget location doesn't exist there.
- Each widget is disfavored for the full set of families it already declares via `supportedFamilies`.
- Control widgets (iOS 18+) and the Live Activity use different configuration types that don't appear in the CarPlay widget gallery, so they're untouched.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — this only affects the ordering/section of widgets in the CarPlay widget gallery (the "Other" section) on iOS 26+; there is no visual change to the widgets themselves.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Family lists are reused verbatim from each widget's existing `supportedFamilies` declaration, so disfavoring stays in sync if those lists change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
