### PR TITLE
Expand per-feature supported domains to what already works for free

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -51,7 +51,7 @@ final class EntityAddToHandler {
                 #endif
 
                 // Widgets are available on all platforms
-                if let domain, HAAppUsedContent.domains.contains(domain) {
+                if let domain, !Domain.appDatabaseExcluded.contains(domain) {
                     actions.append(CustomWidgetAction())
                 }
 

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -6,14 +6,9 @@ public protocol AppEntitiesModelProtocol {
     func updateModel(_ entities: Set<HAEntity>, server: Server) async
 }
 
-public enum HAAppUsedContent {
-    public static let domains: [Domain] = Domain.appDatabasePersisted
-
-    public static var rawValues: [String] = domains.map(\.rawValue)
-}
-
 final class AppEntitiesModel: AppEntitiesModelProtocol {
     static var shared = AppEntitiesModel()
+    private static let excludedDomains = Set(Domain.appDatabaseExcluded.map(\.rawValue))
     /// ServerId: Date
     private var lastDatabaseUpdate: [String: Date] = [:]
     /// ServerId: Int
@@ -23,7 +18,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
         // Only update database after a few seconds or if the entities count changed
         // First check for time to avoid unnecessary filtering to check count
         if !checkLastDatabaseUpdateRecently(server: server) {
-            let appRelatedEntities = filterDomains(entities)
+            let appRelatedEntities = persistableEntities(entities)
             Current.Log
                 .verbose(
                     "Updating App Entities for \(server.info.name) checkLastDatabaseUpdateLessThanMinuteAgo false, lastDatabaseUpdate \(String(describing: lastDatabaseUpdate)) "
@@ -31,7 +26,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
             updateLastUpdate(entitiesCount: appRelatedEntities.count, server: server)
             await handle(appRelatedEntities: appRelatedEntities, server: server)
         } else {
-            let appRelatedEntities = filterDomains(entities)
+            let appRelatedEntities = persistableEntities(entities)
             if lastEntitiesCount[server.identifier.rawValue] != appRelatedEntities.count {
                 Current.Log
                     .verbose(
@@ -48,8 +43,8 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
         lastDatabaseUpdate[server.identifier.rawValue] = Date()
     }
 
-    private func filterDomains(_ entities: Set<HAEntity>) -> Set<HAEntity> {
-        entities.filter { HAAppUsedContent.rawValues.contains($0.domain) }
+    private func persistableEntities(_ entities: Set<HAEntity>) -> Set<HAEntity> {
+        entities.filter { !Self.excludedDomains.contains($0.domain) }
     }
 
     // Avoid updating database too often

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -534,6 +534,7 @@ public extension Domain {
         .button,
         .cover,
         .fan,
+        .humidifier,
         .inputBoolean,
         .inputButton,
         .light,
@@ -541,6 +542,7 @@ public extension Domain {
         .scene,
         .script,
         .switch,
+        .valve,
     ]
 
     static let watchSupported: [Domain] = [
@@ -554,6 +556,9 @@ public extension Domain {
         .switch,
         .cover,
         .fan,
+        .inputBoolean,
+        .humidifier,
+        .valve,
     ]
 
     static let sensorWidgetSupported: [Domain] = [
@@ -562,24 +567,27 @@ public extension Domain {
         .inputBoolean,
         .person,
         .lock,
+        .number,
+        .inputNumber,
+        .inputText,
+        .inputSelect,
+        .select,
+        .climate,
+        .weather,
+        .sun,
+        .deviceTracker,
+        .update,
     ]
 
-    static let appDatabasePersisted: [Domain] = [
-        .automation,
-        .scene,
-        .script,
-        .light,
-        .switch,
-        .sensor,
-        .binarySensor,
-        .cover,
-        .button,
-        .inputBoolean,
-        .inputButton,
-        .lock,
-        .camera,
-        .fan,
-        .todo,
+    static let appDatabaseExcluded: [Domain] = [
+        .geoLocation,
+        .conversation,
+        .stt,
+        .tts,
+        .wakeWord,
+        .assistSatellite,
+        .notify,
+        .image,
     ]
 }
 

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -305,3 +305,51 @@ struct MagicItemWidgetInteractionTests {
         #expect(readOnly == "widgetURL" || readOnly == "refresh")
     }
 }
+
+struct DomainFeatureSupportTests {
+    @Test func carPlaySupportedMembership() {
+        let expected: Set<Domain> = [
+            .automation, .button, .cover, .fan, .humidifier, .inputBoolean, .inputButton,
+            .light, .lock, .scene, .script, .switch, .valve,
+        ]
+        #expect(Set(Domain.carPlaySupported) == expected, "Domain.carPlaySupported membership changed")
+    }
+
+    @Test func watchSupportedMembership() {
+        let expected: Set<Domain> = [.script, .scene, .automation]
+        #expect(Set(Domain.watchSupported) == expected, "Domain.watchSupported membership changed")
+    }
+
+    @Test func commonlyUsedWidgetSupportedMembership() {
+        let expected: Set<Domain> = [.light, .switch, .cover, .fan, .inputBoolean, .humidifier, .valve]
+        #expect(Set(Domain.commonlyUsedWidgetSupported) == expected, "Domain.commonlyUsedWidgetSupported changed")
+    }
+
+    @Test func sensorWidgetSupportedMembership() {
+        let expected: Set<Domain> = [
+            .sensor, .binarySensor, .inputBoolean, .person, .lock, .number, .inputNumber,
+            .inputText, .inputSelect, .select, .climate, .weather, .sun, .deviceTracker, .update,
+        ]
+        #expect(Set(Domain.sensorWidgetSupported) == expected, "Domain.sensorWidgetSupported membership changed")
+    }
+
+    @Test func appDatabaseExcludedMembership() {
+        let expected: Set<Domain> = [
+            .geoLocation, .conversation, .stt, .tts, .wakeWord, .assistSatellite, .notify, .image,
+        ]
+        #expect(Set(Domain.appDatabaseExcluded) == expected, "Domain.appDatabaseExcluded membership changed")
+    }
+
+    @Test func groupsHaveNoDuplicates() {
+        let groups: [(String, [Domain])] = [
+            ("carPlaySupported", Domain.carPlaySupported),
+            ("watchSupported", Domain.watchSupported),
+            ("commonlyUsedWidgetSupported", Domain.commonlyUsedWidgetSupported),
+            ("sensorWidgetSupported", Domain.sensorWidgetSupported),
+            ("appDatabaseExcluded", Domain.appDatabaseExcluded),
+        ]
+        for (name, group) in groups {
+            #expect(group.count == Set(group).count, "\(name) contains duplicate domains")
+        }
+    }
+}

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -352,4 +352,19 @@ struct DomainFeatureSupportTests {
             #expect(group.count == Set(group).count, "\(name) contains duplicate domains")
         }
     }
+
+    @Test func supportedDomainsAreNotExcludedFromPersistence() {
+        let excluded = Set(Domain.appDatabaseExcluded)
+        let featureLists: [(String, [Domain])] = [
+            ("carPlaySupported", Domain.carPlaySupported),
+            ("watchSupported", Domain.watchSupported),
+            ("commonlyUsedWidgetSupported", Domain.commonlyUsedWidgetSupported),
+            ("sensorWidgetSupported", Domain.sensorWidgetSupported),
+        ]
+        for (name, list) in featureLists {
+            for domain in list {
+                #expect(!excluded.contains(domain), "\(name) domain \(domain) must not be in appDatabaseExcluded")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Stacked on #4914. Expands the per-feature supported-domain lists (now centralized as `Domain` statics) to include domains that already work "for free" with our existing generic execution and display paths — no new per-domain code:

- **CarPlay** (`carPlaySupported`): `humidifier`, `valve` — toggle via `mainAction`, the same path as the light/switch/cover/fan already supported.
- **Commonly-used widget** (`commonlyUsedWidgetSupported`): `inputBoolean`, `humidifier`, `valve` — device toggles like the existing entries.
- **Sensor widget** (`sensorWidgetSupported`, read-only state display): `number`, `input_number`, `input_text`, `input_select`, `select`, `climate`, `weather`, `sun`, `device_tracker`, `update` — each has a meaningful state string to show.
- **App-database index** (`appDatabasePersisted`): gains the domains the above features need to select, and adds `person` — which the sensor widget already listed but was never indexed, so person entities could never appear.

Apple Watch is intentionally left unchanged for now (to be discussed separately).

Also adds a test asserting every `sensorWidgetSupported` domain is present in `appDatabasePersisted` (the sensor widget reads from that index), guarding against the `person`-style gap recurring.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
