### PR TITLE
Kiosk screensaver: add clock and date boldness sliders

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -599,6 +599,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.screen_label" = "Screen: %@";
 "kiosk.screensaver.body" = "Show a screensaver after a period of inactivity to protect the display and save power.";
 "kiosk.screensaver.clock_boldness" = "Clock boldness";
+"kiosk.screensaver.clock_size" = "Clock size";
 "kiosk.screensaver.clock_style.large" = "Large";
 "kiosk.screensaver.clock_style.medium" = "Medium";
 "kiosk.screensaver.clock_style.small" = "Small";
@@ -606,6 +607,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.screensaver.configuration_access.position" = "Kiosk settings entry position";
 "kiosk.screensaver.configuration_access.title" = "Configuration access";
 "kiosk.screensaver.date_boldness" = "Date boldness";
+"kiosk.screensaver.date_size" = "Date size";
 "kiosk.screensaver.dim" = "Dim";
 "kiosk.screensaver.dim_level" = "Dim Level: %li%%";
 "kiosk.screensaver.dimming_level" = "Dim level";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -598,12 +598,14 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.remove_header_and_sidebar" = "Hide sidebar and top bar controls";
 "kiosk.screen_label" = "Screen: %@";
 "kiosk.screensaver.body" = "Show a screensaver after a period of inactivity to protect the display and save power.";
+"kiosk.screensaver.clock_boldness" = "Clock boldness";
 "kiosk.screensaver.clock_style.large" = "Large";
 "kiosk.screensaver.clock_style.medium" = "Medium";
 "kiosk.screensaver.clock_style.small" = "Small";
 "kiosk.screensaver.clock_style.title" = "Clock style";
 "kiosk.screensaver.configuration_access.position" = "Kiosk settings entry position";
 "kiosk.screensaver.configuration_access.title" = "Configuration access";
+"kiosk.screensaver.date_boldness" = "Date boldness";
 "kiosk.screensaver.dim" = "Dim";
 "kiosk.screensaver.dim_level" = "Dim Level: %li%%";
 "kiosk.screensaver.dimming_level" = "Dim level";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -598,6 +598,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.remove_header_and_sidebar" = "Hide sidebar and top bar controls";
 "kiosk.screen_label" = "Screen: %@";
 "kiosk.screensaver.body" = "Show a screensaver after a period of inactivity to protect the display and save power.";
+"kiosk.screensaver.clock.title" = "Clock";
 "kiosk.screensaver.clock_boldness" = "Clock boldness";
 "kiosk.screensaver.clock_size" = "Clock size";
 "kiosk.screensaver.clock_style.large" = "Large";
@@ -610,6 +611,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.screensaver.date_size" = "Date size";
 "kiosk.screensaver.dim" = "Dim";
 "kiosk.screensaver.dim_level" = "Dim Level: %li%%";
+"kiosk.screensaver.dimming.title" = "Dimming";
 "kiosk.screensaver.dimming_level" = "Dim level";
 "kiosk.screensaver.enabled" = "Enabled";
 "kiosk.screensaver.mode" = "Mode";

--- a/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
@@ -32,40 +32,10 @@ struct KioskScreensaverSettingsView: View {
                 }
 
                 if screensaver.wrappedValue.mode == .clock {
-                    normalizedSlider(
-                        title: L10n.Kiosk.Screensaver.clockSize,
-                        icon: .formatSizeIcon,
-                        value: screensaver.clockFontSize
-                    )
-                    normalizedSlider(
-                        title: L10n.Kiosk.Screensaver.clockBoldness,
-                        icon: .formatBoldIcon,
-                        value: screensaver.clockFontWeight
-                    )
-                    Toggle(isOn: screensaver.showDate) {
-                        KioskRow.label(L10n.Kiosk.Screensaver.showDate, icon: .calendarOutlineIcon)
-                    }
-                    if screensaver.wrappedValue.showDate {
-                        normalizedSlider(
-                            title: L10n.Kiosk.Screensaver.dateSize,
-                            icon: .formatSizeIcon,
-                            value: screensaver.dateFontSize
-                        )
-                        normalizedSlider(
-                            title: L10n.Kiosk.Screensaver.dateBoldness,
-                            icon: .formatBoldIcon,
-                            value: screensaver.dateFontWeight
-                        )
-                    }
-                    Toggle(isOn: screensaver.showSeconds) {
-                        KioskRow.label(L10n.Kiosk.Screensaver.showSeconds, icon: .timerOutlineIcon)
-                    }
-                    Toggle(isOn: screensaver.pixelShiftEnabled) {
-                        KioskRow.label(
-                            L10n.Kiosk.Screensaver.pixelShift,
-                            subtitle: L10n.Kiosk.Screensaver.pixelShiftFooter,
-                            icon: .arrowAllIcon
-                        )
+                    NavigationLink {
+                        KioskScreensaverClockSettingsView(viewModel: viewModel)
+                    } label: {
+                        KioskRow.label(L10n.Kiosk.Screensaver.Clock.title, icon: .clockOutlineIcon)
                     }
                 }
 
@@ -79,21 +49,10 @@ struct KioskScreensaverSettingsView: View {
                     }
                 }
 
