### PR TITLE
Live Activity: tint the progress bar with progress_bar_color

### DIFF
--- a/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
@@ -173,7 +173,7 @@ struct HAExpandedBottomView: View {
             if let fraction = state.progressFraction {
                 HAActivityProgressBar(
                     fraction: fraction,
-                    fillColor: accentColor,
+                    fillColor: barColor,
                     trackColor: .white.opacity(0.16),
                     height: 8
                 )
@@ -182,9 +182,9 @@ struct HAExpandedBottomView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Accent color from ContentState, fallback to Home Assistant primary blue.
-    private var accentColor: Color {
-        HAActivityVisualStyle.color(from: state.color)
+    /// Progress bar tint: `progress_bar_color`, else the icon color, else HA blue.
+    private var barColor: Color {
+        HAActivityVisualStyle.color(from: state.progressBarColor ?? state.color)
     }
 }
 #endif

--- a/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
@@ -48,7 +48,7 @@ struct HALockScreenView: View {
             if let fraction = state.progressFraction {
                 HAActivityProgressBar(
                     fraction: fraction,
-                    fillColor: accentColor,
+                    fillColor: barColor,
                     trackColor: trackColor,
                     height: 10
                 )
@@ -111,6 +111,11 @@ struct HALockScreenView: View {
     /// Accent color from ContentState, fallback to Home Assistant primary blue.
     private var accentColor: Color {
         HAActivityVisualStyle.color(from: state.color)
+    }
+
+    /// Progress bar tint: `progress_bar_color`, else the icon color, else HA blue.
+    private var barColor: Color {
+        HAActivityVisualStyle.color(from: state.progressBarColor ?? state.color)
     }
 
     /// Luma of the resolved background — drives element opacities and the auto-contrast default.

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -85,6 +85,10 @@ public struct HALiveActivityAttributes: ActivityAttributes {
         /// Overrides the auto-contrast default. Maps to `text_color`.
         public var textColor: String?
 
+        /// Hex tint for the progress bar, parsed like `notification_icon_color`. Falls back to
+        /// `notification_icon_color` when omitted. Maps to `progress_bar_color`.
+        public var progressBarColor: String?
+
         // MARK: - Computed helpers (not sent over wire)
 
         /// Progress as a fraction in [0, 1] for use in SwiftUI ProgressView.
@@ -109,6 +113,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             case url
             case backgroundColor = "background_color"
             case textColor = "text_color"
+            case progressBarColor = "progress_bar_color"
         }
 
         // MARK: - Init
@@ -125,7 +130,8 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             color: String? = nil,
             url: String? = nil,
             backgroundColor: String? = nil,
-            textColor: String? = nil
+            textColor: String? = nil,
+            progressBarColor: String? = nil
         ) {
             self.title = title
             self.message = message
@@ -139,6 +145,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             self.url = url
             self.backgroundColor = backgroundColor
             self.textColor = textColor
+            self.progressBarColor = progressBarColor
         }
 
         // MARK: - Codable
@@ -165,6 +172,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             self.url = try container.decodeIfPresent(String.self, forKey: .url)
             self.backgroundColor = try container.decodeIfPresent(String.self, forKey: .backgroundColor)
             self.textColor = try container.decodeIfPresent(String.self, forKey: .textColor)
+            self.progressBarColor = try container.decodeIfPresent(String.self, forKey: .progressBarColor)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -183,6 +191,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             try container.encodeIfPresent(url, forKey: .url)
             try container.encodeIfPresent(backgroundColor, forKey: .backgroundColor)
             try container.encodeIfPresent(textColor, forKey: .textColor)
+            try container.encodeIfPresent(progressBarColor, forKey: .progressBarColor)
         }
     }
 

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -116,6 +116,7 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
         let url = payload["url"] as? String
         let backgroundColor = payload["background_color"] as? String
         let textColor = payload["text_color"] as? String
+        let progressBarColor = payload["progress_bar_color"] as? String
 
         // `when` + `when_relative` → absolute countdown end date.
         // Parsed as Double to preserve sub-second Unix timestamps sent by HA.
@@ -141,7 +142,8 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
             color: color,
             url: url,
             backgroundColor: backgroundColor,
-            textColor: textColor
+            textColor: textColor,
+            progressBarColor: progressBarColor
         )
     }
 }

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -87,6 +87,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNil(state.color)
         XCTAssertNil(state.backgroundColor)
         XCTAssertNil(state.textColor)
+        XCTAssertNil(state.progressBarColor)
     }
 
     func testContentState_fullPayload_mapsAllFields() {
@@ -101,6 +102,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
             "notification_icon_color": "#FF5733",
             "background_color": "#101820",
             "text_color": "#FFFFFF",
+            "progress_bar_color": "#FF9800",
         ]
         let state = HandlerStartOrUpdateLiveActivity.contentState(from: payload)
         XCTAssertEqual(state.title, "Test title")
@@ -113,6 +115,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertEqual(state.color, "#FF5733")
         XCTAssertEqual(state.backgroundColor, "#101820")
         XCTAssertEqual(state.textColor, "#FFFFFF")
+        XCTAssertEqual(state.progressBarColor, "#FF9800")
         XCTAssertNil(state.countdownEnd)
     }
 

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -55,7 +55,8 @@ final class LiveActivityContractTests: XCTestCase {
             color: "#FF0000",
             url: "/lovelace/0",
             backgroundColor: "#000000",
-            textColor: "#FFFFFF"
+            textColor: "#FFFFFF",
+            progressBarColor: "#FF9800"
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970
@@ -76,6 +77,7 @@ final class LiveActivityContractTests: XCTestCase {
             "url",
             "background_color",
             "text_color",
+            "progress_bar_color",
         ]
         XCTAssertEqual(Set(dict.keys), expectedKeys)
     }
@@ -94,7 +96,8 @@ final class LiveActivityContractTests: XCTestCase {
             color: "#2196F3",
             url: "/lovelace/laundry",
             backgroundColor: "#101820",
-            textColor: "#FFFFFF"
+            textColor: "#FFFFFF",
+            progressBarColor: "#FF9800"
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds an optional **`progress_bar_color`** field that tints the Live Activity progress bar. Parsed with the same rules as `notification_icon_color`; when omitted, the bar falls back to `notification_icon_color` (current behavior). Applies to both the Lock Screen and the Dynamic Island expanded view; the icon accent is unchanged.

- `HALiveActivityAttributes.ContentState`: new optional `progressBarColor` (wire key `progress_bar_color`).
- `HandlerStartOrUpdateLiveActivity`: reads `progress_bar_color` (local push path).
- `HALockScreenView` / `HADynamicIslandView`: the progress bar fill uses `progress_bar_color ?? notification_icon_color`.
- Tests: contract (wire key + key set + round-trip) and handler parsing.

Relay passthrough: home-assistant/mobile-apps-fcm-push#326
