### PR TITLE
Remove kiosk auto-reload intervals under 10 minutes

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -551,11 +551,9 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.authentication.title" = "Authentication";
 "kiosk.authentication.unlock_button" = "Unlock";
 "kiosk.auto_reload.hours_1" = "1 hour";
-"kiosk.auto_reload.minutes_1" = "1 minute";
 "kiosk.auto_reload.minutes_10" = "10 minutes";
 "kiosk.auto_reload.minutes_15" = "15 minutes";
 "kiosk.auto_reload.minutes_30" = "30 minutes";
-"kiosk.auto_reload.minutes_5" = "5 minutes";
 "kiosk.auto_reload.never" = "Never";
 "kiosk.auto_reload.subtitle" = "The time between automatic page reloads.";
 "kiosk.auto_reload.title" = "Auto reload";

--- a/Sources/App/Settings/Kiosk/KioskSettings.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettings.swift
@@ -56,8 +56,6 @@ public struct KioskSettings: Codable, FetchableRecord, PersistableRecord, Equata
         self.keepScreenOn = try container.decodeIfPresent(Bool.self, forKey: .keepScreenOn) ?? false
         self.removeHeaderAndSidebar = try container.decodeIfPresent(Bool.self, forKey: .removeHeaderAndSidebar) ?? false
         self.hideStatusBar = try container.decodeIfPresent(Bool.self, forKey: .hideStatusBar) ?? false
