### PR TITLE
Fix macOS distribute CI: raise xcodebuild build-settings probe timeout

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -10,11 +10,6 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
   FASTLANE_SKIP_UPDATE_CHECK: true
   FASTLANE_XCODE_LIST_TIMEOUT: 60
-  # `xcodebuild -showBuildSettings` runs cold (SPM resolution is skipped), so for this
-  # large workspace it exceeds 60s on the macOS leg. When it times out, gym can't read
-  # SUPPORTS_MACCATALYST, assumes the project is iOS-only, archives `generic/platform=iOS`,
-  # and the resulting iOS archive fails to export the macOS `developer-id` method on
-  # Xcode 26.4.1. Give the probe enough time to complete. See home-assistant/iOS#4807.
   FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
   HOMEBREW_NO_INSTALL_CLEANUP: TRUE
   BUNDLE_PATH: vendor/bundle

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -10,7 +10,12 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
   FASTLANE_SKIP_UPDATE_CHECK: true
   FASTLANE_XCODE_LIST_TIMEOUT: 60
-  FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+  # `xcodebuild -showBuildSettings` runs cold (SPM resolution is skipped), so for this
+  # large workspace it exceeds 60s on the macOS leg. When it times out, gym can't read
+  # SUPPORTS_MACCATALYST, assumes the project is iOS-only, archives `generic/platform=iOS`,
+  # and the resulting iOS archive fails to export the macOS `developer-id` method on
+  # Xcode 26.4.1. Give the probe enough time to complete. See home-assistant/iOS#4807.
+  FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
   HOMEBREW_NO_INSTALL_CLEANUP: TRUE
   BUNDLE_PATH: vendor/bundle
 

--- a/fastlane/lanes/macos.rb
+++ b/fastlane/lanes/macos.rb
@@ -6,11 +6,6 @@ platform :mac do
 
     specifiers = provisioning_profile_specifiers(sdk: 'macosx')
     developer_id_app_path = build_mac_app(
-      # Force the Mac Catalyst (macOS) variant. Without this gym archives for
-      # `generic/platform=iOS`, producing an iOS archive whose only valid export
-      # methods are the iOS set. The macOS-only `developer-id` method was tolerated
-      # by older Xcode but is rejected by Xcode 26.4.1's stricter -exportArchive.
-      catalyst_platform: 'macos',
       export_method: 'developer-id',
       skip_package_dependencies_resolution: true,
       skip_profile_detection: true,
@@ -23,7 +18,6 @@ platform :mac do
       }
     )
     app_store_pkg_path = build_mac_app(
-      catalyst_platform: 'macos',
       archive_path: lane_context[SharedValues::XCODEBUILD_ARCHIVE],
       export_method: 'app-store',
       skip_package_dependencies_resolution: true,

--- a/fastlane/lanes/macos.rb
+++ b/fastlane/lanes/macos.rb
@@ -6,6 +6,11 @@ platform :mac do
 
     specifiers = provisioning_profile_specifiers(sdk: 'macosx')
     developer_id_app_path = build_mac_app(
+      # Force the Mac Catalyst (macOS) variant. Without this gym archives for
+      # `generic/platform=iOS`, producing an iOS archive whose only valid export
+      # methods are the iOS set. The macOS-only `developer-id` method was tolerated
+      # by older Xcode but is rejected by Xcode 26.4.1's stricter -exportArchive.
+      catalyst_platform: 'macos',
       export_method: 'developer-id',
       skip_package_dependencies_resolution: true,
       skip_profile_detection: true,
@@ -18,6 +23,7 @@ platform :mac do
       }
     )
     app_store_pkg_path = build_mac_app(
+      catalyst_platform: 'macos',
       archive_path: lane_context[SharedValues::XCODEBUILD_ARCHIVE],
       export_method: 'app-store',
       skip_package_dependencies_resolution: true,


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The macOS `distribute` job fails at the **export** step on the `macos-26` runner (archive succeeds; export fails):

```
error: exportArchive exportOptionsPlist error for key "method"
expected one {app-store-connect, release-testing, enterprise, debugging, validation} but found developer-id
```

### Root cause
The export rejection is a downstream symptom. The real cause is **earlier**, in gym's platform detection:

```
[10:06:11]: Skipped Swift Package Manager dependencies resolution.
$ xcodebuild -showBuildSettings -workspace HomeAssistant.xcworkspace -scheme App-Release 2>&1
[10:07:11]: Command timed out after 60 seconds on try 1 of 4, trying again with a 120 second timeout...
[10:07:35]: Could not read the "SUPPORTED_PLATFORMS" build setting, assuming that the project supports iOS only.
```

`build_mac_app` already sets `catalyst_platform = "macos"` internally, but gym only honours it when `supports_mac_catalyst?` is true. That check runs `xcodebuild -showBuildSettings`, which — because SPM resolution is skipped — runs cold and, for this large workspace, **exceeds the 60s `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT`**. When it times out, gym can't read `SUPPORTS_MACCATALYST`, assumes the project is iOS-only, and archives `generic/platform=iOS`. The resulting **iOS** archive can't export the macOS-only `developer-id` method under Xcode 26.4.1's stricter `-exportArchive` (older Xcode tolerated it). The `app-store` build never runs because the `developer-id` export fails first.

This also explains why it "worked before": the probe used to complete within 60s, so `supports_mac_catalyst?` was true and gym archived the Mac Catalyst variant. As the workspace grew / Xcode got slower, the cold probe started timing out.

### Fix
Raise `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT` from `60` to `180` so the cold `-showBuildSettings` probe completes. gym then reads `SUPPORTS_MACCATALYST=YES`, archives `generic/platform=macOS` (Mac Catalyst), takes the pkg/app export path, and exports `developer-id` + `app-store` as designed.

> Note: an earlier revision of this PR added `catalyst_platform: 'macos'` to the `build_mac_app` calls. That was wrong — `build_mac_app` rejects that option (it sets it internally), which only produced a new error. It has been reverted; the lane is unchanged from `main`.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — CI / build tooling only, no app or UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
- The `Distribute` workflow only runs on push to `main` / `workflow_dispatch`, so PR CI does not exercise this path. Please confirm with a manual `Distribute` run on this branch before merging.
- If 180s still proves tight on a cold runner, `FASTLANE_XCODEBUILD_SETTINGS_RETRIES` (default 3, with doubling backoff) provides additional headroom, or the workflow could pre-resolve SPM packages before `fastlane mac build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)