### PR TITLE
Log Live Activity lifecycle and push token delivery to the client event log

### DIFF
--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -107,6 +107,9 @@ public class WebhookManager: NSObject {
         }
 
         register(responseHandler: WebhookResponseUnhandled.self, for: .unhandled)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        register(responseHandler: WebhookResponseLiveActivityToken.self, for: .liveActivityToken)
+        #endif
     }
 
     func register(

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -141,6 +141,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 staleDate: computeStaleDate(for: state)
             )
             await existing.activity.update(content)
+            Current.clientEventStore.addEvent(
+                .init(text: "Live Activity updated: \(tag)", type: .notification)
+            )
             return true
         }
 
@@ -152,6 +155,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 staleDate: computeStaleDate(for: state)
             )
             await live.update(content)
+            Current.clientEventStore.addEvent(
+                .init(text: "Live Activity updated: \(tag)", type: .notification)
+            )
             let observationTask = makeObservationTask(for: live)
             entries[tag] = Entry(activity: live, observationTask: observationTask)
             return true
@@ -201,6 +207,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
 
         let observationTask = makeObservationTask(for: activity)
         await confirmReservation(id: tag, entry: Entry(activity: activity, observationTask: observationTask))
+        Current.clientEventStore.addEvent(
+            .init(text: "Live Activity started: \(tag)", type: .notification)
+        )
         Current.Log.verbose("LiveActivityRegistry: started activity for tag \(tag), id=\(activity.id)")
         return true
     }
@@ -209,6 +218,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     public func end(tag: String, dismissalPolicy: ActivityUIDismissalPolicy = .immediate) async {
         if let existing = remove(id: tag) {
             await existing.activity.end(nil, dismissalPolicy: dismissalPolicy)
+            Current.clientEventStore.addEvent(
+                .init(text: "Live Activity ended: \(tag)", type: .notification)
+            )
             Current.Log.verbose("LiveActivityRegistry: ended activity for tag \(tag)")
             return
         }
@@ -295,6 +307,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
 
             let observationTask = makeObservationTask(for: activity)
             entries[tag] = Entry(activity: activity, observationTask: observationTask)
+            Current.clientEventStore.addEvent(
+                .init(text: "Live Activity started remotely: \(tag)", type: .notification)
+            )
             Current.Log.verbose(
                 "LiveActivityRegistry: observed remotely started activity for tag \(tag), id=\(activity.id)"
             )
@@ -353,6 +368,10 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                     for await state in activity.activityStateUpdates {
                         switch state {
                         case .dismissed, .ended:
+                            Current.clientEventStore.addEvent(.init(
+                                text: "Live Activity dismissed: \(activity.attributes.tag)",
+                                type: .notification
+                            ))
                             await self.reportActivityDismissed(tag: activity.attributes.tag)
                             _ = await self.remove(id: activity.attributes.tag)
                             return
@@ -386,13 +405,21 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 "expires_at": expiresAt,
             ]
         )
+        Current.clientEventStore.addEvent(
+            .init(text: "Sending Live Activity push token: \(tag)", type: .networkRequest)
+        )
         for server in Current.servers.all {
             // Background session: the OS owns this upload and keeps retrying it (up to its 2 h
             // resource timeout) across connectivity changes even if the app is suspended or
             // terminated — so a momentary drop, or losing foreground time, doesn't lose the token.
             // Reliable token delivery is what lets Core flush the buffered update and stop sending
-            // starts, so it should not be best-effort like sendEphemeral.
-            Current.webhooks.sendPassive(server: server, request: request).cauterize()
+            // starts, so it should not be best-effort like sendEphemeral. The response handler logs
+            // the actual delivery outcome (the promise here only signals enqueue).
+            Current.webhooks.sendPassive(
+                identifier: .liveActivityToken,
+                server: server,
+                request: request
+            ).cauterize()
         }
         rememberReportedTokenTag(tag)
     }
@@ -776,6 +803,42 @@ public final class LiveActivityPendingStartObserver {
                     DispatchQueue.main.async { seal.fulfill(()) }
                 }
             }
