### PR TITLE
Replace ReachabilitySwift dependency with NWPathMonitor

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -45,8 +45,6 @@ end
 abstract_target 'iOS' do
   platform :ios, '15.0'
 
-  pod 'ReachabilitySwift'
-
   # fixes newer cocoapods search path issues for Clibsodium build failures
   shared_fwk_pods
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,6 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (8.1.2):
     - PromiseKit/CorePromise
-  - ReachabilitySwift (5.0.0)
   - Realm (10.35.0):
     - Realm/Headers (= 10.35.0)
   - Realm/Headers (10.35.0)
@@ -60,7 +59,6 @@ DEPENDENCIES:
   - ObjectMapper (from `https://github.com/tristanhimmelman/ObjectMapper.git`, branch `master`)
   - OHHTTPStubs/Swift
   - PromiseKit (~> 8.1.1)
-  - ReachabilitySwift
   - RealmSwift
   - Sodium (from `https://github.com/zacwest/swift-sodium.git`, branch `xcode-14.0.1`)
   - Starscream (from `https://github.com/bgoncal/starscream`, tag `4.0.9`)
@@ -75,7 +73,6 @@ SPEC REPOS:
     - ObjcExceptionBridging
     - OHHTTPStubs
     - PromiseKit
-    - ReachabilitySwift
     - Realm
     - RealmSwift
     - SwiftFormat
@@ -125,7 +122,6 @@ SPEC CHECKSUMS:
   ObjectMapper: e6e4d91ff7f2861df7aecc536c92d8363f4c9677
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   PromiseKit: e057b5b3c0ce9a0145674d633930924234104ee3
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   Realm: e6b04f15a814cb22aae621e7e15f2ccb27ac8f95
   RealmSwift: b358779c10ba6d2648d541f8a1bcd671f73485c1
   Sodium: a7d42cb46e789d2630fa552d35870b416ed055ae
@@ -136,6 +132,6 @@ SPEC CHECKSUMS:
   Version: de5907f2c5d0f3cf21708db7801d1d5401139486
   XCGLogger: 1943831ef907df55108b0b18657953f868de973b
 
-PODFILE CHECKSUM: f1f3f4803de5d663773e0bb46a5aebb2e9fbcded
+PODFILE CHECKSUM: 21128e9cdc6075f2f0c1baffeefe9174a2ce2851
 
 COCOAPODS: 1.15.2

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -8,9 +8,6 @@ import PromiseKit
 import RealmSwift
 import UIKit
 import Version
-#if os(iOS)
-import Reachability
-#endif
 
 public class HomeAssistantAPI {
     public enum APIError: Error, Equatable {

--- a/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
@@ -2,7 +2,6 @@ import Foundation
 import PromiseKit
 #if os(iOS)
 import CoreTelephony
-import Reachability
 #endif
 
 final class ConnectivitySensorUpdateSignaler: SensorProviderUpdateSignaler, SensorObserver {

--- a/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
+++ b/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
@@ -99,7 +99,7 @@ public enum NetworkType: Int, CaseIterable {
 public final class NetworkReachability {
     public static let didChangeNotification = Notification.Name("NetworkReachabilityChanged")
 
-    private enum Connection {
+    private enum Connection: Equatable {
         case unavailable
         case wifi
         case cellular
@@ -107,9 +107,14 @@ public final class NetworkReachability {
 
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "io.home-assistant.reachability")
+    private var lastConnection: Connection?
 
     public init() {
-        monitor.pathUpdateHandler = { _ in
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let connection = Self.connection(for: path)
+            guard connection != lastConnection else { return }
+            self.lastConnection = connection
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: NetworkReachability.didChangeNotification, object: nil)
             }
@@ -121,13 +126,16 @@ public final class NetworkReachability {
         monitor.cancel()
     }
 
-    private var connection: Connection {
-        let path = monitor.currentPath
+    private static func connection(for path: NWPath) -> Connection {
         guard path.status == .satisfied else { return .unavailable }
         if path.usesInterfaceType(.cellular) {
             return .cellular
         }
         return .wifi
+    }
+
+    private var connection: Connection {
+        Self.connection(for: monitor.currentPath)
     }
 
     public func getSimpleNetworkType() -> NetworkType {

--- a/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
+++ b/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
@@ -1,7 +1,7 @@
 import Foundation
 #if os(iOS)
 import CoreTelephony
-import Reachability
+import Network
 #endif
 
 public enum NetworkType: Int, CaseIterable {
@@ -96,38 +96,63 @@ public enum NetworkType: Int, CaseIterable {
 }
 
 #if os(iOS)
-public extension Reachability {
-    func getSimpleNetworkType() -> NetworkType {
-        try? startNotifier()
+public final class NetworkReachability {
+    public static let didChangeNotification = Notification.Name("NetworkReachabilityChanged")
 
+    private enum Connection {
+        case unavailable
+        case wifi
+        case cellular
+    }
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "io.home-assistant.reachability")
+
+    public init() {
+        monitor.pathUpdateHandler = { _ in
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: NetworkReachability.didChangeNotification, object: nil)
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    private var connection: Connection {
+        let path = monitor.currentPath
+        guard path.status == .satisfied else { return .unavailable }
+        if path.usesInterfaceType(.cellular) {
+            return .cellular
+        }
+        return .wifi
+    }
+
+    public func getSimpleNetworkType() -> NetworkType {
         switch connection {
-        case .none:
+        case .unavailable:
             return .noConnection
         case .wifi:
             return .wifi
         case .cellular:
             return .cellular
-        case .unavailable:
-            return .noConnection
         }
     }
 
-    func getNetworkType() -> NetworkType {
-        try? startNotifier()
-
+    public func getNetworkType() -> NetworkType {
         switch connection {
-        case .none:
+        case .unavailable:
             return .noConnection
         case .wifi:
             return .wifi
         case .cellular:
             #if !targetEnvironment(macCatalyst)
-            return Reachability.getWWANNetworkType()
+            return Self.getWWANNetworkType()
             #else
             return .cellular
             #endif
-        case .unavailable:
-            return .noConnection
         }
     }
 

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -1,7 +1,6 @@
 import Foundation
 #if os(iOS)
 import CoreTelephony
-import Reachability
 #endif
 import NetworkExtension
 
@@ -51,13 +50,8 @@ public class ConnectivityWrapper {
 
     #elseif os(iOS)
     init() {
-        let reachability = try? Reachability()
+        let reachability = NetworkReachability()
 
-        do {
-            try reachability?.startNotifier()
-        } catch {
-            Current.Log.error("failed to start reachability notifier: \(error)")
-        }
         self.hasWiFi = { true }
         self.currentWiFiSSID = {
             nil
@@ -65,9 +59,9 @@ public class ConnectivityWrapper {
         self.currentWiFiBSSID = {
             nil
         }
-        self.connectivityDidChangeNotification = { .reachabilityChanged }
-        self.simpleNetworkType = { reachability?.getSimpleNetworkType() ?? .unknown }
-        self.cellularNetworkType = { reachability?.getNetworkType() ?? .unknown }
+        self.connectivityDidChangeNotification = { NetworkReachability.didChangeNotification }
+        self.simpleNetworkType = { reachability.getSimpleNetworkType() }
+        self.cellularNetworkType = { reachability.getNetworkType() }
         self.currentNetworkHardwareAddress = { nil }
         self.networkAttributes = { [:] }
 
@@ -76,7 +70,7 @@ public class ConnectivityWrapper {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(connectivityDidChange(_:)),
-            name: .reachabilityChanged,
+            name: NetworkReachability.didChangeNotification,
             object: nil
         )
     }


### PR DESCRIPTION
## Summary
Drops the `ReachabilitySwift` CocoaPod in favour of Apple's `Network` framework.

Its used surface was small (coarse Wi-Fi / cellular / no-connection detection plus a change notification), so it's reimplemented as a native `NetworkReachability` wrapper around `NWPathMonitor` in `Reachability+NetworkType.swift`. The `.connection` semantics are preserved to match the old behaviour: `satisfied + cellular → cellular`, otherwise `wifi`; the cellular WWAN sub-typing via `CoreTelephony` is unchanged. `NWPathMonitor` is already used elsewhere in the app.

Also removed two dead `import Reachability` lines (`HAAPI`, `ConnectivitySensor`).

> Note: the watch's `Reachability` (from Communicator, `currentReachability` / `Reachability.observe`) is a different type and is left untouched — ReachabilitySwift was never linked on watchOS.

> This drops a CocoaPod, so `pod install` must run to regenerate the Pods project (CI does this on a fresh checkout). `Podfile.lock` is already updated.

## Screenshots
N/A — no user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Verified with SwiftFormat and SwiftLint (no violations), and a native `pod install` (ReachabilitySwift removed cleanly; `Manifest.lock` matches `Podfile.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)