### PR TITLE
Kiosk: add mode, brightness and volume sensors

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1111,6 +1111,12 @@
 		42E95C592CA46AD50010ECE3 /* ShareActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E95C582CA46AD50010ECE3 /* ShareActivityView.swift */; };
 		42E9AFFF2CE63944009DDA46 /* AudioOutputSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */; };
 		42E9B0002CE63944009DDA46 /* AudioOutputSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */; };
+		FF79AFA7BB50A4412EA3D90F /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
+		FE977E5AF3716CC177054DF8 /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
+		72BA28D07496C22E40A84DDB /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
+		5189F6FB2CC89777A8E2172A /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
+		C2485C745F81BBEB2BEB9DB0 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
+		7BFD0239CA1B74E2C14C92E2 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
 		42EB030A2C6E4D0E00A184A6 /* WatchMagicViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EB03092C6E4D0E00A184A6 /* WatchMagicViewRow.swift */; };
 		42EEEFE22E2791430080E973 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE12E2791430080E973 /* Service.swift */; };
 		42EEEFE32E2791430080E973 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE12E2791430080E973 /* Service.swift */; };
@@ -1232,6 +1238,8 @@
 		5B715903CB3450FE351399BC /* Pods-iOS-Extensions-Share-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 207E35C8F1554A9AD616FFA2 /* Pods-iOS-Extensions-Share-metadata.plist */; };
 		5D4737422F241342009A70EA /* FolderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4737412F241342009A70EA /* FolderDetailView.swift */; };
 		5D5F19CD200C051E13C940E2 /* KioskScreensaverSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B10F23CD68334A0873B5707 /* KioskScreensaverSettingsView.swift */; };
+		AF7DBAD13854615BE06CED9F /* KioskSensorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */; };
+		F89D0E47CCB3A8D13BE70EC2 /* KioskSensorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */; };
 		5F2ECF3C2CA505A59A1CFFAF /* Pods_iOS_SharedTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65B4DC669522BB7A70C5EED0 /* Pods_iOS_SharedTesting.framework */; };
 		61495A70232316478717CF27 /* Pods_iOS_Shared_iOS_Tests_Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF3A67FB1C2B548C6C7730C /* Pods_iOS_Shared_iOS_Tests_Shared.framework */; };
 		61826BB51EF447EA760E65F8 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 067B845F1477358424F0C5FD /* GRDB */; };
@@ -2994,6 +3002,9 @@
 		42E95C562CA45EFA0010ECE3 /* OnboardingErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingErrorView.swift; sourceTree = "<group>"; };
 		42E95C582CA46AD50010ECE3 /* ShareActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareActivityView.swift; sourceTree = "<group>"; };
 		42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputSensor.swift; sourceTree = "<group>"; };
+		98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskModeSensor.swift; sourceTree = "<group>"; };
+		F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskBrightnessSensor.swift; sourceTree = "<group>"; };
+		E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskVolumeSensor.swift; sourceTree = "<group>"; };
 		42EB03092C6E4D0E00A184A6 /* WatchMagicViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMagicViewRow.swift; sourceTree = "<group>"; };
 		42EEEFE12E2791430080E973 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		42EEEFE42E2792B20080E973 /* Service.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.test.swift; sourceTree = "<group>"; };
@@ -3103,6 +3114,8 @@
 		6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Widgets-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Widgets-metadata.plist"; sourceTree = "<group>"; };
 		6A7FF77B68D19A4AD68F8FE3 /* CustomWidgetIntentHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomWidgetIntentHelper.swift; sourceTree = "<group>"; };
 		6B10F23CD68334A0873B5707 /* KioskScreensaverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskScreensaverSettingsView.swift; sourceTree = "<group>"; };
+		E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsView.swift; sourceTree = "<group>"; };
+		53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsViewModel.swift; sourceTree = "<group>"; };
 		6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-Shared-watchOS-metadata.plist"; path = "Pods/Pods-watchOS-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
 		6BC23DE131CA8813C2DBD657 /* IconSearchPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IconSearchPicker.swift; sourceTree = "<group>"; };
 		6BECEB2525564358A124F818 /* FolderEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderEditView.swift; sourceTree = "<group>"; };
@@ -4260,6 +4273,9 @@
 			children = (
 				B6D3B4EB225B26300082BB4F /* SensorContainer.swift */,
 				42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */,
+				98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */,
+				F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */,
+				E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */,
 				11AF4D10249C7DFD006C74C0 /* ActivitySensor.swift */,
 				1396822195C7FF562AB891F2 /* BarometerSensor.swift */,
 				11AF4D1B249C8AA0006C74C0 /* BatterySensor.swift */,
