### PR TITLE
Add Assist and Assist prompt to the in-car CarPlay item picker

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "carPlay.debug.settings.tts_playback.title" = "TTS Playback";
 "carPlay.labels.already_added_server" = "Already added";
 "carPlay.labels.empty_area_list" = "No areas available";
+"carPlay.labels.empty_assist_list" = "No Assist pipelines with both speech-to-text and text-to-speech available";
 "carPlay.labels.empty_domain_list" = "No domains available";
 "carPlay.labels.no_servers_available" = "No servers available. Add a server in the app.";
 "carPlay.labels.select_server" = "Select server";
@@ -286,6 +287,7 @@
 "carPlay.notification.action.intro.title" = "Create iOS Action";
 "carPlay.notification.quick_access.intro.body" = "Tap to create your CarPlay configuration.";
 "carPlay.notification.quick_access.intro.title" = "Create CarPlay configuration";
+"carPlay.quick_access.add_item.assist_prompt.message" = "Assist prompts can only be created in the Home Assistant app on your iPhone.";
 "carPlay.quick_access.add_item.back" = "Back";
 "carPlay.quick_access.add_item.button" = "Add item";
 "carPlay.quick_access.add_item.confirmation.footer" = "For more customization, configure Quick Access in the Home Assistant app on your iPhone.";

--- a/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemFlow.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemFlow.swift
@@ -10,6 +10,7 @@ final class CarPlayAddItemFlow {
         case areas(Server)
         case domains(Server)
         case entities(server: Server, title: String, entities: [HAAppEntity])
+        case assist(Server)
     }
 
     private weak var interfaceController: CPInterfaceController?
@@ -80,6 +81,8 @@ final class CarPlayAddItemFlow {
             return domainsSection(server: server)
         case let .entities(server, title, entities):
             return entitiesSection(server: server, title: title, entities: entities)
+        case let .assist(server):
+            return assistSection(server: server)
         }
     }
 
@@ -101,7 +104,21 @@ final class CarPlayAddItemFlow {
             title: L10n.CarPlay.Navigation.Tab.domains,
             image: MaterialDesignIcons.devicesIcon.carPlayIcon()
         ) { [weak self] in self?.go(to: .domains(server)) }
