### PR TITLE
Live activity: make notification title optional with default

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -648,6 +648,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.sensors.title" = "Sensors";
 "kiosk.title" = "Kiosk Mode";
 "legacy_actions.disclaimer" = "Legacy iOS Actions are not the recommended way to interact with Home Assistant anymore, please use Scripts, Scenes and Automations directly in your Widgets, Apple Watch and CarPlay.";
+"live_activity.default_title" = "Home Assistant";
 "live_activity.empty_state" = "No active Live Activities";
 "live_activity.end_all.button" = "End All Activities";
 "live_activity.end_all.confirm.button" = "End All";

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -21,9 +21,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
     /// Display title for the activity. Maps to `title` in the notification payload.
     public let title: String
 
-public static var defaultTitle: String {
-    L10n.About.Logo.title
-}
+    public static var defaultTitle: String { L10n.LiveActivity.defaultTitle }
 
     /// Webhook id of the Home Assistant server that started this activity, so a tap can open
     /// the originating server when several are configured. Optional: nil for activities created
@@ -160,7 +158,11 @@ public static var defaultTitle: String {
         // avoid a ~31-year offset. The encoder is symmetric for round-tripping.
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.title = try container.decodeIfPresent(String.self, forKey: .title)
+            if let decodedTitle = try container.decodeIfPresent(String.self, forKey: .title), !decodedTitle.isEmpty {
+                self.title = decodedTitle
+            } else {
+                self.title = nil
+            }
             self.message = try container.decode(String.self, forKey: .message)
             self.criticalText = try container.decodeIfPresent(String.self, forKey: .criticalText)
             self.progress = try container.decodeIfPresent(Int.self, forKey: .progress)

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -21,7 +21,9 @@ public struct HALiveActivityAttributes: ActivityAttributes {
     /// Display title for the activity. Maps to `title` in the notification payload.
     public let title: String
 
-    public static let defaultTitle = "Home Assistant"
+public static var defaultTitle: String {
+    L10n.About.Logo.title
+}
 
     /// Webhook id of the Home Assistant server that started this activity, so a tap can open
     /// the originating server when several are configured. Optional: nil for activities created

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -21,6 +21,8 @@ public struct HALiveActivityAttributes: ActivityAttributes {
     /// Display title for the activity. Maps to `title` in the notification payload.
     public let title: String
 
+    public static let defaultTitle = "Home Assistant"
+
     /// Webhook id of the Home Assistant server that started this activity, so a tap can open
     /// the originating server when several are configured. Optional: nil for activities created
     /// before this shipped, or when the start path doesn't supply it.
@@ -201,6 +203,17 @@ public struct HALiveActivityAttributes: ActivityAttributes {
         self.tag = tag
         self.title = title
         self.serverWebhookId = serverWebhookId
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.tag = try container.decode(String.self, forKey: .tag)
+        if let decodedTitle = try container.decodeIfPresent(String.self, forKey: .title), !decodedTitle.isEmpty {
+            self.title = decodedTitle
+        } else {
+            self.title = Self.defaultTitle
+        }
+        self.serverWebhookId = try container.decodeIfPresent(String.self, forKey: .serverWebhookId)
     }
 }
 #endif

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -18,7 +18,6 @@ import PromiseKit
 struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
     private enum ValidationError: Error {
         case missingTag
-        case missingTitle
         case invalidTag
     }
 
@@ -63,7 +62,7 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
                     // Fulfill rather than reject for known validation/auth errors so HA
                     // doesn't treat them as transient failures and retry indefinitely.
                     switch error {
-                    case ValidationError.missingTag, ValidationError.missingTitle, ValidationError.invalidTag:
+                    case ValidationError.missingTag, ValidationError.invalidTag:
                         seal.fulfill(())
                     default:
                         seal.reject(error)
@@ -85,9 +84,8 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
             )
             throw ValidationError.invalidTag
         }
-        guard let title = payload["title"] as? String, !title.isEmpty else {
-            throw ValidationError.missingTitle
-        }
+        let rawTitle = payload["title"] as? String ?? ""
+        let title = rawTitle.isEmpty ? HALiveActivityAttributes.defaultTitle : rawTitle
         return LiveActivityPendingStart.Request(
             tag: tag,
             title: title,

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -122,7 +122,7 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
     // MARK: - Payload Parsing
 
     static func contentState(from payload: [String: Any]) -> HALiveActivityAttributes.ContentState {
-        let title = payload["title"] as? String
+        let title = (payload["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         let message = payload["message"] as? String ?? ""
         let criticalText = payload["critical_text"] as? String
         // Use NSNumber coercion so both Int and Double JSON values (e.g. 50 vs 50.0) decode correctly.

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -204,16 +204,18 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertTrue(mockRegistry.startOrUpdateCalls.isEmpty)
     }
 
-    func testHandle_missingTitle_fulfillsWithoutCallingRegistry() {
+    func testHandle_missingTitle_startsWithDefaultTitle() throws {
         let payload: [String: Any] = ["tag": "valid-tag"]
         XCTAssertNoThrow(try hang(sut.handle(payload)))
-        XCTAssertTrue(mockRegistry.startOrUpdateCalls.isEmpty)
+        XCTAssertEqual(mockRegistry.startOrUpdateCalls.count, 1)
+        XCTAssertEqual(mockRegistry.startOrUpdateCalls[0].title, HALiveActivityAttributes.defaultTitle)
     }
 
-    func testHandle_emptyTitle_fulfillsWithoutCallingRegistry() {
+    func testHandle_emptyTitle_startsWithDefaultTitle() throws {
         let payload: [String: Any] = ["tag": "valid-tag", "title": ""]
         XCTAssertNoThrow(try hang(sut.handle(payload)))
-        XCTAssertTrue(mockRegistry.startOrUpdateCalls.isEmpty)
+        XCTAssertEqual(mockRegistry.startOrUpdateCalls.count, 1)
+        XCTAssertEqual(mockRegistry.startOrUpdateCalls[0].title, HALiveActivityAttributes.defaultTitle)
     }
 
     // MARK: - handle(_:) — successful path

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -92,6 +92,11 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNil(state.progressBarColor)
     }
 
+    func testContentState_emptyTitle_isNil() {
+        let state = HandlerStartOrUpdateLiveActivity.contentState(from: ["title": ""])
+        XCTAssertNil(state.title)
+    }
+
     func testContentState_fullPayload_mapsAllFields() {
         let payload: [String: Any] = [
             "title": "Test title",
@@ -209,13 +214,15 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNoThrow(try hang(sut.handle(payload)))
         XCTAssertEqual(mockRegistry.startOrUpdateCalls.count, 1)
         XCTAssertEqual(mockRegistry.startOrUpdateCalls[0].title, HALiveActivityAttributes.defaultTitle)
+        XCTAssertNil(mockRegistry.startOrUpdateCalls[0].state.title)
     }
 
-    func testHandle_emptyTitle_startsWithDefaultTitle() throws {
+    func testHandle_emptyTitle_startsWithDefaultTitleAndNilStateTitle() throws {
         let payload: [String: Any] = ["tag": "valid-tag", "title": ""]
         XCTAssertNoThrow(try hang(sut.handle(payload)))
         XCTAssertEqual(mockRegistry.startOrUpdateCalls.count, 1)
         XCTAssertEqual(mockRegistry.startOrUpdateCalls[0].title, HALiveActivityAttributes.defaultTitle)
+        XCTAssertNil(mockRegistry.startOrUpdateCalls[0].state.title)
     }
 
     // MARK: - handle(_:) — successful path

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -40,6 +40,21 @@ final class LiveActivityContractTests: XCTestCase {
         XCTAssertEqual(decoded.title, "Title")
     }
 
+    func testAttributes_missingOrEmptyTitle_decodesAsDefault() throws {
+        let missing = try JSONDecoder().decode(
+            HALiveActivityAttributes.self,
+            from: Data(#"{"tag":"t"}"#.utf8)
+        )
+        XCTAssertEqual(missing.title, HALiveActivityAttributes.defaultTitle)
+        XCTAssertEqual(missing.tag, "t")
+
+        let empty = try JSONDecoder().decode(
+            HALiveActivityAttributes.self,
+            from: Data(#"{"tag":"t","title":""}"#.utf8)
+        )
+        XCTAssertEqual(empty.title, HALiveActivityAttributes.defaultTitle)
+    }
+
     /// CodingKeys define the JSON field names in APNs content-state payloads.
     /// Adding new optional fields is safe; renaming or removing breaks in-flight activities.
     func testContentState_codingKeys_areFrozen() {

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -55,6 +55,20 @@ final class LiveActivityContractTests: XCTestCase {
         XCTAssertEqual(empty.title, HALiveActivityAttributes.defaultTitle)
     }
 
+    func testContentState_emptyOrMissingTitle_decodesAsNil() throws {
+        let empty = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","title":""}"#.utf8)
+        )
+        XCTAssertNil(empty.title)
+
+        let missing = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m"}"#.utf8)
+        )
+        XCTAssertNil(missing.title)
+    }
+
     /// CodingKeys define the JSON field names in APNs content-state payloads.
     /// Adding new optional fields is safe; renaming or removing breaks in-flight activities.
     func testContentState_codingKeys_areFrozen() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Makes the Live Activity `title` optional at start. The app previously rejected any start without a non-empty `title`, which was stricter than the server: `mobile_app` notify only requires `message`, and the push relay forwards the APNs payload without validating `title`.

Now a missing or empty `title` falls back to a default header (`Home Assistant`). A later content-state update can still override it (the views prefer `state.title` over the static attributes `title`).

This covers both start paths:
- The `live_activity` / `live_update: true` notification-command handler no longer rejects a title-less start.
- APNs **push-to-start**, where the attributes are decoded directly — the decoder now defaults a missing/empty `title` instead of failing the whole decode (which would silently drop the remote start).

`title` stays non-optional on `HALiveActivityAttributes` so the views keep using it as the guaranteed fallback header (`state.title ?? attributes.title`); the decoder supplies the default. Unit and contract tests updated/added accordingly.

No server-side change is required — this aligns the app with the existing server contract.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No new UI. The existing Live Activity layout is unchanged; when no `title` is provided, the header simply renders the default text `Home Assistant` instead of failing to start.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
- Removed the now-unused `ValidationError.missingTitle` case.
- The wire format is unchanged: `encode(to:)` on `HALiveActivityAttributes` stays synthesized; only `init(from:)` is customized to be lenient about `title`.