### PR TITLE
Kiosk: add kiosk_default push command to return to the configured dashboard

### DIFF
--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -9,6 +9,7 @@ enum KioskPushCommand: String, CaseIterable {
     case showCamera = "kiosk_show_camera"
     case hideCamera = "kiosk_hide_camera"
     case reload = "kiosk_reload"
+    case defaultDashboard = "kiosk_default"
 
     static let prefix = "kiosk_"
 
@@ -36,6 +37,8 @@ enum KioskPushCommand: String, CaseIterable {
             return L10n.Kiosk.PushCommand.hideCamera
         case .reload:
             return L10n.Kiosk.PushCommand.reload
+        case .defaultDashboard:
+            return L10n.Kiosk.PushCommand.defaultDashboard
         }
     }
 
@@ -55,6 +58,8 @@ enum KioskPushCommand: String, CaseIterable {
             return .videoSlashFill
         case .reload:
             return .arrowClockwise
+        case .defaultDashboard:
+            return .houseFill
         }
     }
 
@@ -70,6 +75,8 @@ enum KioskPushCommand: String, CaseIterable {
             return (.white, .gray)
         case .reload:
             return (.white, .green)
+        case .defaultDashboard:
+            return (.white, .teal)
         }
     }
 }

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -536,6 +536,8 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             hideCamera()
         case .reload:
             Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
+        case .defaultDashboard:
+            Current.sceneManager.webViewControllerPromise.done { $0.applyKioskDashboard() }
         }
     }
 

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -537,7 +537,23 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         case .reload:
             Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
         case .defaultDashboard:
-            Current.sceneManager.webViewControllerPromise.done { $0.applyKioskDashboard() }
+            returnToKioskDefault()
+        }
+    }
+
+    /// Returns the kiosk to its configured server and dashboard. If the kiosk is pinned to a server
+    /// other than the one on screen, switching to it rebuilds the web view (which loads the kiosk
+    /// dashboard on creation); otherwise the current web view navigates to the configured dashboard.
+    /// Mirrors `OnboardingStateObservable.applyKioskTarget(_:)`.
+    private func returnToKioskDefault() {
+        let serverId = Current.kioskSettings.serverId
+        Current.sceneManager.webViewControllerPromise.done { webViewController in
+            if let serverId, serverId != webViewController.server.identifier.rawValue,
+               let server = Current.servers.server(forServerIdentifier: serverId) {
+                Current.sceneManager.appCoordinator.done { $0.open(server: server) }
+            } else {
+                webViewController.applyKioskDashboard()
+            }
         }
     }
 

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -588,6 +588,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.footer.description" = "When enabled, the display will be locked to the dashboard. Use Face ID, Touch ID, or device passcode to exit.";
 "kiosk.hide_status_bar" = "Hide status bar";
 "kiosk.keep_screen_on" = "Keep screen on";
+"kiosk.push_command.default_dashboard" = "Returning to dashboard";
 "kiosk.push_command.hide_camera" = "Hiding camera";
 "kiosk.push_command.hide_screensaver" = "Hiding screensaver";
 "kiosk.push_command.reload" = "Reloading dashboard";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2123,6 +2123,8 @@ public enum L10n {
       public static var description: String { return L10n.tr("Localizable", "kiosk.footer.description") }
     }
     public enum PushCommand {
+      /// Returning to dashboard
+      public static var defaultDashboard: String { return L10n.tr("Localizable", "kiosk.push_command.default_dashboard") }
       /// Hiding camera
       public static var hideCamera: String { return L10n.tr("Localizable", "kiosk.push_command.hide_camera") }
       /// Hiding screensaver

--- a/Tests/App/Notifications/KioskPushCommandTests.swift
+++ b/Tests/App/Notifications/KioskPushCommandTests.swift
@@ -9,6 +9,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand(message: "kiosk_show_camera"), .showCamera)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_hide_camera"), .hideCamera)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_reload"), .reload)
+        XCTAssertEqual(KioskPushCommand(message: "kiosk_default"), .defaultDashboard)
     }
 
     func testParsingTrimsWhitespaceAndIgnoresCase() {
@@ -35,6 +36,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand.showCamera.rawValue, "kiosk_show_camera")
         XCTAssertEqual(KioskPushCommand.hideCamera.rawValue, "kiosk_hide_camera")
         XCTAssertEqual(KioskPushCommand.reload.rawValue, "kiosk_reload")
+        XCTAssertEqual(KioskPushCommand.defaultDashboard.rawValue, "kiosk_default")
     }
 
     func testEveryCommandResolvesASymbol() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new kiosk push command, `kiosk_default`, that navigates the dashboard back to the server and dashboard configured in kiosk settings (or the server default when no specific dashboard is set). This lets an automation guarantee a wall-mounted kiosk always returns to its main dashboard after someone has navigated away from it for a moment.

A notification whose body is `kiosk_default` mirrors the existing kiosk-target logic: if the kiosk is pinned to a server other than the one currently on screen, it switches to that server (rebuilding the web view, which loads the kiosk dashboard on creation); otherwise it navigates the current web view to the configured dashboard via `applyKioskDashboard()`. As with the other kiosk commands, it is gated behind the "Accept remote commands" kiosk setting and shows a localized in-app toast (iOS 18+) instead of a banner.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<!-- TODO: add the "Returning to dashboard" toast in light and dark mode -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1363

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Builds on the existing kiosk push-command infrastructure. The server/dashboard restoration reuses the same logic as `OnboardingStateObservable.applyKioskTarget(_:)`, so navigation behaviour stays consistent with the kiosk settings pickers.
