### PR TITLE
Fix Live Activity start/update notifications sent via local push

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -412,6 +412,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private var liveActivityPendingEndObserver: Any?
+    private var liveActivityPendingStartObserver: Any?
 
     private func setupLiveActivityReattachment() {
         #if os(iOS) && !targetEnvironment(macCatalyst)
@@ -421,10 +422,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // concurrently from a background thread.
             guard let registry = Current.liveActivityRegistry else { return }
 
-            // Register before draining so ends enqueued while the app was gone aren't missed.
+            // Register before draining so ends/starts enqueued while the app was gone aren't missed.
             let pendingEndObserver = LiveActivityPendingEndObserver()
             liveActivityPendingEndObserver = pendingEndObserver
             pendingEndObserver.drain()
+
+            // Starts handed off by the PushProvider extension (local-push live_update notifications,
+            // which can't touch ActivityKit in-process). Drained here and on foreground.
+            let pendingStartObserver = LiveActivityPendingStartObserver()
+            liveActivityPendingStartObserver = pendingStartObserver
+            pendingStartObserver.drain()
 
             Task {
                 // Re-attach observation tasks (push token + lifecycle) to any Live Activities

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -56,8 +56,9 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         localPushManager.scheduleAppOpenLocalPushRetries()
         #if os(iOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 17.2, *) {
-            // Catch ends enqueued by the extension while the app was suspended.
+            // Catch ends and starts enqueued by the extension while the app was suspended.
             LiveActivityPendingEndObserver.drain()
+            LiveActivityPendingStartObserver.drain()
         }
         #endif
     }
@@ -354,6 +355,16 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
 
         Current.Log.verbose("User info in incoming notification \(userInfo) with response \(response)")
+
+        // A tap must still run any HA command the notification carries. willPresent covers the
+        // foreground path; this covers taps from the background/lock screen. Notably, a
+        // `live_update` Live Activity start delivered over local push is handled by the
+        // PushProvider extension (which can't touch ActivityKit), so without this a tap would
+        // never start the activity. Fire-and-forget: it's independent of the tap routing below.
+        if let hadict = userInfo["homeassistant"] as? [String: Any],
+           (hadict["command"] as? String) != nil || (hadict["live_update"] as? Bool) == true {
+            commandManager.handle(userInfo).cauterize()
+        }
 
         if Current.kiosk.settings.acceptRemoteCommands,
            KioskPushCommand(message: response.notification.request.content.body) == .showCamera,

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -461,6 +461,11 @@ enum LiveActivityPendingEnd {
             Current.Log.error("LiveActivityPendingEnd: rejected invalid tag '\(tag)'")
             return
         }
+        // A newer end supersedes a stale start queued earlier for the same tag. Done before
+        // taking our lock so the two queues are never held simultaneously (no lock-order inversion).
+        if #available(iOS 17.2, *) {
+            LiveActivityPendingStart.remove(tag: tag)
+        }
         lock.lock()
         defer { lock.unlock() }
         guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
@@ -468,6 +473,20 @@ enum LiveActivityPendingEnd {
         tags.insert(tag)
         defaults.set(Array(tags), forKey: storeKey)
         Current.Log.verbose("LiveActivityPendingEnd: enqueued '\(tag)', pending=\(tags.count)")
+    }
+
+    /// Remove a queued end for `tag` (called when a newer start is enqueued for the same tag).
+    static func remove(tag: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
+        var tags = Set(defaults.stringArray(forKey: storeKey) ?? [])
+        guard tags.remove(tag) != nil else { return }
+        if tags.isEmpty {
+            defaults.removeObject(forKey: storeKey)
+        } else {
+            defaults.set(Array(tags), forKey: storeKey)
+        }
     }
 
     static func drainAll() -> [String] {
@@ -504,6 +523,118 @@ enum LiveActivityPendingEnd {
             charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
         )
         return tag.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}
