### PR TITLE
Avoid sending rejected auth to Home Assistant on connect

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1124,6 +1124,7 @@
 		42F158482CA15FA7009C7201 /* SwitchIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F158472CA15FA7009C7201 /* SwitchIntent.swift */; };
 		42F161442D661D11003DDC75 /* ServersPickerPillList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F161422D661CBA003DDC75 /* ServersPickerPillList.swift */; };
 		42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */; };
+		42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */; };
 		42F1DA5B2B4BF7DF002729BC /* WindowSizeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1DA5A2B4BF7DF002729BC /* WindowSizeObserver.swift */; };
 		42F1DA5D2B4BF85F002729BC /* WindowScenesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1DA5C2B4BF85F002729BC /* WindowScenesManager.swift */; };
 		42F1DA5F2B4D4B32002729BC /* CarPlayServerListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1DA5E2B4D4B32002729BC /* CarPlayServerListTemplate.swift */; };
@@ -3004,6 +3005,7 @@
 		42F158472CA15FA7009C7201 /* SwitchIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchIntent.swift; sourceTree = "<group>"; };
 		42F161422D661CBA003DDC75 /* ServersPickerPillList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServersPickerPillList.swift; sourceTree = "<group>"; };
 		42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAssistantAPIIdentity.test.swift; sourceTree = "<group>"; };
+		42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAPITokenFetchFailure.test.swift; sourceTree = "<group>"; };
 		42F1DA5A2B4BF7DF002729BC /* WindowSizeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSizeObserver.swift; sourceTree = "<group>"; };
 		42F1DA5C2B4BF85F002729BC /* WindowScenesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScenesManager.swift; sourceTree = "<group>"; };
 		42F1DA5E2B4D4B32002729BC /* CarPlayServerListTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayServerListTemplate.swift; sourceTree = "<group>"; };
@@ -7303,6 +7305,7 @@
 				1130A5752751BA1800640E38 /* Server.test.swift */,
 				1130A5772751BDD900640E38 /* ServerManager.test.swift */,
 				42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */,
+				42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */,
 				11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */,
 				480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */,
 				114CBAEA2839FC2500A9BAFF /* SecurityExceptions.test.swift */,
@@ -10588,6 +10591,7 @@
 				11CD94B524B2C06700BA801D /* WebhookResponseUpdateSensors.test.swift in Sources */,
 				1130A5782751BDD900640E38 /* ServerManager.test.swift in Sources */,
 				42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */,
