### PR TITLE
Migrate CallbackURLKit, UIColor-Hex-Swift and KeychainAccess to SPM

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -23,6 +23,16 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+	CA11B4CC0000000000000011 /* CallbackURLKit in Frameworks */ = {isa = PBXBuildFile; productRef = CA11B4CC0000000000000010 /* CallbackURLKit */; };
+	C010F1E50000000000000011 /* UIColorHexSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C010F1E50000000000000010 /* UIColorHexSwift */; };
+	C010F1E50000000000000021 /* UIColorHexSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C010F1E50000000000000020 /* UIColorHexSwift */; };
+	C010F1E50000000000000031 /* UIColorHexSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C010F1E50000000000000030 /* UIColorHexSwift */; };
+	C010F1E50000000000000041 /* UIColorHexSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C010F1E50000000000000040 /* UIColorHexSwift */; };
+	CEA1C4A10000000000000011 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CEA1C4A10000000000000010 /* KeychainAccess */; };
+	CEA1C4A10000000000000021 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CEA1C4A10000000000000020 /* KeychainAccess */; };
+	CEA1C4A10000000000000031 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CEA1C4A10000000000000030 /* KeychainAccess */; };
+	CEA1C4A10000000000000041 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CEA1C4A10000000000000040 /* KeychainAccess */; };
+	CEA1C4A10000000000000051 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CEA1C4A10000000000000050 /* KeychainAccess */; };
 		00345F0517E14EC186DFB25D /* TestFlightCommunicationEngine.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EE842480AD406D8305F377 /* TestFlightCommunicationEngine.test.swift */; };
 		00C267608DCC88B783816CBF /* FanIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6888525DCF492642BA7EA3 /* FanIntent.swift */; };
 		01783C74005B40978CE7508B /* NotificationIdentifierField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99EC7EF1136575D0E7A17091 /* NotificationIdentifierField.swift */; };
@@ -3659,6 +3669,7 @@
 			files = (
 				42FA000000000000000C0002 /* WebRTC in Frameworks */,
 				42FA000000000000000C0009 /* SFSafeSymbols in Frameworks */,
+				CEA1C4A10000000000000041 /* KeychainAccess in Frameworks */,
 				B6E42613215C4333007FEB7E /* Shared.framework in Frameworks */,
 				42A1F0B42E000000000000B4 /* Alamofire in Frameworks */,
 				B627CB0B1D83C87B0057173E /* UserNotificationsUI.framework in Frameworks */,
@@ -3673,6 +3684,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				50099BBED6A1441E8A6B6C5C /* SFSafeSymbols in Frameworks */,
+				CA11B4CC0000000000000011 /* CallbackURLKit in Frameworks */,
+				C010F1E50000000000000031 /* UIColorHexSwift in Frameworks */,
+				CEA1C4A10000000000000011 /* KeychainAccess in Frameworks */,
 				42B18FD72F38CA2300A1537A /* FirebaseMessaging in Frameworks */,
 				42A1F0B12E000000000000B1 /* Alamofire in Frameworks */,
 				1148A44E24E8B59100345050 /* WidgetKit.framework in Frameworks */,
@@ -3725,6 +3739,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				13E4D63B90C14B0DA25F2827 /* SFSafeSymbols in Frameworks */,
+				C010F1E50000000000000021 /* UIColorHexSwift in Frameworks */,
+				CEA1C4A10000000000000031 /* KeychainAccess in Frameworks */,
 				427692E52B98B83200F24321 /* SharedPush in Frameworks */,
 				42A1F0B32E000000000000B3 /* Alamofire in Frameworks */,
 				6596FA74E1A501276EA62D86 /* Pods_watchOS_Shared_watchOS.framework in Frameworks */,
@@ -3748,6 +3764,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D29A20E07C24BE4ACFD33A2 /* SFSafeSymbols in Frameworks */,
+				C010F1E50000000000000041 /* UIColorHexSwift in Frameworks */,
+				CEA1C4A10000000000000051 /* KeychainAccess in Frameworks */,
 				42A1F0B72E000000000000B7 /* Alamofire in Frameworks */,
 				4273F7E02E258827000629F7 /* SharedPush in Frameworks */,
 				B67CE82B22200D420034C1D0 /* Shared.framework in Frameworks */,
@@ -3761,6 +3779,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				223B508E6D6C41C599FC6838 /* SFSafeSymbols in Frameworks */,
+				C010F1E50000000000000011 /* UIColorHexSwift in Frameworks */,
+				CEA1C4A10000000000000021 /* KeychainAccess in Frameworks */,
 				11B63B0F297A19DC00D908ED /* MatterSupport.framework in Frameworks */,
 				1182620A24F9D2EE000795C6 /* CoreMediaIO.framework in Frameworks */,
 				D0EEF301214D8EAB00D1D360 /* CoreLocation.framework in Frameworks */,
@@ -7817,6 +7837,7 @@
 				42FA000000000000000C0008 /* SFSafeSymbols */,
 				3932B484D8AF4C056AB1A84D /* GRDB */,
 				42A1F0A42E000000000000A4 /* Alamofire */,
+				CEA1C4A10000000000000040 /* KeychainAccess */,
 			);
 			productName = NotificationContentExtension;
 			productReference = B627CB071D83C87B0057173E /* HomeAssistant-Extensions-NotificationContent.appex */;
@@ -7857,6 +7878,9 @@
 				8BF085C5243838861E8635E7 /* GRDB */,
 				42A1F0A12E000000000000A1 /* Alamofire */,
 				EBD991757B454B819925F6B9 /* SFSafeSymbols */,
+				CA11B4CC0000000000000010 /* CallbackURLKit */,
+				C010F1E50000000000000030 /* UIColorHexSwift */,
+				CEA1C4A10000000000000010 /* KeychainAccess */,
 			);
 			productName = HomeAssistant;
 			productReference = B657A8E61CA646EB00121384 /* Home Assistant Δ.app */;
@@ -7950,6 +7974,8 @@
 				B19185B1C20DABFD5B0D1B5D /* GRDB */,
 				42A1F0A32E000000000000A3 /* Alamofire */,
 				C8FA7E5B23954D258050DD72 /* SFSafeSymbols */,
+				C010F1E50000000000000020 /* UIColorHexSwift */,
+				CEA1C4A10000000000000030 /* KeychainAccess */,
 			);
 			productName = "Shared-watchOS";
 			productReference = B67CE82422200D420034C1D0 /* Shared.framework */;
@@ -8017,6 +8043,8 @@
 				E516764DF55905E4F0FE2003 /* GRDB */,
 				CB3CFAA8C32849229F7F7B59 /* SFSafeSymbols */,
 				42A1F0A72E000000000000A7 /* Alamofire */,
+				C010F1E50000000000000040 /* UIColorHexSwift */,
+				CEA1C4A10000000000000050 /* KeychainAccess */,
 			);
 			productName = "WatchApp Extension";
 			productReference = B6CC5D8E2159D10E00833E5D /* HomeAssistant-WatchExtension-Watch.appex */;
@@ -8046,6 +8074,8 @@
 				638EC9AD85B8C58C9C77DCC7 /* GRDB */,
 				42A1F0A22E000000000000A2 /* Alamofire */,
 				294DFA6C65284F6E95CC08F1 /* SFSafeSymbols */,
+				C010F1E50000000000000010 /* UIColorHexSwift */,
+				CEA1C4A10000000000000020 /* KeychainAccess */,
 			);
 			productName = Shared;
 			productReference = D03D891720E0A85200D4F28D /* Shared.framework */;
@@ -8306,6 +8336,9 @@
 				42F384032FB49C9500390AFC /* XCRemoteSwiftPackageReference "DebugSwift" */,
 				5C81525C99BE463C89623E8D /* XCRemoteSwiftPackageReference "SFSafeSymbols" */,
 				CEF4014BDE11E7E12A6C1F73 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
+				CA11B4CC0000000000000001 /* XCRemoteSwiftPackageReference "CallbackURLKit" */,
+				C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */,
+				CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 			);
 			productRefGroup = B657A8E71CA646EB00121384 /* Products */;
 			projectDirPath = "";
@@ -12072,6 +12105,30 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+	CA11B4CC0000000000000001 /* XCRemoteSwiftPackageReference "CallbackURLKit" */ = {
+		isa = XCRemoteSwiftPackageReference;
+		repositoryURL = "https://github.com/phimage/CallbackURLKit.git";
+		requirement = {
+			kind = exactVersion;
+			version = 2.3.2;
+		};
+	};
+	C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */ = {
+		isa = XCRemoteSwiftPackageReference;
+		repositoryURL = "https://github.com/yeahdongcn/UIColor-Hex-Swift.git";
+		requirement = {
+			kind = exactVersion;
+			version = 5.1.9;
+		};
+	};
+	CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
+		isa = XCRemoteSwiftPackageReference;
+		repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess.git";
+		requirement = {
+			kind = exactVersion;
+			version = 4.2.2;
+		};
+	};
 		420E64BB2D676B2400A31E86 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
@@ -12139,6 +12196,56 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+	CA11B4CC0000000000000010 /* CallbackURLKit */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CA11B4CC0000000000000001 /* XCRemoteSwiftPackageReference "CallbackURLKit" */;
+		productName = CallbackURLKit;
+	};
+	C010F1E50000000000000010 /* UIColorHexSwift */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */;
+		productName = UIColorHexSwift;
+	};
+	C010F1E50000000000000020 /* UIColorHexSwift */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */;
+		productName = UIColorHexSwift;
+	};
+	C010F1E50000000000000030 /* UIColorHexSwift */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */;
+		productName = UIColorHexSwift;
+	};
+	C010F1E50000000000000040 /* UIColorHexSwift */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = C010F1E50000000000000001 /* XCRemoteSwiftPackageReference "UIColor-Hex-Swift" */;
+		productName = UIColorHexSwift;
+	};
+	CEA1C4A10000000000000010 /* KeychainAccess */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+		productName = KeychainAccess;
+	};
+	CEA1C4A10000000000000020 /* KeychainAccess */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+		productName = KeychainAccess;
+	};
+	CEA1C4A10000000000000030 /* KeychainAccess */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+		productName = KeychainAccess;
+	};
+	CEA1C4A10000000000000040 /* KeychainAccess */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+		productName = KeychainAccess;
+	};
+	CEA1C4A10000000000000050 /* KeychainAccess */ = {
+		isa = XCSwiftPackageProductDependency;
+		package = CEA1C4A10000000000000001 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+		productName = KeychainAccess;
+	};
 		067B845F1477358424F0C5FD /* GRDB */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CEF4014BDE11E7E12A6C1F73 /* XCRemoteSwiftPackageReference "GRDB.swift" */;

--- a/HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HomeAssistant.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5dba052ae32874c9548f68bbf06fa235c3391f8914a82aa80579228f7417fcec",
+  "originHash" : "97da907994d3036c3561f73ed946c5bdf6b3f2747f4e8d1c8914353a648e0a67",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "callbackurlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/phimage/CallbackURLKit.git",
+      "state" : {
+        "revision" : "28664b3d4f37bb359d5ed729aa463cbedfba5d82",
+        "version" : "2.3.2"
       }
     },
     {
@@ -119,6 +128,15 @@
       }
     },
     {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
@@ -179,6 +197,15 @@
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "uicolor-hex-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yeahdongcn/UIColor-Hex-Swift.git",
+      "state" : {
+        "revision" : "f37f97bc1a5b545b39ab5330e133e56fa4f38cff",
+        "version" : "5.1.9"
       }
     },
     {

--- a/Podfile
+++ b/Podfile
@@ -22,13 +22,11 @@ end
 plugin 'cocoapods-acknowledgements'
 
 pod 'Communicator', git: 'https://github.com/zacwest/Communicator.git', branch: 'observation-memory-direct'
-pod 'KeychainAccess'
 pod 'ObjectMapper', git: 'https://github.com/tristanhimmelman/ObjectMapper.git', branch: 'master'
 pod 'PromiseKit', '~> 8.1.1'
 pod 'Improv-iOS', '~> 0.0.6'
 
 pod 'RealmSwift'
-pod 'UIColor_Hex_Swift'
 pod 'Version'
 pod 'XCGLogger'
 
@@ -65,7 +63,6 @@ abstract_target 'iOS' do
   end
 
   target 'App' do
-    pod 'CallbackURLKit'
     pod 'CPDAcknowledgements', git: 'https://github.com/CocoaPods/CPDAcknowledgements', branch: 'master'
 
     support_modules

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,4 @@
 PODS:
-  - CallbackURLKit (2.3.0):
-    - CallbackURLKit/Core (= 2.3.0)
-  - CallbackURLKit/Core (2.3.0)
   - Communicator (4.1.0)
   - CPDAcknowledgements (1.0.0)
   - EMTLoadingIndicator (4.0.0)
@@ -15,7 +12,6 @@ PODS:
     - HAKit/Core
     - PromiseKit (~> 8.1.1)
   - Improv-iOS (0.0.6)
-  - KeychainAccess (4.2.2)
   - MBProgressHUD (1.2.0)
   - ObjcExceptionBridging (1.0.1):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 1.0.1)
@@ -54,7 +50,6 @@ PODS:
   - SwiftFormat/CLI (0.53.1)
   - SwiftGen (6.5.1)
   - SwiftLint (0.54.0)
-  - UIColor_Hex_Swift (5.1.9)
   - Version (0.8.0)
   - XCGLogger (7.0.1):
     - XCGLogger/Core (= 7.0.1)
@@ -62,7 +57,6 @@ PODS:
     - ObjcExceptionBridging
 
 DEPENDENCIES:
-  - CallbackURLKit
   - Communicator (from `https://github.com/zacwest/Communicator.git`, branch `observation-memory-direct`)
   - CPDAcknowledgements (from `https://github.com/CocoaPods/CPDAcknowledgements`, branch `master`)
   - EMTLoadingIndicator (from `https://github.com/hirokimu/EMTLoadingIndicator`, branch `master`)
@@ -70,7 +64,6 @@ DEPENDENCIES:
   - HAKit/Mocks (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.16`)
   - HAKit/PromiseKit (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.16`)
   - Improv-iOS (~> 0.0.6)
-  - KeychainAccess
   - MBProgressHUD (~> 1.2.0)
   - ObjectMapper (from `https://github.com/tristanhimmelman/ObjectMapper.git`, branch `master`)
   - OHHTTPStubs/Swift
@@ -82,15 +75,12 @@ DEPENDENCIES:
   - SwiftFormat/CLI (= 0.53.1)
   - SwiftGen (~> 6.5.0)
   - SwiftLint (= 0.54.0)
-  - UIColor_Hex_Swift
   - Version
   - XCGLogger
 
 SPEC REPOS:
   trunk:
-    - CallbackURLKit
     - Improv-iOS
-    - KeychainAccess
     - MBProgressHUD
     - ObjcExceptionBridging
     - OHHTTPStubs
@@ -101,7 +91,6 @@ SPEC REPOS:
     - SwiftFormat
     - SwiftGen
     - SwiftLint
-    - UIColor_Hex_Swift
     - Version
     - XCGLogger
 
@@ -152,13 +141,11 @@ CHECKOUT OPTIONS:
     :tag: 4.0.9
 
 SPEC CHECKSUMS:
-  CallbackURLKit: a940d1b869c70e1fa700ea06f988ba2a8963dafb
   Communicator: 027085fbfac0fbb02c8e045f5f409df0882e1630
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
   EMTLoadingIndicator: 0d3256b0de3e6ba5ab17048acc7aa93af34e48d3
   HAKit: ef185a67991484219a7ecd74aab25f186274d7dd
   Improv-iOS: 8973990c1b1f3e3aed7fc600c8efce95359cadd0
-  KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
   ObjectMapper: 5a6c9f063ef67e7fc0d7eb8958919e3121396a96
@@ -172,10 +159,9 @@ SPEC CHECKSUMS:
   SwiftFormat: a8623113c7adcbeb4289a013cac68ec801e1ed24
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
-  UIColor_Hex_Swift: 20cb4e8d51b63e168a9da6933bc5d39cd8fb4ab5
   Version: de5907f2c5d0f3cf21708db7801d1d5401139486
   XCGLogger: 1943831ef907df55108b0b18657953f868de973b
 
-PODFILE CHECKSUM: e49a34370ffb33387e79fbac036223c420cacd00
+PODFILE CHECKSUM: 92d87b5a274e2b51fd9c4adf5a7e895b58f6c0ee
 
 COCOAPODS: 1.15.2

--- a/Sources/Shared/API/Models/WatchComplication.swift
+++ b/Sources/Shared/API/Models/WatchComplication.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ObjectMapper
 import RealmSwift
-import UIColor_Hex_Swift
+import UIColorHexSwift
 import UIKit
 #if os(watchOS)
 import ClockKit

--- a/Sources/Shared/Extensions/Color+Hex.swift
+++ b/Sources/Shared/Extensions/Color+Hex.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import UIColor_Hex_Swift
+import UIColorHexSwift
 
 public extension Color {
     init(hex: String) {


### PR DESCRIPTION
## Summary
Moves CallbackURLKit, UIColor-Hex-Swift and KeychainAccess from CocoaPods to Swift Package Manager.

- CallbackURLKit: 2.3.0 → 2.3.2 (first release with a valid SPM manifest)
- UIColor-Hex-Swift: 5.1.9 (imported as `UIColorHexSwift`)
- KeychainAccess: 4.2.2

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
