### PR TITLE
TestFlight: ask testers to share contact info when reporting issues

### DIFF
--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
@@ -27,5 +27,21 @@ import Shared
 /// ]
 /// ```
 enum TestFlightCommunicationCatalog {
-    static let messages: [TestFlightMessage] = []
+    static let messages: [TestFlightMessage] = [
+        TestFlightMessage(
+            id: .includeEmailWhenReporting,
+            title: "Reporting an issue?",
+            items: [
+                WhatsNewItem(
+                    id: .testFlightIncludeEmail,
+                    title: "Optional, but it helps a lot",
+                    body: "When you report a problem through TestFlight, it's optional but really valuable to " +
+                        "include your email address or Discord handle. With it we can reach out to share " +
+                        "setup instructions or ask follow-up questions — without it we have no way to get " +
+                        "back to you.",
+                    icon: .sfSymbol(.envelope)
+                ),
+            ]
+        ),
+    ]
 }

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
@@ -15,6 +15,10 @@ struct TestFlightMessageId: RawRepresentable, Hashable {
     init(rawValue: String) { self.rawValue = rawValue }
 }
 
+extension TestFlightMessageId {
+    static let includeEmailWhenReporting = TestFlightMessageId("include-email-when-reporting-2026-06")
+}
+
 struct TestFlightMessage: Identifiable, Equatable {
     struct CallToAction: Equatable {
         let title: String

--- a/Sources/App/WhatsNew/WhatsNewModels.swift
+++ b/Sources/App/WhatsNew/WhatsNewModels.swift
@@ -59,6 +59,7 @@ enum WhatsNewIcon: Equatable {
 enum WhatsNewItemId: Hashable {
     case whatsNewValidationIntro
     case whatsNewValidationPlatforms
+    case testFlightIncludeEmail
 }
 
 struct WhatsNewItem: Identifiable, Equatable {


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a single entry to the (previously empty) TestFlight announcements catalog asking beta testers to include their **email address or Discord handle** when they report a problem through TestFlight. Without a way to reach back, we can't share setup instructions or ask follow-up questions, so feedback often dead-ends. The message is framed as optional but valuable.

This is a TestFlight-only message (shown via the existing `TestFlightCommunicationView`/engine), so it does not affect App Store builds.

Changes:
- Populate `TestFlightCommunicationCatalog.messages` with the new announcement.
- Add a stable `TestFlightMessageId.includeEmailWhenReporting` constant for seen-state tracking.
- Add a `WhatsNewItemId.testFlightIncludeEmail` case for the item.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — content-only change to an existing TestFlight message screen; no new UI was added. The text renders in the existing `TestFlightCommunicationView` layout (light & dark already supported).

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Strings are intentionally plain English literals rather than `L10n` keys: the TestFlight communication subsystem is beta-only and its `WhatsNewItem` fields are `String` (the documented catalog example uses literals), so this content is not routed through Lokalise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)