### PR TITLE
Fix multi-finger web view gestures and move ownership to SwiftUI layer

### DIFF
--- a/Sources/App/Frontend/WebView/FrontendView.swift
+++ b/Sources/App/Frontend/WebView/FrontendView.swift
@@ -12,6 +12,10 @@ struct FrontendView: UIViewControllerRepresentable {
     var reconnectManager: WebViewReconnectManager?
     let overlayState: WebFrontendOverlayState
 
+    /// SwiftUI-owned gesture manager wired in via the `webViewGestures(_:)` modifier. Optional so the
+    /// representable can be constructed without it (e.g. in tests).
+    fileprivate var gestureManager: WebViewGestureManager?
+
     init(
         server: Server,
         restorationType: WebViewRestorationType? = nil,
@@ -30,6 +34,7 @@ struct FrontendView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> WebViewController {
         let webViewController = makeWebViewController()
+        gestureManager?.attach(to: webViewController)
         onWebViewController?(webViewController)
         return webViewController
     }
@@ -46,5 +51,15 @@ struct FrontendView: UIViewControllerRepresentable {
         controller.resetFrontendAction = resetFrontendAction
         controller.reconnectManager = reconnectManager
         return controller
+    }
+}
+
+extension FrontendView {
+    /// Wires the SwiftUI-owned gesture manager so it attaches its swipe/edge recognizers to the hosted
+    /// `WebViewController`. Modifier-style so gesture handling reads declaratively at the call site.
+    func webViewGestures(_ manager: WebViewGestureManager) -> FrontendView {
+        var copy = self
+        copy.gestureManager = manager
+        return copy
     }
 }

--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -22,6 +22,10 @@ struct HomeAssistantView: View, WebFrontendView {
 
     @StateObject private var reconnectManager = WebViewReconnectManager()
 
+    /// Owns the web frontend's swipe/edge gesture recognizers, attaching them to each hosted
+    /// `WebViewController` so gesture handling lives in this SwiftUI layer rather than in `WebViewController`.
+    @StateObject private var gestureManager = WebViewGestureManager()
+
     /// Changing this forces SwiftUI to discard the current `FrontendView` and create a fresh `WebViewController`.
     @State private var webViewResetID = UUID()
 
@@ -57,6 +61,7 @@ struct HomeAssistantView: View, WebFrontendView {
                 reconnectManager: reconnectManager,
                 overlayState: overlayState
             )
+            .webViewGestures(gestureManager)
             .id(webViewResetID)
             .ignoresSafeArea(edges: webViewIgnoredSafeAreaEdges)
 

--- a/Sources/App/Frontend/WebView/WebViewController+Gestures.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+Gestures.swift
@@ -1,43 +1,123 @@
+import Combine
 import Shared
 import UIKit
 
-// MARK: - Gesture Setup & Handling
+// MARK: - Gesture ownership at the SwiftUI layer
 
-extension WebViewController {
-    func setupGestures(numberOfTouchesRequired: Int) {
-        let gestures = [.left, .right, .up, .down].map { (direction: UISwipeGestureRecognizer.Direction) in
-            let gesture = UISwipeGestureRecognizer()
-            gesture.numberOfTouchesRequired = numberOfTouchesRequired
-            gesture.direction = direction
-            gesture.addTarget(self, action: #selector(swipe(_:)))
-            gesture.delegate = self
-            return gesture
+/// Owns the web frontend's swipe/edge gesture recognizers. It is created and held by `HomeAssistantView`
+/// (the SwiftUI layer) and attached to the hosted `WebViewController`'s view, rather than being wired up
+/// inside `WebViewController` itself.
+///
+/// Each recognizer is bound to a specific `AppGesture`, so the action it triggers is resolved from that fixed
+/// identity. Previously the action was inferred from the recognizer's live `numberOfTouches` at recognition
+/// time, which is unreliable for a discrete `UISwipeGestureRecognizer` (the touches have usually lifted by the
+/// time `.ended` fires, so it reports `0`). That made every 2- and 3-finger swipe resolve to `.none` and
+/// silently do nothing.
+@MainActor
+final class WebViewGestureManager: NSObject, ObservableObject {
+    private weak var gestureHandler: WebViewGestureHandler?
+    private weak var attachedView: UIView?
+
+    /// Attaches the gesture recognizers to the controller's view. A no-op if already attached to that exact
+    /// view; if a different view is provided (e.g. a server switch built a fresh controller), the recognizers
+    /// move to the new view.
+    func attach(to controller: WebViewController) {
+        guard attachedView !== controller.view else { return }
+        detach()
+
+        let view = controller.view
+        gestureHandler = controller.webViewGestureHandler
+        attachedView = view
+
+        // Multi-finger swipes (2- and 3-finger) anywhere over the frontend.
+        for gesture in AppGesture.multiFingerSwipes {
+            guard let direction = gesture.direction, let touches = gesture.numberOfTouchesRequired else { continue }
+            let recognizer = AppSwipeGestureRecognizer(
+                appGesture: gesture,
+                target: self,
+                action: #selector(handleSwipe(_:))
+            )
+            recognizer.direction = direction
+            recognizer.numberOfTouchesRequired = touches
+            recognizer.delegate = self
+            view?.addGestureRecognizer(recognizer)
         }
 
-        for gesture in gestures {
-            view.addGestureRecognizer(gesture)
-        }
+        // Single-finger swipes are recognized as screen-edge pans: a swipe-right starts at the left edge and
+        // a swipe-left starts at the right edge.
+        view?.addGestureRecognizer(makeEdgeRecognizer(edges: .left, appGesture: .swipeRight))
+        view?.addGestureRecognizer(makeEdgeRecognizer(edges: .right, appGesture: .swipeLeft))
     }
 
-    func setupEdgeGestures() {
-        webView.addGestureRecognizer(leftEdgePanGestureRecognizer)
-        webView.addGestureRecognizer(rightEdgeGestureRecognizer)
+    /// Removes the recognizers this manager added from whatever view they are currently attached to.
+    func detach() {
+        guard let attachedView else { return }
+        for recognizer in attachedView.gestureRecognizers ?? [] where recognizer is AppGestureRecognizing {
+            attachedView.removeGestureRecognizer(recognizer)
+        }
+        self.attachedView = nil
     }
 
-    @objc func swipe(_ gesture: UISwipeGestureRecognizer) {
-        guard gesture.state == .ended else {
-            return
-        }
-        let action = Current.settingsStore.gestures.getAction(for: gesture, numberOfTouches: gesture.numberOfTouches)
-        webViewGestureHandler.handleGestureAction(action)
+    private func makeEdgeRecognizer(edges: UIRectEdge, appGesture: AppGesture) -> AppScreenEdgePanGestureRecognizer {
+        let recognizer = AppScreenEdgePanGestureRecognizer(
+            appGesture: appGesture,
+            target: self,
+            action: #selector(handleEdgePan(_:))
+        )
+        recognizer.edges = edges
+        recognizer.delegate = self
+        return recognizer
     }
 
-    @objc func screenEdgeGestureRecognizerAction(_ gesture: UIScreenEdgePanGestureRecognizer) {
-        guard gesture.state == .ended else {
-            return
-        }
-        let gesture: AppGesture = gesture.edges == .left ? .swipeRight : .swipeLeft
+    @objc private func handleSwipe(_ recognizer: AppSwipeGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        perform(recognizer.appGesture)
+    }
+
+    @objc private func handleEdgePan(_ recognizer: AppScreenEdgePanGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        perform(recognizer.appGesture)
+    }
+
+    private func perform(_ gesture: AppGesture) {
         let action = Current.settingsStore.gestures[gesture] ?? .none
-        webViewGestureHandler.handleGestureAction(action)
+        gestureHandler?.handleGestureAction(action)
+    }
+}
+
+extension WebViewGestureManager: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
+// MARK: - AppGesture-bound recognizers
+
+/// Marker that lets the manager identify (and later remove) only the recognizers it added.
+protocol AppGestureRecognizing: AnyObject {
+    var appGesture: AppGesture { get }
+}
+
+/// A swipe recognizer that remembers which `AppGesture` it represents, so the resolved action never depends on
+/// the recognizer's live touch count.
+final class AppSwipeGestureRecognizer: UISwipeGestureRecognizer, AppGestureRecognizing {
+    let appGesture: AppGesture
+
+    init(appGesture: AppGesture, target: Any?, action: Selector?) {
+        self.appGesture = appGesture
+        super.init(target: target, action: action)
+    }
+}
+
+/// A screen-edge pan recognizer bound to a specific `AppGesture` (used for single-finger edge swipes).
+final class AppScreenEdgePanGestureRecognizer: UIScreenEdgePanGestureRecognizer, AppGestureRecognizing {
+    let appGesture: AppGesture
+
+    init(appGesture: AppGesture, target: Any?, action: Selector?) {
+        self.appGesture = appGesture
+        super.init(target: target, action: action)
     }
 }

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -246,12 +246,3 @@ extension WebViewController {
         decisionHandler(.grant)
     }
 }
-
-extension WebViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        true
-    }
-}

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -20,8 +20,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     var tokens = [HACancellable]()
 
     let refreshControl = UIRefreshControl()
-    let leftEdgePanGestureRecognizer: UIScreenEdgePanGestureRecognizer
-    let rightEdgeGestureRecognizer: UIScreenEdgePanGestureRecognizer
 
     var statusBarView: UIView?
     var webViewTopConstraint: NSLayoutConstraint?
@@ -142,21 +140,12 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
     init(server: Server, shouldLoadImmediately: Bool = false) {
         self.server = server
-        self.leftEdgePanGestureRecognizer = with(UIScreenEdgePanGestureRecognizer()) {
-            $0.edges = .left
-        }
-        self.rightEdgeGestureRecognizer = with(UIScreenEdgePanGestureRecognizer()) {
-            $0.edges = .right
-        }
 
         super.init(nibName: nil, bundle: nil)
 
         userActivity = with(NSUserActivity(activityType: "\(AppConstants.BundleID).frontend")) {
             $0.isEligibleForHandoff = true
         }
-
-        leftEdgePanGestureRecognizer.addTarget(self, action: #selector(screenEdgeGestureRecognizerAction(_:)))
-        rightEdgeGestureRecognizer.addTarget(self, action: #selector(screenEdgeGestureRecognizerAction(_:)))
 
         if shouldLoadImmediately {
             loadViewIfNeeded()
@@ -249,9 +238,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         webView.isOpaque = false
         view!.addSubview(webView)
 
-        setupGestures(numberOfTouchesRequired: 2)
-        setupGestures(numberOfTouchesRequired: 3)
-        setupEdgeGestures()
         setupURLObserver()
 
         webView.navigationDelegate = self

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -194,6 +194,29 @@ public enum AppGesture: CaseIterable, Codable {
             nil
         }
     }
+
+    /// Number of simultaneous touches the swipe requires, or `nil` for non-swipe gestures (shake). This is the
+    /// recognizer's *configured* requirement — distinct from a recognizer's live `numberOfTouches`, which is
+    /// unreliable once a discrete swipe has been recognized (the touches have already lifted).
+    public var numberOfTouchesRequired: Int? {
+        switch self {
+        case .swipeRight, .swipeLeft:
+            1
+        case ._2FingersSwipeLeft, ._2FingersSwipeRight:
+            2
+        case ._3FingersSwipeUp, ._3FingersSwipeLeft, ._3FingersSwipeRight:
+            3
+        case .shake:
+            nil
+        }
+    }
+
+    /// The multi-finger swipe gestures (2- and 3-finger), each of which is recognized by a dedicated
+    /// `UISwipeGestureRecognizer`. Single-finger swipes use screen-edge pans and `shake` uses motion events,
+    /// so neither is included here.
+    public static var multiFingerSwipes: [AppGesture] {
+        allCases.filter { $0.direction != nil && ($0.numberOfTouchesRequired ?? 0) >= 2 }
+    }
 }
 
 public extension [AppGesture: HAGestureAction] {
@@ -207,51 +230,5 @@ public extension [AppGesture: HAGestureAction] {
             ._3FingersSwipeLeft: .previousServer,
             .shake: .openDebug,
         ]
-    }
-
-    func getAction(for gesture: UISwipeGestureRecognizer, numberOfTouches: Int) -> HAGestureAction {
-        switch gesture.direction {
-        case .down:
-            switch numberOfTouches {
-            case 1:
-                return .none
-            default:
-                return .none
-            }
-        case .left:
-            switch numberOfTouches {
-            case 1:
-                return Current.settingsStore.gestures[.swipeLeft] ?? .none
-            case 2:
-                return Current.settingsStore.gestures[._2FingersSwipeLeft] ?? .none
-            case 3:
-                return Current.settingsStore.gestures[._3FingersSwipeLeft] ?? .none
-            default:
-                return .none
-            }
-        case .right:
-            switch numberOfTouches {
-            case 1:
-                return Current.settingsStore.gestures[.swipeRight] ?? .none
-            case 2:
-                return Current.settingsStore.gestures[._2FingersSwipeRight] ?? .none
-            case 3:
-                return Current.settingsStore.gestures[._3FingersSwipeRight] ?? .none
-            default:
-                return .none
-            }
-
-        case .up:
-            switch numberOfTouches {
-            case 1:
-                return .none
-            case 3:
-                return Current.settingsStore.gestures[._3FingersSwipeUp] ?? .none
-            default:
-                return .none
-            }
-        default:
-            return .none
-        }
     }
 }

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -47,4 +47,50 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertTrue(resetCalled)
         XCTAssertIdentical(controller.reconnectManager, reconnectManager)
     }
+
+    // MARK: - Gestures
+
+    /// The set of multi-finger swipes the gesture manager installs a dedicated recognizer for — single-finger
+    /// swipes (screen-edge pans) and shake (motion events) are intentionally excluded.
+    func testMultiFingerSwipesCoverExactlyTheTwoAndThreeFingerSwipes() {
+        XCTAssertEqual(Set(AppGesture.multiFingerSwipes), [
+            ._2FingersSwipeLeft,
+            ._2FingersSwipeRight,
+            ._3FingersSwipeUp,
+            ._3FingersSwipeLeft,
+            ._3FingersSwipeRight,
+        ])
+    }
+
+    func testNumberOfTouchesRequiredPerGesture() {
+        XCTAssertEqual(AppGesture.swipeLeft.numberOfTouchesRequired, 1)
+        XCTAssertEqual(AppGesture.swipeRight.numberOfTouchesRequired, 1)
+        XCTAssertEqual(AppGesture._2FingersSwipeLeft.numberOfTouchesRequired, 2)
+        XCTAssertEqual(AppGesture._2FingersSwipeRight.numberOfTouchesRequired, 2)
+        XCTAssertEqual(AppGesture._3FingersSwipeUp.numberOfTouchesRequired, 3)
+        XCTAssertEqual(AppGesture._3FingersSwipeLeft.numberOfTouchesRequired, 3)
+        XCTAssertEqual(AppGesture._3FingersSwipeRight.numberOfTouchesRequired, 3)
+        XCTAssertNil(AppGesture.shake.numberOfTouchesRequired)
+    }
+
+    /// Regression guard: a swipe recognizer keeps a fixed `AppGesture` binding (and the matching configured
+    /// touch count) so the resolved action never depends on the recognizer's unreliable live `numberOfTouches`.
+    func testSwipeRecognizerKeepsItsConfiguredTouchCountAndGestureBinding() throws {
+        for gesture in AppGesture.multiFingerSwipes {
+            let touches = try XCTUnwrap(gesture.numberOfTouchesRequired)
+            let recognizer = AppSwipeGestureRecognizer(appGesture: gesture, target: nil, action: nil)
+            recognizer.numberOfTouchesRequired = touches
+
+            XCTAssertEqual(recognizer.appGesture, gesture)
+            XCTAssertEqual(recognizer.numberOfTouchesRequired, touches)
+        }
+    }
+
+    func testEdgePanRecognizerKeepsItsGestureBinding() {
+        let left = AppScreenEdgePanGestureRecognizer(appGesture: .swipeRight, target: nil, action: nil)
+        let right = AppScreenEdgePanGestureRecognizer(appGesture: .swipeLeft, target: nil, action: nil)
+
+        XCTAssertEqual(left.appGesture, .swipeRight)
+        XCTAssertEqual(right.appGesture, .swipeLeft)
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Multi-finger swipe gestures (2- and 3-finger swipes configured in Settings → Gestures, e.g. back/forward page, server switching, server list) stopped working after the SwiftUI migration.

The swipe handler resolved the configured action from the recognizer's live `numberOfTouches` at `.ended`. For a discrete `UISwipeGestureRecognizer` the touches have already lifted by then, so it reads `0` and every multi-finger swipe fell through to `.none`. Single-finger edge swipes and shake were unaffected (they don't consult `numberOfTouches`), which is why only some gestures broke.

This fixes it by binding each recognizer to a fixed `AppGesture` instead of inferring it from the live touch count, and moves gesture ownership out of `WebViewController` into a SwiftUI-owned `WebViewGestureManager` wired via a `webViewGestures(_:)` modifier on `FrontendView` (held by `HomeAssistantView`). Adds `AppGesture` metadata (`numberOfTouchesRequired`, `multiFingerSwipes`) and unit tests covering the binding.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01A3NrJPHAxcsVof6HHh5wWD)_