### PR TITLE
Indicate snoozed notifications with a prefix

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1442,6 +1442,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.notifications.snooze_actions.add_sheet.title" = "New Snooze Action";
 "settings_details.notifications.snooze_actions.footer" = "Quick actions shown on notifications to snooze them for a set amount of time. Snoozing re-shows the notification later.";
 "settings_details.notifications.snooze_actions.header" = "Snooze Actions";
+"settings_details.notifications.snooze_actions.prefix_footer" = "Snoozed notifications reappear with a “↺” prefix in their title.";
 "settings_details.notifications.snooze_actions.title_hour" = "Snooze 1 hour";
 "settings_details.notifications.snooze_actions.title_hour_minutes" = "Snooze 1 hour and %li min";
 "settings_details.notifications.snooze_actions.title_hours" = "Snooze %li hours";

--- a/Sources/App/Settings/Notifications/NotificationSnoozeActionsView.swift
+++ b/Sources/App/Settings/Notifications/NotificationSnoozeActionsView.swift
@@ -24,10 +24,9 @@ struct NotificationSnoozeActionsView: View {
                     Label(L10n.addButtonLabel, systemSymbol: .plus)
                 }
             } footer: {
-                VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
-                    Text(L10n.SettingsDetails.Notifications.SnoozeActions.footer)
-                    Text(L10n.SettingsDetails.Notifications.SnoozeActions.prefixFooter)
-                }
+                Text(L10n.SettingsDetails.Notifications.SnoozeActions.footer)
+                    + Text(verbatim: "\n\n")
+                    + Text(L10n.SettingsDetails.Notifications.SnoozeActions.prefixFooter)
             }
         }
         .navigationTitle(L10n.SettingsDetails.Notifications.SnoozeActions.header)

--- a/Sources/App/Settings/Notifications/NotificationSnoozeActionsView.swift
+++ b/Sources/App/Settings/Notifications/NotificationSnoozeActionsView.swift
@@ -24,7 +24,10 @@ struct NotificationSnoozeActionsView: View {
                     Label(L10n.addButtonLabel, systemSymbol: .plus)
                 }
             } footer: {
-                Text(L10n.SettingsDetails.Notifications.SnoozeActions.footer)
+                VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
+                    Text(L10n.SettingsDetails.Notifications.SnoozeActions.footer)
+                    Text(L10n.SettingsDetails.Notifications.SnoozeActions.prefixFooter)
+                }
             }
         }
         .navigationTitle(L10n.SettingsDetails.Notifications.SnoozeActions.header)

--- a/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
+++ b/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
@@ -54,7 +54,7 @@ public final class LocalNotificationDispatcher: LocalNotificationDispatcherProto
         }
     }
 
-    static let snoozePrefix = "↺ "
+    private static let snoozePrefix = "↺ "
 
     /// Re-delivers `content` locally after `delay`, preserving its category/userInfo so any dynamic
     /// actions (e.g. snooze presets) attached to the original notification still show up.

--- a/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
+++ b/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
@@ -54,11 +54,16 @@ public final class LocalNotificationDispatcher: LocalNotificationDispatcherProto
         }
     }
 
+    static let snoozePrefix = "↺ "
+
     /// Re-delivers `content` locally after `delay`, preserving its category/userInfo so any dynamic
     /// actions (e.g. snooze presets) attached to the original notification still show up.
     public func reschedule(_ content: UNNotificationContent, after delay: TimeInterval) {
         // swiftlint:disable:next force_cast
         let copy = content.mutableCopy() as! UNMutableNotificationContent
+        if !copy.title.hasPrefix(Self.snoozePrefix) {
+            copy.title = Self.snoozePrefix + copy.title
+        }
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,
             content: copy,

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4810,6 +4810,8 @@ public enum L10n {
         public static var footer: String { return L10n.tr("Localizable", "settings_details.notifications.snooze_actions.footer") }
         /// Snooze Actions
         public static var header: String { return L10n.tr("Localizable", "settings_details.notifications.snooze_actions.header") }
+        /// Snoozed notifications reappear with a “↺” prefix in their title.
+        public static var prefixFooter: String { return L10n.tr("Localizable", "settings_details.notifications.snooze_actions.prefix_footer") }
         /// Snooze 1 hour
         public static var titleHour: String { return L10n.tr("Localizable", "settings_details.notifications.snooze_actions.title_hour") }
         /// Snooze 1 hour and %li min


### PR DESCRIPTION
## Summary
The snooze notification actions re-deliver the same notification later, but there was no way to tell a notification had been snoozed once it came back. This adds a "↺" prefix to the title of re-delivered snoozed notifications, and a short footer on the Snooze Actions settings screen explaining the behavior.

The prefix is added once, so snoozing an already-snoozed notification does not stack multiple prefixes.

## Screenshots
_Notification title gains a "↺ " prefix when it reappears after being snoozed; the Snooze Actions settings screen gains a short explanatory footer._

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#1369

## Any other notes
Applies to both the on-device snooze presets and the debug ten-second snooze action, since both re-deliver through the same code path.