### PR TITLE
Add Live Activities documentation link to settings

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -660,7 +660,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "legacy_actions.disclaimer" = "Legacy iOS Actions are not the recommended way to interact with Home Assistant anymore, please use Scripts, Scenes and Automations directly in your Widgets, Apple Watch and CarPlay.";
 "live_activity.accessibility.progress" = "Progress";
 "live_activity.default_title" = "Home Assistant";
-"live_activity.documentation" = "Learn more";
+"live_activity.documentation" = "Documentation";
 "live_activity.empty_state" = "No active Live Activities";
 "live_activity.end_all.button" = "End All Activities";
 "live_activity.end_all.confirm.button" = "End All";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -660,6 +660,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "legacy_actions.disclaimer" = "Legacy iOS Actions are not the recommended way to interact with Home Assistant anymore, please use Scripts, Scenes and Automations directly in your Widgets, Apple Watch and CarPlay.";
 "live_activity.accessibility.progress" = "Progress";
 "live_activity.default_title" = "Home Assistant";
+"live_activity.documentation" = "Learn more";
 "live_activity.empty_state" = "No active Live Activities";
 "live_activity.end_all.button" = "End All Activities";
 "live_activity.end_all.confirm.button" = "End All";

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -23,17 +23,6 @@ struct LiveActivitySettingsView: View {
                 subtitle: L10n.LiveActivity.subtitle
             )
 
-            Section {
-                Link(destination: AppConstants.WebURLs.liveActivitiesDocs) {
-                    HStack {
-                        Text(L10n.LiveActivity.documentation)
-                        Spacer()
-                        Image(systemSymbol: .arrowUpForwardSquare)
-                            .font(.caption)
-                    }
-                }
-            }
-
             statusSection
 
             if activities.isEmpty {
@@ -87,6 +76,17 @@ struct LiveActivitySettingsView: View {
             }
 
             samplesSection
+
+            Section {
+                Link(destination: AppConstants.WebURLs.liveActivitiesDocs) {
+                    HStack {
+                        Text(L10n.LiveActivity.documentation)
+                        Spacer()
+                        Image(systemSymbol: .arrowUpForwardSquare)
+                            .font(.caption)
+                    }
+                }
+            }
         }
         .task { await loadActivities() }
     }

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -23,6 +23,17 @@ struct LiveActivitySettingsView: View {
                 subtitle: L10n.LiveActivity.subtitle
             )
 
+            Section {
+                Link(destination: AppConstants.WebURLs.liveActivitiesDocs) {
+                    HStack {
+                        Text(L10n.LiveActivity.documentation)
+                        Spacer()
+                        Image(systemSymbol: .arrowUpForwardSquare)
+                            .font(.caption)
+                    }
+                }
+            }
+
             statusSection
 
             if activities.isEmpty {

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -30,6 +30,8 @@ public enum AppConstants {
             URL(string: "https://companion.home-assistant.io/app/ios/local-push")!
         public static var nfcDocs =
             URL(string: "https://companion.home-assistant.io/app/ios/nfc")!
+        public static var liveActivitiesDocs =
+            URL(string: "https://companion.home-assistant.io/docs/notifications/live-activities")!
     }
 
     public enum QueryItems: String, CaseIterable {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2300,7 +2300,7 @@ public enum L10n {
   public enum LiveActivity {
     /// Home Assistant
     public static var defaultTitle: String { return L10n.tr("Localizable", "live_activity.default_title") }
-    /// Learn more
+    /// Documentation
     public static var documentation: String { return L10n.tr("Localizable", "live_activity.documentation") }
     /// No active Live Activities
     public static var emptyState: String { return L10n.tr("Localizable", "live_activity.empty_state") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2300,6 +2300,8 @@ public enum L10n {
   public enum LiveActivity {
     /// Home Assistant
     public static var defaultTitle: String { return L10n.tr("Localizable", "live_activity.default_title") }
+    /// Learn more
+    public static var documentation: String { return L10n.tr("Localizable", "live_activity.documentation") }
     /// No active Live Activities
     public static var emptyState: String { return L10n.tr("Localizable", "live_activity.empty_state") }
     /// Real-time Home Assistant updates on your Lock Screen and Dynamic Island.


### PR DESCRIPTION
## Summary

- Add the Live Activities documentation URL (`https://companion.home-assistant.io/docs/notifications/live-activities`) to `AppConstants.WebURLs`.
- Add a "Learn more" documentation link to the Live Activities settings screen, just below the header, opening the docs page.