### PR TITLE
Offer Open App / Open Settings on macOS menu-bar right-click

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -659,6 +659,8 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "menu.application.preferences" = "Preferences…";
 "menu.file.update_sensors" = "Update Sensors";
 "menu.help.help" = "%@ Help";
+"menu.status_item.open" = "Open %1$@";
+"menu.status_item.open_settings" = "Open Settings…";
 "menu.status_item.quit" = "Quit";
 "menu.status_item.toggle" = "Toggle %1$@";
 "menu.view.find" = "Find";

--- a/Sources/App/Utilities/MenuManager.swift
+++ b/Sources/App/Utilities/MenuManager.swift
@@ -286,17 +286,6 @@ class MenuManager {
         )
     }
 
-    private func preferencesMenu() -> AppMacBridgeStatusItemMenuItem {
-        .init(
-            name: L10n.Menu.Application.preferences,
-            keyEquivalentModifier: [.command],
-            keyEquivalent: ","
-        ) { callbackInfo in
-            Current.sceneManager.activateAnyScene(for: .settings)
-            callbackInfo.activate()
-        }
-    }
-
     private func helpMenus() -> [UIMenu] {
         let title = L10n.Menu.Help.help(appName)
 
@@ -367,14 +356,21 @@ class MenuManager {
         )
     }
 
-    private func toggleMenu() -> AppMacBridgeStatusItemMenuItem {
-        .init(name: L10n.Menu.StatusItem.toggle(appName)) { callbackInfo in
-            if callbackInfo.isActive {
-                callbackInfo.deactivate()
-            } else {
-                Current.sceneManager.activateAnyScene(for: .webView)
-                callbackInfo.activate()
-            }
+    private func openAppMenu() -> AppMacBridgeStatusItemMenuItem {
+        .init(name: L10n.Menu.StatusItem.open(appName)) { callbackInfo in
+            Current.sceneManager.activateAnyScene(for: .webView)
+            callbackInfo.activate()
+        }
+    }
+
+    private func openSettingsMenu() -> AppMacBridgeStatusItemMenuItem {
+        .init(
+            name: L10n.Menu.StatusItem.openSettings,
+            keyEquivalentModifier: [.command],
+            keyEquivalent: ","
+        ) { callbackInfo in
+            Current.sceneManager.activateAnyScene(for: .settings)
+            callbackInfo.activate()
         }
     }
 
@@ -397,10 +393,10 @@ class MenuManager {
         }
 
         var menuItems = [AppMacBridgeStatusItemMenuItem]()
-        menuItems.append(toggleMenu())
+        menuItems.append(openAppMenu())
+        menuItems.append(openSettingsMenu())
         menuItems.append(.separator())
         menuItems.append(contentsOf: aboutMenu())
-        menuItems.append(preferencesMenu())
         menuItems.append(quitMenu())
 
         Current.macBridge.configureStatusItem(using: AppMacBridgeStatusItemConfiguration(

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2412,6 +2412,12 @@ public enum L10n {
       }
     }
     public enum StatusItem {
+      /// Open %1$@
+      public static func open(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "menu.status_item.open", String(describing: p1))
+      }
+      /// Open Settings…
+      public static var openSettings: String { return L10n.tr("Localizable", "menu.status_item.open_settings") }
       /// Quit
       public static var quit: String { return L10n.tr("Localizable", "menu.status_item.quit") }
       /// Toggle %1$@


### PR DESCRIPTION
## Summary

When the macOS app runs in the menu bar, right-clicking the status-item icon previously showed an ambiguous **"Toggle Home Assistant"** as its first action. This replaces it with two explicit actions so a right-click clearly offers opening the app or its settings:

- **Open Home Assistant** — activates the main window (`.webView` scene).
- **Open Settings…** — activates the Settings window (`.settings` scene), keeping the existing ⌘, shortcut.

The standalone "Preferences…" status-item entry (which did the same thing as the new "Open Settings…") is removed to avoid duplication; the regular app-menu "Preferences…" (⌘,) is untouched. The **left-click** show/hide toggle behaviour on the icon is unchanged.

Resulting right-click menu: Open Home Assistant · Open Settings… · — · About · Check for Updates · Quit.

## Screenshots
<!-- Right-click the macOS menu-bar icon to see the new menu. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
New localized strings `menu.status_item.open` and `menu.status_item.open_settings` added to `en.lproj/Localizable.strings` (non-English locales sync from Lokalise). `Strings.swift` accessors regenerate via the SwiftGen build phase; updated here to match.