### PR TITLE
Fix false disconnected empty state after in-frontend navigation

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -84,6 +84,22 @@ extension WebViewController: WebViewControllerProtocol {
         }
     }
 
+    /// Called after a main-frame load finishes successfully.
+    ///
+    /// `didStartProvisionalNavigation` pessimistically forces `.disconnected` on every navigation so the
+    /// empty state can appear if the load hangs. For in-frontend navigations (e.g. dashboard → automations)
+    /// the websocket is reused rather than re-established, so the frontend never re-emits
+    /// `connection-status: connected` — which previously left the 10-second timer to drop a false
+    /// disconnected empty state over a fully working frontend. A successful load means the page is up, so
+    /// optimistically restore the connected state here. The frontend stays authoritative: if its websocket
+    /// actually fails it downgrades us back to `.disconnected`/`.auth-invalid` via the external bus.
+    func restoreConnectedStateAfterSuccessfulFrontendLoad() {
+        // Don't override an auth-invalid state (a successful reload of an auth-invalid page is still invalid)
+        // or the no-active-URL screen (about:blank is loaded there and is not a connected frontend).
+        guard connectionState != .authInvalid, overlayState?.showsNoActiveURL != true else { return }
+        updateFrontendConnectionState(state: FrontEndConnectionState.connected.rawValue)
+    }
+
     func navigateToPath(path: String) {
         if let activeURL = server.info.connection.activeURL(), let url = URL(string: activeURL.absoluteString + path) {
             load(request: URLRequest(url: url))

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -88,6 +88,10 @@ extension WebViewController {
         // in case the view appears again, don't reload
         initialURL = nil
 
+        // Clear the navigation-induced disconnected state so a working frontend isn't covered by a false
+        // disconnected empty state when the websocket was reused across the navigation.
+        restoreConnectedStateAfterSuccessfulFrontendLoad()
+
         updateWebViewSettings(reason: .load)
     }
 

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -110,6 +110,43 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertNil(overlayState.emptyState)
     }
 
+    func testRestoreConnectedStateAfterSuccessfulFrontendLoadClearsNavigationDisconnect() {
+        let sut = makeSUT()
+        sut.overlayState = WebFrontendOverlayState()
+        // Mimics didStartProvisionalNavigation forcing disconnected + arming the empty-state timer.
+        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+        XCTAssertEqual(sut.connectionState, .disconnected)
+        XCTAssertNotNil(sut.emptyStateTimer)
+
+        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
+
+        XCTAssertEqual(sut.connectionState, .connected)
+        XCTAssertTrue(sut.isConnected)
+        XCTAssertNil(sut.emptyStateTimer)
+    }
+
+    func testRestoreConnectedStateAfterSuccessfulFrontendLoadKeepsAuthInvalid() {
+        let sut = makeSUT()
+        sut.overlayState = WebFrontendOverlayState()
+        sut.connectionState = .authInvalid
+
+        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+    }
+
+    func testRestoreConnectedStateAfterSuccessfulFrontendLoadIgnoresNoActiveURLScreen() {
+        let sut = makeSUT()
+        let overlayState = WebFrontendOverlayState()
+        overlayState.showsNoActiveURL = true
+        sut.overlayState = overlayState
+        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+
+        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
+
+        XCTAssertEqual(sut.connectionState, .disconnected)
+    }
+
     private func makeSUT() -> WebViewController {
         let sut = WebViewController(server: .fake())
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))


### PR DESCRIPTION
Navigating between frontend pages (e.g. dashboard → automations) showed
the disconnected empty state over a fully connected, working frontend;
dismissing it revealed the live app.

`didStartProvisionalNavigation` pessimistically forces the connection
state to `.disconnected` on every navigation and arms a 10s timer to
show the empty state. The state was only ever cleared back to
`.connected` by a `connection-status: connected` external-bus message
from the frontend. For in-frontend navigations the websocket is reused
rather than re-established, so the frontend never re-emits that event,
the timer fires, and a false empty state covers a working frontend.

Restore the connected state on a successful main-frame load
(`didFinish`), unless we're auth-invalid or showing the no-active-URL
screen. The frontend stays authoritative: if its websocket actually
fails it still downgrades us back to disconnected/auth-invalid via the
external bus.