+				42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */,
 				11BC9E5724FDC1C900B9FBF7 /* ActiveSensor.test.swift in Sources */,
 				11F2F2A92587288200F61F7C /* NotificationAttachmentParserCamera.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,

--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -70,7 +70,11 @@ class LifecycleManager {
             })
         }.cauterize()
 
-        periodicUpdateManager.connectAPI(reason: .cold)
+        // Resolve the network info (SSID) before the first connect so we don't pick the remote URL while on
+        // the home network and get rejected. On Catalyst the completion is invoked synchronously.
+        Current.connectivity.syncNetworkInformation { [periodicUpdateManager] in
+            periodicUpdateManager.connectAPI(reason: .cold)
+        }
     }
 
     @objc private func willEnterForeground() {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1485,6 +1485,9 @@ extension HomeAssistantAPI: HAConnectionDelegate {
     private func scheduleRejectedReconnectRecoveryIfNeeded() {
         guard rejectedReconnectAttempts < Self.rejectedReconnectDelays.count else {
             Current.Log.error("websocket rejected; giving up after \(rejectedReconnectAttempts) attempts")
+            // Drop any still-pending final attempt so we don't fire another `connect()` after giving up.
+            rejectedReconnectWorkItem?.cancel()
+            rejectedReconnectWorkItem = nil
             return
         }
 
@@ -1502,7 +1505,9 @@ extension HomeAssistantAPI: HAConnectionDelegate {
             connection.connect()
         }
         rejectedReconnectWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        // Schedule on the connection's callback queue so reading `connection.state` and calling `connect()`
+        // stay serialized with HAKit's own delegate callbacks instead of racing across queues.
+        connection.callbackQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     private func resetRejectedReconnectRecovery() {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -54,6 +54,13 @@ public class HomeAssistantAPI {
     public var server: Server
     public internal(set) var connection: HAConnection
 
+    private var rejectedReconnectAttempts = 0
+    private var rejectedReconnectWorkItem: DispatchWorkItem?
+
+    /// Backoff (seconds) for reconnect attempts after a rejected websocket; its count also bounds the
+    /// number of attempts. Overridable for tests.
+    static var rejectedReconnectDelays: [TimeInterval] = [0, 5, 10]
+
     public static var clientVersionDescription: String {
         "\(AppConstants.version) (\(AppConstants.build))"
     }
@@ -1455,13 +1462,52 @@ extension HomeAssistantAPI: SensorObserver {
 
 extension HomeAssistantAPI: HAConnectionDelegate {
     public func connection(_ connection: HAConnection, didTransitionTo state: HAConnectionState) {
-        guard case let .disconnected(reason: .waitingToReconnect(lastError: error, atLatest: _, retryCount: _)) = state,
-              let tokenFetchFailure = error as? TokenFetchFailure,
-              tokenFetchFailure.shouldDisconnectPermanently else {
+        switch state {
+        case .ready:
+            resetRejectedReconnectRecovery()
+        case .disconnected(reason: .rejected):
+            scheduleRejectedReconnectRecoveryIfNeeded()
+        case let .disconnected(reason: .waitingToReconnect(lastError: error, atLatest: _, retryCount: _)):
+            guard let tokenFetchFailure = error as? TokenFetchFailure,
+                  tokenFetchFailure.shouldDisconnectPermanently else {
+                return
+            }
+            Current.Log.info("stopping websocket reconnects after fatal auth token fetch failure")
+            connection.disconnect()
+        case .connecting, .authenticating, .disconnected(reason: .disconnected):
+            break
+        }
+    }
+
+    /// Recovers from a rejected websocket (`auth: invalid`): HAKit won't auto-reconnect a rejected
+    /// connection, so we explicitly `connect()` (re-resolving the URL and refreshing the token), bounded by
+    /// a backoff budget so a genuinely-invalid token can't loop on Home Assistant's auth-ban endpoint.
+    private func scheduleRejectedReconnectRecoveryIfNeeded() {
+        guard rejectedReconnectAttempts < Self.rejectedReconnectDelays.count else {
+            Current.Log.error("websocket rejected; giving up after \(rejectedReconnectAttempts) attempts")
             return
         }
 
-        Current.Log.info("stopping websocket reconnects after fatal auth token fetch failure")
-        connection.disconnect()
+        let delay = Self.rejectedReconnectDelays[rejectedReconnectAttempts]
+        rejectedReconnectAttempts += 1
+        let attempt = rejectedReconnectAttempts
+
+        Current.Log.info("websocket rejected; scheduling reconnect attempt \(attempt) in \(delay)s")
+
+        rejectedReconnectWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard case .disconnected(reason: .rejected) = connection.state else { return }
+            Current.Log.info("retrying websocket connect after rejection (attempt \(attempt))")
+            connection.connect()
+        }
+        rejectedReconnectWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func resetRejectedReconnectRecovery() {
+        rejectedReconnectWorkItem?.cancel()
+        rejectedReconnectWorkItem = nil
+        rejectedReconnectAttempts = 0
     }
 }

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -258,6 +258,9 @@ class HAAPIAutomaticWebSocketConnectTests: XCTestCase {
 
     func testRetryAwareConnectionDoesNotReconnectWhileBackoffIsActive() {
         let underlying = HAMockConnection()
+        // The mock otherwise flips to `.connecting` on any send; disable that so the test observes only
+        // RetryAwareHAConnection's own connect gating, not the mock's behavior.
+        underlying.automaticallyTransitionToConnecting = false
         let connection = RetryAwareHAConnection(underlying: underlying)
         let expectedState = HAConnectionState.disconnected(reason: .waitingToReconnect(
             lastError: URLError(.cannotConnectToHost),
@@ -284,6 +287,9 @@ class HAAPIAutomaticWebSocketConnectTests: XCTestCase {
 
     func testRetryAwareConnectionDoesNotConnectRestRequests() {
         let underlying = HAMockConnection()
+        // The mock otherwise flips to `.connecting` on any send; disable that so the test observes only
+        // RetryAwareHAConnection's own connect gating, not the mock's behavior.
+        underlying.automaticallyTransitionToConnecting = false
         let connection = RetryAwareHAConnection(underlying: underlying)
 
         _ = connection.send(.init(type: .rest(.get, "config")), completion: { _ in })

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -83,6 +83,117 @@ class HAAPITokenFetchFailureTests: XCTestCase {
 
         XCTAssertEqual(connection.state, expectedState)
     }
+
+    func testConnectionDelegateRecoversFromRejectedStateWhenReconnectSucceeds() {
+        let priorDelays = HomeAssistantAPI.rejectedReconnectDelays
+        HomeAssistantAPI.rejectedReconnectDelays = [0, 0, 0]
+        defer { HomeAssistantAPI.rejectedReconnectDelays = priorDelays }
+
+        let api = HomeAssistantAPI(server: .fake())
+        let connection = HAMockConnection()
+        connection.delegate = api
+        api.connection = connection
+
+        connection.setState(.disconnected(reason: .rejected), waitForQueue: false)
+        drainMainQueue(cycles: 10)
+
+        // HAKit won't auto-reconnect a rejected connection, but our delegate explicitly retries; the
+        // mock's connect() succeeds, so the rejection is recovered instead of dead-ending the socket.
+        XCTAssertEqual(connection.state, .ready(version: "1.0-mock"))
+    }
+
+    func testConnectionDelegateGivesUpAfterExhaustingRejectedReconnectBudget() {
+        let priorDelays = HomeAssistantAPI.rejectedReconnectDelays
+        HomeAssistantAPI.rejectedReconnectDelays = [0, 0, 0]
+        defer { HomeAssistantAPI.rejectedReconnectDelays = priorDelays }
+
+        let api = HomeAssistantAPI(server: .fake())
+        let connection = RejectingMockConnection()
+        connection.delegate = api
+        api.connection = connection
+
+        connection.setState(.disconnected(reason: .rejected))
+        drainMainQueue(cycles: 20)
+
+        // One reconnect per backoff entry, then we stop — a genuinely-invalid token must not loop forever
+        // (which would keep tripping HA's auth-ban endpoint).
+        XCTAssertEqual(connection.connectCount, 3)
+        XCTAssertEqual(connection.state, .disconnected(reason: .rejected))
+    }
+}
+
+/// A minimal `HAConnection` whose `connect()` always lands back in the rejected state, used to exercise
+/// the reconnect-budget cap. `HAMockConnection` is `public` (not `open`), so it can't be subclassed here.
+private final class RejectingMockConnection: HAConnection {
+    weak var delegate: HAConnectionDelegate?
+    var configuration: HAConnectionConfiguration = .fake
+    var callbackQueue: DispatchQueue = .main
+    private(set) var connectCount = 0
+    lazy var caches: HACachesContainer = .init(connection: self)
+
+    private(set) var state: HAConnectionState = .disconnected(reason: .disconnected) {
+        didSet {
+            callbackQueue.async { [self, state] in
+                delegate?.connection(self, didTransitionTo: state)
+            }
+        }
+    }
+
+    func setState(_ state: HAConnectionState) {
+        self.state = state
+    }
+
+    func connect() {
+        connectCount += 1
+        state = .disconnected(reason: .rejected)
+    }
+
+    func disconnect() {
+        state = .disconnected(reason: .disconnected)
+    }
+
+    private func noopCancellable() -> HACancellable { HAMockCancellable {} }
+
+    func send(_ request: HARequest, completion: @escaping (Result<HAData, HAError>) -> Void) -> HACancellable {
+        noopCancellable()
+    }
+
+    func send<T>(
+        _ request: HATypedRequest<T>,
+        completion: @escaping (Result<T, HAError>) -> Void
+    ) -> HACancellable {
+        noopCancellable()
+    }
+
+    func subscribe(
+        to request: HARequest,
+        handler: @escaping (HACancellable, HAData) -> Void
+    ) -> HACancellable {
+        noopCancellable()
+    }
+
+    func subscribe(
+        to request: HARequest,
+        initiated: @escaping (Result<HAData, HAError>) -> Void,
+        handler: @escaping (HACancellable, HAData) -> Void
+    ) -> HACancellable {
+        noopCancellable()
+    }
+
+    func subscribe<T>(
+        to request: HATypedSubscription<T>,
+        handler: @escaping (HACancellable, T) -> Void
+    ) -> HACancellable {
+        noopCancellable()
+    }
+
+    func subscribe<T>(
+        to request: HATypedSubscription<T>,
+        initiated: @escaping (Result<HAData, HAError>) -> Void,
+        handler: @escaping (HACancellable, T) -> Void
+    ) -> HACancellable {
+        noopCancellable()
+    }
 }
 
 class HAAPIAutomaticWebSocketConnectTests: XCTestCase {


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Stops the app from repeatedly sending rejected authentication to Home Assistant, which trips HA's HTTP auth-ban (`Login attempt or request with invalid authentication from … /api/websocket`).

At launch the native WebSocket can connect before the Wi‑Fi SSID has resolved, so `ConnectionInfo.activeURL()` selects the remote/cloud URL even while on the home network. That connection is rejected with `auth: invalid`, and HAKit then marks the connection `rejected` and won't auto-retry — so each subsequent reconnect re-sends bad auth and gets banned.

- **Connect after the network is known:** gate the cold-start connect on `syncNetworkInformation()` so the active URL is resolved before the first connect (`LifecycleManager`), matching what the web view already does before loading its URL.
- **Recover from a rejected socket instead of dead-ending** (`HomeAssistantAPI`): re-`connect()` (which re-resolves the URL and refreshes the token) with a small backoff, and give up after the backoff budget so a genuinely-invalid token can't loop on the ban endpoint.
- **Restore lost test coverage:** `HAAPITokenFetchFailure.test.swift` had been missing from the Xcode project since #4509 (its tests never ran); register it and add coverage for the new recovery path.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not applicable — native connection/auth behavior, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not applicable — internal bug fix, no documented behavior changes.
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Split out from a larger investigation into kiosk web-view reconnection; this PR is only the connection-auth fix (the part confirmed on-device). The web-view recovery work is intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)