### PR TITLE
Add Mac settings screen to manage toolbar entities

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -890,6 +890,7 @@
 		429997BF2DDB59E400CC6C12 /* WebViewRestorationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429997BE2DDB59E400CC6C12 /* WebViewRestorationType.swift */; };
 		429AFE5C2DB7BE4000AF0836 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429AFE5B2DB7BE4000AF0836 /* GeneralSettingsView.swift */; };
 		429AFE5E2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429AFE5D2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift */; };
+		42AC70B0000000000000FA11 /* MacToolbarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AC70B0000000000000FA10 /* MacToolbarSettingsView.swift */; };
 		429BA2AF2C800CAB00A50996 /* SFSymbolEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429BA2AE2C800CAB00A50996 /* SFSymbolEntity.swift */; };
 		429BEA1A2D102F3A00F070F9 /* ConnectionErrorDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429BEA192D102F3A00F070F9 /* ConnectionErrorDetailsView.swift */; };
 		429BEA1D2D10315F00F070F9 /* SheetCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429BEA1B2D1030EA00F070F9 /* SheetCloseButton.swift */; };
@@ -2688,6 +2689,7 @@
 		429997BE2DDB59E400CC6C12 /* WebViewRestorationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewRestorationType.swift; sourceTree = "<group>"; };
 		429AFE5B2DB7BE4000AF0836 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		429AFE5D2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsTemplateEditor.swift; sourceTree = "<group>"; };
+		42AC70B0000000000000FA10 /* MacToolbarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacToolbarSettingsView.swift; sourceTree = "<group>"; };
 		429BA2AE2C800CAB00A50996 /* SFSymbolEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbolEntity.swift; sourceTree = "<group>"; };
 		429BEA192D102F3A00F070F9 /* ConnectionErrorDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionErrorDetailsView.swift; sourceTree = "<group>"; };
 		429BEA1B2D1030EA00F070F9 /* SheetCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetCloseButton.swift; sourceTree = "<group>"; };
@@ -5555,6 +5557,14 @@
 			path = General;
 			sourceTree = "<group>";
 		};
+		42AC70B0000000000000FA12 /* MacToolbar */ = {
+			isa = PBXGroup;
+			children = (
+				42AC70B0000000000000FA10 /* MacToolbarSettingsView.swift */,
+			);
+			path = MacToolbar;
+			sourceTree = "<group>";
+		};
 		429C33BE2F17988D0033EF5E /* EntityPicker */ = {
 			isa = PBXGroup;
 			children = (
@@ -7028,6 +7038,7 @@
 				A95FDD182F6B8A5B008EF72F /* LiveActivity */,
 				4257EA912F1790DE00D81506 /* EntityPicker */,
 				429AFE5A2DB7BE3200AF0836 /* General */,
+				42AC70B0000000000000FA12 /* MacToolbar */,
 				4211551F2D3525E800A71630 /* AppIcon */,
 				AC730020000000000000AA01 /* AppIconShortcuts */,
 				4278CB862D01F0BE00CFAAC9 /* Gestures */,
@@ -9695,6 +9706,7 @@
 				424DD05A2B3509170057E456 /* CarPlayQuickAccessTemplate.swift in Sources */,
 				451D63FF25213F1E2AF7C73A /* CarPlayAssistSession.swift in Sources */,
 				429AFE5E2DB7DED300AF0836 /* GeneralSettingsTemplateEditor.swift in Sources */,
+				42AC70B0000000000000FA11 /* MacToolbarSettingsView.swift in Sources */,
 				42B94BDE2B9606CD00DEE060 /* AssistViewModel.swift in Sources */,
 				D0C88462211ED16300CCB501 /* OnboardingAuth.swift in Sources */,
 				42F1DA5F2B4D4B32002729BC /* CarPlayServerListTemplate.swift in Sources */,

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -327,12 +327,6 @@ final class EntityAddToHandler {
     }
 }
 
-extension Notification.Name {
-    /// Posted whenever `MacToolbarConfig` gains a new entity, so any visible `MacWebViewTitleBar`
-    /// can insert the corresponding item into its toolbar without waiting for the next launch.
-    static let macToolbarConfigDidChange = Notification.Name("macToolbarConfigDidChange")
-}
-
 // MARK: - Error Types
 
 extension EntityAddToError {

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -157,6 +157,15 @@ extension MacWebViewTitleBar {
         private func handleMacToolbarConfigChanged() {
             loadMacToolbarItems()
             guard let toolbar else { return }
+            let desiredIdentifiers = Set(macToolbarItems.map { NSToolbarItem.Identifier(magicItem: $0) })
+
+            // Remove entity items the user deleted from the config (leave built-in items untouched).
+            for index in toolbar.items.indices.reversed() {
+                let identifier = toolbar.items[index].itemIdentifier
+                guard identifier.isEntityIdentifier, !desiredIdentifiers.contains(identifier) else { continue }
+                toolbar.removeItem(at: index)
+            }
+
             let currentIdentifiers = Set(toolbar.items.map(\.itemIdentifier))
             for item in macToolbarItems {
                 let identifier = NSToolbarItem.Identifier(magicItem: item)
@@ -515,6 +524,10 @@ private extension NSToolbarItem.Identifier {
 
     init(magicItem: MagicItem) {
         self.init(Self.entityPrefix + magicItem.serverId + "::" + magicItem.id)
+    }
+
+    var isEntityIdentifier: Bool {
+        rawValue.hasPrefix(Self.entityPrefix)
     }
 }
 #else

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1206,6 +1206,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.mac_toolbar.how_to_add.body" = "To add an entity, open its more info dialog in Home Assistant, select the \"Add to\" button, then choose \"Mac Toolbar\".";
 "settings.mac_toolbar.how_to_add.header" = "Adding entities";
 "settings.mac_toolbar.remove" = "Remove";
+"settings.mac_toolbar.remove_accessibility_label" = "Remove %@";
 "settings.mac_toolbar.remove_confirmation.title" = "Remove \"%@\" from the toolbar?";
 "settings.mac_toolbar.title" = "Toolbar";
 "settings.navigation_bar.about_button.title" = "About";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1200,6 +1200,14 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.location_history.detail.explanation" = "The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are additional regions used for sub-100 m zones.";
 "settings.location_history.empty" = "No Location History";
 "settings.location_history.title" = "Location History";
+"settings.mac_toolbar.empty_state" = "You haven't added any entities to the toolbar yet.";
+"settings.mac_toolbar.entities_section.header" = "Added entities";
+"settings.mac_toolbar.header_subtitle" = "Entities you added to the window toolbar for quick access.";
+"settings.mac_toolbar.how_to_add.body" = "To add an entity, open its more info dialog in Home Assistant, select the \"Add to\" button, then choose \"Mac Toolbar\".";
+"settings.mac_toolbar.how_to_add.header" = "Adding entities";
+"settings.mac_toolbar.remove" = "Remove";
+"settings.mac_toolbar.remove_confirmation.title" = "Remove \"%@\" from the toolbar?";
+"settings.mac_toolbar.title" = "Toolbar";
 "settings.navigation_bar.about_button.title" = "About";
 "settings.navigation_bar.title" = "Settings";
 "settings.reset_section.reset_alert.message" = "Your settings will be reset and this device will be unregistered from push notifications as well as removed from your Home Assistant configuration.";

--- a/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
+++ b/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
@@ -1,0 +1,128 @@
+import Shared
+import SwiftUI
+
+struct MacToolbarSettingsView: View {
+    @StateObject private var viewModel = MacToolbarSettingsViewModel()
+
+    var body: some View {
+        List {
+            AppleLikeListTopRowHeader(
+                image: .dockWindowIcon,
+                title: L10n.Settings.MacToolbar.title,
+                subtitle: L10n.Settings.MacToolbar.headerSubtitle
+            )
+
+            Section(header: Text(L10n.Settings.MacToolbar.HowToAdd.header)) {
+                Label {
+                    Text(L10n.Settings.MacToolbar.HowToAdd.body)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                } icon: {
+                    Image(systemSymbol: .infoCircle)
+                        .foregroundColor(.haPrimary)
+                }
+            }
+
+            Section(header: Text(L10n.Settings.MacToolbar.EntitiesSection.header)) {
+                if viewModel.items.isEmpty {
+                    Text(L10n.Settings.MacToolbar.emptyState)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(viewModel.items, id: \.self) { item in
+                        MacToolbarEntityRow(item: item) {
+                            viewModel.remove(item)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.Settings.MacToolbar.title)
+        .onAppear {
+            viewModel.load()
+        }
+    }
+}
+
+private struct MacToolbarEntityRow: View {
+    let item: MagicItem
+    let onDelete: () -> Void
+
+    @State private var isConfirmingDelete = false
+
+    private var icon: MaterialDesignIcons {
+        MaterialDesignIcons(named: item.customization?.icon ?? "", fallback: .dotsGridIcon)
+    }
+
+    private var serverName: String? {
+        guard Current.servers.all.count > 1 else { return nil }
+        return Current.servers.server(forServerIdentifier: item.serverId)?.info.name
+    }
+
+    var body: some View {
+        HStack {
+            Label {
+                VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+                    Text(item.displayText ?? item.id)
+                    if let serverName {
+                        Text(serverName)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            } icon: {
+                MaterialDesignIconsImage(icon: icon, size: 24)
+            }
+            Spacer()
+            Button(role: .destructive) {
+                isConfirmingDelete = true
+            } label: {
+                Image(systemSymbol: .trash)
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(L10n.Settings.MacToolbar.remove)
+            .confirmationDialog(
+                L10n.Settings.MacToolbar.RemoveConfirmation.title(item.displayText ?? item.id),
+                isPresented: $isConfirmingDelete,
+                titleVisibility: .visible
+            ) {
+                Button(L10n.Settings.MacToolbar.remove, role: .destructive) {
+                    onDelete()
+                }
+                Button(L10n.cancelLabel, role: .cancel) {}
+            }
+        }
+    }
+}
+
+@MainActor
+final class MacToolbarSettingsViewModel: ObservableObject {
+    @Published private(set) var items: [MagicItem] = []
+
+    func load() {
+        do {
+            items = try MacToolbarConfig.config()?.items ?? []
+        } catch {
+            Current.Log.error("Failed to load Mac toolbar config: \(error.localizedDescription)")
+            items = []
+        }
+    }
+
+    func remove(_ item: MagicItem) {
+        persist(items: items.filter { $0 != item })
+    }
+
+    private func persist(items newItems: [MagicItem]) {
+        do {
+            var config = try MacToolbarConfig.config() ?? MacToolbarConfig()
+            config.items = newItems
+            try Current.database().write { db in
+                try config.insert(db, onConflict: .replace)
+            }
+            items = newItems
+            NotificationCenter.default.post(name: .macToolbarConfigDidChange, object: nil)
+        } catch {
+            Current.Log.error("Failed to update Mac toolbar config: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
+++ b/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
@@ -80,7 +80,7 @@ private struct MacToolbarEntityRow: View {
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel(L10n.Settings.MacToolbar.remove)
+            .accessibilityLabel(L10n.Settings.MacToolbar.removeAccessibilityLabel(item.displayText ?? item.id))
             .confirmationDialog(
                 L10n.Settings.MacToolbar.RemoveConfirmation.title(item.displayText ?? item.id),
                 isPresented: $isConfirmingDelete,

--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -11,6 +11,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
     case liveActivities
     case sensors
     case nfc
+    case macToolbar
     case widgets
     case appIconShortcuts
     case watch
@@ -25,6 +26,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
         switch self {
         case .servers: return L10n.Settings.ConnectionSection.servers
         case .general: return L10n.SettingsDetails.General.title
+        case .macToolbar: return L10n.Settings.MacToolbar.title
         case .gestures: return L10n.Gestures.Screen.title
         case .kiosk: return L10n.Kiosk.title
         case .location: return L10n.Settings.DetailsSection.LocationSettingsRow.title
@@ -53,6 +55,8 @@ enum SettingsItem: String, Hashable, CaseIterable {
                 MaterialDesignIconsImage(icon: .serverIcon, size: Self.iconSize)
             case .general:
                 MaterialDesignIconsImage(icon: .paletteOutlineIcon, size: Self.iconSize)
+            case .macToolbar:
+                MaterialDesignIconsImage(icon: .dockWindowIcon, size: Self.iconSize)
             case .gestures:
                 MaterialDesignIconsImage(icon: .gestureIcon, size: Self.iconSize)
             case .kiosk:
@@ -105,6 +109,8 @@ enum SettingsItem: String, Hashable, CaseIterable {
             SettingsServersView()
         case .general:
             GeneralSettingsView()
+        case .macToolbar:
+            MacToolbarSettingsView()
         case .gestures:
             GesturesSetupView()
         case .kiosk:
@@ -151,6 +157,11 @@ enum SettingsItem: String, Hashable, CaseIterable {
         allCases.filter { item in
             if item == .liveActivities {
                 return canShowLiveActivities
+            }
+
+            // Managing toolbar entities only makes sense on macOS, where the toolbar exists.
+            if item == .macToolbar {
+                return Current.isCatalyst
             }
 
             // Filter based on platform

--- a/Sources/Shared/Database/Tables/MacToolbarConfigTable.swift
+++ b/Sources/Shared/Database/Tables/MacToolbarConfigTable.swift
@@ -21,6 +21,13 @@ public struct MacToolbarConfig: Codable, FetchableRecord, PersistableRecord, Equ
     }
 }
 
+public extension Notification.Name {
+    /// Posted whenever `MacToolbarConfig` changes (an entity is added or removed), so any visible
+    /// `MacWebViewTitleBar` can insert or remove the corresponding toolbar item without waiting for
+    /// the next launch.
+    static let macToolbarConfigDidChange = Notification.Name("macToolbarConfigDidChange")
+}
+
 final class MacToolbarConfigTable: DatabaseTableProtocol {
     var tableName: String { GRDBDatabaseTable.macToolbarConfig.rawValue }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4085,6 +4085,32 @@ public enum L10n {
         public static var explanation: String { return L10n.tr("Localizable", "settings.location_history.detail.explanation") }
       }
     }
+    public enum MacToolbar {
+      /// You haven't added any entities to the toolbar yet.
+      public static var emptyState: String { return L10n.tr("Localizable", "settings.mac_toolbar.empty_state") }
+      /// Entities you added to the window toolbar for quick access.
+      public static var headerSubtitle: String { return L10n.tr("Localizable", "settings.mac_toolbar.header_subtitle") }
+      /// Remove
+      public static var remove: String { return L10n.tr("Localizable", "settings.mac_toolbar.remove") }
+      /// Toolbar
+      public static var title: String { return L10n.tr("Localizable", "settings.mac_toolbar.title") }
+      public enum EntitiesSection {
+        /// Added entities
+        public static var header: String { return L10n.tr("Localizable", "settings.mac_toolbar.entities_section.header") }
+      }
+      public enum HowToAdd {
+        /// To add an entity, open its more info dialog in Home Assistant, select the "Add to" button, then choose "Mac Toolbar".
+        public static var body: String { return L10n.tr("Localizable", "settings.mac_toolbar.how_to_add.body") }
+        /// Adding entities
+        public static var header: String { return L10n.tr("Localizable", "settings.mac_toolbar.how_to_add.header") }
+      }
+      public enum RemoveConfirmation {
+        /// Remove "%@" from the toolbar?
+        public static func title(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "settings.mac_toolbar.remove_confirmation.title", String(describing: p1))
+        }
+      }
+    }
     public enum NavigationBar {
       /// Settings
       public static var title: String { return L10n.tr("Localizable", "settings.navigation_bar.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4092,6 +4092,10 @@ public enum L10n {
       public static var headerSubtitle: String { return L10n.tr("Localizable", "settings.mac_toolbar.header_subtitle") }
       /// Remove
       public static var remove: String { return L10n.tr("Localizable", "settings.mac_toolbar.remove") }
+      /// Remove %@
+      public static func removeAccessibilityLabel(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "settings.mac_toolbar.remove_accessibility_label", String(describing: p1))
+      }
       /// Toolbar
       public static var title: String { return L10n.tr("Localizable", "settings.mac_toolbar.title") }
       public enum EntitiesSection {


### PR DESCRIPTION
## Summary
Adds a Mac-only settings screen for managing the entities added to the window toolbar. Users can see the entities they previously added through the entity more info dialog's "Add to" button and remove them (with a confirmation dialog). The screen also explains how to add entities to the toolbar. Removing an entity updates an open window's toolbar live.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
