### PR TITLE
Fix re-adding an entity resurrecting all removed Mac toolbar entities

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -155,27 +155,36 @@ final class EntityAddToHandler {
         do {
             var config = try MacToolbarConfig.config() ?? MacToolbarConfig()
 
-            if !config.items.contains(where: { $0.id == entityId && $0.serverId == serverId }) {
+            let addedItem: MagicItem
+            if let existing = config.items.first(where: { $0.id == entityId && $0.serverId == serverId }) {
+                addedItem = existing
+            } else {
                 let appEntity = HAAppEntity.entity(id: entityId, serverId: serverId)
                 let iconName = appEntity?.icon
                     ?? Domain(rawValue: appEntity?.domain ?? "")?.icon(deviceClass: appEntity?.rawDeviceClass).name
                     ?? MaterialDesignIcons.dotsGridIcon.name
 
-                config.items.append(MagicItem(
+                let item = MagicItem(
                     id: entityId,
                     serverId: serverId,
                     type: .entity,
                     customization: .init(icon: iconName),
                     action: .moreInfoDialog,
                     displayText: appEntity?.name
-                ))
+                )
+                config.items.append(item)
+                addedItem = item
 
                 try Current.database().write { db in
                     try config.insert(db, onConflict: .replace)
                 }
             }
 
-            NotificationCenter.default.post(name: .macToolbarConfigDidChange, object: nil)
+            NotificationCenter.default.post(
+                name: .macToolbarConfigDidChange,
+                object: nil,
+                userInfo: [MacToolbarConfigChange.userInfoKey: MacToolbarConfigChange.added(addedItem)]
+            )
         } catch {
             Current.Log.error("Failed to add entity \(entityId) to Mac toolbar: \(error.localizedDescription)")
         }

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -149,28 +149,36 @@ extension MacWebViewTitleBar {
                 forName: .macToolbarConfigDidChange,
                 object: nil,
                 queue: .main
-            ) { [weak self] _ in
-                self?.handleMacToolbarConfigChanged()
+            ) { [weak self] notification in
+                let change = notification.userInfo?[MacToolbarConfigChange.userInfoKey] as? MacToolbarConfigChange
+                self?.handleMacToolbarConfigChanged(change)
             }
         }
 
-        private func handleMacToolbarConfigChanged() {
+        private func handleMacToolbarConfigChanged(_ change: MacToolbarConfigChange?) {
             loadMacToolbarItems()
             guard let toolbar, titlebar?.toolbar === toolbar else { return }
-            let desiredIdentifiers = Set(macToolbarItems.map { NSToolbarItem.Identifier(magicItem: $0) })
 
-            // Remove entity items the user deleted from the config (leave built-in items untouched).
-            for index in toolbar.items.indices.reversed() {
-                let identifier = toolbar.items[index].itemIdentifier
-                guard identifier.isEntityIdentifier, !desiredIdentifiers.contains(identifier) else { continue }
-                toolbar.removeItem(at: index)
-            }
-
-            for item in macToolbarItems {
+            switch change {
+            case let .added(item):
                 let identifier = NSToolbarItem.Identifier(magicItem: item)
-                guard !toolbar.items.contains(where: { $0.itemIdentifier == identifier }) else { continue }
-                toolbar.insertItem(withItemIdentifier: identifier, at: toolbar.items.count)
+                if !toolbar.items.contains(where: { $0.itemIdentifier == identifier }) {
+                    toolbar.insertItem(withItemIdentifier: identifier, at: toolbar.items.count)
+                }
+            case let .removed(item):
+                let identifier = NSToolbarItem.Identifier(magicItem: item)
+                if let index = toolbar.items.firstIndex(where: { $0.itemIdentifier == identifier }) {
+                    toolbar.removeItem(at: index)
+                }
+            case nil:
+                let desiredIdentifiers = Set(macToolbarItems.map { NSToolbarItem.Identifier(magicItem: $0) })
+                for index in toolbar.items.indices.reversed() {
+                    let identifier = toolbar.items[index].itemIdentifier
+                    guard identifier.isEntityIdentifier, !desiredIdentifiers.contains(identifier) else { continue }
+                    toolbar.removeItem(at: index)
+                }
             }
+
             updateEnabledItems()
         }
 

--- a/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
+++ b/Sources/App/Settings/MacToolbar/MacToolbarSettingsView.swift
@@ -109,10 +109,10 @@ final class MacToolbarSettingsViewModel: ObservableObject {
     }
 
     func remove(_ item: MagicItem) {
-        persist(items: items.filter { $0 != item })
+        persist(items: items.filter { $0 != item }, change: .removed(item))
     }
 
-    private func persist(items newItems: [MagicItem]) {
+    private func persist(items newItems: [MagicItem], change: MacToolbarConfigChange) {
         do {
             var config = try MacToolbarConfig.config() ?? MacToolbarConfig()
             config.items = newItems
@@ -120,7 +120,11 @@ final class MacToolbarSettingsViewModel: ObservableObject {
                 try config.insert(db, onConflict: .replace)
             }
             items = newItems
-            NotificationCenter.default.post(name: .macToolbarConfigDidChange, object: nil)
+            NotificationCenter.default.post(
+                name: .macToolbarConfigDidChange,
+                object: nil,
+                userInfo: [MacToolbarConfigChange.userInfoKey: change]
+            )
         } catch {
             Current.Log.error("Failed to update Mac toolbar config: \(error.localizedDescription)")
         }

--- a/Sources/Shared/Database/Tables/MacToolbarConfigTable.swift
+++ b/Sources/Shared/Database/Tables/MacToolbarConfigTable.swift
@@ -24,8 +24,20 @@ public struct MacToolbarConfig: Codable, FetchableRecord, PersistableRecord, Equ
 public extension Notification.Name {
     /// Posted whenever `MacToolbarConfig` changes (an entity is added or removed), so any visible
     /// `MacWebViewTitleBar` can insert or remove the corresponding toolbar item without waiting for
-    /// the next launch.
+    /// the next launch. The changed item travels in `userInfo` under `MacToolbarConfigChange.userInfoKey`.
     static let macToolbarConfigDidChange = Notification.Name("macToolbarConfigDidChange")
+}
+
+/// Describes which entity changed in `MacToolbarConfig`, carried in the `.macToolbarConfigDidChange`
+/// `userInfo`. The observing toolbar must act on this specific item rather than reconciling against the
+/// whole config: entities the user removed via Customize Toolbar stay in the config (only `NSToolbar`'s
+/// separate `autosavesConfiguration` visibility changes), so re-inserting every known item would
+/// resurrect all of them instead of only the entity just added.
+public enum MacToolbarConfigChange {
+    case added(MagicItem)
+    case removed(MagicItem)
+
+    public static let userInfoKey = "MacToolbarConfigChange"
 }
 
 final class MacToolbarConfigTable: DatabaseTableProtocol {


### PR DESCRIPTION
## Summary
Fixes a Mac toolbar bug where re-adding one entity brought back every entity that had been removed. Entities added via the "Add to" feature stay in the app's config even after being removed through the native Customize Toolbar, since NSToolbar tracks visibility separately. Adding another entity then re-inserted every known entity instead of just the new one. The change notification now carries the specific entity that was added or removed, so the toolbar updates only that item.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
