### PR TITLE
Hide Edge to edge experimental section on Mac

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1258,6 +1258,9 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
+"settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";
+"settings_details.general.edge_to_edge.section_header" = "Experimental";
+"settings_details.general.edge_to_edge.title" = "Edge to edge display";
 "settings_details.general.full_screen.title" = "Full Screen";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";
 "settings_details.general.links.title" = "Links";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1258,6 +1258,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
+"settings_details.general.edge_to_edge.enabled.title" = "Enabled";
 "settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";
 "settings_details.general.edge_to_edge.title" = "Edge to edge display";
 "settings_details.general.full_screen.title" = "Full Screen";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1258,7 +1258,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
-"settings_details.general.edge_to_edge.enabled.title" = "Enabled";
+"settings_details.general.edge_to_edge.enabled.title" = "Enable";
 "settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";
 "settings_details.general.edge_to_edge.title" = "Edge to edge display";
 "settings_details.general.full_screen.title" = "Full Screen";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1259,7 +1259,6 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
 "settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";
-"settings_details.general.edge_to_edge.section_header" = "Experimental";
 "settings_details.general.edge_to_edge.title" = "Edge to edge display";
 "settings_details.general.full_screen.title" = "Full Screen";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -189,10 +189,10 @@ struct GeneralSettingsView: View {
                     Text(L10n.SettingsDetails.General.EdgeToEdge.Enabled.title)
                 }
             } header: {
-                HStack {
+                HStack(spacing: DesignSystem.Spaces.one) {
                     Text(L10n.SettingsDetails.General.EdgeToEdge.title)
-                    Spacer()
                     LabsLabel()
+                    Spacer()
                 }
             } footer: {
                 Text(L10n.SettingsDetails.General.EdgeToEdge.footer)

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -186,10 +186,12 @@ struct GeneralSettingsView: View {
                     Current.settingsStore.edgeToEdge = newValue
                     redrawView()
                 })) {
-                    Text(L10n.SettingsDetails.General.EdgeToEdge.title)
+                    HStack {
+                        Text(L10n.SettingsDetails.General.EdgeToEdge.title)
+                        Spacer()
+                        LabsLabel()
+                    }
                 }
-            } header: {
-                Text(L10n.SettingsDetails.General.EdgeToEdge.sectionHeader)
             } footer: {
                 Text(L10n.SettingsDetails.General.EdgeToEdge.footer)
             }

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -178,8 +178,8 @@ struct GeneralSettingsView: View {
 
     @ViewBuilder
     private var edgeToEdge: some View {
-        Section {
-            if !Current.isCatalyst {
+        if !Current.isCatalyst {
+            Section {
                 Toggle(isOn: .init(get: {
                     Current.settingsStore.edgeToEdge
                 }, set: { newValue in
@@ -188,13 +188,13 @@ struct GeneralSettingsView: View {
                 })) {
                     Text("Edge to edge display")
                 }
+            } header: {
+                Text("Experimental")
+            } footer: {
+                Text(
+                    "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues."
+                )
             }
-        } header: {
-            Text("Experimental")
-        } footer: {
-            Text(
-                "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues."
-            )
         }
     }
 

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -186,14 +186,12 @@ struct GeneralSettingsView: View {
                     Current.settingsStore.edgeToEdge = newValue
                     redrawView()
                 })) {
-                    Text("Edge to edge display")
+                    Text(L10n.SettingsDetails.General.EdgeToEdge.title)
                 }
             } header: {
-                Text("Experimental")
+                Text(L10n.SettingsDetails.General.EdgeToEdge.sectionHeader)
             } footer: {
-                Text(
-                    "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues."
-                )
+                Text(L10n.SettingsDetails.General.EdgeToEdge.footer)
             }
         }
     }

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -186,11 +186,13 @@ struct GeneralSettingsView: View {
                     Current.settingsStore.edgeToEdge = newValue
                     redrawView()
                 })) {
-                    HStack {
-                        Text(L10n.SettingsDetails.General.EdgeToEdge.title)
-                        Spacer()
-                        LabsLabel()
-                    }
+                    Text(L10n.SettingsDetails.General.EdgeToEdge.Enabled.title)
+                }
+            } header: {
+                HStack {
+                    Text(L10n.SettingsDetails.General.EdgeToEdge.title)
+                    Spacer()
+                    LabsLabel()
                 }
             } footer: {
                 Text(L10n.SettingsDetails.General.EdgeToEdge.footer)

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -192,7 +192,6 @@ struct GeneralSettingsView: View {
                 HStack(spacing: DesignSystem.Spaces.one) {
                     Text(L10n.SettingsDetails.General.EdgeToEdge.title)
                     LabsLabel()
-                    Spacer()
                 }
             } footer: {
                 Text(L10n.SettingsDetails.General.EdgeToEdge.footer)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4301,7 +4301,7 @@ public enum L10n {
         /// Edge to edge display
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.title") }
         public enum Enabled {
-          /// Enabled
+          /// Enable
           public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.enabled.title") }
         }
       }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4300,6 +4300,10 @@ public enum L10n {
         public static var footer: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.footer") }
         /// Edge to edge display
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.title") }
+        public enum Enabled {
+          /// Enabled
+          public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.enabled.title") }
+        }
       }
       public enum FullScreen {
         /// Full Screen

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4295,6 +4295,14 @@ public enum L10n {
         /// Device Name
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.device_name.title") }
       }
+      public enum EdgeToEdge {
+        /// Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.
+        public static var footer: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.footer") }
+        /// Experimental
+        public static var sectionHeader: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.section_header") }
+        /// Edge to edge display
+        public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.title") }
+      }
       public enum FullScreen {
         /// Full Screen
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.full_screen.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4298,8 +4298,6 @@ public enum L10n {
       public enum EdgeToEdge {
         /// Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.
         public static var footer: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.footer") }
-        /// Experimental
-        public static var sectionHeader: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.section_header") }
         /// Edge to edge display
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.title") }
       }


### PR DESCRIPTION
## Summary
- The "Edge to edge display" toggle in General Settings was already hidden on Mac Catalyst via `!Current.isCatalyst`, but the surrounding `Section` (with its "Experimental" header and footer explanation text) was not gated the same way, so an empty "Experimental" section still leaked through on Mac.
- Moved the `!Current.isCatalyst` check to wrap the entire `Section`, so the header/footer disappear along with the toggle on Mac.