### PR TITLE
Fix my.home-assistant.io links showing "not a valid route"

### DIFF
--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -34,6 +34,15 @@ class IncomingURLHandler {
             serviceData = queryItems
         }
         guard let host = url.host else { return true }
+
+        // Universal / web links (e.g. `my.home-assistant.io`, including HACS "my" redirect links) can be
+        // delivered through `onOpenURL` as well as `onContinueUserActivity` under the SwiftUI lifecycle.
+        // They are not deep-link actions, so route them to the my-link handler instead of treating the
+        // host as an `IncomingURLAction` (which would otherwise show a "not a valid route" error).
+        if host.lowercased() == "my.home-assistant.io" {
+            return showMy(for: url)
+        }
+
         if let requestedAction = IncomingURLAction(rawValue: host.lowercased()) {
             switch requestedAction {
             case .xCallbackURL:

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -39,7 +39,10 @@ class IncomingURLHandler {
         // delivered through `onOpenURL` as well as `onContinueUserActivity` under the SwiftUI lifecycle.
         // They are not deep-link actions, so route them to the my-link handler instead of treating the
         // host as an `IncomingURLAction` (which would otherwise show a "not a valid route" error).
-        if host.lowercased() == "my.home-assistant.io" {
+        // Restrict to web schemes since `showMy(for:)` presents an `SFSafariViewController`, which only
+        // supports http/https; this also prevents a crafted `homeassistant://my.home-assistant.io/...`
+        // from reaching Safari.
+        if ["http", "https"].contains(url.scheme?.lowercased()), host.lowercased() == "my.home-assistant.io" {
             return showMy(for: url)
         }
 


### PR DESCRIPTION
## Summary
After migrating to the SwiftUI app lifecycle, `my.home-assistant.io` links (e.g. HACS "my" redirect links) can be delivered through `.onOpenURL` → `handle(url:)` as well as `.onContinueUserActivity` → `handle(userActivity:)`. Only the latter handled the `my.home-assistant.io` host; `handle(url:)` treated it as an unknown deep-link action and showed "my.home-assistant.io is not a valid route".

This routes the `my.home-assistant.io` host to `showMy(for:)` in `handle(url:)` so both entry points behave consistently.

## Screenshots
N/A — fixes a broken navigation path; no visual change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVWXYnRACwULYqQfuH76gV)_