### PR TITLE
Live activity: deliver local-push updates as activities, not banners

### DIFF
--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -1,6 +1,7 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
 import ActivityKit
 import Foundation
+import HAKit
 import PromiseKit
 
 /// Stale date offset for all Live Activity content updates.
@@ -9,12 +10,13 @@ private let kLiveActivityStaleInterval: TimeInterval = 30 * 60
 
 public protocol LiveActivityRegistryProtocol: AnyObject {
     @available(iOS 17.2, *)
+    @discardableResult
     func startOrUpdate(
         tag: String,
         title: String,
         serverWebhookId: String?,
         state: HALiveActivityAttributes.ContentState
-    ) async throws
+    ) async throws -> Bool
     @available(iOS 17.2, *)
     func end(tag: String, dismissalPolicy: ActivityUIDismissalPolicy) async
     @available(iOS 17.2, *)
@@ -125,12 +127,13 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     // MARK: - Public API
 
     /// Start a new Live Activity for `tag`, or update the existing one if already running.
+    @discardableResult
     public func startOrUpdate(
         tag: String,
         title: String,
         serverWebhookId: String?,
         state: HALiveActivityAttributes.ContentState
-    ) async throws {
+    ) async throws -> Bool {
         // UPDATE path — activity already running with this tag
         if let existing = entries[tag] {
             let content = ActivityContent(
@@ -138,7 +141,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 staleDate: computeStaleDate(for: state)
             )
             await existing.activity.update(content)
-            return
+            return true
         }
 
         // Also check system list in case we lost track after crash/relaunch
@@ -151,12 +154,12 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             await live.update(content)
             let observationTask = makeObservationTask(for: live)
             entries[tag] = Entry(activity: live, observationTask: observationTask)
-            return
+            return true
         }
 
         guard Current.isTestFlight else {
             Current.Log.info("LiveActivityRegistry: start gated to TestFlight, skipping tag \(tag)")
-            return
+            return false
         }
 
         // START path — guard against duplicates with reservation
@@ -168,13 +171,13 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                     "LiveActivityRegistry: duplicate start for tag \(tag), will apply latest state on confirm"
                 )
             }
-            return
+            return true
         }
 
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             cancelReservation(id: tag)
             Current.Log.info("LiveActivityRegistry: activities disabled on this device, skipping start for tag \(tag)")
-            return
+            return false
         }
 
         let attributes = HALiveActivityAttributes(tag: tag, title: title, serverWebhookId: serverWebhookId)
@@ -199,6 +202,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         let observationTask = makeObservationTask(for: activity)
         await confirmReservation(id: tag, entry: Entry(activity: activity, observationTask: observationTask))
         Current.Log.verbose("LiveActivityRegistry: started activity for tag \(tag), id=\(activity.id)")
+        return true
     }
 
     /// End and dismiss the Live Activity for `tag`.
@@ -544,6 +548,18 @@ enum LiveActivityPendingStart {
         let title: String
         let serverWebhookId: String?
         let state: HALiveActivityAttributes.ContentState
+        let confirmID: String?
+    }
+
+    static func confirmLocalPushDelivery(for request: Request) {
+        guard let confirmID = request.confirmID, let webhookID = request.serverWebhookId else { return }
+        guard let server = Current.servers.all.first(where: { $0.info.connection.webhookID == webhookID }),
+              let api = Current.api(for: server) else {
+            Current.Log.error("LiveActivityPendingStart: no server for webhook to confirm local push delivery")
+            return
+        }
+        Current.Log.verbose("LiveActivityPendingStart: confirming local push delivery for tag \(request.tag)")
+        api.connection.send(.localPushConfirm(webhookID: webhookID, confirmID: confirmID)).promise.cauterize()
     }
 
     // Namespaced by App Group id so dev/beta/release installs never cross-signal.
