### PR TITLE
Remove close button from re-authentication empty state

### DIFF
--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
@@ -64,8 +64,10 @@ enum WebViewEmptyStateStyle: Equatable {
 
     var trailingHeaderAccessory: HeaderAccessory {
         switch self {
-        case .disconnected, .unauthenticated:
+        case .disconnected:
             .close
+        case .unauthenticated:
+            .none
         case .recoveredServerNeedingReauthentication:
             .settings
         }


### PR DESCRIPTION
## Summary

The in-session re-authentication empty state (`.unauthenticated`) showed a close button in its trailing header accessory. When a server token becomes invalid, `showReAuthPopup` loads `about:blank` behind the overlay before presenting it, so tapping close dismissed the overlay and left the user on a blank screen with no obvious way forward.

This removes the close button from the `.unauthenticated` style. The Settings button, the re-authenticate action, and the server picker remain available, so the user always has a way out. The `.disconnected` style keeps its close button (it has a real web view behind it), and this now matches the launch-time recovered-server re-authentication screen, which already omits a close button for the same reason.