### PR TITLE
Update live activity expiration to 12 hours

### DIFF
--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -53,7 +53,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     /// Keys in the token webhook request data dictionary.
     static let tokenWebhookKeys: Set<String> = ["tag", "push_token", "expires_at"]
     /// ActivityKit expires Live Activities after eight hours.
-    static let pushTokenTimeToLive: TimeInterval = 8 * 60 * 60
+    static let pushTokenTimeToLive: TimeInterval = 12 * 60 * 60
 
     /// Webhook type for reporting that a Live Activity was dismissed.
     static let webhookTypeDismissed = "live_activity_dismissed"

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -52,7 +52,8 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     static let webhookTypeToken = "live_activity_token"
     /// Keys in the token webhook request data dictionary.
     static let tokenWebhookKeys: Set<String> = ["tag", "push_token", "expires_at"]
-    /// ActivityKit expires Live Activities after eight hours.
+    /// ActivityKit limits Dynamic Island updates to 12 hours and Live Activities may persist longer; push tokens
+    /// are given a 12-hour TTL to match the Dynamic Island cap.
     static let pushTokenTimeToLive: TimeInterval = 12 * 60 * 60
 
     /// Webhook type for reporting that a Live Activity was dismissed.

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -148,10 +148,10 @@ final class LiveActivityContractTests: XCTestCase {
     }
 
     /// The iOS app owns the token expiry window it sends to HA core.
-    func testTokenWebhookExpiry_isEightHours() {
+    func testTokenWebhookExpiry_isTwelveHours() {
         XCTAssertEqual(
             LiveActivityRegistry.pushTokenTimeToLive,
-            8 * 60 * 60
+            12 * 60 * 60
         )
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Dynamic island expiration is 8 hours, live activity though is 12, this PR updates the value https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities#Understand-constraints

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