+        }
+    }
+}
+
+extension WebhookResponseIdentifier {
+    static var liveActivityToken: Self { .init(rawValue: "liveActivityToken") }
+}
+
+/// Logs the outcome of a Live Activity push-token report. The token is sent on the background
+/// session, so the returned promise only signals that the upload was enqueued — the real delivery
+/// result is delivered here and recorded in the client event log.
+struct WebhookResponseLiveActivityToken: WebhookResponseHandler {
+    init(api: HomeAssistantAPI) {}
+
+    static func shouldReplace(request current: WebhookRequest, with proposed: WebhookRequest) -> Bool {
+        false
+    }
+
+    func handle(
+        request: Promise<WebhookRequest>,
+        result: Promise<Any>
+    ) -> Guarantee<WebhookResponseHandlerResult> {
+        result.done { _ in
+            Current.clientEventStore.addEvent(
+                .init(text: "Live Activity push token sent to Home Assistant", type: .networkRequest)
+            )
+        }.map { _ in
+            WebhookResponseHandlerResult.default
+        }.recover { error in
+            Current.clientEventStore.addEvent(
+                .init(
+                    text: "Live Activity push token failed: \(error.localizedDescription)",
+                    type: .networkRequest
+                )
+            )
+            return Guarantee.value(WebhookResponseHandlerResult.default)
         }
     }
 }

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -368,8 +368,9 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                     for await state in activity.activityStateUpdates {
                         switch state {
                         case .dismissed, .ended:
+                            let lifecycle = state == .ended ? "ended" : "dismissed"
                             Current.clientEventStore.addEvent(.init(
-                                text: "Live Activity dismissed: \(activity.attributes.tag)",
+                                text: "Live Activity \(lifecycle): \(activity.attributes.tag)",
                                 type: .notification
                             ))
                             await self.reportActivityDismissed(tag: activity.attributes.tag)
@@ -818,27 +819,42 @@ struct WebhookResponseLiveActivityToken: WebhookResponseHandler {
     init(api: HomeAssistantAPI) {}
 
     static func shouldReplace(request current: WebhookRequest, with proposed: WebhookRequest) -> Bool {
-        false
+        // A newer token report for the same tag supersedes an older in-flight one, so background
+        // session retries can't deliver a stale token after a newer one. Reports for other tags
+        // are independent and must not cancel each other.
+        guard let currentTag = (current.data as? [String: Any])?["tag"] as? String,
+              let proposedTag = (proposed.data as? [String: Any])?["tag"] as? String else {
+            return false
+        }
+        return currentTag == proposedTag
     }
 
     func handle(
         request: Promise<WebhookRequest>,
         result: Promise<Any>
     ) -> Guarantee<WebhookResponseHandlerResult> {
-        result.done { _ in
-            Current.clientEventStore.addEvent(
-                .init(text: "Live Activity push token sent to Home Assistant", type: .networkRequest)
-            )
-        }.map { _ in
-            WebhookResponseHandlerResult.default
-        }.recover { error in
-            Current.clientEventStore.addEvent(
-                .init(
-                    text: "Live Activity push token failed: \(error.localizedDescription)",
-                    type: .networkRequest
+        firstly {
+            request
+        }.map { request in
+            (request.data as? [String: Any])?["tag"] as? String ?? "unknown"
+        }.then { tag in
+            result.done { _ in
+                Current.clientEventStore.addEvent(
+                    .init(text: "Live Activity push token sent: \(tag)", type: .networkRequest)
                 )
-            )
-            return Guarantee.value(WebhookResponseHandlerResult.default)
+            }.map { _ in
+                WebhookResponseHandlerResult.default
+            }.recover { error in
+                Current.clientEventStore.addEvent(
+                    .init(
+                        text: "Live Activity push token failed: \(tag) — \(error.localizedDescription)",
+                        type: .networkRequest
+                    )
+                )
+                return Guarantee.value(WebhookResponseHandlerResult.default)
+            }
+        }.recover { _ in
+            Guarantee.value(WebhookResponseHandlerResult.default)
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds client event log entries across the Live Activity flow so on-device behavior is easy to
diagnose: when an activity is started (locally or via push-to-start), updated, ended, or
dismissed; when a per-activity push token is sent to Home Assistant; and whether that send
succeeded or failed. Because the token is sent over the background session (#4877), its real
delivery outcome is logged from a dedicated webhook response handler rather than the enqueue
promise.
