### PR TITLE
Release stale Live Activity tokens on launch

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -76,6 +76,17 @@ class LifecycleManager {
     @objc private func willEnterForeground() {
         isActive = true
         syncNetworkInformation()
+        syncLiveActivities()
+    }
+
+    /// Reconcile running Live Activities with Core on every foreground, releasing tokens for any
+    /// that ended while the app was backgrounded so Core stops pushing to them.
+    private func syncLiveActivities() {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        if #available(iOS 17.2, *) {
+            Task { await Current.liveActivityRegistry?.reattach() }
+        }
+        #endif
     }
 
     @objc private func didEnterBackground() {

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -712,6 +712,9 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.status.not_supported" = "Not available on iPad";
 "live_activity.status.open_settings" = "Open Settings";
 "live_activity.subtitle" = "Real-time Home Assistant updates on your Lock Screen and Dynamic Island.";
+"live_activity.sync.button" = "Sync with Home Assistant";
+"live_activity.sync.done" = "Synced";
+"live_activity.sync.footer" = "Reports running Live Activities to Home Assistant and releases tokens for any that have ended. Runs automatically when the app opens.";
 "live_activity.title" = "Live Activities";
 "location_change_notification.app_shortcut.body" = "Location updated via App Shortcut";
 "location_change_notification.background_fetch.body" = "Current location delivery triggered via background fetch";

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -11,6 +11,7 @@ struct LiveActivitySettingsView: View {
     @State private var authorizationEnabled: Bool = false
     @State private var frequentUpdatesEnabled: Bool = false
     @State private var showEndAllConfirmation = false
+    @State private var didSync = false
 
     // MARK: Body
 
@@ -58,9 +59,33 @@ struct LiveActivitySettingsView: View {
                 }
             }
 
+            Section {
+                Button {
+                    syncActivities()
+                } label: {
+                    Label(L10n.LiveActivity.Sync.button, systemSymbol: .arrowTriangle2Circlepath)
+                }
+
+                if didSync {
+                    Label(L10n.LiveActivity.Sync.done, systemSymbol: .checkmarkCircleFill)
+                        .foregroundStyle(.green)
+                        .font(.subheadline)
+                }
+            } footer: {
+                Text(L10n.LiveActivity.Sync.footer)
+            }
+
             samplesSection
         }
         .task { await loadActivities() }
+    }
+
+    private func syncActivities() {
+        Task {
+            await Current.liveActivityRegistry?.reattach()
+            await loadActivities()
+            didSync = true
+        }
     }
 
     // MARK: - Sections

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -396,10 +396,14 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 "tag": tag,
             ]
         )
-        for server in Current.servers.all {
-            Current.webhooks.sendEphemeral(server: server, request: request).cauterize()
+        let sends = Current.servers.all.map { Current.webhooks.sendEphemeral(server: $0, request: request) }
+        // Forget the tag only once every server confirms the release. If any send fails (e.g. the
+        // device is offline when the activity ends), keep it so reattach() retries on next launch.
+        when(fulfilled: sends).done { [weak self] in
+            Task { await self?.forgetReportedTokenTag(tag) }
+        }.catch { error in
+            Current.Log.verbose("LiveActivityRegistry: dismiss not confirmed for tag \(tag), will retry: \(error)")
         }
-        forgetReportedTokenTag(tag)
     }
 
     /// Report the push-to-start token to all HA servers via registration update.

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -224,15 +224,32 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         }
     }
 
-    /// Re-attach observation tasks to any Live Activities that survived process termination.
-    /// Call this at app launch before any notification handlers are invoked.
+    /// Re-attach observation tasks to any Live Activities that survived process termination,
+    /// then sync Core: release the push token for any activity Core still thinks is live but
+    /// is no longer running (e.g. it ended during an app update, so its dismissal was never
+    /// observed). Call this at app launch before any notification handlers are invoked.
     public func reattach() async {
+        var runningTags: Set<String> = []
         for activity in Activity<HALiveActivityAttributes>.activities {
             let tag = activity.attributes.tag
+            runningTags.insert(tag)
             guard entries[tag] == nil else { continue }
             let observationTask = makeObservationTask(for: activity)
             entries[tag] = Entry(activity: activity, observationTask: observationTask)
             Current.Log.verbose("LiveActivityRegistry: reattached activity for tag \(tag), id=\(activity.id)")
+        }
+        await releaseStaleTokens(runningTags: runningTags)
+    }
+
+    /// Tell Core to drop tokens for activities that are no longer running. Without this, an
+    /// activity that ended while the app wasn't running (its `.dismissed` state unobserved)
+    /// leaves Core pushing to a dead token until it expires (8 h).
+    private func releaseStaleTokens(runningTags: Set<String>) async {
+        let stale = reportedTokenTags().subtracting(runningTags)
+        guard !stale.isEmpty else { return }
+        Current.Log.verbose("LiveActivityRegistry: releasing \(stale.count) stale Live Activity token(s) at launch")
+        for tag in stale {
+            await reportActivityDismissed(tag: tag)
         }
     }
 