+
+/// Cross-process hand-off for starting/updating Live Activities. The PushProvider extension
+/// has no working ActivityKit, so when a `live_update` notification arrives over the local-push
+/// channel it serializes the request and posts a Darwin signal; the app drains the queue and
+/// calls `startOrUpdate`. Mirrors `LiveActivityPendingEnd`. The persisted queue is the durable
+/// path — Darwin does not wake a suspended app, so the app also drains at launch/foreground.
+///
+/// ⚠️ A start delivered via local push while the app is suspended therefore only materializes
+/// when the app is next active — not in real time. Real-time background starts require APNs
+/// push-to-start, which the registry already supports.
+@available(iOS 17.2, *)
+enum LiveActivityPendingStart {
+    /// A serialized start/update request mirroring the arguments of `startOrUpdate`.
+    struct Request: Codable {
+        let tag: String
+        let title: String
+        let serverWebhookId: String?
+        let state: HALiveActivityAttributes.ContentState
+    }
+
+    // Namespaced by App Group id so dev/beta/release installs never cross-signal.
+    static var darwinNotificationName: String {
+        AppConstants.AppGroupID + ".liveActivityPendingStart"
+    }
+
+    private static let storeKey = "liveActivityPendingStartRequests"
+    private static let lock = NSLock()
+
+    /// Enqueue a start/update request. Coalesces by tag (the latest state for a tag wins, so a
+    /// burst of updates collapses to the freshest) and cancels any end queued earlier for the
+    /// same tag — last writer wins.
+    static func append(_ request: Request) {
+        guard LiveActivityPendingEnd.isValidTag(request.tag) else {
+            Current.Log.error("LiveActivityPendingStart: rejected invalid tag '\(request.tag)'")
+            return
+        }
+        // A newer start supersedes a stale end queued earlier. Done before taking our lock so the
+        // two queues are never held simultaneously (no lock-order inversion).
+        LiveActivityPendingEnd.remove(tag: request.tag)
+        lock.lock()
+        defer { lock.unlock() }
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
+        var requests = load(from: defaults).filter { $0.tag != request.tag }
+        requests.append(request)
+        store(requests, to: defaults)
+        Current.Log.verbose("LiveActivityPendingStart: enqueued '\(request.tag)', pending=\(requests.count)")
+    }
+
+    /// Remove a queued start for `tag` (called when a newer end is enqueued for the same tag).
+    static func remove(tag: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return }
+        let requests = load(from: defaults)
+        let remaining = requests.filter { $0.tag != tag }
+        guard remaining.count != requests.count else { return }
+        if remaining.isEmpty {
+            defaults.removeObject(forKey: storeKey)
+        } else {
+            store(remaining, to: defaults)
+        }
+    }
+
+    static func drainAll() -> [Request] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let defaults = UserDefaults(suiteName: AppConstants.AppGroupID) else { return [] }
+        let observed = load(from: defaults)
+        guard !observed.isEmpty else { return [] }
+        // Subtract only the tags we read, so a concurrent extension append of a different tag
+        // isn't clobbered (mirrors LiveActivityPendingEnd.drainAll).
+        let observedTags = Set(observed.map(\.tag))
+        let remaining = load(from: defaults).filter { !observedTags.contains($0.tag) }
+        if remaining.isEmpty {
+            defaults.removeObject(forKey: storeKey)
+        } else {
+            store(remaining, to: defaults)
+        }
+        return observed
+    }
+
+    // Payload-less wake; the requests travel via the App Group store above.
+    static func postDarwinSignal() {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(rawValue: darwinNotificationName as CFString),
+            nil,
+            nil,
+            true
+        )
+    }
+
+    private static func load(from defaults: UserDefaults) -> [Request] {
+        guard let data = defaults.data(forKey: storeKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([Request].self, from: data)
+        } catch {
+            Current.Log.error("LiveActivityPendingStart: failed to decode queue, dropping it: \(error)")
+            defaults.removeObject(forKey: storeKey)
+            return []
+        }
+    }
+
+    private static func store(_ requests: [Request], to defaults: UserDefaults) {
+        do {
+            let data = try JSONEncoder().encode(requests)
+            defaults.set(data, forKey: storeKey)
+        } catch {
+            Current.Log.error("LiveActivityPendingStart: failed to encode queue: \(error)")
+        }
     }
 }
 
