### PR TITLE
Fix non-exhaustive switch in KioskPushCommand.levelKey

### DIFF
--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -34,7 +34,7 @@ enum KioskPushCommand: String, CaseIterable {
             return "level"
         case .setVolume:
             return "volume"
-        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .reload:
+        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .reload, .defaultDashboard:
             return nil
         }
     }


### PR DESCRIPTION
Add the missing .defaultDashboard case to the levelKey switch, which
returns nil for commands that don't take a numeric level. This case was
added to the enum but not to this switch, breaking the build.