@@ -737,12 +753,15 @@ public final class LiveActivityPendingStartObserver {
                 Task {
                     for request in requests {
                         do {
-                            try await Current.liveActivityRegistry?.startOrUpdate(
+                            let presented = try await Current.liveActivityRegistry?.startOrUpdate(
                                 tag: request.tag,
                                 title: request.title,
                                 serverWebhookId: request.serverWebhookId,
                                 state: request.state
                             )
+                            if presented == true {
+                                LiveActivityPendingStart.confirmLocalPushDelivery(for: request)
+                            }
                         } catch {
                             Current.Log.error(
                                 "LiveActivityPendingStart: startOrUpdate failed for tag \(request.tag): \(error)"

--- a/Sources/Shared/Notifications/LocalPush/LocalPushManager.swift
+++ b/Sources/Shared/Notifications/LocalPush/LocalPushManager.swift
@@ -168,11 +168,37 @@ public class LocalPushManager {
         state.increment()
 
         let baseContent = event.content(server: server)
+        var userInfo = baseContent.userInfo
+        let isLiveActivity = Self.isLiveActivityCommand(userInfo)
+        if isLiveActivity, let confirmID = event.confirmID {
+            userInfo[Self.confirmIDUserInfoKey] = confirmID
+        }
 
-        delegate?.localPushManager(self, didReceiveRemoteNotification: baseContent.userInfo)
+        delegate?.localPushManager(self, didReceiveRemoteNotification: userInfo)
+
+        if isLiveActivity {
+            Current.Log.info("local push: Live Activity command, deferring confirm until presented")
+            return
+        }
 
         guard let api = Current.api(for: server) else {
             Current.Log.error("No API available to handle local push event")
+            return
+        }
+
+        let confirmReceipt: () -> Promise<Void> = { [subscription] in
+            guard let confirmID = event.confirmID, let webhookID = subscription?.webhookID else {
+                return .value(())
+            }
+            return api.connection.send(.localPushConfirm(
+                webhookID: webhookID,
+                confirmID: confirmID
+            )).promise.map { _ in () }
+        }
+
+        if Self.isCommand(userInfo) {
+            Current.Log.info("local push: handled as command, suppressing banner")
+            confirmReceipt().cauterize()
             return
         }
 
@@ -183,19 +209,24 @@ public class LocalPushManager {
             return .value(baseContent)
         }.then { [add] content -> Promise<Void> in
             add(UNNotificationRequest(identifier: event.identifier, content: content, trigger: nil))
-        }.then { [subscription] () -> Promise<Void> in
-            if let confirmID = event.confirmID, let webhookID = subscription?.webhookID {
-                return api.connection.send(.localPushConfirm(
-                    webhookID: webhookID,
-                    confirmID: confirmID
-                )).promise.map { _ in () }
-            } else {
-                return .value(())
-            }
+        }.then { () -> Promise<Void> in
+            confirmReceipt()
         }.done {
             Current.Log.info("added local notification")
         }.catch { error in
             Current.Log.error("failed to add local notification: \(error)")
         }
+    }
+
+    static let confirmIDUserInfoKey = "hass_confirm_id"
+
+    private static func isLiveActivityCommand(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard let hadict = userInfo["homeassistant"] as? [String: Any] else { return false }
+        return (hadict["live_update"] as? Bool) == true || (hadict["command"] as? String) == "live_activity"
+    }
+
+    private static func isCommand(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard let hadict = userInfo["homeassistant"] as? [String: Any] else { return false }
+        return (hadict["command"] as? String) != nil || (hadict["live_update"] as? Bool) == true
     }
 }

--- a/Sources/Shared/Notifications/LocalPush/LocalPushManager.swift
+++ b/Sources/Shared/Notifications/LocalPush/LocalPushManager.swift
@@ -227,6 +227,6 @@ public class LocalPushManager {
 
     private static func isCommand(_ userInfo: [AnyHashable: Any]) -> Bool {
         guard let hadict = userInfo["homeassistant"] as? [String: Any] else { return false }
-        return (hadict["command"] as? String) != nil || (hadict["live_update"] as? Bool) == true
+        return (hadict["command"] as? String) != nil
     }
 }

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -50,12 +50,15 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
                         return
                     }
 
-                    try await Current.liveActivityRegistry?.startOrUpdate(
+                    let presented = try await Current.liveActivityRegistry?.startOrUpdate(
                         tag: request.tag,
                         title: request.title,
                         serverWebhookId: request.serverWebhookId,
                         state: request.state
                     )
+                    if presented == true {
+                        LiveActivityPendingStart.confirmLocalPushDelivery(for: request)
+                    }
                     seal.fulfill(())
                 } catch {
                     Current.Log.error("HandlerStartOrUpdateLiveActivity: \(error)")
@@ -90,7 +93,8 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
             tag: tag,
             title: title,
             serverWebhookId: payload["webhook_id"] as? String,
-            state: contentState(from: payload)
+            state: contentState(from: payload),
+            confirmID: payload[LocalPushManager.confirmIDUserInfoKey] as? String
         )
     }
 

--- a/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift
@@ -50,6 +50,10 @@ public class NotificationCommandManager {
             hadict["webhook_id"] = webhookId
         }
 
+        if let confirmID = payload[LocalPushManager.confirmIDUserInfoKey] as? String {
+            hadict[LocalPushManager.confirmIDUserInfoKey] = confirmID
+        }
+
         // Support data.live_update: true — the same field Android uses for Live Updates.
         // A single YAML automation can target both platforms with no platform-specific keys.
         #if os(iOS) && !targetEnvironment(macCatalyst)

--- a/Tests/Shared/LiveActivity/MockLiveActivityRegistry.swift
+++ b/Tests/Shared/LiveActivity/MockLiveActivityRegistry.swift
@@ -30,14 +30,18 @@ final class MockLiveActivityRegistry: LiveActivityRegistryProtocol {
     /// Set to make the next `startOrUpdate` throw.
     var startOrUpdateError: Error?
 
+    /// Value returned by `startOrUpdate` — `true` simulates the activity being presented.
+    var startOrUpdateResult = true
+
     // MARK: - LiveActivityRegistryProtocol
 
+    @discardableResult
     func startOrUpdate(
         tag: String,
         title: String,
         serverWebhookId: String?,
         state: HALiveActivityAttributes.ContentState
-    ) async throws {
+    ) async throws -> Bool {
         if let error = startOrUpdateError {
             startOrUpdateError = nil
             throw error
@@ -45,6 +49,7 @@ final class MockLiveActivityRegistry: LiveActivityRegistryProtocol {
         startOrUpdateCalls.append(
             StartOrUpdateCall(tag: tag, title: title, serverWebhookId: serverWebhookId, state: state)
         )
+        return startOrUpdateResult
     }
 
     func end(tag: String, dismissalPolicy: ActivityUIDismissalPolicy) async {

--- a/Tests/Shared/LocalPushManager.test.swift
+++ b/Tests/Shared/LocalPushManager.test.swift
@@ -381,6 +381,56 @@ class LocalPushManagerTests: XCTestCase {
                 .contains(where: { $0.request.type == "mobile_app/push_notification_confirm" })
         )
     }
+
+    func testLiveActivityCommandSuppressesBannerAndDefersConfirm() throws {
+        setUpManager(webhookID: "webhook1")
+
+        let sub = try XCTUnwrap(apiConnection.pendingSubscriptions.first)
+        sub.handler(sub.cancellable, .dictionary([
+            "message": "test_message",
+            "hass_confirm_id": "test_confirm_id",
+            "data": [
+                "live_update": true,
+                "tag": "test_tag",
+            ],
+        ]))
+
+        let runLoop = expectation(description: "run loop")
+        DispatchQueue.main.async(execute: runLoop.fulfill)
+        waitForExpectations(timeout: 10.0)
+
+        XCTAssertTrue(attachmentManager.contentRequests.isEmpty)
+        XCTAssertTrue(added.isEmpty)
+        XCTAssertFalse(
+            apiConnection.pendingRequests
+                .contains(where: { $0.request.type == "mobile_app/push_notification_confirm" })
+        )
+    }
+
+    func testNonLiveActivityCommandSuppressesBannerButConfirms() throws {
+        setUpManager(webhookID: "webhook1")
+
+        let sub = try XCTUnwrap(apiConnection.pendingSubscriptions.first)
+        sub.handler(sub.cancellable, .dictionary([
+            "message": "clear_notification",
+            "hass_confirm_id": "test_confirm_id",
+            "data": [
+                "tag": "test_tag",
+            ],
+        ]))
+
+        let runLoop = expectation(description: "run loop")
+        DispatchQueue.main.async(execute: runLoop.fulfill)
+        waitForExpectations(timeout: 10.0)
+
+        XCTAssertTrue(attachmentManager.contentRequests.isEmpty)
+        XCTAssertTrue(added.isEmpty)
+        let confirm = try XCTUnwrap(
+            apiConnection.pendingRequests
+                .first(where: { $0.request.type == "mobile_app/push_notification_confirm" })
+        )
+        XCTAssertEqual(confirm.request.data["confirm_id"] as? String, "test_confirm_id")
+    }
 }
 
 private class FakeNotificationAttachmentManager: NotificationAttachmentManager {


### PR DESCRIPTION
## Summary
Live Activity notifications delivered over the local push channel were shown as a normal notification banner instead of starting/updating the Live Activity, because the push provider extension can't use ActivityKit.

For `live_update` / `live_activity` notifications received over local push, the banner is now suppressed and delivery is confirmed to the server only once the Live Activity is actually presented. If it can't be presented (e.g. the app is suspended), the notification is left unconfirmed, so the server's push timeout falls back to the cloud push-to-start path, which renders the Live Activity without the app.

## Screenshots
N/A — changes notification delivery behavior, no UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No server changes required; relies on the existing local-push confirm/fallback mechanism (HA Core 2021.10+) and the existing Live Activity cloud push-to-start path.