### PR TITLE
Show a countdown-driven progress bar in Live Activities

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -841,11 +841,11 @@
 		428DBFFB2F0C9141003B08D5 /* AppDeviceRegistryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DBFFA2F0C9141003B08D5 /* AppDeviceRegistryTable.swift */; };
 		428DBFFC2F0C9141003B08D5 /* AppDeviceRegistryTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DBFFA2F0C9141003B08D5 /* AppDeviceRegistryTable.swift */; };
 		428DBFFE2F0C95D8003B08D5 /* DeviceRegistry.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DBFFD2F0C95D8003B08D5 /* DeviceRegistry.test.swift */; };
-		428DC0132F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0122F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift */; };
-		428DC0112F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0102F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift */; };
 		428DC0022F0C961E003B08D5 /* deviceregistry.json in Resources */ = {isa = PBXBuildFile; fileRef = 428DC0012F0C961E003B08D5 /* deviceregistry.json */; };
 		428DC00A2F0CAAE7003B08D5 /* EntityProvider+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0032F0CA1D8003B08D5 /* EntityProvider+Details.swift */; };
 		428DC00B2F0CAAE7003B08D5 /* EntityProvider+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0032F0CA1D8003B08D5 /* EntityProvider+Details.swift */; };
+		428DC0112F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0102F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift */; };
+		428DC0132F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428DC0122F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift */; };
 		428ED98B2E9E4FBF0019113B /* CheckmarkDrawOnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428ED98A2E9E4FBF0019113B /* CheckmarkDrawOnView.swift */; };
 		428ED98E2E9E555D0019113B /* OnboardingPermissionsNavigationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428ED98C2E9E54E60019113B /* OnboardingPermissionsNavigationViewModelTests.swift */; };
 		428EDB652DAFD97F00A271A1 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42CE8FAC2B46C12C00C707F9 /* Domain.swift */; };
@@ -878,6 +878,8 @@
 		4298587E2EB1025E00E33710 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4298587D2EB1025E00E33710 /* LocationManager.swift */; };
 		4298587F2EB1025E00E33710 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4298587D2EB1025E00E33710 /* LocationManager.swift */; };
 		429858862EB1066400E33710 /* LocationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429858832EB102D000E33710 /* LocationManagerTests.swift */; };
+		42991E542FF32AF000C2C76B /* HAActivityProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42991E532FF32AF000C2C76B /* HAActivityProgressBar.swift */; };
+		42991E562FF32AF000C2C76B /* HAActivityTimerProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42991E552FF32AF000C2C76B /* HAActivityTimerProgressBar.swift */; };
 		429997BF2DDB59E400CC6C12 /* WebViewRestorationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429997BE2DDB59E400CC6C12 /* WebViewRestorationType.swift */; };
 		429AFE5C2DB7BE4000AF0836 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429AFE5B2DB7BE4000AF0836 /* GeneralSettingsView.swift */; };
 		429AFE5E2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429AFE5D2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift */; };
@@ -1117,12 +1119,6 @@
 		42E95C592CA46AD50010ECE3 /* ShareActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E95C582CA46AD50010ECE3 /* ShareActivityView.swift */; };
 		42E9AFFF2CE63944009DDA46 /* AudioOutputSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */; };
 		42E9B0002CE63944009DDA46 /* AudioOutputSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */; };
-		FF79AFA7BB50A4412EA3D90F /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
-		FE977E5AF3716CC177054DF8 /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
-		72BA28D07496C22E40A84DDB /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
-		5189F6FB2CC89777A8E2172A /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
-		C2485C745F81BBEB2BEB9DB0 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
-		7BFD0239CA1B74E2C14C92E2 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
 		42EB030A2C6E4D0E00A184A6 /* WatchMagicViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EB03092C6E4D0E00A184A6 /* WatchMagicViewRow.swift */; };
 		42EEEFE22E2791430080E973 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE12E2791430080E973 /* Service.swift */; };
 		42EEEFE32E2791430080E973 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE12E2791430080E973 /* Service.swift */; };
@@ -1239,14 +1235,13 @@
 		5002BDAF2FEE000100BEEF01 /* WhatsNewEngine.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5002BDAE2FEE000100BEEF01 /* WhatsNewEngine.test.swift */; };
 		50099BBED6A1441E8A6B6C5C /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = EBD991757B454B819925F6B9 /* SFSafeSymbols */; };
 		504A2C862F8133E6002A3C0E /* CarPlayTabsSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504A2C852F8133E6002A3C0E /* CarPlayTabsSelectionView.swift */; };
+		5189F6FB2CC89777A8E2172A /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
 		54B2C38995814098B677135A /* WidgetCommonlyUsedEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEEA3344F064DB183F46C47 /* WidgetCommonlyUsedEntities.swift */; };
 		577142E05D7B54FFFEB61CED /* WidgetGaugeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403AE9262C2F333A00D48147 /* WidgetGaugeView.swift */; };
 		58213D5B1792311CD4CA261D /* Pods_iOS_Extensions_NotificationService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6DA82FEEE2DDC3B2CC20DA3 /* Pods_iOS_Extensions_NotificationService.framework */; };
 		5B715903CB3450FE351399BC /* Pods-iOS-Extensions-Share-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 207E35C8F1554A9AD616FFA2 /* Pods-iOS-Extensions-Share-metadata.plist */; };
 		5D4737422F241342009A70EA /* FolderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4737412F241342009A70EA /* FolderDetailView.swift */; };
 		5D5F19CD200C051E13C940E2 /* KioskScreensaverSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B10F23CD68334A0873B5707 /* KioskScreensaverSettingsView.swift */; };
-		AF7DBAD13854615BE06CED9F /* KioskSensorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */; };
-		F89D0E47CCB3A8D13BE70EC2 /* KioskSensorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */; };
 		5F2ECF3C2CA505A59A1CFFAF /* Pods_iOS_SharedTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65B4DC669522BB7A70C5EED0 /* Pods_iOS_SharedTesting.framework */; };
 		61495A70232316478717CF27 /* Pods_iOS_Shared_iOS_Tests_Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF3A67FB1C2B548C6C7730C /* Pods_iOS_Shared_iOS_Tests_Shared.framework */; };
 		61826BB51EF447EA760E65F8 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 067B845F1477358424F0C5FD /* GRDB */; };
@@ -1264,7 +1259,9 @@
 		70BD8A8EA1ABC5DC1F0A0D6E /* Pods_iOS_Shared_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C663B0750E0318469E7008C3 /* Pods_iOS_Shared_iOS.framework */; };
 		70E2B868FFDDA96DAF138814 /* KioskSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FD2BAEEAE31310280CB33D /* KioskSettings.swift */; };
 		71E0BF803A854C3B9F0CB726 /* HandlerLiveActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58D524991C142DBB38A1968 /* HandlerLiveActivityTests.swift */; };
+		72BA28D07496C22E40A84DDB /* KioskBrightnessSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */; };
 		78F6EC29BAE43C9BAAFBAB1A /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12960782B4F42B5C4811E859 /* WhatsNewView.swift */; };
+		7BFD0239CA1B74E2C14C92E2 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
 		7EB1B6B52775DAF12C3B2B27 /* KioskSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FD2BAEEAE31310280CB33D /* KioskSettings.swift */; };
 		7F5261AFA361C741413A782D /* KioskModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCF41D72CA895DB501333EF /* KioskModeManager.swift */; };
 		8411EA28D9F5FEF26D01A39E /* CameraZoomGestureOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5A1F2C65420338C176B7BD /* CameraZoomGestureOverlay.swift */; };
@@ -1302,6 +1299,7 @@
 		AC730005000000000000AA01 /* AppIconShortcutItemsUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC730021000000000000AA01 /* AppIconShortcutItemsUpdater.swift */; };
 		AC730006000000000000AA01 /* AppIconShortcutsConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC730022000000000000AA01 /* AppIconShortcutsConfigurationViewModel.swift */; };
 		AC730007000000000000AA01 /* AppIconShortcutsConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC730023000000000000AA01 /* AppIconShortcutsConfigurationView.swift */; };
+		AF7DBAD13854615BE06CED9F /* KioskSensorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */; };
 		B33AA2540A50911557F33BEB /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 8BF085C5243838861E8635E7 /* GRDB */; };
 		B3FD7A16B24D03BE49029BB0 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 638EC9AD85B8C58C9C77DCC7 /* GRDB */; };
 		B5B0ED4D411BE12F4C7DC29A /* CallServiceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94616AE6CF9100E44C576B8D /* CallServiceResponse.swift */; };
@@ -1553,6 +1551,7 @@
 		BECCC152A4E3F69A8EF5A6F3 /* Database/TableSchemaTests.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE9A0E08E6FEBDDE425D0D4 /* Database/TableSchemaTests.test.swift */; };
 		C10D762EFE08D347D0538339 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B2F5238669D8A7416FBD2B55 /* Pods-iOS-Shared-iOS-Tests-Shared-metadata.plist */; };
 		C1AE883A374C598B5BCCAE23 /* CustomWidgetIntentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7FF77B68D19A4AD68F8FE3 /* CustomWidgetIntentHelper.swift */; };
+		C2485C745F81BBEB2BEB9DB0 /* KioskVolumeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */; };
 		C35621B95F7E4548BC8F6D75 /* FolderEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BECEB2525564358A124F818 /* FolderEditView.swift */; };
 		C3EB3740FA097F36D51F525E /* BarometerSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1396822195C7FF562AB891F2 /* BarometerSensor.swift */; };
 		C5A9D6D06B794615BE1299F9 /* CarPlayAddItemFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3632CE0EC0E141A8B30CD245 /* CarPlayAddItemFlow.swift */; };
@@ -1618,6 +1617,7 @@
 		EF407595A931C19EBCCC9E87 /* KioskModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCF41D72CA895DB501333EF /* KioskModeManager.swift */; };
 		F0D1DD41A8F55F6D767EBF37 /* TemplatePreviewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332C060487B468055C487070 /* TemplatePreviewSection.swift */; };
 		F155B3EE44F62779FADE7DFA /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 2715B836C33E6EDA430278BD /* GRDB */; };
+		F89D0E47CCB3A8D13BE70EC2 /* KioskSensorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */; };
 		FA11C0DE0000000000000002 /* HAApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11C0DE0000000000000001 /* HAApp.swift */; };
 		FA11C0DE0000000000000004 /* SceneManagerEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11C0DE0000000000000003 /* SceneManagerEnvironmentKey.swift */; };
 		FA11C0DE0000000000000006 /* HomeAssistantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11C0DE0000000000000005 /* HomeAssistantView.swift */; };
@@ -1636,6 +1636,8 @@
 		FD3BC66C29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66B29BA00D600B19FBE /* CarPlayEntitiesListTemplate.swift */; };
 		FD3BC66E29BA010A00B19FBE /* CarPlayDomainsListTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66D29BA010A00B19FBE /* CarPlayDomainsListTemplate.swift */; };
 		FE626519D14570FF70598F85 /* Pods_iOS_Extensions_Matter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02DC1D2083B5FBC480E4C51D /* Pods_iOS_Extensions_Matter.framework */; };
+		FE977E5AF3716CC177054DF8 /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
+		FF79AFA7BB50A4412EA3D90F /* KioskModeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */; };
 		JARVIS0001000000000002 /* TodoListAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = JARVIS0001000000000001 /* TodoListAppEntity.swift */; };
 		JARVIS0001000000000003 /* TodoListAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = JARVIS0001000000000001 /* TodoListAppEntity.swift */; };
 		JARVIS0002000000000002 /* TodoListRefreshAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = JARVIS0002000000000001 /* TodoListRefreshAppIntent.swift */; };
@@ -2627,10 +2629,10 @@
 		428DBFF72F0C9009003B08D5 /* DeviceRegistryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegistryEntry.swift; sourceTree = "<group>"; };
 		428DBFFA2F0C9141003B08D5 /* AppDeviceRegistryTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDeviceRegistryTable.swift; sourceTree = "<group>"; };
 		428DBFFD2F0C95D8003B08D5 /* DeviceRegistry.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegistry.test.swift; sourceTree = "<group>"; };
-		428DC0122F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAreasRegistryResponse.test.swift; sourceTree = "<group>"; };
-		428DC0102F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAFloorRegistryResponse.test.swift; sourceTree = "<group>"; };
 		428DC0012F0C961E003B08D5 /* deviceregistry.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = deviceregistry.json; sourceTree = "<group>"; };
 		428DC0032F0CA1D8003B08D5 /* EntityProvider+Details.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntityProvider+Details.swift"; sourceTree = "<group>"; };
+		428DC0102F0C95D8003B08D5 /* HAFloorRegistryResponse.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAFloorRegistryResponse.test.swift; sourceTree = "<group>"; };
+		428DC0122F0C95D8003B08D5 /* HAAreasRegistryResponse.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAreasRegistryResponse.test.swift; sourceTree = "<group>"; };
 		428ED98A2E9E4FBF0019113B /* CheckmarkDrawOnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkDrawOnView.swift; sourceTree = "<group>"; };
 		428ED98C2E9E54E60019113B /* OnboardingPermissionsNavigationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPermissionsNavigationViewModelTests.swift; sourceTree = "<group>"; };
 		428EDB672DAFD9B900A271A1 /* HAEntity+DeviceClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+DeviceClass.swift"; sourceTree = "<group>"; };
@@ -2654,6 +2656,8 @@
 		429821162CD0DDCD005ECD39 /* HAButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAButtonStyles.swift; sourceTree = "<group>"; };
 		4298587D2EB1025E00E33710 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		429858832EB102D000E33710 /* LocationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerTests.swift; sourceTree = "<group>"; };
+		42991E532FF32AF000C2C76B /* HAActivityProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAActivityProgressBar.swift; sourceTree = "<group>"; };
+		42991E552FF32AF000C2C76B /* HAActivityTimerProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAActivityTimerProgressBar.swift; sourceTree = "<group>"; };
 		429997BE2DDB59E400CC6C12 /* WebViewRestorationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewRestorationType.swift; sourceTree = "<group>"; };
 		429AFE5B2DB7BE4000AF0836 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		429AFE5D2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTemplateEditor.swift; sourceTree = "<group>"; };
@@ -3013,9 +3017,6 @@
 		42E95C562CA45EFA0010ECE3 /* OnboardingErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingErrorView.swift; sourceTree = "<group>"; };
 		42E95C582CA46AD50010ECE3 /* ShareActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareActivityView.swift; sourceTree = "<group>"; };
 		42E9AFFE2CE63944009DDA46 /* AudioOutputSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioOutputSensor.swift; sourceTree = "<group>"; };
-		98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskModeSensor.swift; sourceTree = "<group>"; };
-		F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskBrightnessSensor.swift; sourceTree = "<group>"; };
-		E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskVolumeSensor.swift; sourceTree = "<group>"; };
 		42EB03092C6E4D0E00A184A6 /* WatchMagicViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMagicViewRow.swift; sourceTree = "<group>"; };
 		42EEEFE12E2791430080E973 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		42EEEFE42E2792B20080E973 /* Service.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.test.swift; sourceTree = "<group>"; };
@@ -3113,6 +3114,7 @@
 		504A2C852F8133E6002A3C0E /* CarPlayTabsSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayTabsSelectionView.swift; sourceTree = "<group>"; };
 		50D9C22ED2834EC9DAAC63AC /* Pods-iOS-Extensions-Intents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Intents.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Intents/Pods-iOS-Extensions-Intents.debug.xcconfig"; sourceTree = "<group>"; };
 		512A72C5F1BCC979E74F7629 /* ComplicationEditViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComplicationEditViewModel.swift; sourceTree = "<group>"; };
+		53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsViewModel.swift; sourceTree = "<group>"; };
 		553A33E097387AA44265DB13 /* Pods-iOS-App-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-App-metadata.plist"; path = "Pods/Pods-iOS-App-metadata.plist"; sourceTree = "<group>"; };
 		592EED7A6C2444872F11C17B /* Pods-iOS-Extensions-NotificationService-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-NotificationService-metadata.plist"; path = "Pods/Pods-iOS-Extensions-NotificationService-metadata.plist"; sourceTree = "<group>"; };
 		5BFD0D30836C69840AB63A8A /* LoadingButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoadingButton.swift; sourceTree = "<group>"; };
@@ -3127,8 +3129,6 @@
 		6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Widgets-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Widgets-metadata.plist"; sourceTree = "<group>"; };
 		6A7FF77B68D19A4AD68F8FE3 /* CustomWidgetIntentHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomWidgetIntentHelper.swift; sourceTree = "<group>"; };
 		6B10F23CD68334A0873B5707 /* KioskScreensaverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskScreensaverSettingsView.swift; sourceTree = "<group>"; };
-		E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsView.swift; sourceTree = "<group>"; };
-		53247A6215E54ECABE16375E /* KioskSensorsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsViewModel.swift; sourceTree = "<group>"; };
 		6B55CB9064A0477C9F456B6A /* Pods-watchOS-Shared-watchOS-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-Shared-watchOS-metadata.plist"; path = "Pods/Pods-watchOS-Shared-watchOS-metadata.plist"; sourceTree = "<group>"; };
 		6BC23DE131CA8813C2DBD657 /* IconSearchPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IconSearchPicker.swift; sourceTree = "<group>"; };
 		6BECEB2525564358A124F818 /* FolderEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderEditView.swift; sourceTree = "<group>"; };
@@ -3151,6 +3151,7 @@
 		8D6888525DCF492642BA7EA3 /* FanIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FanIntent.swift; sourceTree = "<group>"; };
 		9249824D575933DFA1530BB2 /* Pods-watchOS-WatchExtension-Watch-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-watchOS-WatchExtension-Watch-metadata.plist"; path = "Pods/Pods-watchOS-WatchExtension-Watch-metadata.plist"; sourceTree = "<group>"; };
 		94616AE6CF9100E44C576B8D /* CallServiceResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallServiceResponse.swift; sourceTree = "<group>"; };
+		98FB38C417E1928C8AEB2106 /* KioskModeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskModeSensor.swift; sourceTree = "<group>"; };
 		993127A375AC6F04532F9E40 /* Pods-iOS-Extensions-Intents.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Extensions-Intents.beta.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Extensions-Intents/Pods-iOS-Extensions-Intents.beta.xcconfig"; sourceTree = "<group>"; };
 		99EC7EF1136575D0E7A17091 /* NotificationIdentifierField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationIdentifierField.swift; sourceTree = "<group>"; };
 		9C2D92E2BDA4753B19B91E11 /* Pods-iOS-SharedTesting.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-SharedTesting.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-SharedTesting/Pods-iOS-SharedTesting.debug.xcconfig"; sourceTree = "<group>"; };
@@ -3545,9 +3546,12 @@
 		E3D5CF14402325076CA105EB /* Pods-iOS-Extensions-PushProvider-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-PushProvider-metadata.plist"; path = "Pods/Pods-iOS-Extensions-PushProvider-metadata.plist"; sourceTree = "<group>"; };
 		E41A4AAEF642A72ACDB6C006 /* Pods-iOS-Extensions-Intents-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-iOS-Extensions-Intents-metadata.plist"; path = "Pods/Pods-iOS-Extensions-Intents-metadata.plist"; sourceTree = "<group>"; };
 		E70F7D3E8E4B489FA1514E7C /* KioskSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSettingsViewModel.swift; sourceTree = "<group>"; };
+		E78C6E1C01A872D8B4DA275D /* KioskSensorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSensorsView.swift; sourceTree = "<group>"; };
+		E90C5ED6BFAE78B948D25DC0 /* KioskVolumeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskVolumeSensor.swift; sourceTree = "<group>"; };
 		ED4B2D38DF1316D881D79769 /* Pods-iOS-Shared-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Shared-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS-Shared-iOS/Pods-iOS-Shared-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EE9D38AFF8103605A5E02F62 /* KioskSettingsTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSettingsTable.swift; sourceTree = "<group>"; };
 		EF91E383A44843F087423FB5 /* WidgetCommonlyUsedEntitiesTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCommonlyUsedEntitiesTimelineProvider.swift; sourceTree = "<group>"; };
+		F1D3EF229B8D9A2DB7DF078A /* KioskBrightnessSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskBrightnessSensor.swift; sourceTree = "<group>"; };
 		F6DA82FEEE2DDC3B2CC20DA3 /* Pods_iOS_Extensions_NotificationService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Extensions_NotificationService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA11C0DE0000000000000001 /* HAApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAApp.swift; sourceTree = "<group>"; };
 		FA11C0DE0000000000000003 /* SceneManagerEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneManagerEnvironmentKey.swift; sourceTree = "<group>"; };
@@ -6580,6 +6584,8 @@
 				A95FDD102F6B8A3E008EF72F /* HADynamicIslandView.swift */,
 				A95FDD112F6B8A3E008EF72F /* HALiveActivityConfiguration.swift */,
 				A95FDD122F6B8A3E008EF72F /* HALockScreenView.swift */,
+				42991E532FF32AF000C2C76B /* HAActivityProgressBar.swift */,
+				42991E552FF32AF000C2C76B /* HAActivityTimerProgressBar.swift */,
 			);
 			path = LiveActivity;
 			sourceTree = "<group>";
@@ -9308,6 +9314,7 @@
 				3E4087EE2CE62B5A0085DF29 /* WidgetBasicViewProtocol.swift in Sources */,
 				42D3E4AE2C5D2AFA00444BE6 /* WidgetScripts.swift in Sources */,
 				403AE92B2C2F3A9200D48147 /* IntentServerAppEntitiy.swift in Sources */,
+				42991E542FF32AF000C2C76B /* HAActivityProgressBar.swift in Sources */,
 				422F88192D42989E00706A0A /* CustomWidgetPressButtonAppIntent.swift in Sources */,
 				4276471E2C8F2F100027B21F /* IntentLightEntity.swift in Sources */,
 				4273C48D2C8859530065A5B4 /* PageAppEntity.swift in Sources */,
@@ -9349,6 +9356,7 @@
 				428CB3382CF7FC0800F1320E /* WidgetFamilySizes.swift in Sources */,
 				4223688B2D40F9B7005911E4 /* WidgetCustom.swift in Sources */,
 				429BA2AF2C800CAB00A50996 /* SFSymbolEntity.swift in Sources */,
+				42991E562FF32AF000C2C76B /* HAActivityTimerProgressBar.swift in Sources */,
 				420461692C8F29440062E89F /* ControlLight.swift in Sources */,
 				3BB66E53094D6C7C2F395D54 /* ControlFan.swift in Sources */,
 				00C267608DCC88B783816CBF /* FanIntent.swift in Sources */,

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -652,6 +652,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.sensors.title" = "Sensors";
 "kiosk.title" = "Kiosk Mode";
 "legacy_actions.disclaimer" = "Legacy iOS Actions are not the recommended way to interact with Home Assistant anymore, please use Scripts, Scenes and Automations directly in your Widgets, Apple Watch and CarPlay.";
+"live_activity.accessibility.progress" = "Progress";
 "live_activity.default_title" = "Home Assistant";
 "live_activity.empty_state" = "No active Live Activities";
 "live_activity.end_all.button" = "End All Activities";

--- a/Sources/Extensions/Widgets/LiveActivity/HAActivityProgressBar.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HAActivityProgressBar.swift
@@ -1,0 +1,44 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+import Shared
+import SwiftUI
+
+@available(iOS 17.2, *)
+struct HAActivityProgressBar: View {
+    let fraction: Double
+    let fillColor: Color
+    let trackColor: Color
+    let height: CGFloat
+
+    private var clampedFraction: Double {
+        min(max(fraction, 0), 1)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = clampedFraction == 0 ? 0 : max(geometry.size.width * clampedFraction, height)
+
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(trackColor)
+
+                Capsule(style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                fillColor.opacity(0.9),
+                                fillColor,
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: width)
+            }
+        }
+        .frame(height: height)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L10n.LiveActivity.Accessibility.progress)
+        .accessibilityValue(Text(HAActivityVisualStyle.accessibilityPercentString(for: clampedFraction)))
+    }
+}
+#endif

--- a/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
@@ -1,0 +1,21 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+import SwiftUI
+
+@available(iOS 17.2, *)
+struct HAActivityTimerProgressBar: View {
+    let end: Date
+    let tint: Color
+
+    var body: some View {
+        ProgressView(
+            timerInterval: Date.now ... end,
+            countsDown: true,
+            label: { EmptyView() },
+            currentValueLabel: { EmptyView() }
+        )
+        .tint(tint)
+        .scaleEffect(y: 2)
+        .clipShape(.capsule)
+    }
+}
+#endif

--- a/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
@@ -135,17 +135,19 @@ struct HACompactTrailingView: View {
 @available(iOS 17.2, *)
 struct HAExpandedTrailingView: View {
     let state: HALiveActivityAttributes.ContentState
-
+    private let minimumScaleFactor: CGFloat = 0.7
     var body: some View {
         if let fraction = state.progressFraction {
             Text(HAActivityVisualStyle.percentString(for: fraction))
                 .font(.headline.monospacedDigit())
                 .foregroundStyle(.white)
+                .minimumScaleFactor(minimumScaleFactor)
         } else if let critical = state.criticalText {
             Text(critical)
                 .font(.headline)
                 .foregroundStyle(.white)
                 .lineLimit(1)
+                .minimumScaleFactor(minimumScaleFactor)
         }
     }
 }
@@ -177,6 +179,8 @@ struct HAExpandedBottomView: View {
                     trackColor: .white.opacity(0.16),
                     height: 8
                 )
+            } else if state.chronometer == true, let end = state.countdownEnd {
+                HAActivityTimerProgressBar(end: end, tint: barColor)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
@@ -52,6 +52,8 @@ struct HALockScreenView: View {
                     trackColor: trackColor,
                     height: 10
                 )
+            } else if state.chronometer == true, let end = state.countdownEnd {
+                HAActivityTimerProgressBar(end: end, tint: barColor)
             }
         }
         .padding(.horizontal, DesignSystem.Spaces.two)
@@ -138,46 +140,6 @@ struct HALockScreenView: View {
 
     private var trackColor: Color {
         foreground.opacity(useLightText ? 0.14 : 0.08)
-    }
-}
-
-@available(iOS 17.2, *)
-struct HAActivityProgressBar: View {
-    let fraction: Double
-    let fillColor: Color
-    let trackColor: Color
-    let height: CGFloat
-
-    private var clampedFraction: Double {
-        min(max(fraction, 0), 1)
-    }
-
-    var body: some View {
-        GeometryReader { geometry in
-            let width = clampedFraction == 0 ? 0 : max(geometry.size.width * clampedFraction, height)
-
-            ZStack(alignment: .leading) {
-                Capsule(style: .continuous)
-                    .fill(trackColor)
-
-                Capsule(style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                fillColor.opacity(0.9),
-                                fillColor,
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: width)
-            }
-        }
-        .frame(height: height)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Progress")
-        .accessibilityValue(Text(HAActivityVisualStyle.accessibilityPercentString(for: clampedFraction)))
     }
 }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2284,6 +2284,10 @@ public enum L10n {
     public static var subtitle: String { return L10n.tr("Localizable", "live_activity.subtitle") }
     /// Live Activities
     public static var title: String { return L10n.tr("Localizable", "live_activity.title") }
+    public enum Accessibility {
+      /// Progress
+      public static var progress: String { return L10n.tr("Localizable", "live_activity.accessibility.progress") }
+    }
     public enum EndAll {
       /// End All Activities
       public static var button: String { return L10n.tr("Localizable", "live_activity.end_all.button") }


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Live Activities previously rendered a progress bar only when explicit `progress`/`progress_max` values were supplied. When an activity is started as a countdown (`chronometer` + `when`) without those values, the Lock Screen and Dynamic Island now show a progress bar driven by the countdown itself — it fills as the timer approaches its end, using SwiftUI's time-driven `ProgressView(timerInterval:)` so it animates without requiring push updates.

Explicit `progress`/`progress_max` still takes precedence; when neither explicit progress nor a countdown is present, no bar is shown. The countdown bar is tinted with the existing `progress_bar_color` / notification icon color.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
