### PR TITLE
Kiosk: add kiosk_reload push command to reload the dashboard

### DIFF
--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -8,6 +8,7 @@ enum KioskPushCommand: String, CaseIterable {
     case hideScreensaver = "kiosk_hide_screensaver"
     case showCamera = "kiosk_show_camera"
     case hideCamera = "kiosk_hide_camera"
+    case reload = "kiosk_reload"
 
     static let prefix = "kiosk_"
 
@@ -33,6 +34,8 @@ enum KioskPushCommand: String, CaseIterable {
             return L10n.Kiosk.PushCommand.showCamera
         case .hideCamera:
             return L10n.Kiosk.PushCommand.hideCamera
+        case .reload:
+            return L10n.Kiosk.PushCommand.reload
         }
     }
 
@@ -50,6 +53,8 @@ enum KioskPushCommand: String, CaseIterable {
             return .videoFill
         case .hideCamera:
             return .videoSlashFill
+        case .reload:
+            return .arrowClockwise
         }
     }
 
@@ -63,6 +68,8 @@ enum KioskPushCommand: String, CaseIterable {
             return (.white, .blue)
         case .hideCamera:
             return (.white, .gray)
+        case .reload:
+            return (.white, .green)
         }
     }
 }

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -535,17 +535,8 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         case .hideCamera:
             hideCamera()
         case .reload:
-            reloadWebView()
+            Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
         }
-    }
-
-    private func reloadWebView() {
-        Current.sceneManager.webViewControllerPromise
-            .done { webViewController in
-                webViewController.refresh()
-            }.catch { error in
-                Current.Log.error("Failed to reload web view from push command: \(error)")
-            }
     }
 
     public func userNotificationCenter(

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -534,7 +534,18 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             openCamera(from: userInfo)
         case .hideCamera:
             hideCamera()
+        case .reload:
+            reloadWebView()
         }
+    }
+
+    private func reloadWebView() {
+        Current.sceneManager.webViewControllerPromise
+            .done { webViewController in
+                webViewController.refresh()
+            }.catch { error in
+                Current.Log.error("Failed to reload web view from push command: \(error)")
+            }
     }
 
     public func userNotificationCenter(

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -590,6 +590,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.keep_screen_on" = "Keep screen on";
 "kiosk.push_command.hide_camera" = "Hiding camera";
 "kiosk.push_command.hide_screensaver" = "Hiding screensaver";
+"kiosk.push_command.reload" = "Reloading dashboard";
 "kiosk.push_command.show_camera" = "Showing camera";
 "kiosk.push_command.show_screensaver" = "Showing screensaver";
 "kiosk.push_command.subtitle" = "Kiosk command";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2127,6 +2127,8 @@ public enum L10n {
       public static var hideCamera: String { return L10n.tr("Localizable", "kiosk.push_command.hide_camera") }
       /// Hiding screensaver
       public static var hideScreensaver: String { return L10n.tr("Localizable", "kiosk.push_command.hide_screensaver") }
+      /// Reloading dashboard
+      public static var reload: String { return L10n.tr("Localizable", "kiosk.push_command.reload") }
       /// Showing camera
       public static var showCamera: String { return L10n.tr("Localizable", "kiosk.push_command.show_camera") }
       /// Showing screensaver

--- a/Tests/App/Notifications/KioskPushCommandTests.swift
+++ b/Tests/App/Notifications/KioskPushCommandTests.swift
@@ -8,6 +8,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand(message: "kiosk_hide_screensaver"), .hideScreensaver)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_show_camera"), .showCamera)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_hide_camera"), .hideCamera)
+        XCTAssertEqual(KioskPushCommand(message: "kiosk_reload"), .reload)
     }
 
     func testParsingTrimsWhitespaceAndIgnoresCase() {
@@ -33,6 +34,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand.hideScreensaver.rawValue, "kiosk_hide_screensaver")
         XCTAssertEqual(KioskPushCommand.showCamera.rawValue, "kiosk_show_camera")
         XCTAssertEqual(KioskPushCommand.hideCamera.rawValue, "kiosk_hide_camera")
+        XCTAssertEqual(KioskPushCommand.reload.rawValue, "kiosk_reload")
     }
 
     func testEveryCommandResolvesASymbol() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new kiosk push command, `kiosk_reload`, that reloads the dashboard webview on the kiosk device. A notification whose body is `kiosk_reload` triggers `WebViewController.refresh()`, refreshing the frontend without requiring physical access to the device. As with the other kiosk commands, it is gated behind the "Accept remote commands" kiosk setting and shows a localized in-app toast (iOS 18+) instead of a banner.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<!-- TODO: add the "Reloading dashboard" toast in light and dark mode -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1363

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Builds on the existing kiosk push-command infrastructure (#4821). Uses `refresh()` rather than `reload()` so internal/external URL changes are handled. No notification-parser changes are needed since the command carries no extra payload data.