@@ -4460,6 +4476,8 @@
 				E70F7D3E8E4B489FA1514E7C /* KioskSettingsViewModel.swift */,
 				22AA95E1438BC6A0DE7EF820 /* KioskSettingsView.swift */,
 				6B10F23CD68334A0873B5707 /* KioskScreensaverSettingsView.swift */,
+				E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */,
+				53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */,
 			);
 			path = Kiosk;
 			sourceTree = "<group>";
@@ -9388,6 +9406,8 @@
 				1AA7D3A6102D7CC4601EEC6F /* KioskSettingsViewModel.swift in Sources */,
 				E864AF283C52DCFA11B83545 /* KioskSettingsView.swift in Sources */,
 				5D5F19CD200C051E13C940E2 /* KioskScreensaverSettingsView.swift in Sources */,
+				AF7DBAD13854615BE06CED9F /* KioskSensorsView.swift in Sources */,
+				F89D0E47CCB3A8D13BE70EC2 /* KioskSensorsViewModel.swift in Sources */,
 				CA0CA15000000000000000A2 /* LocationSettingsView.swift in Sources */,
 				CA0CA15000000000000000B2 /* LocationSettingsViewModel.swift in Sources */,
 				423B5E0B2D677B9B0000CB95 /* WidgetCustom.swift in Sources */,
@@ -10055,6 +10075,9 @@
 				1120C580274638330046C38B /* PerServerContainer.swift in Sources */,
 				427647262C8F38590027B21F /* HAAreasRegistryResponse.swift in Sources */,
 				42E9AFFF2CE63944009DDA46 /* AudioOutputSensor.swift in Sources */,
+				FF79AFA7BB50A4412EA3D90F /* KioskModeSensor.swift in Sources */,
+				72BA28D07496C22E40A84DDB /* KioskBrightnessSensor.swift in Sources */,
+				C2485C745F81BBEB2BEB9DB0 /* KioskVolumeSensor.swift in Sources */,
 				C3EB3740FA097F36D51F525E /* BarometerSensor.swift in Sources */,
 				110ED56425A563D600489AF7 /* DisplaySensor.swift in Sources */,
 				42383F702D9576F700C745F2 /* AppTriggerSource.swift in Sources */,
@@ -10503,6 +10526,9 @@
 				42FCCFDA2B9B19F70057783F /* ThreadClientService.swift in Sources */,
 				1101568724D7712F009424C9 /* TagManagerProtocol.swift in Sources */,
 				42E9B0002CE63944009DDA46 /* AudioOutputSensor.swift in Sources */,
+				FE977E5AF3716CC177054DF8 /* KioskModeSensor.swift in Sources */,
+				5189F6FB2CC89777A8E2172A /* KioskBrightnessSensor.swift in Sources */,
+				7BFD0239CA1B74E2C14C92E2 /* KioskVolumeSensor.swift in Sources */,
 				D87EC7A89E0515C4CAB93220 /* BarometerSensor.swift in Sources */,
 				1141182624AF9A0500E6525C /* WebhookManager.swift in Sources */,
 				119A7E0F2529769A00D7000D /* UIImageView+UIActivityIndicator.swift in Sources */,

--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -3,6 +3,15 @@ import Shared
 import SwiftUI
 import UIKit
 