-        // Intervals under 10 minutes were removed; a stored value that no longer resolves falls back to
-        // `.never` (the feature is in beta, so we don't migrate the removed values).
         self.autoReload = try container.decodeIfPresent(String.self, forKey: .autoReload)
             .flatMap(KioskAutoReloadInterval.init(rawValue:)) ?? .never
         self.settingsEntryPosition = try container.decodeIfPresent(

--- a/Sources/App/Settings/Kiosk/KioskSettings.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettings.swift
@@ -56,7 +56,10 @@ public struct KioskSettings: Codable, FetchableRecord, PersistableRecord, Equata
         self.keepScreenOn = try container.decodeIfPresent(Bool.self, forKey: .keepScreenOn) ?? false
         self.removeHeaderAndSidebar = try container.decodeIfPresent(Bool.self, forKey: .removeHeaderAndSidebar) ?? false
         self.hideStatusBar = try container.decodeIfPresent(Bool.self, forKey: .hideStatusBar) ?? false
-        self.autoReload = try container.decodeIfPresent(KioskAutoReloadInterval.self, forKey: .autoReload) ?? .never
+        // Intervals under 10 minutes were removed; a stored value that no longer resolves falls back to
+        // `.never` (the feature is in beta, so we don't migrate the removed values).
+        self.autoReload = try container.decodeIfPresent(String.self, forKey: .autoReload)
+            .flatMap(KioskAutoReloadInterval.init(rawValue:)) ?? .never
         self.settingsEntryPosition = try container.decodeIfPresent(
             KioskCornerPosition.self,
             forKey: .settingsEntryPosition
@@ -126,8 +129,6 @@ public struct KioskScreensaverSettings: Codable, Equatable {
 
 public enum KioskAutoReloadInterval: String, Codable, CaseIterable, Identifiable, DatabaseValueConvertible {
     case never
-    case minutes1
-    case minutes5
     case minutes10
     case minutes15
     case minutes30
@@ -138,8 +139,6 @@ public enum KioskAutoReloadInterval: String, Codable, CaseIterable, Identifiable
     public var timeInterval: TimeInterval? {
         switch self {
         case .never: return nil
-        case .minutes1: return 60
-        case .minutes5: return 5 * 60
         case .minutes10: return 10 * 60
         case .minutes15: return 15 * 60
         case .minutes30: return 30 * 60
@@ -150,8 +149,6 @@ public enum KioskAutoReloadInterval: String, Codable, CaseIterable, Identifiable
     public var title: String {
         switch self {
         case .never: return L10n.Kiosk.AutoReload.never
-        case .minutes1: return L10n.Kiosk.AutoReload.minutes1
-        case .minutes5: return L10n.Kiosk.AutoReload.minutes5
         case .minutes10: return L10n.Kiosk.AutoReload.minutes10
         case .minutes15: return L10n.Kiosk.AutoReload.minutes15
         case .minutes30: return L10n.Kiosk.AutoReload.minutes30

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2031,16 +2031,12 @@ public enum L10n {
     public enum AutoReload {
       /// 1 hour
       public static var hours1: String { return L10n.tr("Localizable", "kiosk.auto_reload.hours_1") }
-      /// 1 minute
-      public static var minutes1: String { return L10n.tr("Localizable", "kiosk.auto_reload.minutes_1") }
       /// 10 minutes
       public static var minutes10: String { return L10n.tr("Localizable", "kiosk.auto_reload.minutes_10") }
       /// 15 minutes
       public static var minutes15: String { return L10n.tr("Localizable", "kiosk.auto_reload.minutes_15") }
       /// 30 minutes
       public static var minutes30: String { return L10n.tr("Localizable", "kiosk.auto_reload.minutes_30") }
-      /// 5 minutes
-      public static var minutes5: String { return L10n.tr("Localizable", "kiosk.auto_reload.minutes_5") }
       /// Never
       public static var never: String { return L10n.tr("Localizable", "kiosk.auto_reload.never") }
       /// The time between automatic page reloads.

--- a/Tests/App/Kiosk/KioskSettings.test.swift
+++ b/Tests/App/Kiosk/KioskSettings.test.swift
@@ -17,7 +17,7 @@ struct KioskSettingsTests {
             keepScreenOn: true,
             removeHeaderAndSidebar: true,
             hideStatusBar: true,
-            autoReload: .minutes5,
+            autoReload: .minutes10,
             settingsEntryPosition: .topLeading,
             screensaver: KioskScreensaverSettings(
                 enabled: true,
@@ -64,6 +64,34 @@ struct KioskSettingsTests {
         #expect(loaded?.autoReload == .never)
         #expect(loaded?.settingsEntryPosition == .bottomTrailing)
         #expect(loaded?.screensaver == KioskScreensaverSettings())
+    }
+
+    @Test func decodesRemovedOrUnknownAutoReloadIntervalsAsNever() throws {
+        // Intervals under 10 minutes were removed; a stored value that no longer resolves (the removed
+        // sub-10-minute ones, or anything unrecognized) falls back to `.never` instead of failing to decode.
+        let database = try DatabaseQueue()
+        try KioskSettingsTable().createIfNeeded(database: database)
+
+        func loadAutoReload(storedRawValue: String) throws -> KioskAutoReloadInterval? {
+            try database.write { db in
+                try db.execute(
+                    sql: "INSERT OR REPLACE INTO \(GRDBDatabaseTable.kioskSettings.rawValue) (id, autoReload) "
+                        + "VALUES (?, ?)",
+                    arguments: [KioskSettings.kioskSettingsId, storedRawValue]
+                )
+            }
+            return try database.read { db in try KioskSettings.fetchOne(db)?.autoReload }
+        }
+
+        let fromOneMinute = try loadAutoReload(storedRawValue: "minutes1")
+        let fromFiveMinutes = try loadAutoReload(storedRawValue: "minutes5")
+        let fromThirtyMinutes = try loadAutoReload(storedRawValue: "minutes30")
+        let fromUnknown = try loadAutoReload(storedRawValue: "garbage")
+
+        #expect(fromOneMinute == .never)
+        #expect(fromFiveMinutes == .never)
+        #expect(fromThirtyMinutes == .minutes30)
+        #expect(fromUnknown == .never)
     }
 
     @Test func decodesDefaultsWhenScreensaverFieldsAreMissing() throws {


### PR DESCRIPTION
## Summary
The kiosk **Auto reload** setting offered intervals as short as 1 and 5 minutes. Reloading the whole dashboard that often is rarely useful and churns the web view far more than needed. This removes the sub‑10‑minute options, so the shortest selectable interval is now **10 minutes** — the picker keeps *Never / 10 minutes / 15 minutes / 30 minutes / 1 hour*.

A kiosk already configured to 1 or 5 minutes falls back to **Never** when its settings load (a stored value that no longer resolves isn't migrated). The feature is in beta, so this is acceptable.

Intended as a small, temporary improvement while web‑view reconnection behavior is investigated separately.

## Screenshots
The only user‑facing change is that **Settings → Kiosk → Auto reload** no longer lists "1 minute" and "5 minutes". <!-- maintainer: add light/dark screenshots if desired -->

## Link to pull request in Documentation repository
<!-- No documented functionality changes; the setting and its remaining options already exist. -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- `KioskAutoReloadInterval` drops its `minutes1`/`minutes5` cases; decoding reads the stored string and falls back to `.never` when it no longer resolves (instead of throwing).
- Added a unit test covering the removed/unknown → `.never` fallback.
- Only English strings were edited; other locales sync from Lokalise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