@@ -367,6 +384,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         for server in Current.servers.all {
             Current.webhooks.sendEphemeral(server: server, request: request).cauterize()
         }
+        rememberReportedTokenTag(tag)
     }
 
     /// Notify HA servers that the Live Activity was dismissed or ended externally.
@@ -381,6 +399,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         for server in Current.servers.all {
             Current.webhooks.sendEphemeral(server: server, request: request).cauterize()
         }
+        forgetReportedTokenTag(tag)
     }
 
     /// Report the push-to-start token to all HA servers via registration update.
@@ -392,6 +411,31 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 Current.Log.error("LiveActivityRegistry: failed to report push-to-start token: \(error)")
             }
         }
+    }
+
+    // MARK: - Private — Reported-token bookkeeping (App Group)
+
+    /// Tags we currently hold a per-activity push token for in Core. Persisted across launches
+    /// so `reattach()` can release tokens for activities that ended while the app wasn't running.
+    private static let reportedTokenTagsKey = "liveActivityReportedTokenTags"
+
+    private func reportedTokenTags() -> Set<String> {
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return [] }
+        return Set(defaults.stringArray(forKey: Self.reportedTokenTagsKey) ?? [])
+    }
+
+    private func rememberReportedTokenTag(_ tag: String) {
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
+        var tags = Set(defaults.stringArray(forKey: Self.reportedTokenTagsKey) ?? [])
+        guard tags.insert(tag).inserted else { return }
+        defaults.set(Array(tags), forKey: Self.reportedTokenTagsKey)
+    }
+
+    private func forgetReportedTokenTag(_ tag: String) {
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
+        var tags = Set(defaults.stringArray(forKey: Self.reportedTokenTagsKey) ?? [])
+        guard tags.remove(tag) != nil else { return }
+        defaults.set(Array(tags), forKey: Self.reportedTokenTagsKey)
     }
 }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2437,6 +2437,14 @@ public enum L10n {
       /// Open Settings
       public static var openSettings: String { return L10n.tr("Localizable", "live_activity.status.open_settings") }
     }
+    public enum Sync {
+      /// Sync with Home Assistant
+      public static var button: String { return L10n.tr("Localizable", "live_activity.sync.button") }
+      /// Synced
+      public static var done: String { return L10n.tr("Localizable", "live_activity.sync.done") }
+      /// Reports running Live Activities to Home Assistant and releases tokens for any that have ended. Runs automatically when the app opens.
+      public static var footer: String { return L10n.tr("Localizable", "live_activity.sync.footer") }
+    }
   }
 
   public enum LocationChangeNotification {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When a Live Activity ends while the app is **not running** to observe it — most commonly an **app update**, but also a force-quit — its `.dismissed`/`.ended` state is never seen, so `reportActivityDismissed` never fires and **Core keeps a stale per-activity push token** until it expires (8 h), pushing to a dead activity in the meantime.

This syncs Core to the actually-running activities at launch:
- The registry now persists (App Group) the set of tags it holds a Core token for — added in `reportPushToken`, removed in `reportActivityDismissed`.
- `reattach()` (already called once at launch, before any notification handler) now also releases tokens: any persisted tag that is **not** in `Activity.activities` gets a `live_activity_dismissed` so Core drops it.

Reuses the existing `live_activity_dismissed` webhook — no wire-format or Core change. Warm foregrounds are unaffected (the observers stay alive and report dismissals normally); the gap only exists on a cold launch after the process was terminated, which is exactly when `reattach()` runs.