### PR TITLE
Media types requiring user action for playback

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -188,7 +188,9 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
         // Avoid interrupting background audio when the frontend loads media-capable elements.
-        config.mediaTypesRequiringUserActionForPlayback = .audio
+        config.mediaTypesRequiringUserActionForPlayback = Current.settingsStore
+            .mediaTypesRequiringUserActionForPlayback
+            .wkMediaTypes
         return config
     }
 
@@ -312,6 +314,21 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
             let action = Current.settingsStore.gestures[.shake] ?? .openDebug
             webViewGestureHandler.handleGestureAction(action)
         }
+    }
+}
+
+private extension Set<SettingsStore.MediaTypeRequiringUserActionForPlayback> {
+    var wkMediaTypes: WKAudiovisualMediaTypes {
+        var mediaTypes: WKAudiovisualMediaTypes = []
+
+        if contains(.audio) {
+            mediaTypes.insert(.audio)
+        }
+        if contains(.video) {
+            mediaTypes.insert(.video)
+        }
+
+        return mediaTypes
     }
 }
 

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -126,6 +126,15 @@ struct DebugView: View {
                 }
 
                 NavigationLink {
+                    MediaTypesRequiringUserActionForPlaybackView()
+                } label: {
+                    linkContent(
+                        image: .init(systemSymbol: .speakerWave2Fill),
+                        title: "Media playback"
+                    )
+                }
+
+                NavigationLink {
                     DatabaseExplorerView()
                 } label: {
                     linkContent(
@@ -593,6 +602,57 @@ struct DebugView: View {
                 continuation.resume()
             }
         }
+    }
+}
+
+private struct MediaTypesRequiringUserActionForPlaybackView: View {
+    @State private var selectedMediaTypes: Set<SettingsStore.MediaTypeRequiringUserActionForPlayback>
+    @State private var showRestartAlert = false
+
+    init() {
+        _selectedMediaTypes = State(initialValue: Current.settingsStore.mediaTypesRequiringUserActionForPlayback)
+    }
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(SettingsStore.MediaTypeRequiringUserActionForPlayback.allCases, id: \.self) { mediaType in
+                    Button {
+                        toggle(mediaType)
+                    } label: {
+                        HStack {
+                            Text(mediaType.title)
+                            Spacer()
+                            if selectedMediaTypes.contains(mediaType) {
+                                Image(systemSymbol: .checkmark)
+                                    .foregroundStyle(Color.haPrimary)
+                            }
+                        }
+                    }
+                    .foregroundStyle(Color(uiColor: .label))
+                }
+            } footer: {
+                Text("Select which frontend media types require a user action before playback.")
+            }
+        }
+        .navigationTitle("Media playback")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Force close required", isPresented: $showRestartAlert) {
+            Button(L10n.okLabel, role: .cancel) {}
+        } message: {
+            Text("Force close and reopen the app for this change to take effect.")
+        }
+    }
+
+    private func toggle(_ mediaType: SettingsStore.MediaTypeRequiringUserActionForPlayback) {
+        if selectedMediaTypes.contains(mediaType) {
+            selectedMediaTypes.remove(mediaType)
+        } else {
+            selectedMediaTypes.insert(mediaType)
+        }
+
+        Current.settingsStore.mediaTypesRequiringUserActionForPlayback = selectedMediaTypes
+        showRestartAlert = true
     }
 }
 

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -130,7 +130,7 @@ struct DebugView: View {
                 } label: {
                     linkContent(
                         image: .init(systemSymbol: .speakerWave2Fill),
-                        title: "Media playback"
+                        title: "WKWebView Media Playback"
                     )
                 }
 
@@ -635,7 +635,7 @@ private struct MediaTypesRequiringUserActionForPlaybackView: View {
                 Text("Select which frontend media types require a user action before playback.")
             }
         }
-        .navigationTitle("Media playback")
+        .navigationTitle("WKWebView Media Playback")
         .navigationBarTitleDisplayMode(.inline)
         .alert("Force close required", isPresented: $showRestartAlert) {
             Button(L10n.okLabel, role: .cancel) {}

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -159,6 +159,20 @@ public class SettingsStore {
         ]
     }
 
+    public enum MediaTypeRequiringUserActionForPlayback: String, CaseIterable, Hashable {
+        case audio
+        case video
+
+        public var title: String {
+            switch self {
+            case .audio:
+                return "Audio"
+            case .video:
+                return "Video"
+            }
+        }
+    }
+
     public var pageZoom: PageZoom {
         get {
             if let pageZoom = PageZoom(preference: prefs.integer(forKey: "page_zoom")) {
@@ -541,6 +555,19 @@ public class SettingsStore {
         }
         set {
             prefs.set(newValue, forKey: "toastsHandledByApp")
+        }
+    }
+
+    public var mediaTypesRequiringUserActionForPlayback: Set<MediaTypeRequiringUserActionForPlayback> {
+        get {
+            let rawValues = prefs.stringArray(forKey: "mediaTypesRequiringUserActionForPlayback") ?? [
+                MediaTypeRequiringUserActionForPlayback.audio.rawValue,
+            ]
+            return Set(rawValues.compactMap(MediaTypeRequiringUserActionForPlayback.init(rawValue:)))
+        }
+        set {
+            let rawValues = newValue.map(\.rawValue).sorted()
+            prefs.set(rawValues, forKey: "mediaTypesRequiringUserActionForPlayback")
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add to debug settings a configuration menu to choose which media types applies to `WKWebView` `mediaTypesRequiringUserActionForPlayback`
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img width="1206" height="2622" alt="Simulator Screenshot - Daily tester 2 - 2026-06-24 at 13 14 05" src="https://github.com/user-attachments/assets/bef64127-fd5e-4b8b-b4f0-a68f0a4d09ff" />
<img width="1206" height="2622" alt="Simulator Screenshot - Daily tester 2 - 2026-06-24 at 13 14 06" src="https://github.com/user-attachments/assets/766de066-f0be-4ab2-b466-44b2efd2a579" />



## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
