### PR TITLE
Merge Watch script/scene picker into one entity list, add automations

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -764,6 +764,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "magic_item.item_type.entity.list.title" = "Entity";
 "magic_item.item_type.scene.list.title" = "Scenes";
 "magic_item.item_type.script.list.title" = "Scripts";
+"magic_item.item_type.scripts_scenes_automations.list.title" = "Scripts, Scenes & Automations";
 "magic_item.item_type.selection.list.title" = "Item type";
 "magic_item.name.title" = "Name";
 "magic_item.name_and_icon.footer" = "Edit script name and icon in frontend under 'Settings' > 'Automations & scenes' > 'Scripts'.";

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -7,6 +7,7 @@ enum WatchSupportedDomains {
     static var all: [Domain] = [
         .script,
         .scene,
+        .automation,
     ]
 }
 

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -20,7 +20,7 @@ struct EntityPicker: View {
     init(
         selectedServerId: String? = nil,
         selectedEntity: Binding<HAAppEntity?>,
-        domainFilter: Domain?,
+        domainFilter: [Domain]?,
         mode: Mode = .button
     ) {
         self._selectedEntity = selectedEntity

--- a/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
@@ -34,14 +34,13 @@ final class EntityPickerViewModel: ObservableObject {
     private var cachedAreaIdToEntityIds: [String: Set<String>] = [:]
     private var cachedEntitiesByServer: [String: [HAAppEntity]] = [:]
 
-    let domainFilter: Domain?
+    let domainFilter: [Domain]?
     private var filterTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
     /// Returns true if any filter (excluding server) has a non-default value
     var hasActiveFilters: Bool {
-        let defaultDomainFilter = domainFilter?.rawValue
-        let isDomainFilterActive = selectedDomainFilter != defaultDomainFilter
+        let isDomainFilterActive = domainFilter == nil && selectedDomainFilter != nil
         let isAreaFilterActive = selectedAreaFilter != nil
         let isGroupingFilterActive = selectedGrouping != .area
         return isDomainFilterActive || isAreaFilterActive || isGroupingFilterActive
@@ -49,15 +48,15 @@ final class EntityPickerViewModel: ObservableObject {
 
     /// Resets all filters (except server) to their default values
     func resetFilters() {
-        selectedDomainFilter = domainFilter?.rawValue
+        selectedDomainFilter = nil
         selectedAreaFilter = nil
         selectedGrouping = .area
     }
 
-    init(domainFilter: Domain?, selectedServerId: String?) {
+    init(domainFilter: [Domain]?, selectedServerId: String?) {
         self.domainFilter = domainFilter
         self.selectedServerId = selectedServerId
-        self.selectedDomainFilter = domainFilter?.rawValue
+        self.selectedDomainFilter = nil
         setupFiltering()
     }
 
@@ -156,7 +155,8 @@ final class EntityPickerViewModel: ObservableObject {
         }
 
         if let domainFilter {
-            groups = groups.filter { $0.key == domainFilter.rawValue }
+            let allowedDomains = Set(domainFilter.map(\.rawValue))
+            groups = groups.filter { allowedDomains.contains($0.key) }
         }
 
         entitiesByDomain = groups
@@ -172,7 +172,8 @@ final class EntityPickerViewModel: ObservableObject {
     private func performFiltering() async {
         // Snapshot state needed for filtering
         let searchTerm = searchTerm
-        let domainFilter = selectedDomainFilter
+        let presetDomains = domainFilter.map { Set($0.map(\.rawValue)) }
+        let selectedDomainFilter = selectedDomainFilter
         let areaFilter = selectedAreaFilter
         let grouping = selectedGrouping
         let noAreaTitle = L10n.EntityPicker.List.Area.NoArea.title
@@ -190,8 +191,11 @@ final class EntityPickerViewModel: ObservableObject {
 
             // First, filter entities by domain, area, and search
             let filteredEntities = serverScopedEntities.filter { entity in
-                // Filter by domain if set
-                if let domainFilter, entity.domain != domainFilter { return false }
+                // Filter by the preset domain(s), if any were provided by the caller
+                if let presetDomains, !presetDomains.contains(entity.domain) { return false }
+
+                // Filter by the user-selected domain (only offered when there's no preset)
+                if let selectedDomainFilter, entity.domain != selectedDomainFilter { return false }
 
                 // Filter by area if set
                 if let areaEntityIds, !areaEntityIds.contains(entity.entityId) { return false }

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
@@ -12,8 +12,7 @@ struct MagicItemAddView: View {
 
     enum PickerOption {
         case entities
-        case scripts
-        case scenes
+        case scriptsScenesAutomations
         case assistPipelines
     }
 
@@ -44,8 +43,7 @@ struct MagicItemAddView: View {
                 // In other context user can just select entities directly
                 // In Apple watch we don't have entity support yet
                 if context == .watch {
-                    options.append(.scripts)
-                    options.append(.scenes)
+                    options.append(.scriptsScenesAutomations)
                 }
             }
             if [.carPlay, .appIconShortcut].contains(context), #available(iOS 26.0, *) {
@@ -70,17 +68,11 @@ struct MagicItemAddView: View {
                             .padding(.horizontal)
                         entitiesPerServerList()
                     }
-                case .scripts:
+                case .scriptsScenesAutomations:
                     VStack {
                         pickerView
                             .padding(.horizontal)
-                        entitiesPerServerList(domainFilter: .script)
-                    }
-                case .scenes:
-                    VStack {
-                        pickerView
-                            .padding(.horizontal)
-                        entitiesPerServerList(domainFilter: .scene)
+                        entitiesPerServerList(domainFilter: [.script, .scene, .automation])
                     }
                 case .assistPipelines:
                     VStack {
@@ -130,12 +122,9 @@ struct MagicItemAddView: View {
                     case .entities:
                         Text(verbatim: L10n.MagicItem.ItemType.Entity.List.title)
                             .tag(MagicItemAddType.entities)
-                    case .scripts:
-                        Text(verbatim: L10n.MagicItem.ItemType.Script.List.title)
-                            .tag(MagicItemAddType.scripts)
-                    case .scenes:
-                        Text(verbatim: L10n.MagicItem.ItemType.Scene.List.title)
-                            .tag(MagicItemAddType.scenes)
+                    case .scriptsScenesAutomations:
+                        Text(verbatim: L10n.MagicItem.ItemType.ScriptsScenesAutomations.List.title)
+                            .tag(MagicItemAddType.scriptsScenesAutomations)
                     case .assistPipelines:
                         Text(verbatim: L10n.Widgets.Action.Name.assist)
                             .tag(MagicItemAddType.assistPipelines)
@@ -161,10 +150,8 @@ struct MagicItemAddView: View {
             switch firstOption {
             case .entities:
                 return .entities
-            case .scripts:
-                return .scripts
-            case .scenes:
-                return .scenes
+            case .scriptsScenesAutomations:
+                return .scriptsScenesAutomations
             case .assistPipelines:
                 return .assistPipelines
             }
@@ -172,14 +159,14 @@ struct MagicItemAddView: View {
 
         switch context {
         case .watch:
-            return .scripts
+            return .scriptsScenesAutomations
         case .carPlay, .widget, .appIconShortcut:
             return .entities
         }
     }
 
     @ViewBuilder
-    private func entitiesPerServerList(domainFilter: Domain? = nil) -> some View {
+    private func entitiesPerServerList(domainFilter: [Domain]? = nil) -> some View {
         EntityPicker(
             selectedServerId: Current.servers.all
                 .first(where: { $0.identifier.rawValue == viewModel.selectedServerId })?.identifier.rawValue,

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
@@ -17,10 +17,9 @@ struct MagicItemAddView: View {
     }
 
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel = MagicItemAddViewModel()
+    @StateObject private var viewModel: MagicItemAddViewModel
     @State private var selectedEntity: HAAppEntity?
     private let visiblePickerOptions: [PickerOption]
-    private let initialItemType: MagicItemAddType
 
     let context: Context
     let itemToAdd: (MagicItem?) -> Void
@@ -52,10 +51,11 @@ struct MagicItemAddView: View {
             return options
         }()
         self.visiblePickerOptions = resolvedPickerOptions
-        self.initialItemType = initialItemType ?? Self.defaultItemType(
+        let resolvedInitialItemType = initialItemType ?? Self.defaultItemType(
             for: context,
             visiblePickerOptions: resolvedPickerOptions
         )
+        self._viewModel = StateObject(wrappedValue: MagicItemAddViewModel(selectedItemType: resolvedInitialItemType))
     }
 
     var body: some View {
@@ -86,8 +86,6 @@ struct MagicItemAddView: View {
                 }
             }
             .onAppear {
-                autoSelectItemType()
-
                 if viewModel.selectedServerId == nil {
                     viewModel.selectedServerId = Current.servers.all.first?.identifier.rawValue
                 }
@@ -136,10 +134,6 @@ struct MagicItemAddView: View {
             .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
             .padding(.top)
         }
-    }
-
-    private func autoSelectItemType() {
-        viewModel.selectedItemType = initialItemType
     }
 
     private static func defaultItemType(

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddViewModel.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddViewModel.swift
@@ -8,6 +8,10 @@ enum MagicItemAddType {
 }
 
 final class MagicItemAddViewModel: ObservableObject {
-    @Published var selectedItemType = MagicItemAddType.scriptsScenesAutomations
+    @Published var selectedItemType: MagicItemAddType
     @Published var selectedServerId: String?
+
+    init(selectedItemType: MagicItemAddType) {
+        self.selectedItemType = selectedItemType
+    }
 }

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddViewModel.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddViewModel.swift
@@ -2,13 +2,12 @@ import Combine
 import Foundation
 
 enum MagicItemAddType {
-    case scripts
-    case scenes
+    case scriptsScenesAutomations
     case entities
     case assistPipelines
 }
 
 final class MagicItemAddViewModel: ObservableObject {
-    @Published var selectedItemType = MagicItemAddType.scripts
+    @Published var selectedItemType = MagicItemAddType.scriptsScenesAutomations
     @Published var selectedServerId: String?
 }

--- a/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
+++ b/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
@@ -298,7 +298,7 @@ struct MagicItemCustomizationView: View {
     private var scriptActionDetails: some View {
         HStack {
             Text(verbatim: L10n.MagicItem.Action.Script.title)
-            EntityPicker(selectedEntity: $viewModel.selectedEntity, domainFilter: .script)
+            EntityPicker(selectedEntity: $viewModel.selectedEntity, domainFilter: [.script])
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .onChange(of: viewModel.selectedEntity) { newValue in
                     guard let newValue else { return }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2676,6 +2676,12 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "magic_item.item_type.script.list.title") }
         }
       }
+      public enum ScriptsScenesAutomations {
+        public enum List {
+          /// Scripts, Scenes & Automations
+          public static var title: String { return L10n.tr("Localizable", "magic_item.item_type.scripts_scenes_automations.list.title") }
+        }
+      }
       public enum Selection {
         public enum List {
           /// Item type

--- a/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
+++ b/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
@@ -45,7 +45,7 @@ private extension AppArea {
 @Suite("EntityPickerViewModel")
 struct EntityPickerViewModelTests {
     private func makeVM(
-        domainFilter: Domain? = nil,
+        domainFilter: [Domain]? = nil,
         selectedServerId: String? = nil,
         entities: [HAAppEntity],
         areas: [AppArea] = []


### PR DESCRIPTION
## Summary
- Replaces the segmented scripts/scenes toggle in the Apple Watch "add item" flow with a single entity picker pre-filtered to scripts, scenes, and automations
- Adds automation support to the Watch (both the config screen's add flow and the "Add to Watch" action from the web frontend)
- `EntityPicker`/`EntityPickerViewModel` now accept an array of domains to filter by, instead of just one, so a single picker can span multiple entity types at once