### PR TITLE
Rework frontend connection state to avoid false disconnected screen

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+EmptyState.swift
@@ -56,44 +56,6 @@ extension WebViewController {
         }
     }
 
-    // To avoid keeping the empty state on screen when user is disconnected in background
-    // due to inactivity, we reset the empty state timer
-    @objc func resetEmptyStateTimerWithLatestConnectedState() {
-        let state: FrontEndConnectionState = if connectionState == .authInvalid {
-            .authInvalid
-        } else {
-            isConnected ? .connected : .disconnected
-        }
-        updateFrontendConnectionState(state: state.rawValue)
-    }
-
-    func emptyStateObservations() {
-        // Hide empty state when enter background
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(hideEmptyState),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil
-        )
-
-        // Show empty state again if after entering foreground it is not connected
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(resetEmptyStateTimerWithLatestConnectedState),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
-    }
-
-    func removeEmptyStateObservations() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
-    }
-
     private func makeEmptyStateContent() -> WebFrontendOverlayState.EmptyStateContent {
         WebFrontendOverlayState.EmptyStateContent(
             style: emptyStateStyle(for: connectionState),

--- a/Sources/App/Frontend/WebView/WebViewController+Navigation.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+Navigation.swift
@@ -89,6 +89,7 @@ extension WebViewController {
     /// Manual reload does not take care of internal/external URL changes, prefer using `refresh()`
     func reload() {
         Current.Log.verbose("Reload webView requested")
+        markDisconnectedForHardReload()
         webView.reload()
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -83,13 +83,9 @@ extension WebViewController: WebViewControllerProtocol {
         }
     }
 
-    /// Marks the connection disconnected because we are about to hard-reload the web view (`reload()` /
-    /// `refresh()`), which tears down the current frontend and its websocket. This arms the grace timer so
-    /// the disconnected empty state appears if the connection doesn't come back; the frontend reports
-    /// `.connected` again once its websocket is ready, clearing it. Soft navigations and app backgrounding do
-    /// NOT call this — only an explicit reload does.
+    /// A hard reload (`reload()`/`refresh()`) tears down the frontend and its websocket, so mark disconnected
+    /// and arm the grace timer until the frontend reports `.connected` again.
     func markDisconnectedForHardReload() {
-        // A reload of an auth-invalid page is still auth-invalid; let `updateFrontendConnectionState` keep it.
         updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -66,7 +66,6 @@ extension WebViewController: WebViewControllerProtocol {
         } else {
             requestedState
         }
-        isConnected = resolvedState == .connected
         connectionState = resolvedState
 
         // Possible values: connected, disconnected, auth-invalid
@@ -84,20 +83,14 @@ extension WebViewController: WebViewControllerProtocol {
         }
     }
 
-    /// Called after a main-frame load finishes successfully.
-    ///
-    /// `didStartProvisionalNavigation` pessimistically forces `.disconnected` on every navigation so the
-    /// empty state can appear if the load hangs. For in-frontend navigations (e.g. dashboard → automations)
-    /// the websocket is reused rather than re-established, so the frontend never re-emits
-    /// `connection-status: connected` — which previously left the 10-second timer to drop a false
-    /// disconnected empty state over a fully working frontend. A successful load means the page is up, so
-    /// optimistically restore the connected state here. The frontend stays authoritative: if its websocket
-    /// actually fails it downgrades us back to `.disconnected`/`.auth-invalid` via the external bus.
-    func restoreConnectedStateAfterSuccessfulFrontendLoad() {
-        // Don't override an auth-invalid state (a successful reload of an auth-invalid page is still invalid)
-        // or the no-active-URL screen (about:blank is loaded there and is not a connected frontend).
-        guard connectionState != .authInvalid, overlayState?.showsNoActiveURL != true else { return }
-        updateFrontendConnectionState(state: FrontEndConnectionState.connected.rawValue)
+    /// Marks the connection disconnected because we are about to hard-reload the web view (`reload()` /
+    /// `refresh()`), which tears down the current frontend and its websocket. This arms the grace timer so
+    /// the disconnected empty state appears if the connection doesn't come back; the frontend reports
+    /// `.connected` again once its websocket is ready, clearing it. Soft navigations and app backgrounding do
+    /// NOT call this — only an explicit reload does.
+    func markDisconnectedForHardReload() {
+        // A reload of an auth-invalid page is still auth-invalid; let `updateFrontendConnectionState` keep it.
+        updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
     }
 
     func navigateToPath(path: String) {
@@ -127,6 +120,7 @@ extension WebViewController: WebViewControllerProtocol {
                 if webView.url?.baseIsEqual(to: webviewURL) == true, !lastNavigationWasServerError {
                     reload()
                 } else {
+                    markDisconnectedForHardReload()
                     load(request: URLRequest(url: webviewURL))
                 }
                 hideNoActiveURLError()

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -8,7 +8,10 @@ import WebKit
 
 extension WebViewController {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+        // Intentionally does NOT mark the connection as disconnected. A navigation starting (in-frontend
+        // soft navigation, redirect, etc.) does not mean we lost the connection. Disconnection is driven only
+        // by the frontend (`connection-status` via the external bus) or by an explicit hard reload
+        // (`reload()`/`refresh()`), so a working frontend is never covered by a false disconnected empty state.
         webViewExternalMessageHandler.stopImprovScanIfNeeded()
     }
 
@@ -87,10 +90,6 @@ extension WebViewController {
 
         // in case the view appears again, don't reload
         initialURL = nil
-
-        // Clear the navigation-induced disconnected state so a working frontend isn't covered by a false
-        // disconnected empty state when the websocket was reused across the navigation.
-        restoreConnectedStateAfterSuccessfulFrontendLoad()
 
         updateWebViewSettings(reason: .load)
     }

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -8,10 +8,8 @@ import WebKit
 
 extension WebViewController {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        // Intentionally does NOT mark the connection as disconnected. A navigation starting (in-frontend
-        // soft navigation, redirect, etc.) does not mean we lost the connection. Disconnection is driven only
-        // by the frontend (`connection-status` via the external bus) or by an explicit hard reload
-        // (`reload()`/`refresh()`), so a working frontend is never covered by a false disconnected empty state.
+        // Deliberately does not mark disconnected: a navigation starting isn't a lost connection. Only the
+        // frontend (via the external bus) or a hard reload (`reload()`/`refresh()`) sets disconnected.
         webViewExternalMessageHandler.stopImprovScanIfNeeded()
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -76,10 +76,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     /// updateFrontendConnectionState in WebViewController+ProtocolConformance.swift)
     var emptyStateTimer: Timer?
 
-    /// Frontend notifies when connection is established or not
-    /// Each navigation resets this to false so we can show the empty state
-    var isConnected = false
-
     var underlyingPreferredStatusBarStyle: UIStatusBarStyle = .lightContent
 
     override var prefersHomeIndicatorAutoHidden: Bool {
@@ -184,7 +180,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     }
 
     deinit {
-        removeEmptyStateObservations()
         self.urlObserver = nil
         self.tokens.forEach { $0.cancel() }
         autoReloadTimer?.invalidate()
@@ -280,7 +275,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         }
 
         postOnboardingNotificationPermission()
-        emptyStateObservations()
         checkForLocalSecurityLevelDecisionNeeded()
     }
 

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -100,13 +100,13 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertNil(overlayState.emptyState)
     }
 
-    func testReloadMarksDisconnectedAndArmsTimer() {
+    func testMarkDisconnectedForHardReloadArmsTimer() {
         let sut = makeSUT()
         sut.overlayState = WebFrontendOverlayState()
         sut.updateFrontendConnectionState(state: FrontEndConnectionState.connected.rawValue)
         XCTAssertEqual(sut.connectionState, .connected)
 
-        sut.reload()
+        sut.markDisconnectedForHardReload()
 
         XCTAssertEqual(sut.connectionState, .disconnected)
         XCTAssertNotNil(sut.emptyStateTimer)

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -29,16 +29,6 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(style, .disconnected)
     }
 
-    func testResetEmptyStateTimerKeepsAuthInvalidConnectionState() {
-        let sut = makeSUT()
-        sut.connectionState = .authInvalid
-        sut.isConnected = false
-
-        sut.resetEmptyStateTimerWithLatestConnectedState()
-
-        XCTAssertEqual(sut.connectionState, .authInvalid)
-    }
-
     func testUpdateFrontendConnectionStateDoesNotDowngradeAuthInvalidToDisconnected() {
         let sut = makeSUT()
         sut.connectionState = .authInvalid
@@ -110,41 +100,26 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertNil(overlayState.emptyState)
     }
 
-    func testRestoreConnectedStateAfterSuccessfulFrontendLoadClearsNavigationDisconnect() {
+    func testReloadMarksDisconnectedAndArmsTimer() {
         let sut = makeSUT()
         sut.overlayState = WebFrontendOverlayState()
-        // Mimics didStartProvisionalNavigation forcing disconnected + arming the empty-state timer.
-        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
+        sut.updateFrontendConnectionState(state: FrontEndConnectionState.connected.rawValue)
+        XCTAssertEqual(sut.connectionState, .connected)
+
+        // A hard reload tears down the frontend, so it is a legitimate disconnect trigger.
+        sut.reload()
+
         XCTAssertEqual(sut.connectionState, .disconnected)
         XCTAssertNotNil(sut.emptyStateTimer)
-
-        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
-
-        XCTAssertEqual(sut.connectionState, .connected)
-        XCTAssertTrue(sut.isConnected)
-        XCTAssertNil(sut.emptyStateTimer)
     }
 
-    func testRestoreConnectedStateAfterSuccessfulFrontendLoadKeepsAuthInvalid() {
+    func testMarkDisconnectedForHardReloadKeepsAuthInvalid() {
         let sut = makeSUT()
-        sut.overlayState = WebFrontendOverlayState()
         sut.connectionState = .authInvalid
 
-        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
+        sut.markDisconnectedForHardReload()
 
         XCTAssertEqual(sut.connectionState, .authInvalid)
-    }
-
-    func testRestoreConnectedStateAfterSuccessfulFrontendLoadIgnoresNoActiveURLScreen() {
-        let sut = makeSUT()
-        let overlayState = WebFrontendOverlayState()
-        overlayState.showsNoActiveURL = true
-        sut.overlayState = overlayState
-        sut.updateFrontendConnectionState(state: FrontEndConnectionState.disconnected.rawValue)
-
-        sut.restoreConnectedStateAfterSuccessfulFrontendLoad()
-
-        XCTAssertEqual(sut.connectionState, .disconnected)
     }
 
     private func makeSUT() -> WebViewController {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -106,7 +106,6 @@ final class WebViewControllerTests: XCTestCase {
         sut.updateFrontendConnectionState(state: FrontEndConnectionState.connected.rawValue)
         XCTAssertEqual(sut.connectionState, .connected)
 
-        // A hard reload tears down the frontend, so it is a legitimate disconnect trigger.
         sut.reload()
 
         XCTAssertEqual(sut.connectionState, .disconnected)


### PR DESCRIPTION
The disconnected empty state could appear over a fully connected app —
most visibly when returning from background: willEnterForeground ran
resetEmptyStateTimerWithLatestConnectedState, which forced .disconnected
whenever isConnected was stale-false (the frontend's connected event is
ignored while backgrounded and the websocket is silently reused, so it
is never re-emitted), arming the 10s timer over a live connection.

Make the connection state driven only by authoritative signals:
- The frontend, via connection-status on the external bus.
- An explicit hard reload (reload()/refresh()), which tears down the
  frontend and its websocket — markDisconnectedForHardReload() arms the
  grace timer until the frontend reports connected again.

Stop deriving disconnection from incidental signals:
- didStartProvisionalNavigation no longer forces .disconnected (soft
  navigations and redirects do not mean the connection was lost).
- Remove the background/foreground observers that hid and re-derived the
  empty state; app lifecycle no longer affects connection state.

This supersedes restoreConnectedStateAfterSuccessfulFrontendLoad (the
didFinish band-aid for the navigation-induced disconnect) and the now
write-only isConnected flag, both removed. Tests updated accordingly.