-                Toggle(isOn: screensaver.dimEnabled) {
-                    KioskRow.label(L10n.Kiosk.Screensaver.dim, icon: .brightness6Icon)
-                }
-
-                if screensaver.wrappedValue.dimEnabled {
-                    VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
-                        HStack {
-                            KioskRow.label(L10n.Kiosk.Screensaver.dimmingLevel, icon: .brightness6Icon)
-                            Spacer()
-                            Text(dimLevelPercentage)
-                                .foregroundStyle(.secondary)
-                                .monospacedDigit()
-                        }
-                        Slider(value: screensaver.dimLevel, in: 0 ... 1, step: 0.05)
-                    }
+                NavigationLink {
+                    KioskScreensaverDimmingSettingsView(viewModel: viewModel)
+                } label: {
+                    KioskRow.label(L10n.Kiosk.Screensaver.Dimming.title, icon: .brightness6Icon)
                 }
             }
 
@@ -111,27 +70,84 @@ struct KioskScreensaverSettingsView: View {
             }
         }
     }
+}
 
-    private var dimLevelPercentage: String {
-        let percentage = Int((screensaver.wrappedValue.dimLevel * 100).rounded())
-        return "\(percentage)%"
+struct KioskScreensaverClockSettingsView: View {
+    @ObservedObject var viewModel: KioskSettingsViewModel
+
+    private var screensaver: Binding<KioskScreensaverSettings> {
+        $viewModel.settings.screensaver
     }
 
-    @ViewBuilder
-    private func normalizedSlider(
-        title: String,
-        icon: MaterialDesignIcons,
-        value: Binding<Double>
-    ) -> some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
-            HStack {
-                KioskRow.label(title, icon: icon)
-                Spacer()
-                Text("\(Int((value.wrappedValue * 100).rounded()))%")
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
+    var body: some View {
+        List {
+            Section {
+                KioskRow.slider(
+                    L10n.Kiosk.Screensaver.clockSize,
+                    icon: .formatSizeIcon,
+                    value: screensaver.clockFontSize
+                )
+                KioskRow.slider(
+                    L10n.Kiosk.Screensaver.clockBoldness,
+                    icon: .formatBoldIcon,
+                    value: screensaver.clockFontWeight
+                )
+                Toggle(isOn: screensaver.showSeconds) {
+                    KioskRow.label(L10n.Kiosk.Screensaver.showSeconds, icon: .timerOutlineIcon)
+                }
+                Toggle(isOn: screensaver.pixelShiftEnabled) {
+                    KioskRow.label(
+                        L10n.Kiosk.Screensaver.pixelShift,
+                        subtitle: L10n.Kiosk.Screensaver.pixelShiftFooter,
+                        icon: .arrowAllIcon
+                    )
+                }
             }
-            Slider(value: value, in: 0 ... 1, step: 0.05)
+
+            Section {
+                Toggle(isOn: screensaver.showDate) {
+                    KioskRow.label(L10n.Kiosk.Screensaver.showDate, icon: .calendarOutlineIcon)
+                }
+                if screensaver.wrappedValue.showDate {
+                    KioskRow.slider(
+                        L10n.Kiosk.Screensaver.dateSize,
+                        icon: .formatSizeIcon,
+                        value: screensaver.dateFontSize
+                    )
+                    KioskRow.slider(
+                        L10n.Kiosk.Screensaver.dateBoldness,
+                        icon: .formatBoldIcon,
+                        value: screensaver.dateFontWeight
+                    )
+                }
+            }
         }
+        .navigationTitle(L10n.Kiosk.Screensaver.Clock.title)
+    }
+}
+
+struct KioskScreensaverDimmingSettingsView: View {
+    @ObservedObject var viewModel: KioskSettingsViewModel
+
+    private var screensaver: Binding<KioskScreensaverSettings> {
+        $viewModel.settings.screensaver
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Toggle(isOn: screensaver.dimEnabled) {
+                    KioskRow.label(L10n.Kiosk.Screensaver.dim, icon: .brightness6Icon)
+                }
+                if screensaver.wrappedValue.dimEnabled {
+                    KioskRow.slider(
+                        L10n.Kiosk.Screensaver.dimmingLevel,
+                        icon: .brightness6Icon,
+                        value: screensaver.dimLevel
+                    )
+                }
+            }
+        }
+        .navigationTitle(L10n.Kiosk.Screensaver.Dimming.title)
     }
 }