+/// Presents app Settings from above the kiosk/container swap (hosted by `ConditionalContainerView`) so that
+/// toggling kiosk mode — reachable via Settings → Kiosk — doesn't tear the Settings sheet down with the
+/// container it would otherwise be presented from.
+final class AppSettingsPresenter: ObservableObject {
+    static let shared = AppSettingsPresenter()
+    @Published var isPresented = false
+    private init() {}
+}
+
 struct ContainerView: View {
     @StateObject private var state = OnboardingStateObservable()
     @StateObject private var viewModel = ContainerViewModel()
@@ -34,7 +43,7 @@ struct ContainerView: View {
         .onAppear {
             coordinator.onOpenServer = { state.showWebView(for: $0) }
             coordinator.onSetup = { state.reevaluate() }
-            coordinator.onShowSettings = { viewModel.presentSettings() }
+            coordinator.onShowSettings = { AppSettingsPresenter.shared.isPresented = true }
             coordinator.onShowAssistSettings = { viewModel.presentAssistSettings() }
             coordinator.onShowDownloadManager = { viewModel.presentDownloadManager($0) }
             coordinator.onShowOnboardingPermissions = { viewModel.presentOnboardingPermissions(server: $0, steps: $1) }
@@ -57,9 +66,6 @@ struct ContainerView: View {
                 TestFlightCommunicationView(message: message) {
                     TestFlightCommunicationEngine().markSeen(message)
                 }
-            case .settings:
-                SettingsView().injectingViewControllerProvider()
-                    .onDisappear { refreshWebViewIfDisconnected() }
             case .assistSettings:
                 AssistSettingsView()
             case let .downloadManager(viewModel):
@@ -104,12 +110,6 @@ struct ContainerView: View {
     /// old `presentOverlayController`'s `onDisappear { refresh() }`.
     private func refreshWebView() {
         Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
-    }
-
-    /// Re-evaluates the web view after Settings closes, but only when it isn't connected — so closing Settings
-    /// on a healthy page doesn't reload it, while the no-active-URL / connection block still re-evaluates.
-    private func refreshWebViewIfDisconnected() {
-        Current.sceneManager.webViewControllerPromise.done { $0.refreshIfDisconnected() }
     }
 
     private var isShowingWebView: Bool {

--- a/Sources/App/Container/ContainerViewModel.swift
+++ b/Sources/App/Container/ContainerViewModel.swift
@@ -11,7 +11,6 @@ final class ContainerViewModel: ObservableObject {
     enum PresentedSheet: Identifiable {
         case whatsNew(WhatsNewRelease)
         case testFlight(TestFlightMessage)
-        case settings
         case assistSettings
         case downloadManager(DownloadManagerViewModel)
         case serverSelect(prompt: String?, includeSettings: Bool, onSelect: (Server) -> Void)
@@ -20,7 +19,6 @@ final class ContainerViewModel: ObservableObject {
             switch self {
             case let .whatsNew(release): return "whatsNew-\(release.id)"
             case let .testFlight(message): return "testFlight-\(message.id.rawValue)"
-            case .settings: return "settings"
             case .assistSettings: return "assistSettings"
             case .downloadManager: return "downloadManager"
             case .serverSelect: return "serverSelect"
@@ -67,11 +65,6 @@ final class ContainerViewModel: ObservableObject {
     func showNextLaunchMessage() {
         guard presentedSheet == nil, !pendingLaunchMessages.isEmpty else { return }
         presentedSheet = pendingLaunchMessages.removeFirst()
-    }
-
-    /// Presents app Settings as a sheet over the web view (user-triggered, e.g. a gesture or the re-auth gear).
-    func presentSettings() {
-        presentedSheet = .settings
     }
 
     /// Presents Assist settings as a sheet over the web view (triggered by the frontend's external bus).

--- a/Sources/App/Container/OnboardingStateObservable.swift
+++ b/Sources/App/Container/OnboardingStateObservable.swift
@@ -1,3 +1,4 @@
+import Combine
 import PromiseKit
 import Shared
 import SwiftUI
@@ -29,14 +30,55 @@ final class OnboardingStateObservable: ObservableObject {
 
     @Published private(set) var screen: Screen
 
+    private var cancellables = Set<AnyCancellable>()
+
     init() {
         self.screen = Self.initialScreen()
         Current.onboardingObservation.register(observer: self)
+        observeKioskTarget()
     }
 
     /// Switches the displayed screen to `server`'s web view. Called by the app coordinator's `open(server:)`.
     func showWebView(for server: Server) {
         screen = .webView(server)
+    }
+
+    /// A change to the kiosk server requires a different web view (rebuilt by `ContainerView` via the
+    /// `.id(server)`); a change to just the dashboard navigates the current web view in place.
+    private struct KioskWebTarget: Equatable {
+        let enabled: Bool
+        let serverId: String?
+        let dashboard: String?
+    }
+
+    /// Live-updates the web view as the kiosk server/dashboard pickers change, so the configured
+    /// dashboard appears in the web view behind the kiosk settings sheet.
+    private func observeKioskTarget() {
+        Current.kiosk.settingsPublisher
+            .map { KioskWebTarget(enabled: $0.enabled, serverId: $0.serverId, dashboard: $0.dashboard) }
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] target in
+                self?.applyKioskTarget(target)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func applyKioskTarget(_ target: KioskWebTarget) {
+        guard target.enabled, let server = Current.servers.server(forServerIdentifier: target.serverId) else { return }
+        if currentServer != server {
+            // Different server: rebuild the web view, which loads its kiosk dashboard on creation.
+            showWebView(for: server)
+        } else {
+            // Same server: just navigate the existing web view to the configured dashboard.
+            Current.sceneManager.webViewControllerPromise.done { $0.applyKioskDashboard() }
+        }
+    }
+
+    private var currentServer: Server? {
+        if case let .webView(server) = screen { return server }
+        return nil
     }
 
     /// Recomputes which screen to show (e.g. after onboarding finishes). Mirrors the launch decision.

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -136,6 +136,17 @@ extension WebViewController {
         return url
     }
 
+    /// Navigates the web view to the kiosk-configured dashboard for the current server (or the server
+    /// default when no specific dashboard is set), so picking a dashboard in kiosk settings updates the
+    /// web view live. Server changes are handled by rebuilding the web view, not here.
+    func applyKioskDashboard() {
+        guard Current.kioskSettings.enabled, let webviewURL = server.info.connection.webviewURL() else { return }
+        let target = kioskDashboardURL(for: webviewURL) ?? webviewURL
+        guard webView.url?.absoluteString != target.absoluteString else { return }
+        Current.Log.info("applying kiosk dashboard to web view: \(target.path)")
+        load(request: URLRequest(url: target))
+    }
+
     func showNoActiveURLError() {
         // Load about:blank in webview to prevent any current connections
         load(request: URLRequest(url: URL(string: "about:blank")!))

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -637,6 +637,9 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.security.hide_status_bar" = "Hide Status Bar";
 "kiosk.security.section" = "Security & Display";
 "kiosk.security.taps_required" = "Taps Required: %li";
+"kiosk.sensors.body" = "Report kiosk mode, brightness, and volume to Home Assistant.";
+"kiosk.sensors.footer" = "These sensors also appear in the app's sensor settings. Enabling or disabling them here keeps both places in sync.";
+"kiosk.sensors.title" = "Sensors";
 "kiosk.title" = "Kiosk Mode";
 "legacy_actions.disclaimer" = "Legacy iOS Actions are not the recommended way to interact with Home Assistant anymore, please use Scripts, Scenes and Automations directly in your Widgets, Apple Watch and CarPlay.";
 "live_activity.empty_state" = "No active Live Activities";

--- a/Sources/App/Settings/Kiosk/KioskSensorsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskSensorsView.swift
@@ -1,0 +1,56 @@
+import Shared
+import SwiftUI
+
+struct KioskSensorsView: View {
+    @StateObject private var viewModel = KioskSensorsViewModel()
+
+    var body: some View {
+        List {
+            AppleLikeListTopRowHeader(
+                image: .motionSensorIcon,
+                title: L10n.Kiosk.Sensors.title,
+                subtitle: L10n.Kiosk.Sensors.body
+            )
+
+            Section {
+                ForEach(viewModel.sensors, id: \.UniqueID) { sensor in
+                    sensorRow(sensor)
+                }
+            } footer: {
+                Text(L10n.Kiosk.Sensors.footer)
+            }
+        }
+        .onAppear {
+            viewModel.refresh()
+        }
+    }
+
+    private func sensorRow(_ sensor: WebhookSensor) -> some View {
+        let isEnabled = viewModel.isEnabled(sensor)
+        return Toggle(isOn: Binding(
+            get: { viewModel.isEnabled(sensor) },
+            set: { viewModel.setEnabled($0, for: sensor) }
+        )) {
+            Label {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(sensor.Name ?? L10n.unknownLabel)
+                    if isEnabled, let state = sensor.StateDescription {
+                        Text(state)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } icon: {
+                if let icon = sensor.Icon.flatMap({ MaterialDesignIcons(serversideValueNamed: $0) }) {
+                    MaterialDesignIconsImage(icon: icon, size: 24)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        KioskSensorsView()
+    }
+}

--- a/Sources/App/Settings/Kiosk/KioskSensorsViewModel.swift
+++ b/Sources/App/Settings/Kiosk/KioskSensorsViewModel.swift
@@ -1,0 +1,73 @@
+import Combine
+import Foundation
+import PromiseKit
+import Shared
+import UIKit
+
+/// Backs the "Sensors" menu inside kiosk settings. The sensors shown here are the same
+/// `WebhookSensor`s exposed in the standard sensor settings, and enabling/disabling them goes
+/// through `Current.sensors`, so the two screens always mirror each other.
+final class KioskSensorsViewModel: ObservableObject {
+    /// Identifiers of the sensors surfaced in the kiosk sensors menu, in display order.
+    static let sensorIds: [WebhookSensorId] = [.kioskMode, .kioskBrightness, .kioskVolume]
+    private static let order: [String: Int] = Dictionary(
+        uniqueKeysWithValues: sensorIds.enumerated().map { ($0.element.rawValue, $0.offset) }
+    )
+
+    @Published private(set) var sensors: [WebhookSensor] = []
+
+    init() {
+        Current.sensors.register(observer: self)
+    }
+
+    deinit {
+        Current.sensors.unregister(observer: self)
+    }
+
+    func isEnabled(_ sensor: WebhookSensor) -> Bool {
+        Current.sensors.isEnabled(sensor: sensor)
+    }
+
+    func setEnabled(_ enabled: Bool, for sensor: WebhookSensor) {
+        Current.sensors.setEnabled(enabled, for: sensor)
+        // Reflect the change immediately; the sensor refresh triggered by the settings change
+        // will follow up with fresh state values.
+        objectWillChange.send()
+    }
+
+    func refresh() {
+        firstly {
+            HomeAssistantAPI.manuallyUpdate(
+                applicationState: UIApplication.shared.applicationState,
+                type: .userRequested
+            )
+        }.catch { error in
+            Current.Log.error("Failed to refresh kiosk sensors: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - SensorObserver
+
+extension KioskSensorsViewModel: SensorObserver {
+    func sensorContainer(
+        _ container: SensorContainer,
+        didSignalForUpdateBecause reason: SensorContainerUpdateReason,
+        lastUpdate: SensorObserverUpdate?
+    ) {
+        refresh()
+    }
+
+    func sensorContainer(_ container: SensorContainer, didUpdate update: SensorObserverUpdate) {
+        firstly {
+            update.sensors
+        }.done { [weak self] sensors in
+            let kioskSensors = sensors
+                .filter { Self.order[$0.UniqueID ?? ""] != nil }
+                .sorted { (Self.order[$0.UniqueID ?? ""] ?? 0) < (Self.order[$1.UniqueID ?? ""] ?? 0) }
+            DispatchQueue.main.async {
+                self?.sensors = kioskSensors
+            }
+        }
+    }
+}

--- a/Sources/App/Settings/Kiosk/KioskSettingsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettingsView.swift
@@ -82,6 +82,11 @@ struct KioskSettingsView: View {
                 } label: {
                     KioskRow.label(L10n.Kiosk.Screensaver.title, icon: .weatherNightIcon)
                 }
+                NavigationLink {
+                    KioskSensorsView()
+                } label: {
+                    KioskRow.label(L10n.Kiosk.Sensors.title, icon: .motionSensorIcon)
+                }
             }
 
             Section(L10n.Kiosk.Screensaver.ConfigurationAccess.title) {

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -6,11 +6,12 @@ import UIKit
 struct ConditionalContainerView: View {
     @StateObject private var kiosk = Current.kiosk
     @Environment(\.scenePhase) private var scenePhase
+    @State private var showKioskSettings = false
 
     var body: some View {
         Group {
             if kiosk.settings.enabled {
-                KioskView()
+                KioskView(showSettings: $showKioskSettings)
             } else {
                 ContainerView()
             }
@@ -19,6 +20,19 @@ struct ConditionalContainerView: View {
         .onChange(of: kiosk.shouldKeepScreenOn) { _ in applyKeepScreenOn() }
         .onChange(of: scenePhase) { phase in
             if phase == .active { applyKeepScreenOn() }
+        }
+        // Hosted here, above the kiosk/container swap, so toggling kiosk mode from within the
+        // settings screen swaps the view underneath without dismissing the settings sheet itself.
+        .sheet(isPresented: $showKioskSettings) {
+            NavigationView {
+                KioskSettingsView()
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            CloseButton { showKioskSettings = false }
+                        }
+                    }
+            }
+            .navigationViewStyle(.stack)
         }
     }
 
@@ -30,7 +44,7 @@ struct ConditionalContainerView: View {
 struct KioskView: View {
     @StateObject private var screensaver = KioskScreensaverController()
     @StateObject private var kiosk = Current.kiosk
-    @State private var showSettings = false
+    @Binding var showSettings: Bool
 
     var body: some View {
         ContainerView()
@@ -58,17 +72,6 @@ struct KioskView: View {
                 }
             }
             .animation(.easeInOut(duration: 0.4), value: screensaver.isActive)
-            .sheet(isPresented: $showSettings) {
-                NavigationView {
-                    KioskSettingsView()
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                CloseButton { showSettings = false }
-                            }
-                        }
-                }
-                .navigationViewStyle(.stack)
-            }
     }
 
     private var settingsEntryAlignment: Alignment {

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -5,10 +5,22 @@ import UIKit
 
 struct ConditionalContainerView: View {
     @StateObject private var kiosk = Current.kiosk
+    @ObservedObject private var appSettings = AppSettingsPresenter.shared
     @Environment(\.scenePhase) private var scenePhase
     @State private var showKioskSettings = false
 
     var body: some View {
+        content
+            .sheet(isPresented: $appSettings.isPresented) {
+                SettingsView()
+                    .injectingViewControllerProvider()
+                    .onDisappear {
+                        Current.sceneManager.webViewControllerPromise.done { $0.refreshIfDisconnected() }
+                    }
+            }
+    }
+
+    private var content: some View {
         Group {
             if kiosk.settings.enabled {
                 KioskView(showSettings: $showKioskSettings)
@@ -21,8 +33,6 @@ struct ConditionalContainerView: View {
         .onChange(of: scenePhase) { phase in
             if phase == .active { applyKeepScreenOn() }
         }
-        // Hosted here, above the kiosk/container swap, so toggling kiosk mode from within the
-        // settings screen swaps the view underneath without dismissing the settings sheet itself.
         .sheet(isPresented: $showKioskSettings) {
             NavigationView {
                 KioskSettingsView()

--- a/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
@@ -20,7 +20,10 @@ final class KioskBrightnessSensorUpdateSignaler: BaseSensorUpdateSignaler, Senso
         super.observe()
         guard !isObserving else { return }
         #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Control Center / hardware changes can fire many notifications in quick succession; debounce so
+        // we send a single sensor update once the brightness settles, instead of a burst of webhooks.
         cancellable = NotificationCenter.default.publisher(for: UIScreen.brightnessDidChangeNotification)
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.signal()
             }

--- a/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
@@ -1,0 +1,65 @@
+import Combine
+import Foundation
+import PromiseKit
+#if os(iOS) && !targetEnvironment(macCatalyst)
+import UIKit
+#endif
+
+final class KioskBrightnessSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
+    private var cancellable: AnyCancellable?
+    private let signal: () -> Void
+
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+        super.init(relatedSensorsIds: [
+            .kioskBrightness,
+        ])
+    }
+
+    override func observe() {
+        super.observe()
+        guard !isObserving else { return }
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        cancellable = NotificationCenter.default.publisher(for: UIScreen.brightnessDidChangeNotification)
+            .sink { [weak self] _ in
+                self?.signal()
+            }
+        #endif
+        isObserving = true
+    }
+
+    override func stopObserving() {
+        super.stopObserving()
+        guard isObserving else { return }
+        cancellable?.cancel()
+        cancellable = nil
+        isObserving = false
+    }
+}
+
+/// Reports the current screen brightness as a percentage. iOS/iPadOS only.
+final class KioskBrightnessSensor: SensorProvider {
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        var sensors: [WebhookSensor] = []
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        let brightness = Int((Current.screenBrightness() * 100).rounded())
+        sensors.append(with(WebhookSensor(
+            name: "Kiosk Brightness",
+            uniqueID: WebhookSensorId.kioskBrightness.rawValue,
+            icon: "mdi:brightness-6",
+            state: brightness
+        )) {
+            $0.UnitOfMeasurement = "%"
+        })
+
+        // Set up our observer for brightness changes
+        let _: KioskBrightnessSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+        #endif
+        return .value(sensors)
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskBrightnessSensor.swift
@@ -37,7 +37,7 @@ final class KioskBrightnessSensorUpdateSignaler: BaseSensorUpdateSignaler, Senso
     }
 }
 
-/// Reports the current screen brightness as a percentage. iOS/iPadOS only.
+/// Reports the current screen brightness as a percentage. Enabled only while kiosk mode is enabled, iOS/iPadOS only.
 final class KioskBrightnessSensor: SensorProvider {
     let request: SensorProviderRequest
     init(request: SensorProviderRequest) {

--- a/Sources/Shared/API/Webhook/Sensors/KioskModeSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskModeSensor.swift
@@ -1,0 +1,63 @@
+import Combine
+import Foundation
+import PromiseKit
+
+final class KioskModeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
+    private var cancellable: AnyCancellable?
+    private let signal: () -> Void
+
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+        super.init(relatedSensorsIds: [
+            .kioskMode,
+        ])
+    }
+
+    override func observe() {
+        super.observe()
+        guard !isObserving else { return }
+        cancellable = Current.kiosk.settingsPublisher
+            .map(\.enabled)
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.signal()
+            }
+        isObserving = true
+    }
+
+    override func stopObserving() {
+        super.stopObserving()
+        guard isObserving else { return }
+        cancellable?.cancel()
+        cancellable = nil
+        isObserving = false
+    }
+}
+
+/// Reports whether the app is currently running in kiosk mode. iOS/iPadOS only.
+final class KioskModeSensor: SensorProvider {
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        var sensors: [WebhookSensor] = []
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        let isEnabled = Current.kioskSettings.enabled
+        let sensor = WebhookSensor(
+            name: "Kiosk Mode",
+            uniqueID: WebhookSensorId.kioskMode.rawValue,
+            icon: isEnabled ? "mdi:tablet-dashboard" : "mdi:tablet",
+            state: isEnabled
+        )
+        sensor.Type = "binary_sensor"
+        sensors.append(sensor)
+
+        // Set up our observer for kiosk mode changes
+        let _: KioskModeSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+        #endif
+        return .value(sensors)
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/KioskModeSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskModeSensor.swift
@@ -20,6 +20,7 @@ final class KioskModeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
             .map(\.enabled)
             .removeDuplicates()
             .dropFirst()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.signal()
             }

--- a/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
@@ -1,9 +1,12 @@
 import AVFoundation
+import Combine
 import Foundation
 import PromiseKit
 
 final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
     private var observation: NSKeyValueObservation?
+    private var cancellable: AnyCancellable?
+    private let volumeChanges = PassthroughSubject<Void, Never>()
     private let signal: () -> Void
 
     init(signal: @escaping () -> Void) {
@@ -23,8 +26,15 @@ final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorPro
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.ambient, options: [.mixWithOthers])
         try? session.setActive(true)
+        // Holding the volume buttons fires many KVO changes in quick succession; debounce so we send a
+        // single sensor update once the volume settles, instead of a burst of webhooks.
+        cancellable = volumeChanges
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.signal()
+            }
         observation = session.observe(\.outputVolume, options: [.new]) { [weak self] _, _ in
-            self?.signal()
+            self?.volumeChanges.send()
         }
         #endif
         isObserving = true
@@ -35,6 +45,8 @@ final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorPro
         guard isObserving else { return }
         observation?.invalidate()
         observation = nil
+        cancellable?.cancel()
+        cancellable = nil
         #if os(iOS) && !targetEnvironment(macCatalyst)
         // Release the audio session we activated for volume observation, letting other audio resume.
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)

--- a/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
@@ -1,0 +1,62 @@
+import AVFoundation
+import Foundation
+import PromiseKit
+
+final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
+    private var observation: NSKeyValueObservation?
+    private let signal: () -> Void
+
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+        super.init(relatedSensorsIds: [
+            .kioskVolume,
+        ])
+    }
+
+    override func observe() {
+        super.observe()
+        guard !isObserving else { return }
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Observe the shared session's output volume. Reading the value is always accurate; live
+        // notifications are best-effort and we intentionally avoid activating the session so we
+        // don't interrupt any audio the user (or Home Assistant) may be playing.
+        observation = AVAudioSession.sharedInstance().observe(\.outputVolume, options: [.new]) { [weak self] _, _ in
+            self?.signal()
+        }
+        #endif
+        isObserving = true
+    }
+
+    override func stopObserving() {
+        super.stopObserving()
+        guard isObserving else { return }
+        observation?.invalidate()
+        observation = nil
+        isObserving = false
+    }
+}
+
+/// Reports the device output volume as a number between 0 and 100. iOS/iPadOS only.
+final class KioskVolumeSensor: SensorProvider {
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        var sensors: [WebhookSensor] = []
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        let volume = Int((AVAudioSession.sharedInstance().outputVolume * 100).rounded())
+        sensors.append(WebhookSensor(
+            name: "Kiosk Volume",
+            uniqueID: WebhookSensorId.kioskVolume.rawValue,
+            icon: "mdi:volume-high",
+            state: volume
+        ))
+
+        // Set up our observer for volume changes
+        let _: KioskVolumeSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+        #endif
+        return .value(sensors)
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskVolumeSensor.swift
@@ -17,10 +17,13 @@ final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorPro
         super.observe()
         guard !isObserving else { return }
         #if os(iOS) && !targetEnvironment(macCatalyst)
-        // Observe the shared session's output volume. Reading the value is always accurate; live
-        // notifications are best-effort and we intentionally avoid activating the session so we
-        // don't interrupt any audio the user (or Home Assistant) may be playing.
-        observation = AVAudioSession.sharedInstance().observe(\.outputVolume, options: [.new]) { [weak self] _, _ in
+        // `outputVolume` only emits KVO changes while the app's audio session is active, so activate
+        // a non-intrusive ambient session that mixes with other audio purely to receive volume
+        // change callbacks. It's deactivated again in `stopObserving()` when the sensor is disabled.
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.ambient, options: [.mixWithOthers])
+        try? session.setActive(true)
+        observation = session.observe(\.outputVolume, options: [.new]) { [weak self] _, _ in
             self?.signal()
         }
         #endif
@@ -32,11 +35,15 @@ final class KioskVolumeSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorPro
         guard isObserving else { return }
         observation?.invalidate()
         observation = nil
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Release the audio session we activated for volume observation, letting other audio resume.
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        #endif
         isObserving = false
     }
 }
 
-/// Reports the device output volume as a number between 0 and 100. iOS/iPadOS only.
+/// Reports the device output volume as a percentage. Enabled only while kiosk mode is enabled, iOS/iPadOS only.
 final class KioskVolumeSensor: SensorProvider {
     let request: SensorProviderRequest
     init(request: SensorProviderRequest) {
@@ -47,12 +54,14 @@ final class KioskVolumeSensor: SensorProvider {
         var sensors: [WebhookSensor] = []
         #if os(iOS) && !targetEnvironment(macCatalyst)
         let volume = Int((AVAudioSession.sharedInstance().outputVolume * 100).rounded())
-        sensors.append(WebhookSensor(
+        sensors.append(with(WebhookSensor(
             name: "Kiosk Volume",
             uniqueID: WebhookSensorId.kioskVolume.rawValue,
             icon: "mdi:volume-high",
             state: volume
-        ))
+        )) {
+            $0.UnitOfMeasurement = "%"
+        })
 
         // Set up our observer for volume changes
         let _: KioskVolumeSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -80,7 +80,11 @@ public class SensorContainer {
 
     public func isEnabled(sensor: WebhookSensor) -> Bool {
         guard let id = sensor.UniqueID else { return false }
-        return !disabledSensorIDs.contains(id)
+        return isEnabled(uniqueID: id)
+    }
+
+    public func isEnabled(uniqueID: String) -> Bool {
+        !disabledSensorIDs.contains(uniqueID)
     }
 
     public func isAllowedToSend(sensor: WebhookSensor, for server: Server) -> Bool {
@@ -94,7 +98,10 @@ public class SensorContainer {
 
     public func setEnabled(_ value: Bool, for sensor: WebhookSensor) {
         guard let id = sensor.UniqueID else { return }
+        setEnabled(value, forUniqueID: id)
+    }
 
+    public func setEnabled(_ value: Bool, forUniqueID id: String) {
         if value {
             disabledSensorIDs.remove(id)
         } else {

--- a/Sources/Shared/API/Webhook/WebhookSensorId.swift
+++ b/Sources/Shared/API/Webhook/WebhookSensorId.swift
@@ -23,4 +23,7 @@ public enum WebhookSensorId: String, CaseIterable {
     case locationPermission = "location-permission"
     case focus
     case pressure
+    case kioskMode
+    case kioskBrightness
+    case kioskVolume
 }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -273,6 +273,9 @@ public class AppEnvironment {
         $0.register(provider: LocationPermissionSensor.self)
         $0.register(provider: AudioOutputSensor.self)
         $0.register(provider: BarometerSensor.self)
+        $0.register(provider: KioskModeSensor.self)
+        $0.register(provider: KioskBrightnessSensor.self)
+        $0.register(provider: KioskVolumeSensor.self)
     }
 
     public var localized = LocalizedManager()

--- a/Sources/Shared/Environment/KioskModeManager.swift
+++ b/Sources/Shared/Environment/KioskModeManager.swift
@@ -58,9 +58,21 @@ public final class KioskModeManager: ObservableObject {
             },
             onChange: { [weak self] settings in
                 // ValueObservation notifies on the main queue by default.
-                Current.Log.info("Kiosk settings changed, enabled: \(settings?.enabled ?? false)")
-                self?.settings = settings ?? KioskSettings()
+                let settings = settings ?? KioskSettings()
+                Current.Log.info("Kiosk settings changed, enabled: \(settings.enabled)")
+                self?.settings = settings
+                self?.syncKioskSensorsEnabled(with: settings)
             }
         )
+    }
+
+    /// The kiosk brightness and volume sensors only make sense on a device acting as a kiosk, so we
+    /// keep them enabled only while kiosk mode is enabled. This runs for the observation's initial
+    /// value and every subsequent change, and is idempotent so it won't fire spurious updates.
+    private func syncKioskSensorsEnabled(with settings: KioskSettings) {
+        for sensorId in [WebhookSensorId.kioskBrightness, .kioskVolume] {
+            guard Current.sensors.isEnabled(uniqueID: sensorId.rawValue) != settings.enabled else { continue }
+            Current.sensors.setEnabled(settings.enabled, forUniqueID: sensorId.rawValue)
+        }
     }
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2236,6 +2236,14 @@ public enum L10n {
         return L10n.tr("Localizable", "kiosk.security.taps_required", p1)
       }
     }
+    public enum Sensors {
+      /// Report kiosk mode, brightness, and volume to Home Assistant.
+      public static var body: String { return L10n.tr("Localizable", "kiosk.sensors.body") }
+      /// These sensors also appear in the app's sensor settings. Enabling or disabling them here keeps both places in sync.
+      public static var footer: String { return L10n.tr("Localizable", "kiosk.sensors.footer") }
+      /// Sensors
+      public static var title: String { return L10n.tr("Localizable", "kiosk.sensors.title") }
+    }
   }
 
   public enum LegacyActions {

--- a/Tests/App/Webhook/WebhookSensorIdTests.swift
+++ b/Tests/App/Webhook/WebhookSensorIdTests.swift
@@ -25,8 +25,11 @@ struct WebhookSensorIdTests {
         assert(WebhookSensorId.locationPermission.rawValue == "location-permission")
         assert(WebhookSensorId.focus.rawValue == "focus")
         assert(WebhookSensorId.pressure.rawValue == "pressure")
+        assert(WebhookSensorId.kioskMode.rawValue == "kioskMode")
+        assert(WebhookSensorId.kioskBrightness.rawValue == "kioskBrightness")
+        assert(WebhookSensorId.kioskVolume.rawValue == "kioskVolume")
         assert(
-            WebhookSensorId.allCases.count == 22,
+            WebhookSensorId.allCases.count == 25,
             "WebhookSensorId has different number of cases than defined in test, \(WebhookSensorId.allCases.count)"
         )
     }


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds iOS/iPadOS Kiosk Mode, Kiosk Brightness and Kiosk Volume sensors, controllable from the usual sensor settings and from a new Sensors menu in Kiosk settings (the two stay in sync).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
