### PR TITLE
Replace MBProgressHUD dependency with in-house implementation

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1505,6 +1505,7 @@
 		B63D28BD215D9E3600F3B907 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B69933931E232AEA0054453D /* Localizable.strings */; };
 		B641BC1F1E2097EF002CCBC1 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641BC1D1E2097EF002CCBC1 /* AboutView.swift */; };
 		B641BC251E20A17B002CCBC1 /* OpenInChromeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B641BC241E20A17B002CCBC1 /* OpenInChromeController.swift */; };
+		B0B0B0B00000000000000011 /* ProgressHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0B0B00000000000000010 /* ProgressHUD.swift */; };
 		B64BB3A81E9C6551001E8B46 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64BB3A71E9C6551001E8B46 /* WebViewController.swift */; };
 		B655E915227FE88A00CFDC94 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B60247FE1FBD343000998205 /* InfoPlist.strings */; };
 		B657A8EA1CA646EB00121384 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B657A8E91CA646EB00121384 /* AppDelegate.swift */; };
@@ -3459,6 +3460,7 @@
 		B640485C1FBBBB1300F0CCCD /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B641BC1D1E2097EF002CCBC1 /* AboutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AboutView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		B641BC241E20A17B002CCBC1 /* OpenInChromeController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenInChromeController.swift; sourceTree = "<group>"; };
+		B0B0B0B00000000000000010 /* ProgressHUD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressHUD.swift; sourceTree = "<group>"; };
 		B646B04C24D10A2900093E6A /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Intents.strings; sourceTree = "<group>"; };
 		B646B04E24D10A2900093E6A /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B646B04F24D10A2A00093E6A /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -7233,6 +7235,7 @@
 				115DA28C24F4646500C00BB1 /* MenuManager.swift */,
 				11BD7B3C25B53D37001826F0 /* AppMacBridgeStatusItemConfiguration.swift */,
 				B641BC241E20A17B002CCBC1 /* OpenInChromeController.swift */,
+				B0B0B0B00000000000000010 /* ProgressHUD.swift */,
 				B6E857A11CB1CCCC00F96925 /* Utils.swift */,
 				B6DA3C7222691A5000DE811C /* AKConverter.swift */,
 				B605C890226E9DAC00EF46DD /* Permissions.swift */,
@@ -9747,6 +9750,7 @@
 				4289DDAB2C85AB56003591C2 /* ControlAssistValueProvider.swift in Sources */,
 				42D5ACDB2C64C82600D9C4E2 /* MagicItemAddViewModel.swift in Sources */,
 				B641BC251E20A17B002CCBC1 /* OpenInChromeController.swift in Sources */,
+				B0B0B0B00000000000000011 /* ProgressHUD.swift in Sources */,
 				119D765F2492F8FA00183C5F /* UIApplication+BackgroundTask.swift in Sources */,
 				42A9E0F22F2B58FF00D22154 /* EntityAddToAction.swift in Sources */,
 				42A9E0F32F2B58FF00D22154 /* EntityAddToHandler.swift in Sources */,
@@ -11740,8 +11744,6 @@
 					"-l\"c++\"",
 					"-l\"z\"",
 					"-framework",
-					"\"MBProgressHUD\"",
-					"-framework",
 					"\"PromiseKit\"",
 					"-framework",
 					"\"Security\"",
@@ -11780,8 +11782,6 @@
 					"-ObjC",
 					"-l\"c++\"",
 					"-l\"z\"",
-					"-framework",
-					"\"MBProgressHUD\"",
 					"-framework",
 					"\"PromiseKit\"",
 					"-framework",

--- a/Podfile
+++ b/Podfile
@@ -45,7 +45,6 @@ end
 abstract_target 'iOS' do
   platform :ios, '15.0'
 
-  pod 'MBProgressHUD', '~> 1.2.0'
   pod 'ReachabilitySwift'
 
   # fixes newer cocoapods search path issues for Clibsodium build failures

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
   - HAKit/PromiseKit (0.4.16):
     - HAKit/Core
     - PromiseKit (~> 8.1.1)
-  - MBProgressHUD (1.2.0)
   - ObjcExceptionBridging (1.0.1):
     - ObjcExceptionBridging/ObjcExceptionBridging (= 1.0.1)
   - ObjcExceptionBridging/ObjcExceptionBridging (1.0.1)
@@ -58,7 +57,6 @@ DEPENDENCIES:
   - HAKit (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.16`)
   - HAKit/Mocks (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.16`)
   - HAKit/PromiseKit (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.16`)
-  - MBProgressHUD (~> 1.2.0)
   - ObjectMapper (from `https://github.com/tristanhimmelman/ObjectMapper.git`, branch `master`)
   - OHHTTPStubs/Swift
   - PromiseKit (~> 8.1.1)
@@ -74,7 +72,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - MBProgressHUD
     - ObjcExceptionBridging
     - OHHTTPStubs
     - PromiseKit
@@ -124,7 +121,6 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
   HAKit: ef185a67991484219a7ecd74aab25f186274d7dd
-  MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
   ObjectMapper: e6e4d91ff7f2861df7aecc536c92d8363f4c9677
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
@@ -140,6 +136,6 @@ SPEC CHECKSUMS:
   Version: de5907f2c5d0f3cf21708db7801d1d5401139486
   XCGLogger: 1943831ef907df55108b0b18657953f868de973b
 
-PODFILE CHECKSUM: be250be323475bbf4e03b5efd59107711db8823f
+PODFILE CHECKSUM: f1f3f4803de5d663773e0bb46a5aebb2e9fbcded
 
 COCOAPODS: 1.15.2

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -7,7 +7,6 @@ import FirebaseCore
 import FirebaseMessaging
 import Intents
 import KeychainAccess
-import MBProgressHUD
 import ObjectMapper
 import PromiseKit
 import RealmSwift

--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MBProgressHUD
 import Shared
 import Version
 
@@ -145,7 +144,7 @@ final class WebViewGestureHandler {
         Current.sceneManager.appCoordinator.done { coordinator in
             coordinator.open(server: nextServer).done { frontend in
                 guard let window = frontend.presentationWindow else { return }
-                let hud = MBProgressHUD.showAdded(to: window, animated: true)
+                let hud = ProgressHUD.showAdded(to: window, animated: true)
                 hud.isUserInteractionEnabled = false
                 hud.mode = .text
                 hud.label.text = nextServer.info.name

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -5,7 +5,6 @@ import CoreLocation
 import HAKit
 import Improv_iOS
 import KeychainAccess
-import MBProgressHUD
 import PromiseKit
 import Shared
 import SwiftUI

--- a/Sources/App/Scenes/SceneManager.swift
+++ b/Sources/App/Scenes/SceneManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MBProgressHUD
 import PromiseKit
 import Shared
 import UIKit
@@ -342,7 +341,7 @@ final class SceneManager {
         onto window: Promise<UIWindow>
     ) {
         window.done { window in
-            let hud = MBProgressHUD.showAdded(to: window, animated: true)
+            let hud = ProgressHUD.showAdded(to: window, animated: true)
             hud.mode = .customView
             hud.backgroundView.style = .blur
             hud.customView = with(IconImageView(frame: .init(x: 0, y: 0, width: 64, height: 64))) {

--- a/Sources/App/Utilities/ProgressHUD.swift
+++ b/Sources/App/Utilities/ProgressHUD.swift
@@ -1,0 +1,182 @@
+import Shared
+import UIKit
+
+final class ProgressHUD: UIView {
+    enum Mode {
+        case indeterminate
+        case text
+        case customView
+    }
+
+    enum BackgroundStyle {
+        case solidColor
+        case blur
+    }
+
+    final class BackgroundView: UIView {
+        var style: BackgroundStyle = .solidColor {
+            didSet { applyStyle() }
+        }
+
+        private var blurView: UIVisualEffectView?
+
+        private func applyStyle() {
+            switch style {
+            case .solidColor:
+                blurView?.removeFromSuperview()
+                blurView = nil
+                backgroundColor = .clear
+            case .blur:
+                guard blurView == nil else { return }
+                backgroundColor = .clear
+                let view = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+                view.frame = bounds
+                view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                addSubview(view)
+                blurView = view
+            }
+        }
+    }
+
+    let label = HUDLabel()
+    let backgroundView = BackgroundView()
+
+    var mode: Mode = .indeterminate {
+        didSet { updateContent() }
+    }
+
+    var customView: UIView? {
+        didSet {
+            oldValue?.removeFromSuperview()
+            if let customView {
+                customView.translatesAutoresizingMaskIntoConstraints = false
+                customViewContainer.addSubview(customView)
+                NSLayoutConstraint.activate([
+                    customView.topAnchor.constraint(equalTo: customViewContainer.topAnchor),
+                    customView.bottomAnchor.constraint(equalTo: customViewContainer.bottomAnchor),
+                    customView.leadingAnchor.constraint(equalTo: customViewContainer.leadingAnchor),
+                    customView.trailingAnchor.constraint(equalTo: customViewContainer.trailingAnchor),
+                    customView.widthAnchor.constraint(equalToConstant: customView.frame.width),
+                    customView.heightAnchor.constraint(equalToConstant: customView.frame.height),
+                ])
+            }
+            updateContent()
+        }
+    }
+
+    private let bezelView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThickMaterial))
+    private let contentStack = UIStackView()
+    private let activityIndicator = UIActivityIndicatorView(style: .large)
+    private let customViewContainer = UIView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @discardableResult
+    static func showAdded(to view: UIView, animated: Bool) -> ProgressHUD {
+        let hud = ProgressHUD(frame: view.bounds)
+        hud.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(hud)
+        hud.show(animated: animated)
+        return hud
+    }
+
+    func hide(animated: Bool) {
+        let removal = { self.removeFromSuperview() }
+        if animated {
+            UIView.animate(withDuration: 0.2, animations: { self.alpha = 0 }) { _ in removal() }
+        } else {
+            removal()
+        }
+    }
+
+    func hide(animated: Bool, afterDelay delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.hide(animated: animated)
+        }
+    }
+
+    private func setup() {
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(backgroundView)
+
+        bezelView.translatesAutoresizingMaskIntoConstraints = false
+        bezelView.layer.cornerRadius = DesignSystem.CornerRadius.two
+        bezelView.layer.cornerCurve = .continuous
+        bezelView.clipsToBounds = true
+        addSubview(bezelView)
+
+        contentStack.axis = .vertical
+        contentStack.alignment = .center
+        contentStack.spacing = DesignSystem.Spaces.two
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        bezelView.contentView.addSubview(contentStack)
+
+        activityIndicator.startAnimating()
+        customViewContainer.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .preferredFont(forTextStyle: .headline)
+        label.onTextChange = { [weak self] in self?.updateContent() }
+
+        contentStack.addArrangedSubview(activityIndicator)
+        contentStack.addArrangedSubview(customViewContainer)
+        contentStack.addArrangedSubview(label)
+
+        NSLayoutConstraint.activate([
+            backgroundView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            bezelView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            bezelView.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            contentStack.topAnchor.constraint(
+                equalTo: bezelView.contentView.topAnchor,
+                constant: DesignSystem.Spaces.two
+            ),
+            contentStack.bottomAnchor.constraint(
+                equalTo: bezelView.contentView.bottomAnchor,
+                constant: -DesignSystem.Spaces.two
+            ),
+            contentStack.leadingAnchor.constraint(
+                equalTo: bezelView.contentView.leadingAnchor,
+                constant: DesignSystem.Spaces.two
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: bezelView.contentView.trailingAnchor,
+                constant: -DesignSystem.Spaces.two
+            ),
+        ])
+
+        updateContent()
+    }
+
+    private func show(animated: Bool) {
+        guard animated else { return }
+        alpha = 0
+        UIView.animate(withDuration: 0.2) { self.alpha = 1 }
+    }
+
+    private func updateContent() {
+        activityIndicator.isHidden = mode != .indeterminate
+        customViewContainer.isHidden = mode != .customView || customView == nil
+        label.isHidden = label.text?.isEmpty ?? true
+    }
+}
+
+final class HUDLabel: UILabel {
+    var onTextChange: (() -> Void)?
+
+    override var text: String? {
+        didSet { onTextChange?() }
+    }
+}

--- a/Sources/Extensions/NotificationContent/NotificationViewController.swift
+++ b/Sources/Extensions/NotificationContent/NotificationViewController.swift
@@ -1,6 +1,5 @@
 import Alamofire
 import KeychainAccess
-import MBProgressHUD
 import PromiseKit
 import Shared
 import UIKit
@@ -110,7 +109,7 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
 
         activeViewController = NotificationLoadingViewController()
 
-        var hud: MBProgressHUD?
+        var indicator: UIActivityIndicatorView?
 
         viewController(
             for: notification,
@@ -126,16 +125,23 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
             if controller.mediaPlayPauseButtonType == .none, !controller.hidesSystemLoadingIndicator,
                let view = self?.view {
                 // don't show the HUD for a screen that has pause/play because it already acts like a loading indicator
-                hud = {
-                    let hud = MBProgressHUD.showAdded(to: view, animated: true)
-                    hud.offset = CGPoint(x: 0, y: -MBProgressMaxOffset + 50)
-                    return hud
+                indicator = {
+                    let indicator = UIActivityIndicatorView(style: .medium)
+                    indicator.translatesAutoresizingMaskIntoConstraints = false
+                    view.addSubview(indicator)
+                    NSLayoutConstraint.activate([
+                        indicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                        indicator.topAnchor.constraint(equalTo: view.topAnchor, constant: 50),
+                    ])
+                    indicator.startAnimating()
+                    return indicator
                 }()
             }
 
             return controller.start()
         }.ensure {
-            hud?.hide(animated: true)
+            indicator?.stopAnimating()
+            indicator?.removeFromSuperview()
         }.catch { [weak self] error in
             Current.Log.error("finally failed: \(error)")
             self?.activeViewController = NotificationErrorViewController(error: error)


### PR DESCRIPTION
## Summary
Drops the `MBProgressHUD` CocoaPod in favour of our own implementation.

MBProgressHUD was used in only a handful of places:
- **App** (server-switch toast in `WebViewGestureHandler`, full-screen confirm in `SceneManager`) → replaced with a small native `ProgressHUD` (`Sources/App/Utilities/ProgressHUD.swift`), a UIKit view supporting the used subset: `showAdded(to:animated:)`, `mode` (indeterminate / text / customView), `label`, `customView`, `backgroundView.style` (solid / blur), and `hide(animated:)` / `hide(animated:afterDelay:)`.
- **NotificationContent extension** → replaced with a plain `UIActivityIndicatorView` pinned near the top (reproducing the previous offset).

Also removed the now-dead `import MBProgressHUD` in `AppDelegate` and `WebViewController`, the pod from the `Podfile` / `Podfile.lock`, and the hardcoded `-framework "MBProgressHUD"` entries in the App target's `OTHER_LDFLAGS`.

> **Note:** this drops a CocoaPod, so `pod install` must be run to regenerate the Pods project (CI does this on a fresh checkout). `Podfile.lock` is already updated to match.

> Stacked on #4929 (UIColor-Hex-Swift removal); base will retarget to `main` once that merges.

## Screenshots
<!-- UI is functionally equivalent: a centered bezel with spinner / icon / text that auto-dismisses. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Verified with SwiftFormat and SwiftLint (no violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)