### PR TITLE
Reliably send the Live Activity push token via the background session

### DIFF
--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -387,7 +387,12 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             ]
         )
         for server in Current.servers.all {
-            Current.webhooks.sendEphemeral(server: server, request: request).cauterize()
+            // Background session: the OS owns this upload and keeps retrying it (up to its 2 h
+            // resource timeout) across connectivity changes even if the app is suspended or
+            // terminated — so a momentary drop, or losing foreground time, doesn't lose the token.
+            // Reliable token delivery is what lets Core flush the buffered update and stop sending
+            // starts, so it should not be best-effort like sendEphemeral.
+            Current.webhooks.sendPassive(server: server, request: request).cauterize()
         }
         rememberReportedTokenTag(tag)
     }


### PR DESCRIPTION
## Summary
Reporting a Live Activity's per-activity push token used `sendEphemeral`, a best-effort foreground
send that is silently dropped if it fails (a network blip, or losing foreground time). This switches
it to `sendPassive`, which goes through the webhook background `URLSession`: the OS owns the upload
and keeps retrying it across connectivity changes — up to that session's resource timeout — even if
the app is suspended or terminated. Reliable token delivery is what lets the server target updates at
the running activity instead of repeatedly starting a new one.