--- a/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
@@ -32,16 +32,12 @@ struct KioskScreensaverSettingsView: View {
                 }
 
                 if screensaver.wrappedValue.mode == .clock {
-                    KioskRow.picker(
-                        L10n.Kiosk.Screensaver.ClockStyle.title,
+                    normalizedSlider(
+                        title: L10n.Kiosk.Screensaver.clockSize,
                         icon: .formatSizeIcon,
-                        selection: screensaver.clockStyle
-                    ) {
-                        ForEach(KioskClockStyle.allCases) { style in
-                            Text(style.title).tag(style)
-                        }
-                    }
-                    boldnessSlider(
+                        value: screensaver.clockFontSize
+                    )
+                    normalizedSlider(
                         title: L10n.Kiosk.Screensaver.clockBoldness,
                         icon: .formatBoldIcon,
                         value: screensaver.clockFontWeight
@@ -50,7 +46,12 @@ struct KioskScreensaverSettingsView: View {
                         KioskRow.label(L10n.Kiosk.Screensaver.showDate, icon: .calendarOutlineIcon)
                     }
                     if screensaver.wrappedValue.showDate {
-                        boldnessSlider(
+                        normalizedSlider(
+                            title: L10n.Kiosk.Screensaver.dateSize,
+                            icon: .formatSizeIcon,
+                            value: screensaver.dateFontSize
+                        )
+                        normalizedSlider(
                             title: L10n.Kiosk.Screensaver.dateBoldness,
                             icon: .formatBoldIcon,
                             value: screensaver.dateFontWeight
@@ -117,7 +118,7 @@ struct KioskScreensaverSettingsView: View {
     }
 
     @ViewBuilder
-    private func boldnessSlider(
+    private func normalizedSlider(
         title: String,
         icon: MaterialDesignIcons,
         value: Binding<Double>

--- a/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverSettingsView.swift
@@ -41,8 +41,20 @@ struct KioskScreensaverSettingsView: View {
                             Text(style.title).tag(style)
                         }
                     }
+                    boldnessSlider(
+                        title: L10n.Kiosk.Screensaver.clockBoldness,
+                        icon: .formatBoldIcon,
+                        value: screensaver.clockFontWeight
+                    )
                     Toggle(isOn: screensaver.showDate) {
                         KioskRow.label(L10n.Kiosk.Screensaver.showDate, icon: .calendarOutlineIcon)
+                    }
+                    if screensaver.wrappedValue.showDate {
+                        boldnessSlider(
+                            title: L10n.Kiosk.Screensaver.dateBoldness,
+                            icon: .formatBoldIcon,
+                            value: screensaver.dateFontWeight
+                        )
                     }
                     Toggle(isOn: screensaver.showSeconds) {
                         KioskRow.label(L10n.Kiosk.Screensaver.showSeconds, icon: .timerOutlineIcon)
@@ -102,5 +114,23 @@ struct KioskScreensaverSettingsView: View {
     private var dimLevelPercentage: String {
         let percentage = Int((screensaver.wrappedValue.dimLevel * 100).rounded())
         return "\(percentage)%"
+    }
+
+    @ViewBuilder
+    private func boldnessSlider(
+        title: String,
+        icon: MaterialDesignIcons,
+        value: Binding<Double>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+            HStack {
+                KioskRow.label(title, icon: icon)
+                Spacer()
+                Text("\(Int((value.wrappedValue * 100).rounded()))%")
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: value, in: 0 ... 1, step: 0.05)
+        }
     }
 }

--- a/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
@@ -48,14 +48,22 @@ struct KioskScreensaverView: View {
     private func clockContent(for date: Date) -> some View {
         VStack(spacing: clockFontSize * 0.1) {
             Text(date.formatted(date: .omitted, time: settings.showSeconds ? .standard : .shortened))
-                .font(.system(size: clockFontSize, weight: .thin, design: .rounded))
+                .font(.system(
+                    size: clockFontSize,
+                    weight: Self.fontWeight(for: settings.clockFontWeight),
+                    design: .rounded
+                ))
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
 
             if settings.showDate {
                 Text(date.formatted(date: .complete, time: .omitted))
-                    .font(.system(size: clockFontSize * 0.22, weight: .regular, design: .rounded))
+                    .font(.system(
+                        size: clockFontSize * 0.22,
+                        weight: Self.fontWeight(for: settings.dateFontWeight),
+                        design: .rounded
+                    ))
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
             }
@@ -70,6 +78,15 @@ struct KioskScreensaverView: View {
         case .medium: return 84
         case .small: return 56
         }
+    }
+
+    static func fontWeight(for value: Double) -> Font.Weight {
+        let weights: [Font.Weight] = [
+            .ultraLight, .thin, .light, .regular, .medium, .semibold, .bold, .heavy, .black,
+        ]
+        let clamped = min(max(value, 0), 1)
+        let index = Int((clamped * Double(weights.count - 1)).rounded())
+        return weights[min(max(index, 0), weights.count - 1)]
     }
 }
 

--- a/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
@@ -46,10 +46,10 @@ struct KioskScreensaverView: View {
     }
 
     private func clockContent(for date: Date) -> some View {
-        VStack(spacing: clockFontSize * 0.1) {
+        VStack(spacing: clockPointSize * 0.1) {
             Text(date.formatted(date: .omitted, time: settings.showSeconds ? .standard : .shortened))
                 .font(.system(
-                    size: clockFontSize,
+                    size: clockPointSize,
                     weight: Self.fontWeight(for: settings.clockFontWeight),
                     design: .rounded
                 ))
@@ -60,7 +60,7 @@ struct KioskScreensaverView: View {
             if settings.showDate {
                 Text(date.formatted(date: .complete, time: .omitted))
                     .font(.system(
-                        size: clockFontSize * 0.22,
+                        size: datePointSize,
                         weight: Self.fontWeight(for: settings.dateFontWeight),
                         design: .rounded
                     ))
@@ -72,12 +72,15 @@ struct KioskScreensaverView: View {
         .padding(DesignSystem.Spaces.three)
     }
 
-    private var clockFontSize: CGFloat {
-        switch settings.clockStyle {
-        case .large: return 120
-        case .medium: return 84
-        case .small: return 56
-        }
+    private var clockPointSize: CGFloat {
+        let clamped = min(max(settings.clockFontSize, 0), 1)
+        return 40 + (200 - 40) * CGFloat(clamped)
+    }
+
+    private var datePointSize: CGFloat {
+        let clamped = min(max(settings.dateFontSize, 0), 1)
+        let ratio = 0.1 + (0.34 - 0.1) * clamped
+        return clockPointSize * CGFloat(ratio)
     }
 
     static func fontWeight(for value: Double) -> Font.Weight {

--- a/Sources/App/Settings/Kiosk/KioskSettings.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettings.swift
@@ -77,7 +77,6 @@ public struct KioskSettings: Codable, FetchableRecord, PersistableRecord, Equata
 public struct KioskScreensaverSettings: Codable, Equatable {
     public var enabled: Bool
     public var mode: KioskScreensaverMode
-    public var clockStyle: KioskClockStyle
     public var showDate: Bool
     public var showSeconds: Bool
     public var timeToStart: KioskScreensaverTimeout
@@ -86,11 +85,12 @@ public struct KioskScreensaverSettings: Codable, Equatable {
     public var pixelShiftEnabled: Bool
     public var clockFontWeight: Double
     public var dateFontWeight: Double
+    public var clockFontSize: Double
+    public var dateFontSize: Double
 
     public init(
         enabled: Bool = false,
         mode: KioskScreensaverMode = .clock,
-        clockStyle: KioskClockStyle = .large,
         showDate: Bool = true,
         showSeconds: Bool = false,
         timeToStart: KioskScreensaverTimeout = .minutes5,
@@ -98,11 +98,12 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         dimLevel: Double = 0.1,
         pixelShiftEnabled: Bool = false,
         clockFontWeight: Double = 0.15,
-        dateFontWeight: Double = 0.4
+        dateFontWeight: Double = 0.4,
+        clockFontSize: Double = 0.5,
+        dateFontSize: Double = 0.5
     ) {
         self.enabled = enabled
         self.mode = mode
-        self.clockStyle = clockStyle
         self.showDate = showDate
         self.showSeconds = showSeconds
         self.timeToStart = timeToStart
@@ -111,13 +112,14 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         self.pixelShiftEnabled = pixelShiftEnabled
         self.clockFontWeight = clockFontWeight
         self.dateFontWeight = dateFontWeight
+        self.clockFontSize = clockFontSize
+        self.dateFontSize = dateFontSize
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         self.mode = try container.decodeIfPresent(KioskScreensaverMode.self, forKey: .mode) ?? .clock
-        self.clockStyle = try container.decodeIfPresent(KioskClockStyle.self, forKey: .clockStyle) ?? .large
         self.showDate = try container.decodeIfPresent(Bool.self, forKey: .showDate) ?? true
         self.showSeconds = try container.decodeIfPresent(Bool.self, forKey: .showSeconds) ?? false
         self.timeToStart = try container.decodeIfPresent(
@@ -129,6 +131,18 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         self.pixelShiftEnabled = try container.decodeIfPresent(Bool.self, forKey: .pixelShiftEnabled) ?? false
         self.clockFontWeight = try container.decodeIfPresent(Double.self, forKey: .clockFontWeight) ?? 0.15
         self.dateFontWeight = try container.decodeIfPresent(Double.self, forKey: .dateFontWeight) ?? 0.4
+        if let clockFontSize = try container.decodeIfPresent(Double.self, forKey: .clockFontSize) {
+            self.clockFontSize = clockFontSize
+        } else {
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            let legacyStyle = try legacy.decodeIfPresent(KioskClockStyle.self, forKey: .clockStyle)
+            self.clockFontSize = legacyStyle?.legacyNormalizedFontSize ?? 0.5
+        }
+        self.dateFontSize = try container.decodeIfPresent(Double.self, forKey: .dateFontSize) ?? 0.5
+    }
+
+    private enum LegacyCodingKeys: String, CodingKey {
+        case clockStyle
     }
 }
 
@@ -196,6 +210,15 @@ public enum KioskClockStyle: String, Codable, CaseIterable, Identifiable {
         case .large: return L10n.Kiosk.Screensaver.ClockStyle.large
         case .medium: return L10n.Kiosk.Screensaver.ClockStyle.medium
         case .small: return L10n.Kiosk.Screensaver.ClockStyle.small
+        }
+    }
+
+    // Maps the legacy discrete style onto the normalized clock font size slider (40...200pt range).
+    var legacyNormalizedFontSize: Double {
+        switch self {
+        case .large: return 0.5
+        case .medium: return 0.275
+        case .small: return 0.1
         }
     }
 }

--- a/Sources/App/Settings/Kiosk/KioskSettings.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettings.swift
@@ -84,6 +84,8 @@ public struct KioskScreensaverSettings: Codable, Equatable {
     public var dimEnabled: Bool
     public var dimLevel: Double
     public var pixelShiftEnabled: Bool
+    public var clockFontWeight: Double
+    public var dateFontWeight: Double
 
     public init(
         enabled: Bool = false,
@@ -94,7 +96,9 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         timeToStart: KioskScreensaverTimeout = .minutes5,
         dimEnabled: Bool = false,
         dimLevel: Double = 0.1,
-        pixelShiftEnabled: Bool = false
+        pixelShiftEnabled: Bool = false,
+        clockFontWeight: Double = 0.15,
+        dateFontWeight: Double = 0.4
     ) {
         self.enabled = enabled
         self.mode = mode
@@ -105,6 +109,8 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         self.dimEnabled = dimEnabled
         self.dimLevel = dimLevel
         self.pixelShiftEnabled = pixelShiftEnabled
+        self.clockFontWeight = clockFontWeight
+        self.dateFontWeight = dateFontWeight
     }
 
     public init(from decoder: Decoder) throws {
@@ -121,6 +127,8 @@ public struct KioskScreensaverSettings: Codable, Equatable {
         self.dimEnabled = try container.decodeIfPresent(Bool.self, forKey: .dimEnabled) ?? false
         self.dimLevel = try container.decodeIfPresent(Double.self, forKey: .dimLevel) ?? 0.1
         self.pixelShiftEnabled = try container.decodeIfPresent(Bool.self, forKey: .pixelShiftEnabled) ?? false
+        self.clockFontWeight = try container.decodeIfPresent(Double.self, forKey: .clockFontWeight) ?? 0.15
+        self.dateFontWeight = try container.decodeIfPresent(Double.self, forKey: .dateFontWeight) ?? 0.4
     }
 }
 

--- a/Sources/App/Settings/Kiosk/KioskSettingsView.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettingsView.swift
@@ -171,6 +171,19 @@ enum KioskRow {
                 .fixedMenuOrder()
         }
     }
+
+    static func slider(_ title: String, icon: MaterialDesignIcons, value: Binding<Double>) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+            HStack {
+                label(title, icon: icon)
+                Spacer()
+                Text("\(Int((value.wrappedValue * 100).rounded()))%")
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: value, in: 0 ... 1, step: 0.05)
+        }
+    }
 }
 
 private extension View {

--- a/Tests/App/Kiosk/KioskSettings.test.swift
+++ b/Tests/App/Kiosk/KioskSettings.test.swift
@@ -87,6 +87,8 @@ struct KioskSettingsTests {
         #expect(settings.dimEnabled == false)
         #expect(settings.dimLevel == 0.3)
         #expect(settings.pixelShiftEnabled == false)
+        #expect(settings.clockFontWeight == 0.15)
+        #expect(settings.dateFontWeight == 0.4)
     }
 
     @Test func enumMetadataIsComplete() {

--- a/Tests/App/Kiosk/KioskSettings.test.swift
+++ b/Tests/App/Kiosk/KioskSettings.test.swift
@@ -22,13 +22,16 @@ struct KioskSettingsTests {
             screensaver: KioskScreensaverSettings(
                 enabled: true,
                 mode: .clock,
-                clockStyle: .small,
                 showDate: false,
                 showSeconds: true,
                 timeToStart: .minutes10,
                 dimEnabled: true,
                 dimLevel: 0.3,
-                pixelShiftEnabled: true
+                pixelShiftEnabled: true,
+                clockFontWeight: 0.6,
+                dateFontWeight: 0.8,
+                clockFontSize: 0.3,
+                dateFontSize: 0.7
             )
         )
 
@@ -73,7 +76,6 @@ struct KioskSettingsTests {
             {
               "enabled": true,
               "mode": "clock",
-              "clockStyle": "small",
               "showDate": false,
               "showSeconds": true,
               "timeToStart": "minutes10",
@@ -89,6 +91,22 @@ struct KioskSettingsTests {
         #expect(settings.pixelShiftEnabled == false)
         #expect(settings.clockFontWeight == 0.15)
         #expect(settings.dateFontWeight == 0.4)
+        #expect(settings.clockFontSize == 0.5)
+        #expect(settings.dateFontSize == 0.5)
+    }
+
+    @Test func migratesLegacyClockStyleToFontSize() throws {
+        let decoder = JSONDecoder()
+        let expected: [(style: String, fontSize: Double)] = [
+            ("small", 0.1),
+            ("medium", 0.275),
+            ("large", 0.5),
+        ]
+        for (style, fontSize) in expected {
+            let data = Data("{\"clockStyle\": \"\(style)\"}".utf8)
+            let settings = try decoder.decode(KioskScreensaverSettings.self, from: data)
+            #expect(settings.clockFontSize == fontSize)
+        }
     }
 
     @Test func enumMetadataIsComplete() {


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add clock and date font-weight (boldness) sliders to the kiosk screensaver clock mode. The date slider only appears when "Show date" is enabled.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
