### PR TITLE
Fix regression that broke app icon quick actions

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1603,6 +1603,7 @@
 		FA11C0DE0000000000000061 /* MockAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11C0DE0000000000000060 /* MockAppCoordinator.swift */; };
 		FC8E9421FDB864726918B612 /* Pods-watchOS-WatchExtension-Watch-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9249824D575933DFA1530BB2 /* Pods-watchOS-WatchExtension-Watch-metadata.plist */; };
 		FD3BC66329B9FF8F00B19FBE /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */; };
+		DE8048842D9FB6C90459E229 /* QuickActionWindowSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1948705C52B43ACD36FD0B32 /* QuickActionWindowSceneDelegate.swift */; };
 		FD3BC66C29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */; };
 		FD3BC66E29BA010A00B19FBE /* CarPlayDomainsListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66D29BA010A00B19FBE /* CarPlayDomainsListTemplate.swift */; };
 		FE626519D14570FF70598F85 /* Pods_iOS_Extensions_Matter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02DC1D2083B5FBC480E4C51D /* Pods_iOS_Extensions_Matter.framework */; };
@@ -3534,6 +3535,7 @@
 		FCE1C6F8FA2181C936758465 /* KioskSecretExitGestureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSecretExitGestureView.swift; sourceTree = "<group>"; };
 		FD370D44DFFB906B05C3EB3A /* Pods_watchOS_Shared_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_watchOS_Shared_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		1948705C52B43ACD36FD0B32 /* QuickActionWindowSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionWindowSceneDelegate.swift; sourceTree = "<group>"; };
 		FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+CarPlay.swift"; sourceTree = "<group>"; };
 		FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayEntitiesListTemplate.swift; sourceTree = "<group>"; };
 		FD3BC66D29BA010A00B19FBE /* CarPlayDomainsListTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayDomainsListTemplate.swift; sourceTree = "<group>"; };
@@ -4358,6 +4360,7 @@
 				11EFCDD924F5FE0600314D85 /* SceneActivity.swift */,
 				118261F424F8C7C1000795C6 /* SceneManager.swift */,
 				FD3BC66229B9FF8F00B19FBE /* CarPlaySceneDelegate.swift */,
+				1948705C52B43ACD36FD0B32 /* QuickActionWindowSceneDelegate.swift */,
 				42F1DA5A2B4BF7DF002729BC /* WindowSizeObserver.swift */,
 				42F1DA5C2B4BF85F002729BC /* WindowScenesManager.swift */,
 			);
@@ -9499,6 +9502,7 @@
 				42A9E0F32F2B58FF00D22154 /* EntityAddToHandler.swift in Sources */,
 				11195F6F267EFC8E003DF674 /* NotificationManagerLocalPushInterfaceDirect.swift in Sources */,
 				FD3BC66329B9FF8F00B19FBE /* CarPlaySceneDelegate.swift in Sources */,
+				DE8048842D9FB6C90459E229 /* QuickActionWindowSceneDelegate.swift in Sources */,
 				11C4629424B189B100031902 /* NotificationRateLimitsAPI.swift in Sources */,
 				11A71C6B24A463FC00D9565F /* ZoneManagerState.swift in Sources */,
 				42106F562F447C6B009351FC /* MTLSLabsLabel.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -221,13 +221,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             if activity == .webView {
                 // The primary window is owned by SwiftUI's `WindowGroup { ContainerView() }` (see `HAApp`).
-                // Return the delegate-less `WebView` config so SwiftUI hosts this scene; auxiliary scenes
-                // keep their Info.plist-bound delegates. The name MUST stay `WebView` (the shipped config
-                // name) — persisted scene sessions reference it, and renaming it blanks the window on upgrade.
-                return UISceneConfiguration(
+                // The name MUST stay `WebView` (the shipped config name) — persisted scene sessions reference
+                // it, and renaming it blanks the window on upgrade. `QuickActionWindowSceneDelegate` only
+                // forwards Home-screen quick actions (it never owns a window), so SwiftUI still hosts the
+                // scene; it restores quick-action handling lost when `WebViewSceneDelegate` was removed.
+                let configuration = UISceneConfiguration(
                     name: "WebView",
                     sessionRole: connectingSceneSession.role
                 )
+                configuration.delegateClass = QuickActionWindowSceneDelegate.self
+                return configuration
             }
 
             return activity.configuration

--- a/Sources/App/Scenes/QuickActionWindowSceneDelegate.swift
+++ b/Sources/App/Scenes/QuickActionWindowSceneDelegate.swift
@@ -1,0 +1,45 @@
+import PromiseKit
+import Shared
+import UIKit
+
+/// Minimal scene delegate whose sole responsibility is forwarding Home-screen quick actions
+/// (app-icon shortcuts / `UIApplicationShortcutItem`) into `IncomingURLHandler.handle(shortcutItem:)`.
+///
+/// Under the SwiftUI `App` lifecycle the app-delegate-level `application(_:performActionFor:)`
+/// is never called, so quick actions must be received at the scene level. This delegate is attached
+/// to the `"WebView"` scene configuration in `AppDelegate.application(_:configurationForConnecting:options:)`.
+///
+/// It deliberately does **not** create or own a `UIWindow` — SwiftUI's `WindowGroup` (see `HAApp`)
+/// keeps hosting `ContainerView`. Adding this delegate must not change scene/window setup, only route
+/// the shortcut item, mirroring how `HAApp` re-wires `.onOpenURL` via the same `appCoordinator` bridge.
+final class QuickActionWindowSceneDelegate: UIResponder, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        // Cold launch: the app was launched by tapping a quick action.
+        // This getter does not exist on macOS 10.15, so check that it responds before accessing it.
+        guard let windowScene = scene as? UIWindowScene,
+              connectionOptions.responds(to: #selector(getter: UIScene.ConnectionOptions.shortcutItem)),
+              let shortcutItem = connectionOptions.shortcutItem else { return }
+        self.windowScene(windowScene, performActionFor: shortcutItem, completionHandler: { _ in })
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        // Warm launch: the app was already running/backgrounded when the quick action was tapped.
+        // Wait for the coordinator (web view ready) just like `HAApp.handleIncoming(url:)`.
+        Current.sceneManager.appCoordinator.done { coordinator in
+            IncomingURLHandler(coordinator: coordinator).handle(shortcutItem: shortcutItem)
+                .done {
+                    completionHandler(true)
+                }.catch { _ in
+                    completionHandler(false)
+                }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
- PR adds a scene delegate to handle app icon quick actions while swiftui cannot handle them automatically.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
