### PR TITLE
Fix re-adding a manually-removed entity to the Mac toolbar

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -154,26 +154,25 @@ final class EntityAddToHandler {
 
         do {
             var config = try MacToolbarConfig.config() ?? MacToolbarConfig()
-            guard !config.items.contains(where: { $0.id == entityId && $0.serverId == serverId }) else {
-                return
-            }
 
-            let appEntity = HAAppEntity.entity(id: entityId, serverId: serverId)
-            let iconName = appEntity?.icon
-                ?? Domain(rawValue: appEntity?.domain ?? "")?.icon(deviceClass: appEntity?.rawDeviceClass).name
-                ?? MaterialDesignIcons.dotsGridIcon.name
+            if !config.items.contains(where: { $0.id == entityId && $0.serverId == serverId }) {
+                let appEntity = HAAppEntity.entity(id: entityId, serverId: serverId)
+                let iconName = appEntity?.icon
+                    ?? Domain(rawValue: appEntity?.domain ?? "")?.icon(deviceClass: appEntity?.rawDeviceClass).name
+                    ?? MaterialDesignIcons.dotsGridIcon.name
 
-            config.items.append(MagicItem(
-                id: entityId,
-                serverId: serverId,
-                type: .entity,
-                customization: .init(icon: iconName),
-                action: .moreInfoDialog,
-                displayText: appEntity?.name
-            ))
+                config.items.append(MagicItem(
+                    id: entityId,
+                    serverId: serverId,
+                    type: .entity,
+                    customization: .init(icon: iconName),
+                    action: .moreInfoDialog,
+                    displayText: appEntity?.name
+                ))
 
-            try Current.database().write { db in
-                try config.insert(db, onConflict: .replace)
+                try Current.database().write { db in
+                    try config.insert(db, onConflict: .replace)
+                }
             }
 
             NotificationCenter.default.post(name: .macToolbarConfigDidChange, object: nil)

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -156,11 +156,10 @@ extension MacWebViewTitleBar {
 
         private func handleMacToolbarConfigChanged() {
             loadMacToolbarItems()
-            guard let toolbar else { return }
-            let currentIdentifiers = Set(toolbar.items.map(\.itemIdentifier))
+            guard let toolbar, titlebar?.toolbar === toolbar else { return }
             for item in macToolbarItems {
                 let identifier = NSToolbarItem.Identifier(magicItem: item)
-                guard !currentIdentifiers.contains(identifier) else { continue }
+                guard !toolbar.items.contains(where: { $0.itemIdentifier == identifier }) else { continue }
                 toolbar.insertItem(withItemIdentifier: identifier, at: toolbar.items.count)
             }
             updateEnabledItems()
@@ -225,7 +224,8 @@ extension MacWebViewTitleBar {
             case .homeAssistantServerPicker:
                 serverPickerToolbarItem(identifier: itemIdentifier, willBeInserted: flag)
             default:
-                if let magicItem = macToolbarItem(for: itemIdentifier) {
+                if let magicItem = macToolbarItem(for: itemIdentifier)
+                    ?? reconstructedEntityItem(for: itemIdentifier) {
                     entityToolbarItem(for: magicItem, identifier: itemIdentifier)
                 } else {
                     gestureToolbarItem(for: itemIdentifier)
@@ -278,7 +278,21 @@ extension MacWebViewTitleBar {
         }
 
         private func macToolbarItem(for identifier: NSToolbarItem.Identifier) -> MagicItem? {
-            macToolbarItems.first { NSToolbarItem.Identifier(magicItem: $0) == identifier }
+            if let item = macToolbarItems.first(where: { NSToolbarItem.Identifier(magicItem: $0) == identifier }) {
+                return item
+            }
+            guard identifier.magicItemComponents != nil else { return nil }
+            loadMacToolbarItems()
+            return macToolbarItems.first { NSToolbarItem.Identifier(magicItem: $0) == identifier }
+        }
+
+        /// A toolbar sharing our identifier forms a family with the toolbars of other windows; NSToolbar
+        /// synchronously asks every family member's delegate to materialize a newly inserted item. A sibling
+        /// whose cached `macToolbarItems` is stale would otherwise return `nil` here, which makes NSToolbar
+        /// raise an uncatchable assertion. Rebuild a minimal item straight from the identifier so we never do.
+        private func reconstructedEntityItem(for identifier: NSToolbarItem.Identifier) -> MagicItem? {
+            guard let components = identifier.magicItemComponents else { return nil }
+            return MagicItem(id: components.entityId, serverId: components.serverId, type: .entity)
         }
 
         private func serverPickerToolbarItem(
@@ -515,6 +529,13 @@ private extension NSToolbarItem.Identifier {
 
     init(magicItem: MagicItem) {
         self.init(Self.entityPrefix + magicItem.serverId + "::" + magicItem.id)
+    }
+
+    var magicItemComponents: (serverId: String, entityId: String)? {
+        guard rawValue.hasPrefix(Self.entityPrefix) else { return nil }
+        let payload = String(rawValue.dropFirst(Self.entityPrefix.count))
+        guard let separator = payload.range(of: "::") else { return nil }
+        return (String(payload[payload.startIndex ..< separator.lowerBound]), String(payload[separator.upperBound...]))
     }
 }
 #else

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -411,12 +411,22 @@ extension MacWebViewTitleBar {
             let item = NSToolbarItem(itemIdentifier: identifier)
             item.label = label
             item.paletteLabel = label
-            item.toolTip = label
+            item.toolTip = entityToolbarToolTip(for: magicItem, label: label)
             item.image = entityToolbarImage(for: magicItem)
             item.target = self
             item.action = #selector(openEntityToolbarItem(_:))
             item.visibilityPriority = Constants.highVisibilityPriority
             return item
+        }
+
+        /// Hover help for an entity button: the entity name followed by the shared `Area • Device`
+        /// context line (see `HAAppEntity.contextualSubtitle`), matching what pickers show elsewhere.
+        private func entityToolbarToolTip(for magicItem: MagicItem, label: String) -> String {
+            guard let context = HAAppEntity.entity(id: magicItem.id, serverId: magicItem.serverId)?
+                .contextualSubtitle, !context.isEmpty, context != label else {
+                return label
+            }
+            return "\(label) • \(context)"
         }
 
         /// Renders the entity's own MDI icon (captured when it was added, see


### PR DESCRIPTION
## Summary
Improves the Mac toolbar "add to" feature:

1. **Re-adding a removed entity does nothing.** An entity stays in `MacToolbarConfig` (the app's record of known items) even after the user removes it from the visible toolbar, because NSToolbar persists visibility separately via `autosavesConfiguration`. Previously `addToMacToolbar` returned early whenever the entity was still present in the config, skipping the `macToolbarConfigDidChange` notification and so never re-inserting the item into the visible toolbar. Now the notification is always posted; the database write is only skipped when the entity is already persisted, and the title bar re-inserts the item into the toolbar if it is missing from the visible set.

2. **Crash when adding an entity with multiple windows open.** All webview toolbars share one identifier, so they form an NSToolbar "family" and an insertion propagates synchronously to every sibling toolbar, asking each one's delegate to materialize the item. A sibling whose cached items were stale returned `nil` for the entity identifier, which made NSToolbar raise an uncatchable assertion and abort. The delegate now always resolves an entity identifier (reloading from the database, and reconstructing a minimal item from the identifier as a last resort), the config-change handler only mutates the toolbar it currently owns, and the duplicate guard is re-checked against the live toolbar contents.

3. **Toolbar entity tooltip now shows area and device.** The hover help for an entity button now appends the shared `Area • Device` context line (reusing `HAAppEntity.contextualSubtitle`, the same source pickers use), so it reads e.g. `Living Room Light • Living Room • Thermostat`.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
