### PR TITLE
Add entity context to configuration screens

### DIFF
--- a/Sources/App/Settings/AppIconShortcuts/AppIconShortcutsConfigurationView.swift
+++ b/Sources/App/Settings/AppIconShortcuts/AppIconShortcutsConfigurationView.swift
@@ -91,8 +91,16 @@ struct AppIconShortcutsConfigurationView: View {
     private func itemRow(item: MagicItem, info: MagicItem.Info) -> some View {
         HStack {
             Image(uiImage: image(for: item, itemInfo: info))
-            Text(item.name(info: info))
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name(info: info))
+                if let contextSubtitle = info.contextSubtitle {
+                    Text(contextSubtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Image(systemSymbol: .line3Horizontal)
                 .foregroundStyle(.gray)
         }

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -274,8 +274,16 @@ struct WatchConfigurationView: View {
     private func itemRow(item: MagicItem, info: MagicItem.Info) -> some View {
         HStack {
             Image(uiImage: image(for: item, itemInfo: info, watchPreview: false, color: .haPrimary))
-            Text(item.name(info: info))
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name(info: info))
+                if let contextSubtitle = info.contextSubtitle {
+                    Text(contextSubtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Image(systemSymbol: .line3Horizontal)
                 .foregroundStyle(.gray)
         }

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -235,7 +235,9 @@ struct CarPlayConfigurationView: View {
             Image(uiImage: image(for: item, itemInfo: info, watchPreview: false, color: .accent))
             VStack(alignment: .leading, spacing: 2) {
                 Text(title(for: item, info: info))
-                if let subtitle = subtitle(for: item) {
+                // Assist-prompt items show their prompt text; everything else shows the
+                // Server • Area • Device context line.
+                if let subtitle = subtitle(for: item) ?? info.contextSubtitle {
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
@@ -179,8 +179,16 @@ struct WidgetCreationView: View {
     private func itemRow(item: MagicItem, info: MagicItem.Info) -> some View {
         HStack {
             Image(uiImage: image(for: item, itemInfo: info, color: .haPrimary))
-            Text(item.name(info: info))
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name(info: info))
+                if let contextSubtitle = info.contextSubtitle {
+                    Text(contextSubtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Image(systemSymbol: .line3Horizontal)
                 .foregroundStyle(.gray)
         }

--- a/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Script/ScriptAppIntent.swift
@@ -75,7 +75,7 @@ final class ScriptAppIntent: AppIntent {
 }
 
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
-struct IntentScriptEntity: AppEntity {
+struct IntentScriptEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Script")
 
     static let defaultQuery = IntentScriptAppEntityQuery()
@@ -91,17 +91,7 @@ struct IntentScriptEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Sensor/IntentSensorsAppEntity.swift
@@ -4,7 +4,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 17.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
-struct IntentSensorsAppEntity: AppEntity {
+struct IntentSensorsAppEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Sensor")
 
     static let defaultQuery = IntentSensorsAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentSensorsAppEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/EntityProvider+Details.swift
+++ b/Sources/Extensions/EntityProvider+Details.swift
@@ -57,6 +57,36 @@ public enum EntityContextSubtitle {
     }
 }
 
+/// A type that carries enough about an entity to render the shared context line (`Area • Device`).
+///
+/// Conformers get `contextSubtitle` for free, so every AppIntent entity / picker row produces the
+/// exact same context — there's no per-type reimplementation to drift out of sync. The formatting
+/// itself still lives in `EntityContextSubtitle.make` (the single source of truth); this protocol is
+/// just the shared, hard-to-get-wrong way to call it.
+public protocol EntityContextRepresentable {
+    /// The entity id (e.g. `light.kitchen`). Also used to derive the domain.
+    var entityId: String { get }
+    /// The entity's resolved display name.
+    var displayString: String { get }
+    /// The area the entity belongs to, if known.
+    var areaName: String? { get }
+    /// The device the entity belongs to, if known.
+    var deviceName: String? { get }
+}
+
+public extension EntityContextRepresentable {
+    /// The shared `Area • Device` context line for this entity. See `EntityContextSubtitle.make`.
+    var contextSubtitle: String? {
+        EntityContextSubtitle.make(
+            areaName: areaName,
+            deviceName: deviceName,
+            entityName: displayString,
+            entityId: entityId,
+            domain: Domain(entityId: entityId)
+        )
+    }
+}
+
 public extension HAAppEntity {
     var area: AppArea? {
         do {

--- a/Sources/Extensions/EntityProvider+Details.swift
+++ b/Sources/Extensions/EntityProvider+Details.swift
@@ -1,22 +1,28 @@
 import Foundation
 import GRDB
 
-/// Builds the secondary "context" line (`Area • Device`) shown under an entity name in pickers.
+/// Builds the secondary "context" line (e.g. `Area • Device`, optionally prefixed with the server
+/// name) shown under an entity name in pickers and configuration screens.
 ///
-/// This is the single source of truth shared by the in-app `EntityPicker` and every AppIntent
-/// based picker (widgets, controls, App Shortcuts) so the context shown stays consistent across
-/// the whole app, matching how Home Assistant core/frontend present entities.
+/// This is the single source of truth shared by the in-app `EntityPicker`, every AppIntent based
+/// picker (widgets, controls, App Shortcuts) and the Watch/Widgets/CarPlay/App-Icon configuration
+/// screens, so the context shown stays consistent across the whole app, matching how Home Assistant
+/// core/frontend present entities.
 public enum EntityContextSubtitle {
     /// - Parameters:
+    ///   - serverName: The server the entity belongs to. Pass this only when more than one server is
+    ///     configured — it's prepended as the first segment; pass `nil` to omit it (single-server).
     ///   - areaName: The area the entity belongs to, if any.
     ///   - deviceName: The device the entity belongs to, if any. Omitted when it merely repeats the entity name.
     ///   - entityName: The entity's resolved display name (used to avoid echoing it as the device name).
-    ///   - entityId: The entity id, used as a last-resort context when no area/device is available.
+    ///   - entityId: The entity id, used as a last-resort context when no other context is available.
     ///   - domain: The entity's domain. Used to decide whether the entity id fallback is meaningful.
-    ///   - fallbackToEntityId: When `true`, returns the entity id if no area/device context exists.
-    /// - Returns: The context line, or `nil` when there's nothing meaningful to show (so callers can
-    ///   omit the subtitle entirely — e.g. a script/scene/automation with no area or device).
+    ///   - fallbackToEntityId: When `true`, returns the entity id if no other context exists.
+    /// - Returns: The context line (e.g. `Home • Living Room • Thermostat`), or `nil` when there's
+    ///   nothing meaningful to show (so callers can omit the subtitle entirely — e.g. a
+    ///   script/scene/automation with no server/area/device context).
     public static func make(
+        serverName: String? = nil,
         areaName: String?,
         deviceName: String?,
         entityName: String,
@@ -25,6 +31,9 @@ public enum EntityContextSubtitle {
         fallbackToEntityId: Bool = true
     ) -> String? {
         var parts: [String] = []
+        if let serverName, !serverName.isEmpty {
+            parts.append(serverName)
+        }
         if let areaName, !areaName.isEmpty {
             parts.append(areaName)
         }

--- a/Sources/Extensions/Widgets/Controls/Automation/IntentAutomationEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Automation/IntentAutomationEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
-struct IntentAutomationEntity: AppEntity {
+struct IntentAutomationEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Automation")
 
     static let defaultQuery = IntentAutomationAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentAutomationEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Controls/Button/IntentButtonEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Button/IntentButtonEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 18.0, *)
-struct IntentButtonEntity: AppEntity {
+struct IntentButtonEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Button")
 
     static let defaultQuery = IntentButtonAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentButtonEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Controls/Cover/IntentCoverEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Cover/IntentCoverEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 18.0, *)
-struct IntentCoverEntity: AppEntity {
+struct IntentCoverEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Cover")
 
     static let defaultQuery = IntentCoverAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentCoverEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Controls/Fan/IntentFanEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Fan/IntentFanEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 18.0, *)
-struct IntentFanEntity: AppEntity {
+struct IntentFanEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Fan")
 
     static let defaultQuery = IntentFanAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentFanEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Controls/Light/IntentLightEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Light/IntentLightEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 18.0, *)
-struct IntentLightEntity: AppEntity {
+struct IntentLightEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Light")
 
     static let defaultQuery = IntentLightAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentLightEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Controls/Switch/IntentSwitchEntity.swift
+++ b/Sources/Extensions/Widgets/Controls/Switch/IntentSwitchEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 18.0, *)
-struct IntentSwitchEntity: AppEntity {
+struct IntentSwitchEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Switch")
 
     static let defaultQuery = IntentSwitchAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentSwitchEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
+++ b/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
@@ -5,7 +5,7 @@ import Shared
 import WidgetKit
 
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
-struct HAAppEntityAppIntentEntity: AppEntity {
+struct HAAppEntityAppIntentEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Entity")
 
     static let defaultQuery = HAAppEntityAppIntentEntityQuery()
@@ -21,17 +21,7 @@ struct HAAppEntityAppIntentEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Extensions/Widgets/Scene/Control/IntentSceneEntity.swift
+++ b/Sources/Extensions/Widgets/Scene/Control/IntentSceneEntity.swift
@@ -5,7 +5,7 @@ import SFSafeSymbols
 import Shared
 
 @available(iOS 16.4, macOS 13.0, watchOS 9.0, *)
-struct IntentSceneEntity: AppEntity {
+struct IntentSceneEntity: AppEntity, EntityContextRepresentable {
     static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Scene")
 
     static let defaultQuery = IntentSceneAppEntityQuery()
@@ -21,17 +21,7 @@ struct IntentSceneEntity: AppEntity {
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
-        )
-    }
-
-    private var subtitle: String? {
-        EntityContextSubtitle.make(
-            areaName: areaName,
-            deviceName: deviceName,
-            entityName: displayString,
-            entityId: entityId,
-            domain: Domain(entityId: entityId)
+            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
         )
     }
 

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -156,12 +156,24 @@ public struct MagicItem: Codable, Equatable, Hashable {
         public let name: String
         public let iconName: String
         public let customization: Customization?
+        /// Optional secondary "context" line shown under the name on configuration screens
+        /// (`[Server • ]Area • Device`). `nil` when there's nothing meaningful to show, or for item
+        /// types without entity context (folders, assist pipelines/prompts). Populated by
+        /// `MagicItemProvider.getInfo`; not used when rendering the item itself on a widget/watch face.
+        public let contextSubtitle: String?
 
-        public init(id: String, name: String, iconName: String, customization: Customization? = nil) {
+        public init(
+            id: String,
+            name: String,
+            iconName: String,
+            customization: Customization? = nil,
+            contextSubtitle: String? = nil
+        ) {
             self.id = id
             self.name = name
             self.iconName = iconName
             self.customization = customization
+            self.contextSubtitle = contextSubtitle
         }
     }
 

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -11,6 +11,10 @@ public protocol MagicItemProviderProtocol {
 
 final class MagicItemProvider: MagicItemProviderProtocol {
     var entitiesPerServer: [String: [HAAppEntity]] = [:]
+    /// Per-server entity→area and entity→device lookups, built once when entities are loaded so
+    /// `getInfo` can attach the "Server • Area • Device" context line without a DB read per item.
+    private var areasPerServer: [String: [String: AppArea]] = [:]
+    private var devicesPerServer: [String: [String: AppDeviceRegistry]] = [:]
 
     func loadInformation(completion: @escaping ([String: [HAAppEntity]]) -> Void) {
         loadAppEntities { [weak self] in
@@ -148,12 +152,18 @@ final class MagicItemProvider: MagicItemProviderProtocol {
         }
         servers.forEach { [weak self] server in
             do {
+                let serverId = server.identifier.rawValue
                 let entities: [HAAppEntity] = try Current.database().read { db in
                     try HAAppEntity
-                        .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == server.identifier.rawValue)
+                        .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
                         .fetchAll(db)
                 }
-                self?.entitiesPerServer[server.identifier.rawValue] = entities
+                self?.entitiesPerServer[serverId] = entities
+                // Build the entity→area / entity→device lookups once per server (each is a small,
+                // fixed number of DB reads) so `getInfo` can attach the context line per item without
+                // a per-item database read.
+                self?.areasPerServer[serverId] = entities.areasMap(for: serverId)
+                self?.devicesPerServer[serverId] = entities.devicesMap(for: serverId)
             } catch {
                 Current.Log.error("Failed to load covers from database: \(error.localizedDescription)")
             }
@@ -182,7 +192,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                 id: scriptItem.id,
                 name: scriptItem.name,
                 iconName: scriptItem.icon ?? MaterialDesignIcons.scriptIcon.name,
-                customization: item.customization
+                customization: item.customization,
+                contextSubtitle: entityContextSubtitle(for: scriptItem)
             )
         case .scene:
             guard let scenesForServer = entitiesPerServer[item.serverId]?
@@ -199,7 +210,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                 id: sceneItem.id,
                 name: sceneItem.name,
                 iconName: sceneItem.icon ?? MaterialDesignIcons.paletteIcon.name,
-                customization: item.customization
+                customization: item.customization,
+                contextSubtitle: entityContextSubtitle(for: sceneItem)
             )
         case .entity:
             guard let entitiesForServer = entitiesPerServer[item.serverId],
@@ -217,7 +229,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                 iconName: entityItem.icon ??
                     Domain(rawValue: entityItem.domain)?.icon(deviceClass: entityItem.rawDeviceClass).name ??
                     MaterialDesignIcons.dotsGridIcon.name,
-                customization: item.customization
+                customization: item.customization,
+                contextSubtitle: entityContextSubtitle(for: entityItem)
             )
         case .folder:
             return .init(
@@ -261,6 +274,23 @@ final class MagicItemProvider: MagicItemProviderProtocol {
         }
 
         return nil
+    }
+
+    /// Builds the "Server • Area • Device" context line for an entity-backed item, reusing the
+    /// per-server maps built in `loadAppEntities` (no per-item DB read). The server segment is only
+    /// included when more than one server is configured, matching the entity picker.
+    private func entityContextSubtitle(for entity: HAAppEntity) -> String? {
+        let serverName = Current.servers.all.count > 1
+            ? Current.servers.server(for: .init(rawValue: entity.serverId))?.info.name
+            : nil
+        return EntityContextSubtitle.make(
+            serverName: serverName,
+            areaName: areasPerServer[entity.serverId]?[entity.entityId]?.name,
+            deviceName: devicesPerServer[entity.serverId]?[entity.entityId]?.name,
+            entityName: entity.name,
+            entityId: entity.entityId,
+            domain: Domain(rawValue: entity.domain)
+        )
     }
 
     private func normalizeCarPlayItems(_ items: [MagicItem]) -> [MagicItem] {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds device and area context to Watch, CarPlay, Widgets and App Icon shortcuts configuration screens.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
