### PR TITLE
Consolidate per-feature supported-domain lists as Domain statics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     activesupport (7.1.3)
       base64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.8)
+    CFPropertyList (3.0.9)
     abbrev (0.1.2)
     activesupport (7.1.3)
       base64

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -33,7 +33,7 @@ final class EntityAddToHandler {
                 // CarPlay is available on iPhone only (not iPad) for supported domains
                 #if !targetEnvironment(macCatalyst)
                 if !Current.isCatalyst, UIDevice.current.userInterfaceIdiom == .phone {
-                    let isCarPlaySupported = domain.map { CarPlaySupportedDomains.all.contains($0) } ?? false
+                    let isCarPlaySupported = domain.map { Domain.carPlaySupported.contains($0) } ?? false
                     if isCarPlaySupported {
                         actions.append(CarPlayQuickAccessAction())
                     }
@@ -43,7 +43,7 @@ final class EntityAddToHandler {
                 // Watch is available on iPhone for supported domains
                 #if os(iOS)
                 if !Current.isCatalyst {
-                    let isWatchSupported = domain.map { WatchSupportedDomains.all.contains($0) } ?? false
+                    let isWatchSupported = domain.map { Domain.watchSupported.contains($0) } ?? false
                     if isWatchSupported {
                         actions.append(WatchItemAction())
                     }

--- a/Sources/App/Scenes/CarPlaySceneDelegate.swift
+++ b/Sources/App/Scenes/CarPlaySceneDelegate.swift
@@ -6,20 +6,6 @@ import HAKit
 import PromiseKit
 import Shared
 
-enum CarPlaySupportedDomains {
-    static var all: [Domain] = [
-        .light,
-        .button,
-        .cover,
-        .inputBoolean,
-        .inputButton,
-        .lock,
-        .scene,
-        .script,
-        .switch,
-    ]
-}
-
 @available(iOS 16.0, *)
 class CarPlaySceneDelegate: UIResponder {
     private var interfaceController: CPInterfaceController?
@@ -30,7 +16,7 @@ class CarPlaySceneDelegate: UIResponder {
     private var serversListTemplate: (any CarPlayTemplateProvider)?
     private var quickAccessListTemplate: (any CarPlayTemplateProvider)?
     private var areasZonesListTemplate: (any CarPlayTemplateProvider)?
-    private var includedDomains: [Domain] = CarPlaySupportedDomains.all
+    private var includedDomains: [Domain] = Domain.carPlaySupported
 
     private var allTemplates: [any CarPlayTemplateProvider] {
         [

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -3,14 +3,6 @@ import Shared
 import StoreKit
 import SwiftUI
 
-enum WatchSupportedDomains {
-    static var all: [Domain] = [
-        .script,
-        .scene,
-        .automation,
-    ]
-}
-
 struct WatchConfigurationView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: WatchConfigurationViewModel

--- a/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsConfig.swift
+++ b/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsConfig.swift
@@ -2,5 +2,5 @@ import Foundation
 import Shared
 
 enum WidgetSensorsConfig {
-    static var domains: [Domain] = [.sensor, .binarySensor, .inputBoolean, .person, .lock]
+    static var domains: [Domain] { Domain.sensorWidgetSupported }
 }

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
@@ -21,9 +21,6 @@ struct WidgetCommonlyUsedEntitiesTimelineProvider: WidgetSingleEntryTimelineProv
         WidgetCommonlyUsedEntitiesConstants.expiration
     }
 
-    /// Domains supported by this widget for entity filtering and display
-    static let supportedDomains: [Domain] = [.light, .switch, .cover, .fan]
-
     /// Cache is considered valid for 1 second to handle iOS widget reload bug
     /// that triggers multiple timeline refreshes
     private static let cacheValiditySeconds: TimeInterval = 1
@@ -99,7 +96,7 @@ struct WidgetCommonlyUsedEntitiesTimelineProvider: WidgetSingleEntryTimelineProv
 
         let filteredEntities = entities.filter { entityId in
             guard let domain = Domain(entityId: entityId) else { return false }
-            return Self.supportedDomains.contains(domain)
+            return Domain.commonlyUsedWidgetSupported.contains(domain)
         }
 
         let magicItems = filteredEntities.map { entityId in

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -7,23 +7,7 @@ public protocol AppEntitiesModelProtocol {
 }
 
 public enum HAAppUsedContent {
-    public static let domains: [Domain] = [
-        .automation,
-        .scene,
-        .script,
-        .light,
-        .switch,
-        .sensor,
-        .binarySensor,
-        .cover,
-        .button,
-        .inputBoolean,
-        .inputButton,
-        .lock,
-        .camera,
-        .fan,
-        .todo,
-    ]
+    public static let domains: [Domain] = Domain.appDatabasePersisted
 
     public static var rawValues: [String] = domains.map(\.rawValue)
 }

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -498,7 +498,7 @@ public enum Domain: String, CaseIterable {
     }
 
     public var isCarPlaySupported: Bool {
-        carPlaySupportedDomains.contains(self)
+        Domain.carPlaySupported.contains(self)
     }
 
     public func localizedState(for state: String) -> String {
@@ -526,24 +526,61 @@ public enum Domain: String, CaseIterable {
     }
 }
 
-// MARK: - CarPlay
+// MARK: - Feature supported domains
 
 public extension Domain {
-    var carPlaySupportedDomains: [Domain] {
-        [
-            .automation,
-            .button,
-            .cover,
-            .fan,
-            .inputBoolean,
-            .inputButton,
-            .light,
-            .lock,
-            .scene,
-            .script,
-            .switch,
-        ]
-    }
+    static let carPlaySupported: [Domain] = [
+        .automation,
+        .button,
+        .cover,
+        .fan,
+        .inputBoolean,
+        .inputButton,
+        .light,
+        .lock,
+        .scene,
+        .script,
+        .switch,
+    ]
+
+    static let watchSupported: [Domain] = [
+        .script,
+        .scene,
+        .automation,
+    ]
+
+    static let commonlyUsedWidgetSupported: [Domain] = [
+        .light,
+        .switch,
+        .cover,
+        .fan,
+    ]
+
+    static let sensorWidgetSupported: [Domain] = [
+        .sensor,
+        .binarySensor,
+        .inputBoolean,
+        .person,
+        .lock,
+    ]
+
+    static let appDatabasePersisted: [Domain] = [
+        .automation,
+        .scene,
+        .script,
+        .light,
+        .switch,
+        .sensor,
+        .binarySensor,
+        .cover,
+        .button,
+        .inputBoolean,
+        .inputButton,
+        .lock,
+        .camera,
+        .fan,
+        .todo,
+    ]
 }
 
 // MARK: - Main Action

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -529,7 +529,7 @@ public enum Domain: String, CaseIterable {
 // MARK: - Feature supported domains
 
 public extension Domain {
-public static let carPlaySupported: [Domain] = [
+    static let carPlaySupported: [Domain] = [
         .automation,
         .button,
         .cover,
@@ -543,20 +543,20 @@ public static let carPlaySupported: [Domain] = [
         .switch,
     ]
 
-public static let watchSupported: [Domain] = [
+    static let watchSupported: [Domain] = [
         .script,
         .scene,
         .automation,
     ]
 
-public static let commonlyUsedWidgetSupported: [Domain] = [
+    static let commonlyUsedWidgetSupported: [Domain] = [
         .light,
         .switch,
         .cover,
         .fan,
     ]
 
-public static let sensorWidgetSupported: [Domain] = [
+    static let sensorWidgetSupported: [Domain] = [
         .sensor,
         .binarySensor,
         .inputBoolean,

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -529,7 +529,7 @@ public enum Domain: String, CaseIterable {
 // MARK: - Feature supported domains
 
 public extension Domain {
-    static let carPlaySupported: [Domain] = [
+public static let carPlaySupported: [Domain] = [
         .automation,
         .button,
         .cover,
@@ -543,20 +543,20 @@ public extension Domain {
         .switch,
     ]
 
-    static let watchSupported: [Domain] = [
+public static let watchSupported: [Domain] = [
         .script,
         .scene,
         .automation,
     ]
 
-    static let commonlyUsedWidgetSupported: [Domain] = [
+public static let commonlyUsedWidgetSupported: [Domain] = [
         .light,
         .switch,
         .cover,
         .fan,
     ]
 
-    static let sensorWidgetSupported: [Domain] = [
+public static let sensorWidgetSupported: [Domain] = [
         .sensor,
         .binarySensor,
         .inputBoolean,


### PR DESCRIPTION
## Summary
Moves the per-feature "supported domains" allowlists that were scattered across the codebase into a single source of truth as static properties on `Domain`: `carPlaySupported`, `watchSupported`, `commonlyUsedWidgetSupported`, `sensorWidgetSupported`, and `appDatabaseSupported` (the list the App database updater routine uses to decide which entities to persist). Each feature (CarPlay, Apple Watch, the commonly-used and sensor widgets, and the app-database persistence step) now references these instead of keeping its own local copy.

This also removes a pre-existing divergence between two CarPlay lists (one included `automation`/`fan`, the other did not) by unifying them into `Domain.carPlaySupported` (the fuller set). As a result CarPlay's entity subscription and the "Add to CarPlay" action now include `automation` and `fan`, consistent with the CarPlay domain-browse and add-item screens. No other feature's supported set changes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