@@ -552,6 +683,70 @@ public final class LiveActivityPendingEndObserver {
                 Task {
                     for tag in tags {
                         await Current.liveActivityRegistry?.end(tag: tag, dismissalPolicy: .immediate)
+                    }
+                    DispatchQueue.main.async { seal.fulfill(()) }
+                }
+            }
+        }
+    }
+}
+
+/// App-side drain for `LiveActivityPendingStart`. Retain one instance to keep the Darwin
+/// observer registered.
+@available(iOS 17.2, *)
+public final class LiveActivityPendingStartObserver {
+    public init() {
+        let callback: CFNotificationCallback = { _, observer, _, _, _ in
+            // C callback can't capture self; re-derive it (see DeviceWrapperBatteryObserver).
+            guard let observer else { return }
+            Unmanaged<LiveActivityPendingStartObserver>.fromOpaque(observer)
+                .takeUnretainedValue()
+                .drain()
+        }
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            callback,
+            LiveActivityPendingStart.darwinNotificationName as CFString,
+            nil,
+            .coalesce
+        )
+    }
+
+    deinit {
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            nil,
+            nil
+        )
+    }
+
+    public func drain() {
+        Self.drain()
+    }
+
+    public static func drain() {
+        let requests = LiveActivityPendingStart.drainAll()
+        guard !requests.isEmpty else { return }
+        Current.Log.verbose("LiveActivityPendingStart: draining \(requests.count) request(s) in app")
+        // Background task so the async start/update finishes even when backgrounded.
+        _ = Current.backgroundTask(withName: "live-activity-pending-start") { _ in
+            Promise<Void> { seal in
+                Task {
+                    for request in requests {
+                        do {
+                            try await Current.liveActivityRegistry?.startOrUpdate(
+                                tag: request.tag,
+                                title: request.title,
+                                serverWebhookId: request.serverWebhookId,
+                                state: request.state
+                            )
+                        } catch {
+                            Current.Log.error(
+                                "LiveActivityPendingStart: startOrUpdate failed for tag \(request.tag): \(error)"
+                            )
+                        }
                     }
                     DispatchQueue.main.async { seal.fulfill(()) }
                 }

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -28,6 +28,12 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
                 do {
                     let request = try Self.makeRequest(from: payload)
 
+                    // Record the disclosure on both start paths. settingsStore is App-Group-backed,
+                    // so the extension's write is visible to the app's Settings screen — without this
+                    // a Live Activity started via the extension hand-off (drained straight through the
+                    // registry, bypassing this handler) would never set the flag.
+                    Self.showPrivacyDisclosureIfNeeded()
+
                     // PushProvider (NEAppPushProvider) runs in a separate OS process — ActivityKit is
                     // unavailable there, and (unlike APNs) a notification delivered over the local-push
                     // channel is never re-delivered to the main app. So instead of dropping the request,
@@ -44,8 +50,6 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
                         seal.fulfill(())
                         return
                     }
-
-                    Self.showPrivacyDisclosureIfNeeded()
 
                     try await Current.liveActivityRegistry?.startOrUpdate(
                         tag: request.tag,

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -23,42 +23,35 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
     }
 
     func handle(_ payload: [String: Any]) -> Promise<Void> {
-        // PushProvider (NEAppPushProvider) runs in a separate OS process — ActivityKit is
-        // unavailable there. The same notification will be re-delivered to the main app via
-        // UNUserNotificationCenter, where it will be handled correctly.
-        guard !Current.isAppExtension else {
-            Current.Log.verbose("HandlerStartOrUpdateLiveActivity: skipping in app extension, will handle in main app")
-            return .value(())
-        }
-
-        return Promise { seal in
+        Promise { seal in
             Task {
                 do {
-                    guard let tag = payload["tag"] as? String, !tag.isEmpty else {
-                        throw ValidationError.missingTag
-                    }
+                    let request = try Self.makeRequest(from: payload)
 
-                    guard Self.isValidTag(tag) else {
-                        Current.Log
-                            .error(
-                                "HandlerStartOrUpdateLiveActivity: invalid tag '\(tag)' — must be [a-zA-Z0-9_-], max 64 chars"
-                            )
-                        throw ValidationError.invalidTag
-                    }
-
-                    guard let title = payload["title"] as? String, !title.isEmpty else {
-                        throw ValidationError.missingTitle
+                    // PushProvider (NEAppPushProvider) runs in a separate OS process — ActivityKit is
+                    // unavailable there, and (unlike APNs) a notification delivered over the local-push
+                    // channel is never re-delivered to the main app. So instead of dropping the request,
+                    // hand it off to the app via the App Group queue + a Darwin signal, mirroring
+                    // HandlerClearNotification's end hand-off. The app drains it on the signal and at
+                    // launch/foreground. (Darwin can't wake a suspended app, so a local-push start only
+                    // materializes when the app is next active; real-time background starts need APNs.)
+                    if Current.isAppExtension {
+                        Current.Log.verbose(
+                            "HandlerStartOrUpdateLiveActivity: handing off start for tag \(request.tag) to the app"
+                        )
+                        LiveActivityPendingStart.append(request)
+                        LiveActivityPendingStart.postDarwinSignal()
+                        seal.fulfill(())
+                        return
                     }
 
                     Self.showPrivacyDisclosureIfNeeded()
 
-                    let state = Self.contentState(from: payload)
-
                     try await Current.liveActivityRegistry?.startOrUpdate(
-                        tag: tag,
-                        title: title,
-                        serverWebhookId: payload["webhook_id"] as? String,
-                        state: state
+                        tag: request.tag,
+                        title: request.title,
+                        serverWebhookId: request.serverWebhookId,
+                        state: request.state
                     )
                     seal.fulfill(())
                 } catch {
@@ -74,6 +67,29 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
                 }
             }
         }
+    }
+
+    /// Validate and parse a notification payload into a serializable start/update request,
+    /// shared by the in-app and extension-handoff paths.
+    static func makeRequest(from payload: [String: Any]) throws -> LiveActivityPendingStart.Request {
+        guard let tag = payload["tag"] as? String, !tag.isEmpty else {
+            throw ValidationError.missingTag
+        }
+        guard isValidTag(tag) else {
+            Current.Log.error(
+                "HandlerStartOrUpdateLiveActivity: invalid tag '\(tag)' — must be [a-zA-Z0-9_-], max 64 chars"
+            )
+            throw ValidationError.invalidTag
+        }
+        guard let title = payload["title"] as? String, !title.isEmpty else {
+            throw ValidationError.missingTitle
+        }
+        return LiveActivityPendingStart.Request(
+            tag: tag,
+            title: title,
+            serverWebhookId: payload["webhook_id"] as? String,
+            state: contentState(from: payload)
+        )
     }
 
     // MARK: - Privacy Disclosure

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -17,6 +17,8 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         mockRegistry = MockLiveActivityRegistry()
         Current.liveActivityRegistry = mockRegistry
         Current.isAppExtension = false
+        // Clear any cross-process hand-off queue left over from a prior test.
+        _ = LiveActivityPendingStart.drainAll()
     }
 
     override func tearDown() {
@@ -152,13 +154,34 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNil(state.countdownEnd)
     }
 
-    // MARK: - handle(_:) — app extension guard
+    // MARK: - handle(_:) — app extension hand-off
 
-    func testHandle_inAppExtension_skipsRegistryAndFulfills() {
+    func testHandle_inAppExtension_enqueuesHandoffAndSkipsRegistry() throws {
         Current.isAppExtension = true
-        let payload: [String: Any] = ["tag": "test-tag", "title": "Test"]
+        let payload: [String: Any] = [
+            "tag": "test-tag",
+            "title": "Test",
+            "message": "Body",
+            "webhook_id": "wh-1",
+        ]
+        XCTAssertNoThrow(try hang(sut.handle(payload)))
+        // ActivityKit is unavailable in the extension, so the registry is not touched directly...
+        XCTAssertTrue(mockRegistry.startOrUpdateCalls.isEmpty)
+        // ...instead the request is handed off to the app via the App Group queue.
+        let pending = LiveActivityPendingStart.drainAll()
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending.first?.tag, "test-tag")
+        XCTAssertEqual(pending.first?.title, "Test")
+        XCTAssertEqual(pending.first?.serverWebhookId, "wh-1")
+        XCTAssertEqual(pending.first?.state.message, "Body")
+    }
+
+    func testHandle_inAppExtension_invalidTag_doesNotEnqueue() throws {
+        Current.isAppExtension = true
+        let payload: [String: Any] = ["tag": "invalid tag", "title": "Test"]
         XCTAssertNoThrow(try hang(sut.handle(payload)))
         XCTAssertTrue(mockRegistry.startOrUpdateCalls.isEmpty)
+        XCTAssertTrue(LiveActivityPendingStart.drainAll().isEmpty)
     }
 
     // MARK: - handle(_:) — validation failures fulfill (no rejection)


### PR DESCRIPTION
## Summary
`live_update` Live Activity notifications delivered over the local push channel were shown as plain notifications, because the push provider extension can't use ActivityKit and the request was dropped. The extension now hands the start/update off to the app, mirroring the existing clear-notification hand-off.

## Screenshots
N/A

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes