### PR TITLE
Report Live Activity push token only to the originating server

### DIFF
--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -448,7 +448,8 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
 
     // MARK: - Private — Webhook Reporting
 
-    /// Report a new activity push token to the server that started the activity.
+    /// Report a new activity push token to the server that started the activity (or to all servers
+    /// when its origin is unknown — see `tokenTargetServers`).
     /// The token is used by the relay server to send APNs updates directly to this activity.
     private func reportPushToken(_ tokenHex: String, for activity: Activity<HALiveActivityAttributes>) async {
         let tag = activity.attributes.tag
@@ -496,11 +497,10 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         let allServers = Current.servers.all
         guard let originWebhookID else { return allServers }
         let matches = allServers.filter { $0.info.connection.webhookID == originWebhookID }
-        guard matches.isEmpty else { return matches }
+        if !matches.isEmpty { return matches }
+        // Don't log the raw webhook id — it routes/authenticates webhook calls and is sensitive.
         if !allServers.isEmpty {
-            Current.Log.warning(
-                "LiveActivityRegistry: no server matches origin \(originWebhookID); reporting token to all servers"
-            )
+            Current.Log.warning("LiveActivityRegistry: no server matches the activity origin; reporting token to all")
         }
         return allServers
     }

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -448,7 +448,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
 
     // MARK: - Private — Webhook Reporting
 
-    /// Report a new activity push token to all connected HA servers.
+    /// Report a new activity push token to the server that started the activity.
     /// The token is used by the relay server to send APNs updates directly to this activity.
     private func reportPushToken(_ tokenHex: String, for activity: Activity<HALiveActivityAttributes>) async {
         let tag = activity.attributes.tag
@@ -457,6 +457,11 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
         // point Core at an activity we are ending and could overwrite the survivor's token slot.
         guard entries[tag]?.activity.id == activity.id else {
             Current.Log.info("LiveActivityRegistry: skipping token report for superseded duplicate, tag \(tag)")
+            return
+        }
+        let targetServers = Self.tokenTargetServers(originWebhookID: activity.attributes.serverWebhookId)
+        guard !targetServers.isEmpty else {
+            Current.Log.warning("LiveActivityRegistry: no servers configured, skipping token report for tag \(tag)")
             return
         }
         let expiresAt = Current.date()
@@ -470,7 +475,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 "expires_at": expiresAt,
             ]
         )
-        for server in Current.servers.all {
+        for server in targetServers {
             // Background session: the OS owns this upload and keeps retrying it (up to its 2 h
             // resource timeout) across connectivity changes even if the app is suspended or
             // terminated — so a momentary drop, or losing foreground time, doesn't lose the token.
@@ -479,6 +484,25 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             Current.webhooks.sendPassive(server: server, request: request).cauterize()
         }
         rememberReportedTokenTag(tag)
+    }
+
+    /// The server(s) a per-activity push token should be reported to. An activity is owned by the
+    /// single server that started it, whose `webhook_id` the relay/handler records in the attributes,
+    /// so only that server should receive the token. Two cases fall back to every server, so a token
+    /// is never silently dropped (no worse than before this was scoped): activities created before
+    /// the origin was recorded carry no `webhook_id`, and an origin id that matches no current server
+    /// (its server was removed, or the id is unrecognised).
+    static func tokenTargetServers(originWebhookID: String?) -> [Server] {
+        let allServers = Current.servers.all
+        guard let originWebhookID else { return allServers }
+        let matches = allServers.filter { $0.info.connection.webhookID == originWebhookID }
+        guard matches.isEmpty else { return matches }
+        if !allServers.isEmpty {
+            Current.Log.warning(
+                "LiveActivityRegistry: no server matches origin \(originWebhookID); reporting token to all servers"
+            )
+        }
+        return allServers
     }
 
     /// Notify HA servers that the Live Activity was dismissed or ended externally.

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -260,4 +260,60 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
     }
 }
 
+// MARK: - LiveActivityRegistry token targeting
+
+@available(iOS 17.2, *)
+final class LiveActivityRegistryTokenTargetingTests: XCTestCase {
+    private var servers: FakeServerManager!
+
+    override func setUp() {
+        super.setUp()
+        servers = FakeServerManager()
+        Current.servers = servers
+    }
+
+    override func tearDown() {
+        servers = nil
+        Current.servers = FakeServerManager()
+        super.tearDown()
+    }
+
+    private func addServer(webhookID: String) {
+        let info = with(ServerInfo.fake()) { $0.connection.webhookID = webhookID }
+        _ = servers.add(identifier: .init(rawValue: webhookID), serverInfo: info)
+    }
+
+    /// A per-activity push token must go only to the server whose `webhook_id` started the activity.
+    func testTokenTargetServers_reportsOnlyToOriginServer() {
+        addServer(webhookID: "wh-1")
+        addServer(webhookID: "wh-2")
+        let targets = LiveActivityRegistry.tokenTargetServers(originWebhookID: "wh-2")
+        XCTAssertEqual(targets.map(\.info.connection.webhookID), ["wh-2"])
+    }
+
+    /// Activities created before the origin was recorded carry no `webhook_id`, so their tokens
+    /// still reach every server and existing activities keep working.
+    func testTokenTargetServers_nilOrigin_reportsToAllServers() {
+        addServer(webhookID: "wh-1")
+        addServer(webhookID: "wh-2")
+        let targets = LiveActivityRegistry.tokenTargetServers(originWebhookID: nil)
+        XCTAssertEqual(Set(targets.map(\.info.connection.webhookID)), ["wh-1", "wh-2"])
+    }
+
+    /// If the origin id matches no current server (its server was removed, or the id is unrecognised),
+    /// fall back to every server rather than silently dropping the token.
+    func testTokenTargetServers_unknownOrigin_fallsBackToAllServers() {
+        addServer(webhookID: "wh-1")
+        addServer(webhookID: "wh-2")
+        let targets = LiveActivityRegistry.tokenTargetServers(originWebhookID: "wh-removed")
+        XCTAssertEqual(Set(targets.map(\.info.connection.webhookID)), ["wh-1", "wh-2"])
+    }
+
+    /// With no servers configured there is nowhere to report; the caller skips and remembers nothing.
+    func testTokenTargetServers_noServers_returnsEmpty() {
+        XCTAssertTrue(LiveActivityRegistry.tokenTargetServers(originWebhookID: "wh-1").isEmpty)
+        XCTAssertTrue(LiveActivityRegistry.tokenTargetServers(originWebhookID: nil).isEmpty)
+    }
+}
+
 #endif


### PR DESCRIPTION
## Summary
The per-activity Live Activity push token was reported to every configured server. An activity is owned by the single server that started it, so this reports the token only to that server — identified by the `webhook_id` the relay/handler records in the activity attributes (`HALiveActivityAttributes.serverWebhookId`). Other servers no longer receive a token for an activity they didn't start.

To avoid ever dropping a token, two cases fall back to reporting to all servers (the prior behaviour): activities created before the origin was recorded (no `webhook_id`), and an origin id that matches no current server (its server was removed, or the id is unrecognised).