### PR TITLE
Fix Apple Watch standalone action execution

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -92,18 +92,7 @@ public class HomeAssistantAPI {
         Current.Log.info("[mTLS] Has client certificate: \(server.info.connection.clientCertificate != nil)")
         Current.Log.info("[mTLS] Has security exceptions: \(server.info.connection.securityExceptions.hasExceptions)")
 
-        let hakitURLSession: URLSession
-        if server.info.connection.clientCertificate != nil || server.info.connection.securityExceptions.hasExceptions {
-            // Use HAKit's certificate provider protocol
-            Current.Log.info("[mTLS] Using HAKit certificate provider")
-            let certificateProvider = HomeAssistantCertificateProvider(server: server)
-            let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
-            let configuration = URLSessionConfiguration.ephemeral
-            hakitURLSession = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
-        } else {
-            Current.Log.info("[mTLS] Using default URLSession for HAKit")
-            hakitURLSession = URLSession(configuration: .ephemeral)
-        }
+        let hakitURLSession = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
 
         let underlyingConnection = HAKit.connection(
             configuration: .init(
@@ -179,6 +168,21 @@ public class HomeAssistantAPI {
         removeOldDownloadDirectory()
 
         Current.sensors.register(observer: self)
+    }
+
+    /// Builds a `URLSession` that presents this server's client certificate and honors its security
+    /// exceptions (mTLS), or a plain ephemeral session when neither is configured. Reused by HAKit's
+    /// REST calls and, on watchOS, by direct REST execution (where WebSocket transport is unavailable).
+    static func makeCertificateAwareURLSession(server: Server) -> URLSession {
+        if server.info.connection.clientCertificate != nil || server.info.connection.securityExceptions.hasExceptions {
+            Current.Log.info("[mTLS] Using HAKit certificate provider")
+            let certificateProvider = HomeAssistantCertificateProvider(server: server)
+            let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
+            return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        } else {
+            Current.Log.info("[mTLS] Using default URLSession for HAKit")
+            return URLSession(configuration: .ephemeral)
+        }
     }
 
     convenience init?() {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -398,7 +398,8 @@ public extension MagicItem {
     /// sockets are denied by NECP policy on real watch devices (see Starscream #957 / Apple DTS thread
     /// 127232) — so it executes via the Home Assistant REST API over `URLSession`, which is the only
     /// networking watchOS reliably supports and which inherits our mTLS client-certificate handling.
-    /// Other platforms use the existing implementation (webhook / WebSocket depending on item type).
+    /// Every other platform executes through the existing `HomeAssistantAPI` paths: scripts and scenes
+    /// via the webhook API (`CallService`) and entity/lock actions over the WebSocket connection.
     ///
     /// `currentItemState` is used only for the lock domain, since it can't be toggled.
     func execute(
@@ -647,7 +648,13 @@ public extension MagicItem {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: serviceCall.data, options: [])
+        // Surface (rather than silently drop) encoding failures before starting the request.
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: serviceCall.data, options: [])
+        } catch {
+            completion(false, error)
+            return
+        }
 
         Current.Log.info("Executing magic item \(id) via REST: POST \(url.absoluteString)")
 

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -392,11 +392,38 @@ public extension MagicItem {
         Color.haPrimary.hex() ?? Color.brand50.hex() ?? ""
     }
 
-    // currentItemState is used only for lock domain since it can't be toggled
+    /// Single entry point for executing a magic item.
+    ///
+    /// Behavior depends on the platform: watchOS cannot use HAKit's WebSocket transport — raw/stream
+    /// sockets are denied by NECP policy on real watch devices (see Starscream #957 / Apple DTS thread
+    /// 127232) — so it executes via the Home Assistant REST API over `URLSession`, which is the only
+    /// networking watchOS reliably supports and which inherits our mTLS client-certificate handling.
+    /// Every other platform executes over the WebSocket connection.
+    ///
+    /// `currentItemState` is used only for the lock domain, since it can't be toggled.
     func execute(
         on server: Server,
         source: AppTriggerSource,
         currentItemState: String = "",
+        completion: @escaping (Bool, Error?) -> Void
+    ) {
+        #if os(watchOS)
+        executeViaREST(on: server, currentItemState: currentItemState, completion: completion)
+        #else
+        executeViaWebSocket(
+            on: server,
+            source: source,
+            currentItemState: currentItemState,
+            completion: completion
+        )
+        #endif
+    }
+
+    #if !os(watchOS)
+    private func executeViaWebSocket(
+        on server: Server,
+        source: AppTriggerSource,
+        currentItemState: String,
         completion: @escaping (Bool, Error?) -> Void
     ) {
         // Fail fast (and audibly) when there's no usable connection — e.g. the watch can't resolve
@@ -502,4 +529,174 @@ public extension MagicItem {
             return .value
         }
     }
+    #endif
+
+    #if os(watchOS)
+    /// The Home Assistant `call_service` (domain / service / data) that running this item performs.
+    private struct WatchServiceCall {
+        let domain: String
+        let service: String
+        let data: [String: Any]
+    }
+
+    /// watchOS executes via the REST API — see `execute(on:source:currentItemState:completion:)`.
+    /// The request reuses the server's mTLS-aware `URLSession` and bearer token (token refresh already
+    /// works over `URLSession` on the watch), so no WebSocket is involved.
+    private func executeViaREST(
+        on server: Server,
+        currentItemState: String,
+        completion: @escaping (Bool, Error?) -> Void
+    ) {
+        let serviceCall: WatchServiceCall?
+        do {
+            serviceCall = try resolveServiceCall(currentItemState: currentItemState)
+        } catch {
+            Current.Log.error("Error resolving service for magic item \(id): \(error.localizedDescription)")
+            completion(false, error)
+            return
+        }
+
+        guard let serviceCall else {
+            // Item types without a direct action (folder/assist) — treat as a no-op success.
+            completion(true, nil)
+            return
+        }
+
+        var connectionInfo = server.info.connection
+        guard let baseURL = connectionInfo.activeURL() else {
+            Current.Log.error("No active URL while executing magic item \(id) on watch")
+            completion(false, ServerConnectionError.noActiveURL(server.info.name))
+            return
+        }
+
+        let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+        tokenManager.bearerToken.done { token, _ in
+            self.sendRESTServiceCall(
+                baseURL: baseURL,
+                server: server,
+                token: token,
+                serviceCall: serviceCall,
+                completion: completion
+            )
+        }.catch { error in
+            Current.Log.error("Token unavailable executing magic item \(self.id): \(error.localizedDescription)")
+            completion(false, error)
+        }
+    }
+
+    /// Maps this item to the service call it performs, mirroring the WebSocket path. Returns nil for
+    /// item types that don't map to a service (folder, assist, no-op lock state).
+    private func resolveServiceCall(currentItemState: String) throws -> WatchServiceCall? {
+        switch type {
+        case .script:
+            let domain = Domain.script.rawValue
+            let service = id.replacingOccurrences(of: "\(domain).", with: "")
+            return WatchServiceCall(domain: domain, service: service, data: [:])
+        case .scene:
+            return WatchServiceCall(
+                domain: Domain.scene.rawValue,
+                service: Service.turnOn.rawValue,
+                data: ["entity_id": id]
+            )
+        case .entity:
+            guard let domain else {
+                throw MagicItemError.unknownDomain
+            }
+            if domain == .lock {
+                guard let state = Domain.State(rawValue: currentItemState) else { return nil }
+                switch state {
+                case .unlocking, .unlocked, .opening:
+                    return WatchServiceCall(
+                        domain: Domain.lock.rawValue,
+                        service: Service.lock.rawValue,
+                        data: ["entity_id": id]
+                    )
+                case .locked, .locking:
+                    return WatchServiceCall(
+                        domain: Domain.lock.rawValue,
+                        service: Service.unlock.rawValue,
+                        data: ["entity_id": id]
+                    )
+                default:
+                    return nil
+                }
+            } else {
+                guard let action = domain.mainAction else { return nil }
+                return WatchServiceCall(domain: domain.rawValue, service: action.rawValue, data: ["entity_id": id])
+            }
+        case .folder, .assistPipeline, .assistPrompt, .unsupported:
+            return nil
+        }
+    }
+
+    private func sendRESTServiceCall(
+        baseURL: URL,
+        server: Server,
+        token: String,
+        serviceCall: WatchServiceCall,
+        completion: @escaping (Bool, Error?) -> Void
+    ) {
+        let url = baseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("services")
+            .appendingPathComponent(serviceCall.domain)
+            .appendingPathComponent(serviceCall.service)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: serviceCall.data, options: [])
+
+        Current.Log.info("Executing magic item \(id) via REST: POST \(url.absoluteString)")
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        let task = session.dataTask(with: request) { [session] data, response, error in
+            // The session strongly retains its delegate until invalidated; do it once the task ends.
+            defer { session.finishTasksAndInvalidate() }
+
+            if let error {
+                Current.Log.error("REST execution of magic item \(self.id) failed: \(error.localizedDescription)")
+                completion(false, error)
+                return
+            }
+
+            guard let http = response as? HTTPURLResponse else {
+                completion(false, WatchRESTExecutionError.invalidResponse)
+                return
+            }
+
+            if (200 ..< 300).contains(http.statusCode) {
+                Current.Log.verbose("Success executing magic item \(self.id) via REST")
+                completion(true, nil)
+            } else {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) }
+                Current.Log.error(
+                    "REST execution of magic item \(self.id) returned \(http.statusCode): \(body ?? "<no body>")"
+                )
+                completion(false, WatchRESTExecutionError.httpStatus(http.statusCode, body: body))
+            }
+        }
+        task.resume()
+    }
+
+    private enum WatchRESTExecutionError: LocalizedError {
+        case invalidResponse
+        case httpStatus(_ statusCode: Int, body: String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                return L10n.Watch.Home.Run.Error.message
+            case let .httpStatus(_, body):
+                // Home Assistant returns a human-readable message on failure; surface it when present.
+                if let body, !body.isEmpty {
+                    return body
+                }
+                return L10n.Watch.Home.Run.Error.message
+            }
+        }
+    }
+    #endif
 }

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -398,7 +398,7 @@ public extension MagicItem {
     /// sockets are denied by NECP policy on real watch devices (see Starscream #957 / Apple DTS thread
     /// 127232) — so it executes via the Home Assistant REST API over `URLSession`, which is the only
     /// networking watchOS reliably supports and which inherits our mTLS client-certificate handling.
-    /// Every other platform executes over the WebSocket connection.
+    /// Other platforms use the existing implementation (webhook / WebSocket depending on item type).
     ///
     /// `currentItemState` is used only for the lock domain, since it can't be toggled.
     func execute(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
- This PR makes all watch actions executed through REST API instead of WebSocket.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
