### PR TITLE
Add "Auto delete unused strings (iOS & Lokalise)" workflow

### DIFF
--- a/.github/workflows/auto_delete_unused_strings.yml
+++ b/.github/workflows/auto_delete_unused_strings.yml
@@ -27,20 +27,26 @@ jobs:
       - name: Detect unused L10n strings
         id: detect
         run: |
-          OUTPUT=$(python3 Tools/detect_unused_strings.py 2>&1 || true)
+          # The detector exits 1 both when unused keys are found AND on real
+          # errors, so branch on its output markers and fail on anything else
+          # rather than blanket-swallowing failures with `|| true`.
+          OUTPUT=$(python3 Tools/detect_unused_strings.py 2>&1) || CODE=$?
+          CODE=${CODE:-0}
           echo "$OUTPUT"
 
           if printf '%s\n' "$OUTPUT" | grep -q "Total unused:"; then
             echo "has_unused=true" >> "$GITHUB_OUTPUT"
-          else
+            # Last non-empty line is the comma-separated list of unused keys.
+            KEYS=$(printf '%s\n' "$OUTPUT" | awk 'NF { last = $0 } END { print last }')
+            echo "keys<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$KEYS" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$OUTPUT" | grep -q "No unused strings found"; then
             echo "has_unused=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::detect_unused_strings.py failed (exit ${CODE})"
+            exit 1
           fi
-
-          # Last non-empty line is the comma-separated list of unused keys.
-          KEYS=$(printf '%s\n' "$OUTPUT" | awk 'NF { last = $0 } END { print last }')
-          echo "keys<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$KEYS" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
 
   # Reuse the existing Lokalise delete + iOS cleanup-PR pipeline for the detected keys.
   delete:

--- a/.github/workflows/auto_delete_unused_strings.yml
+++ b/.github/workflows/auto_delete_unused_strings.yml
@@ -1,0 +1,57 @@
+name: "Auto delete unused strings (iOS & Lokalise)"
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: only list the unused keys that would be deleted."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Detect unused L10n keys with the same script the CI unused-strings check uses.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      has_unused: ${{ steps.detect.outputs.has_unused }}
+      keys: ${{ steps.detect.outputs.keys }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v5.3.0
+        with:
+          python-version: '3.x'
+      - name: Detect unused L10n strings
+        id: detect
+        run: |
+          OUTPUT=$(python3 Tools/detect_unused_strings.py 2>&1 || true)
+          echo "$OUTPUT"
+
+          if printf '%s\n' "$OUTPUT" | grep -q "Total unused:"; then
+            echo "has_unused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_unused=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Last non-empty line is the comma-separated list of unused keys.
+          KEYS=$(printf '%s\n' "$OUTPUT" | awk 'NF { last = $0 } END { print last }')
+          echo "keys<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$KEYS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+  # Reuse the existing Lokalise delete + iOS cleanup-PR pipeline for the detected keys.
+  delete:
+    needs: detect
+    if: ${{ needs.detect.outputs.has_unused == 'true' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/delete_lokalise_keys.yml
+    with:
+      keys: ${{ needs.detect.outputs.keys }}
+      dry_run: ${{ inputs.dry_run }}
+      confirmation: ${{ inputs.dry_run == false && 'DELETE' || '' }}
+    secrets: inherit

--- a/.github/workflows/delete_lokalise_keys.yml
+++ b/.github/workflows/delete_lokalise_keys.yml
@@ -16,6 +16,23 @@ on:
         description: "Type DELETE to confirm. Required when dry_run is false."
         required: false
         type: string
+  # Callable by other workflows (e.g. auto_delete_unused_strings.yml) to reuse the
+  # same Lokalise delete + iOS cleanup-PR pipeline.
+  workflow_call:
+    inputs:
+      keys:
+        description: "Key names to delete (comma or newline separated). Must match exactly."
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run: only list the keys that would be deleted."
+        required: false
+        type: boolean
+        default: true
+      confirmation:
+        description: "Type DELETE to confirm. Required when dry_run is false."
+        required: false
+        type: string
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Adds a new manually-triggered workflow, **Auto delete unused strings (iOS & Lokalise)**, that finds unused localization keys and removes them everywhere by reusing the existing delete pipeline (added in #4833).

- **Detect** job runs `Tools/detect_unused_strings.py` (the same detector the CI unused-strings check uses) and outputs the comma-separated list of unused keys.
- **Delete** job calls `delete_lokalise_keys.yml` via `workflow_call` with those keys — deleting them from Lokalise and opening the iOS cleanup PR (`Localizable.strings` + regenerated `Strings.swift`). Skipped when nothing is unused.
- **`dry_run` defaults to `true`** (lists only). `confirmation=DELETE` is passed to the reused workflow automatically only when `dry_run` is set to `false`.
- To enable reuse, `delete_lokalise_keys.yml` gains a `workflow_call` trigger (same inputs). `secrets: inherit` forwards the Lokalise token / project id / deploy key, and the `delete` job grants `contents`/`pull-requests: write` (a caller can't grant a called workflow more than it has).

## Screenshots
N/A — CI workflow only, no user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Trigger is manual (`workflow_dispatch`); a `schedule:` cron could be added later to run it unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)