-        return section(header: server.info.name, rows: [areas, control])
+        var rows = [areas, control]
+
+        if #available(iOS 26.4, *) {
+            let assist = navigationRow(
+                title: L10n.Widgets.Action.Name.assist,
+                image: MaterialDesignIcons.microphoneIcon.carPlayIcon()
+            ) { [weak self] in self?.go(to: .assist(server)) }
+            let assistPrompt = navigationRow(
+                title: L10n.MagicItem.ItemType.AssistPrompt.title,
+                image: MaterialDesignIcons.messageProcessingOutlineIcon.carPlayIcon()
+            ) { [weak self] in self?.presentAssistPromptInfo() }
+            rows.append(contentsOf: [assist, assistPrompt])
+        }
+
+        return section(header: server.info.name, rows: rows)
     }
 
     private func areasSection(server: Server) -> CPListSection {
@@ -154,6 +171,35 @@ final class CarPlayAddItemFlow {
         return section(header: title, rows: rows, emptyMessage: L10n.CarPlay.NoEntities.title)
     }
 
+    private func assistSection(server: Server) -> CPListSection {
+        let serverId = server.identifier.rawValue
+        let rows = viewModel.assistPipelines(serverId: serverId).map { pipeline -> CPListItem in
+            navigationRow(
+                title: pipeline.name,
+                image: MaterialDesignIcons.microphoneIcon.carPlayIcon()
+            ) { [weak self] in
+                self?.commitAssistPipeline(server: server, pipeline: pipeline)
+            }
+        }
+        return section(
+            header: L10n.Widgets.Action.Name.assist,
+            rows: rows,
+            emptyMessage: L10n.CarPlay.Labels.emptyAssistList
+        )
+    }
+
+    private func presentAssistPromptInfo() {
+        let okAction = CPAlertAction(title: L10n.okLabel, style: .default) { [weak self] _ in
+            self?.interfaceController?.dismissTemplate(animated: true, completion: nil)
+        }
+        let actionSheet = CPActionSheetTemplate(
+            title: L10n.MagicItem.ItemType.AssistPrompt.title,
+            message: L10n.CarPlay.QuickAccess.AddItem.AssistPrompt.message,
+            actions: [okAction]
+        )
+        interfaceController?.presentTemplate(actionSheet, animated: true, completion: nil)
+    }
+
     private func presentConfirmation(server: Server, entity: HAAppEntity) {
         let requireAction = CPAlertAction(
             title: L10n.CarPlay.QuickAccess.AddItem.Confirmation.require,
@@ -189,6 +235,15 @@ final class CarPlayAddItemFlow {
             requiresConfirmation: requiresConfirmation
         )
         interfaceController?.dismissTemplate(animated: true, completion: nil)
+        interfaceController?.popToRootTemplate(animated: true, completion: nil)
+        onFinish()
+    }
+
+    private func commitAssistPipeline(server: Server, pipeline: Pipeline) {
+        viewModel.addAssistPipelineToQuickAccess(
+            pipeline: pipeline,
+            serverId: server.identifier.rawValue
+        )
         interfaceController?.popToRootTemplate(animated: true, completion: nil)
         onFinish()
     }

--- a/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemViewModel.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemViewModel.swift
@@ -63,6 +63,26 @@ final class CarPlayAddItemViewModel {
             .filter { area.entities.contains($0.entityId) }
     }
 
+    func assistPipelines(serverId: String) -> [Pipeline] {
+        let configs: [AssistPipelines]
+        do {
+            configs = try AssistPipelines.config() ?? []
+        } catch {
+            Current.Log.error("Failed to fetch assist pipelines for CarPlay add item: \(error.localizedDescription)")
+            return []
+        }
+        guard let config = configs.first(where: { $0.serverId == serverId }) else { return [] }
+
+        let usablePipelines = config.pipelines.filter(\.hasSpeechToTextAndTextToSpeech)
+        guard !usablePipelines.isEmpty else { return [] }
+
+        let preferredQualifies = usablePipelines.contains { $0.id == config.preferredPipeline }
+        let preferred: [Pipeline] = preferredQualifies
+            ? [.init(id: "", name: L10n.AppIntents.Assist.PreferredPipeline.title)]
+            : []
+        return preferred + usablePipelines
+    }
+
     func icon(for entity: HAAppEntity) -> MaterialDesignIcons {
         let fallback = entity.resolvedDomain?.icon() ?? .dotsGridIcon
         return MaterialDesignIcons(serversideValueNamed: entity.icon ?? "", fallback: fallback)
@@ -99,6 +119,28 @@ final class CarPlayAddItemViewModel {
             Current.Log.info("Added entity \(entityId) to CarPlay quick access from car")
         } catch {
             Current.Log.error("Failed to add entity to CarPlay quick access: \(error.localizedDescription)")
+        }
+    }
+
+    func addAssistPipelineToQuickAccess(pipeline: Pipeline, serverId: String) {
+        let isPreferred = pipeline.id.isEmpty
+        let item = MagicItem(
+            id: isPreferred ? UUID().uuidString : pipeline.id,
+            serverId: serverId,
+            type: .assistPipeline,
+            customization: .init(iconColor: MagicItem.defaultAssistIconColorHex),
+            assistPipelineId: isPreferred ? "" : nil
+        )
+
+        do {
+            var config = try CarPlayConfig.config() ?? CarPlayConfig()
+            config.quickAccessItems.append(item)
+            try Current.database().write { db in
+                try config.insert(db, onConflict: .replace)
+            }
+            Current.Log.info("Added assist pipeline \(item.id) to CarPlay quick access from car")
+        } catch {
+            Current.Log.error("Failed to add assist pipeline to CarPlay quick access: \(error.localizedDescription)")
         }
     }
 
@@ -194,5 +236,13 @@ final class CarPlayAddItemViewModel {
 private extension HAAppEntity {
     var resolvedDomain: Domain? {
         Domain(rawValue: domain)
+    }
+}
+
+private extension Pipeline {
+    var hasSpeechToTextAndTextToSpeech: Bool {
+        let stt = sttEngine?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let tts = ttsEngine?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !stt.isEmpty && !tts.isEmpty
     }
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -987,6 +987,8 @@ public enum L10n {
       public static var alreadyAddedServer: String { return L10n.tr("Localizable", "carPlay.labels.already_added_server") }
       /// No areas available
       public static var emptyAreaList: String { return L10n.tr("Localizable", "carPlay.labels.empty_area_list") }
+      /// No Assist pipelines with both speech-to-text and text-to-speech available
+      public static var emptyAssistList: String { return L10n.tr("Localizable", "carPlay.labels.empty_assist_list") }
       /// No domains available
       public static var emptyDomainList: String { return L10n.tr("Localizable", "carPlay.labels.empty_domain_list") }
       /// No servers available. Add a server in the app.
@@ -1104,6 +1106,10 @@ public enum L10n {
         public static var button: String { return L10n.tr("Localizable", "carPlay.quick_access.add_item.button") }
         /// Add item
         public static var title: String { return L10n.tr("Localizable", "carPlay.quick_access.add_item.title") }
+        public enum AssistPrompt {
+          /// Assist prompts can only be created in the Home Assistant app on your iPhone.
+          public static var message: String { return L10n.tr("Localizable", "carPlay.quick_access.add_item.assist_prompt.message") }
+        }
         public enum Confirmation {
           /// For more customization, configure Quick Access in the Home Assistant app on your iPhone.
           public static var footer: String { return L10n.tr("Localizable", "carPlay.quick_access.add_item.confirmation.footer") }


### PR DESCRIPTION
## Summary
The in-car CarPlay Quick Access **Add item** picker now lets users add **Assist** directly from the car, alongside the existing **Areas** and **Controls** categories.

- **Assist** is its own category. Tapping it lists the server's Assist pipelines and tapping one adds it to Quick Access.
- Only pipelines that have **both speech-to-text and text-to-speech** configured are listed, since CarPlay Assist is voice-only. A **Preferred** entry is shown when the server's preferred pipeline also qualifies (matching the iPhone picker).
- **Assist prompt** is also a category, but because the prompt text can't be typed in the car, tapping it shows a message asking the user to configure it in the iPhone app.
- **Assist** and **Assist prompt** are kept last in the category list.
- Both categories are limited to **iOS 26.4+**, matching CarPlay Assist support (the same gate used by `CarPlayQuickAccessViewModel`).

Pipelines are read from the cached `AssistPipelines` table, so the picker works without a live connection (consistent with the rest of this flow). If a server's pipelines were never cached, its Assist list shows an empty-state message.

## Screenshots
<!-- CarPlay UI change. Screenshots from the CarPlay simulator to be added. -->
_To be added (CarPlay simulator)._

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
This extends the recently added in-car entity picker (`CarPlayAddItemFlow`) — Assist configuration was previously only possible from the iPhone CarPlay settings. Two English strings were added (`carPlay.labels.empty_assist_list`, `carPlay.quick_access.add_item.assist_prompt.message`); other locales sync from Lokalise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
