### PR TITLE
Prevent reopening an already-displayed kiosk camera

### DIFF
--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -34,7 +34,7 @@ enum KioskPushCommand: String, CaseIterable {
             return "level"
         case .setVolume:
             return "volume"
-        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .reload:
+        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .reload, .defaultDashboard:
             return nil
         }
     }

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -94,7 +94,16 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
                     cameraEntityId: entityId
                 )
                 .onDisappear { [weak self] in
-                    self?.displayedCamera = nil
+                    guard let self else { return }
+                    // Only clear state if this overlay is still the active one. When switching
+                    // directly from one camera to another, the old overlay's onDisappear fires
+                    // after displayedCamera has already been updated for the new camera, so
+                    // clearing unconditionally would wipe the new state and desync the flag.
+                    guard self.displayedCamera?.entityId == entityId,
+                          self.displayedCamera?.serverIdentifier == server.identifier else {
+                        return
+                    }
+                    self.displayedCamera = nil
                     Current.kiosk.setCameraOverlayVisible(false)
                 }
                 .embeddedInHostingController()

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -78,12 +78,12 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         Current.sceneManager.webViewControllerPromise
             .done { [weak self] webViewController in
                 guard let self else { return }
-                let server = self.cameraServer(from: userInfo, fallback: webViewController.server)
+                let server = cameraServer(from: userInfo, fallback: webViewController.server)
 
-                if let displayedCamera = self.displayedCamera,
+                if let displayedCamera,
                    displayedCamera.entityId == entityId,
                    displayedCamera.serverIdentifier == server.identifier,
-                   self.cameraOverlayController != nil {
+                   cameraOverlayController != nil {
                     Current.Log
                         .info("Ignoring kiosk_show_camera command because camera \(entityId) is already on display")
                     return
@@ -99,16 +99,16 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
                     // directly from one camera to another, the old overlay's onDisappear fires
                     // after displayedCamera has already been updated for the new camera, so
                     // clearing unconditionally would wipe the new state and desync the flag.
-                    guard self.displayedCamera?.entityId == entityId,
-                          self.displayedCamera?.serverIdentifier == server.identifier else {
+                    guard displayedCamera?.entityId == entityId,
+                          displayedCamera?.serverIdentifier == server.identifier else {
                         return
                     }
-                    self.displayedCamera = nil
+                    displayedCamera = nil
                     Current.kiosk.setCameraOverlayVisible(false)
                 }
                 .embeddedInHostingController()
-                self.cameraOverlayController = view
-                self.displayedCamera = (entityId: entityId, serverIdentifier: server.identifier)
+                cameraOverlayController = view
+                displayedCamera = (entityId: entityId, serverIdentifier: server.identifier)
                 view.modalPresentationStyle = .overFullScreen
                 Current.kiosk.setCameraOverlayVisible(true)
                 webViewController.presentOverlayController(controller: view, animated: true)

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -33,6 +33,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
     var commandManager = NotificationCommandManager()
     private weak var cameraOverlayController: UIViewController?
+    private var displayedCamera: (entityId: String, serverIdentifier: Identifier<Server>)?
 
     override init() {
         super.init()
@@ -76,19 +77,33 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
         Current.sceneManager.webViewControllerPromise
             .done { webViewController in
+                let server = self.cameraServer(from: userInfo, fallback: webViewController.server)
+
+                if let displayedCamera = self.displayedCamera,
+                   displayedCamera.entityId == entityId,
+                   displayedCamera.serverIdentifier == server.identifier,
+                   self.cameraOverlayController != nil {
+                    Current.Log
+                        .info("Ignoring kiosk_show_camera command because camera \(entityId) is already on display")
+                    return
+                }
+
                 let view = CameraPlayerView(
-                    server: self.cameraServer(from: userInfo, fallback: webViewController.server),
+                    server: server,
                     cameraEntityId: entityId
                 )
                 .onDisappear {
+                    self.displayedCamera = nil
                     Current.kiosk.setCameraOverlayVisible(false)
                 }
                 .embeddedInHostingController()
                 self.cameraOverlayController = view
+                self.displayedCamera = (entityId: entityId, serverIdentifier: server.identifier)
                 view.modalPresentationStyle = .overFullScreen
                 Current.kiosk.setCameraOverlayVisible(true)
                 webViewController.presentOverlayController(controller: view, animated: true)
             }.catch { error in
+                self.displayedCamera = nil
                 Current.kiosk.setCameraOverlayVisible(false)
                 Current.Log.error("Failed to show camera from push command: \(error)")
             }
@@ -155,6 +170,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
                 webViewController.dismissOverlayController(animated: true) { [weak self] in
                     self?.cameraOverlayController = nil
+                    self?.displayedCamera = nil
                     Current.kiosk.setCameraOverlayVisible(false)
                 }
             }.catch { error in

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -76,7 +76,8 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         }
 
         Current.sceneManager.webViewControllerPromise
-            .done { webViewController in
+            .done { [weak self] webViewController in
+                guard let self else { return }
                 let server = self.cameraServer(from: userInfo, fallback: webViewController.server)
 
                 if let displayedCamera = self.displayedCamera,
@@ -92,8 +93,8 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
                     server: server,
                     cameraEntityId: entityId
                 )
-                .onDisappear {
-                    self.displayedCamera = nil
+                .onDisappear { [weak self] in
+                    self?.displayedCamera = nil
                     Current.kiosk.setCameraOverlayVisible(false)
                 }
                 .embeddedInHostingController()
@@ -102,8 +103,8 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
                 view.modalPresentationStyle = .overFullScreen
                 Current.kiosk.setCameraOverlayVisible(true)
                 webViewController.presentOverlayController(controller: view, animated: true)
-            }.catch { error in
-                self.displayedCamera = nil
+            }.catch { [weak self] error in
+                self?.displayedCamera = nil
                 Current.kiosk.setCameraOverlayVisible(false)
                 Current.Log.error("Failed to show camera from push command: \(error)")
             }


### PR DESCRIPTION
When kiosk_show_camera is received for a camera entity_id/server that is
already on display, silently log and skip re-presenting the overlay.