### PR TITLE
CarPlay: add close button to Assist template

### DIFF
--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
@@ -69,10 +69,15 @@ final class CarPlayAssistSession: NSObject {
         ) { [weak self] _ in
             self?.showPlaybackHelp()
         }
+        let closeButton = CPButton(
+            image: makeActionButtonImage(icon: .closeIcon, color: .gray)
+        ) { [weak self] _ in
+            self?.stop()
+        }
 
         let actionButtons: [CPButton] = promptToSend == nil
-            ? [recordButton, helpButton]
-            : [recordButton, replayPromptButton, helpButton]
+            ? [recordButton, helpButton, closeButton]
+            : [recordButton, replayPromptButton, helpButton, closeButton]
 
         let idleState = CPVoiceControlState(
             identifier: VoiceControlStateID.idle.rawValue,
@@ -91,6 +96,8 @@ final class CarPlayAssistSession: NSObject {
             image: MaterialDesignIcons.microphoneIcon.carPlayIcon(color: .haPrimary, context: .assistStateIndicator),
             repeats: true
         )
+        recordingState.actionButtons = [closeButton]
+
         let processingState = CPVoiceControlState(
             identifier: VoiceControlStateID.processing.rawValue,
             titleVariants: [L10n.Assist.Carplay.Processing.title],
@@ -100,12 +107,16 @@ final class CarPlayAssistSession: NSObject {
             ),
             repeats: true
         )
+        processingState.actionButtons = [closeButton]
+
         let respondingState = CPVoiceControlState(
             identifier: VoiceControlStateID.responding.rawValue,
             titleVariants: [L10n.Assist.Carplay.Responding.title],
             image: MaterialDesignIcons.volumeHighIcon.carPlayIcon(color: .haPrimary, context: .assistStateIndicator),
             repeats: true
         )
+        respondingState.actionButtons = [closeButton]
+
         let errorState = CPVoiceControlState(
             identifier: VoiceControlStateID.error.rawValue,
             titleVariants: [L10n.errorLabel],


### PR DESCRIPTION
## Summary
Adds a close button to the CarPlay Assist voice control template so users can dismiss Assist at any point.

Previously, action buttons were only shown in the `idle` and `error` states — while Assist was actively recording, processing, or responding there was no button at all, leaving no way to exit until it returned to idle/error. This adds a close button (icon-only, calling the existing `stop()`) that:
- appears alongside the record/replay/help buttons in the `idle` and `error` states, and
- is the sole action button in the `recording`, `processing`, and `responding` states, so Assist can be cancelled mid-flow.

`stop()` already handles full teardown (recorder, TTS players, audio session, observers) and dismisses the template, so close behaves identically to a system dismiss.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No new localized string is required — the close button is icon-only (`MaterialDesignIcons.closeIcon`), consistent with the existing record/replay/help buttons.
