### PR TITLE
Add similarSFSymbol mapping from MaterialDesignIcons to SF Symbols

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 		425762732E71A8B800AE5083 /* ModalCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425762722E71A8B800AE5083 /* ModalCloseButton.swift */; };
 		425762742E71A8B800AE5083 /* ModalCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425762722E71A8B800AE5083 /* ModalCloseButton.swift */; };
 		4259959A2F44708F0023D6A6 /* View+ScreenCaptureProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425995992F44708F0023D6A6 /* View+ScreenCaptureProtection.swift */; };
+		42B7C1A12F78D10000E4F3AB /* MaterialDesignIcons+SFSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B7C1A02F78D10000E4F3AB /* MaterialDesignIcons+SFSymbol.swift */; };
 		425C5A072CF756DF00206B5B /* AssistMicAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425C5A062CF756DF00206B5B /* AssistMicAnimationView.swift */; };
 		425EB4FD2F5F0ACB0067A678 /* TTSVoicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425EB4FC2F5F0ACB0067A678 /* TTSVoicePickerView.swift */; };
 		425EB5002F5F0EDF0067A678 /* MockSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425EB4FE2F5F0EDF0067A678 /* MockSpeechSynthesizer.swift */; };
@@ -1132,6 +1133,7 @@
 		42EEEFE32E2791430080E973 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE12E2791430080E973 /* Service.swift */; };
 		42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE42E2792B20080E973 /* Service.test.swift */; };
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
+		42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */; };
 		42EF0ACD2D4CDC0C0088C91E /* ResetAllCustomWidgetConfirmationAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EF0ACC2D4CDC0C0088C91E /* ResetAllCustomWidgetConfirmationAppIntent.swift */; };
 		42EF0ACE2D4CDC0C0088C91E /* ResetAllCustomWidgetConfirmationAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EF0ACC2D4CDC0C0088C91E /* ResetAllCustomWidgetConfirmationAppIntent.swift */; };
 		42EF0AD12D4CDFF30088C91E /* UpdateWidgetItemConfirmationStateAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EF0ACF2D4CDFF30088C91E /* UpdateWidgetItemConfirmationStateAppIntent.swift */; };
@@ -2542,6 +2544,7 @@
 		4256A70C2F5ECBB3003D464F /* SpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechTranscriber.swift; sourceTree = "<group>"; };
 		425762722E71A8B800AE5083 /* ModalCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalCloseButton.swift; sourceTree = "<group>"; };
 		425995992F44708F0023D6A6 /* View+ScreenCaptureProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ScreenCaptureProtection.swift"; sourceTree = "<group>"; };
+		42B7C1A02F78D10000E4F3AB /* MaterialDesignIcons+SFSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MaterialDesignIcons+SFSymbol.swift"; sourceTree = "<group>"; };
 		425C5A062CF756DF00206B5B /* AssistMicAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistMicAnimationView.swift; sourceTree = "<group>"; };
 		425EB4FC2F5F0ACB0067A678 /* TTSVoicePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSVoicePickerView.swift; sourceTree = "<group>"; };
 		425EB4FE2F5F0EDF0067A678 /* MockSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSpeechSynthesizer.swift; sourceTree = "<group>"; };
@@ -3051,6 +3054,7 @@
 		42EEEFE12E2791430080E973 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		42EEEFE42E2792B20080E973 /* Service.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.test.swift; sourceTree = "<group>"; };
 		DA5459C05BEB77340680D8C6 /* Domain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.test.swift; sourceTree = "<group>"; };
+		42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialDesignIconsSFSymbol.test.swift; sourceTree = "<group>"; };
 		42EF0ACC2D4CDC0C0088C91E /* ResetAllCustomWidgetConfirmationAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetAllCustomWidgetConfirmationAppIntent.swift; sourceTree = "<group>"; };
 		42EF0ACF2D4CDFF30088C91E /* UpdateWidgetItemConfirmationStateAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateWidgetItemConfirmationStateAppIntent.swift; sourceTree = "<group>"; };
 		42EFFAEB2C8882DD002F10FC /* CarPlayConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayConfigurationView.swift; sourceTree = "<group>"; };
@@ -5284,6 +5288,7 @@
 				421B1C1B2BD65BFA001ED18C /* View+ConditionalModifier.swift */,
 				42A3B63A2BD91854007BC0F3 /* Color+Codable.swift */,
 				42A3B63D2BD918D6007BC0F3 /* MaterialDesignIcons+Encodable.swift */,
+				42B7C1A02F78D10000E4F3AB /* MaterialDesignIcons+SFSymbol.swift */,
 				425995992F44708F0023D6A6 /* View+ScreenCaptureProtection.swift */,
 			);
 			path = Extensions;
@@ -7404,6 +7409,7 @@
 				42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */,
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
+				42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */,
 				B90B4A989089C3375C55AF75 /* CallServiceResponse.test.swift */,
 			);
 			path = Shared;
@@ -10377,6 +10383,7 @@
 				B6B74CB6228397D100D58A68 /* WatchHelpers.swift in Sources */,
 				42790C462C4808FA00E31B38 /* AppleLikeBottomSheet.swift in Sources */,
 				4259959A2F44708F0023D6A6 /* View+ScreenCaptureProtection.swift in Sources */,
+				42B7C1A12F78D10000E4F3AB /* MaterialDesignIcons+SFSymbol.swift in Sources */,
 				B6723344225DBACF0031D629 /* AuthRequestMessage.swift in Sources */,
 				D0DD2CEE213BCA8900C3D9F7 /* URL+Extensions.swift in Sources */,
 				427FEE682D9ECFD70047C00C /* PrivacyNoteView.swift in Sources */,
@@ -10699,6 +10706,7 @@
 				8DFA3DEE4881E59961C3B5E2 /* BarometerSensor.test.swift in Sources */,
 				42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */,
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
+				42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */,
 				42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */,
 				118511C224B25BEB00D18F60 /* WebhookManager.test.swift in Sources */,
 				114CBAEB2839FC2500A9BAFF /* SecurityExceptions.test.swift in Sources */,

--- a/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
+++ b/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SFSafeSymbols
 
 public extension MaterialDesignIcons {
@@ -57,6 +56,7 @@ private extension MaterialDesignIcons {
     var sfSymbols4Match: SFSymbol? {
         switch self {
         // MARK: Lighting
+
         case .lightbulbGroupIcon, .lightbulbGroupOutlineIcon, .lightbulbMultipleIcon: return .lightbulb2
         case .lightbulbMultipleOutlineIcon: return .lightbulb2
         case .ceilingLightIcon, .ceilingLightOutlineIcon, .ceilingLightMultipleIcon: return .lampCeiling
@@ -74,6 +74,7 @@ private extension MaterialDesignIcons {
         case .spotlightBeamIcon: return .lightBeaconMax
 
         // MARK: Climate & air
+
         case .thermometerIcon, .thermostatIcon, .thermostatBoxIcon: return .thermometerMedium
         case .thermometerHighIcon: return .thermometerHigh
         case .thermometerLowIcon: return .thermometerLow
@@ -92,6 +93,7 @@ private extension MaterialDesignIcons {
         case .airHumidifierOffIcon: return .humidifierFill
 
         // MARK: Sensors & safety
+
         case .smokeDetectorIcon, .smokeDetectorVariantIcon, .smokeDetectorOutlineIcon: return .sensor
         case .smokeDetectorAlertIcon, .smokeDetectorVariantAlertIcon: return .sensorFill
         case .motionSensorIcon: return .sensorTagRadiowavesForward
@@ -103,6 +105,7 @@ private extension MaterialDesignIcons {
         case .keyWirelessIcon: return .keyRadiowavesForward
 
         // MARK: Doors, windows & covers
+
         case .doorIcon, .doorClosedIcon, .doorClosedLockIcon: return .doorLeftHandClosed
         case .doorOpenIcon: return .doorLeftHandOpen
         case .doorSlidingIcon: return .doorSlidingLeftHandClosed
@@ -125,6 +128,7 @@ private extension MaterialDesignIcons {
         case .stairsIcon, .stairsUpIcon, .stairsDownIcon: return .stairs
 
         // MARK: Rooms, furniture & appliances
+
         case .sofaIcon, .sofaOutlineIcon: return .sofa
         case .sofaSingleIcon, .sofaSingleOutlineIcon: return .chairLounge
         case .chairRollingIcon, .seatIcon, .seatOutlineIcon: return .chair
@@ -147,6 +151,7 @@ private extension MaterialDesignIcons {
         case .cakeVariantIcon, .cakeVariantOutlineIcon, .cakeIcon: return .birthdayCake
 
         // MARK: Water & outdoor
+
         case .pipeValveIcon, .valveIcon: return .spigot
         case .waterPumpIcon: return .spigot
         case .sprinklerIcon, .sprinklerFireIcon: return .sprinkler
@@ -160,6 +165,7 @@ private extension MaterialDesignIcons {
         case .tentIcon: return .tent
 
         // MARK: Power
+
         case .powerSocketIcon: return .poweroutletStrip
         case .powerSocketUsIcon: return .poweroutletTypeB
         case .powerSocketEuIcon, .powerSocketDeIcon: return .poweroutletTypeF
@@ -171,6 +177,7 @@ private extension MaterialDesignIcons {
         case .powerSocketItIcon: return .poweroutletTypeL
 
         // MARK: People & figures
+
         case .accountClockIcon, .accountClockOutlineIcon: return .personBadgeClock
         case .accountKeyIcon, .accountKeyOutlineIcon: return .personBadgeKey
         case .accountChildIcon, .accountChildOutlineIcon: return .figureAndChildHoldinghands
@@ -185,6 +192,7 @@ private extension MaterialDesignIcons {
         case .locationExitIcon: return .figureWalkDeparture
 
         // MARK: Devices & tech
+
         case .routerIcon, .routerWirelessIcon, .routerNetworkIcon: return .wifiRouter
         case .routerWirelessOffIcon: return .wifiRouter
         case .accessPointIcon, .accessPointNetworkIcon: return .wifiRouter
@@ -193,6 +201,7 @@ private extension MaterialDesignIcons {
         case .commentQuestionIcon, .commentQuestionOutlineIcon: return .questionmarkBubble
 
         // MARK: Vehicles & transport
+
         case .roadIcon, .roadVariantIcon, .highwayIcon: return .roadLanes
         case .parkingIcon: return .parkingsign
         case .sailBoatIcon: return .sailboat
@@ -200,6 +209,7 @@ private extension MaterialDesignIcons {
         case .snowboardIcon: return .figureSnowboarding
 
         // MARK: Sports & leisure
+
         case .dumbbellIcon: return .dumbbell
         case .weightLifterIcon: return .figureStrengthtrainingTraditional
         case .yogaIcon, .meditationIcon: return .figureMindAndBody
@@ -216,20 +226,21 @@ private extension MaterialDesignIcons {
         case .partyPopperIcon: return .partyPopper
 
         // MARK: Animals & nature
+
         case .birdIcon: return .bird
         case .fishIcon: return .fish
-        case .virusIcon, .virusOutlineIcon, .bacteriaIcon, .bacteriaOutlineIcon: return .allergens
 
         // MARK: Misc objects
+
         case .wrenchIcon, .wrenchOutlineIcon: return .wrenchAdjustable
         case .pencilRulerIcon: return .pencilAndRuler
         case .bagPersonalIcon, .bagPersonalOutlineIcon: return .backpack
         case .medalIcon, .medalOutlineIcon: return .medal
-        case .compassIcon, .compassOutlineIcon: return .locationNorthCircle
         case .flagCheckeredIcon: return .flagCheckered
         case .robotIcon, .robotOutlineIcon: return .gearshapeArrowTriangle2Circlepath
 
         // MARK: Older-OS fallbacks for SF Symbols 5 matches
+
         case .fanIcon, .fanSpeed1Icon, .fanSpeed2Icon, .fanSpeed3Icon, .fanAutoIcon: return .fanOscillation
         case .speedometerIcon, .speedometerMediumIcon, .speedometerSlowIcon: return .dialMedium
         case .gaugeIcon, .gaugeFullIcon, .gaugeLowIcon, .gaugeEmptyIcon: return .dialMedium
@@ -257,6 +268,7 @@ private extension MaterialDesignIcons {
     var sfSymbols3Match: SFSymbol? {
         switch self {
         // MARK: Home
+
         case .homeIcon, .homeOutlineIcon, .homeVariantIcon, .homeVariantOutlineIcon: return .house
         case .homeAssistantIcon, .homeAutomationIcon, .homeAccountIcon, .homeHeartIcon: return .house
         case .homeCircleIcon, .homeCircleOutlineIcon: return .houseCircle
@@ -266,6 +278,7 @@ private extension MaterialDesignIcons {
         case .homeGroupIcon: return .house
 
         // MARK: Lighting (baseline)
+
         case .lightbulbIcon, .lightbulbOutlineIcon, .lightbulbVariantIcon: return .lightbulb
         case .lightbulbVariantOutlineIcon, .lightbulbCflIcon, .lightbulbCflOffIcon: return .lightbulb
         case .lightbulbOnIcon, .lightbulbOnOutlineIcon: return .lightbulbFill
@@ -276,6 +289,7 @@ private extension MaterialDesignIcons {
         case .candleIcon: return .flame
 
         // MARK: Switches & power (baseline)
+
         case .toggleSwitchIcon, .toggleSwitchOutlineIcon, .toggleSwitchVariantIcon: return .switch2
         case .toggleSwitchOffIcon, .toggleSwitchOffOutlineIcon: return .switch2
         case .toggleSwitchVariantOffIcon, .electricSwitchIcon, .electricSwitchClosedIcon: return .switch2
@@ -291,6 +305,7 @@ private extension MaterialDesignIcons {
         case .carBatteryIcon: return .minusPlusBatteryblock
 
         // MARK: Climate & weather (baseline)
+
         case .weatherSunnyIcon, .whiteBalanceSunnyIcon, .brightness5Icon: return .sunMax
         case .brightness6Icon, .brightness7Icon: return .sunMaxFill
         case .brightness4Icon, .brightnessPercentIcon: return .sunMin
@@ -324,6 +339,7 @@ private extension MaterialDesignIcons {
         case .airballoonIcon, .airballoonOutlineIcon: return .airplane
 
         // MARK: Security & locks
+
         case .lockIcon, .lockOutlineIcon, .lockSmartIcon: return .lock
         case .lockOpenIcon, .lockOpenOutlineIcon, .lockOpenVariantIcon: return .lockOpen
         case .lockOpenVariantOutlineIcon: return .lockOpen
@@ -346,6 +362,7 @@ private extension MaterialDesignIcons {
         case .leakIcon: return .drop
 
         // MARK: People
+
         case .accountIcon, .accountOutlineIcon: return .person
         case .accountCircleIcon, .accountCircleOutlineIcon: return .personCircle
         case .accountMultipleIcon, .accountMultipleOutlineIcon: return .person2
@@ -374,6 +391,7 @@ private extension MaterialDesignIcons {
         case .thumbDownIcon, .thumbDownOutlineIcon: return .handThumbsdown
 
         // MARK: Media players & audio
+
         case .playIcon, .playOutlineIcon: return .play
         case .playCircleIcon, .playCircleOutlineIcon: return .playCircle
         case .pauseIcon: return .pause
@@ -437,6 +455,7 @@ private extension MaterialDesignIcons {
         case .cameraImageIcon: return .photo
 
         // MARK: Communication
+
         case .emailIcon, .emailOutlineIcon, .emailVariantIcon: return .envelope
         case .emailOpenIcon, .emailOpenOutlineIcon: return .envelopeOpen
         case .sendIcon, .sendOutlineIcon, .emailFastIcon, .emailFastOutlineIcon: return .paperplane
@@ -459,6 +478,7 @@ private extension MaterialDesignIcons {
         case .bellPlusIcon, .bellPlusOutlineIcon: return .bellBadge
 
         // MARK: Devices
+
         case .cellphoneIcon, .cellphoneBasicIcon: return .iphone
         case .cellphoneOffIcon: return .iphoneSlash
         case .cellphoneWirelessIcon, .cellphoneNfcIcon: return .iphoneRadiowavesLeftAndRight
@@ -486,6 +506,7 @@ private extension MaterialDesignIcons {
         case .controllerIcon, .controllerClassicIcon, .controllerClassicOutlineIcon: return .gamecontroller
 
         // MARK: Connectivity
+
         case .wifiIcon, .wifiStrength4Icon: return .wifi
         case .wifiStrength1Icon, .wifiStrength2Icon, .wifiStrength3Icon: return .wifi
         case .wifiOffIcon, .wifiStrengthOffIcon, .wifiStrengthOffOutlineIcon: return .wifiSlash
@@ -508,6 +529,7 @@ private extension MaterialDesignIcons {
         case .barcodeScanIcon: return .barcodeViewfinder
 
         // MARK: Transport
+
         case .carIcon, .carSideIcon, .carHatchbackIcon, .carEstateIcon, .taxiIcon: return .car
         case .carSportsIcon, .carConvertibleIcon, .carConnectedIcon, .carWashIcon: return .car
         case .carElectricIcon, .carElectricOutlineIcon: return .boltCar
@@ -535,6 +557,7 @@ private extension MaterialDesignIcons {
         case .routesIcon, .callSplitIcon, .sourceBranchIcon: return .arrowTriangleBranch
 
         // MARK: Time & calendar
+
         case .clockIcon, .clockOutlineIcon, .clockDigitalIcon, .clockFastIcon: return .clock
         case .alarmIcon: return .alarm
         case .timerIcon, .timerOutlineIcon, .timerOffIcon, .timerOffOutlineIcon: return .timer
@@ -551,6 +574,7 @@ private extension MaterialDesignIcons {
         case .calendarAlertIcon: return .calendarBadgeExclamationmark
 
         // MARK: Files & documents
+
         case .fileIcon, .fileOutlineIcon: return .doc
         case .fileDocumentIcon, .fileDocumentOutlineIcon: return .docText
         case .fileMultipleIcon, .fileMultipleOutlineIcon: return .docOnDoc
@@ -588,6 +612,7 @@ private extension MaterialDesignIcons {
         case .receiptIcon, .receiptTextIcon, .receiptTextOutlineIcon: return .docPlaintext
 
         // MARK: Editing & actions
+
         case .pencilIcon, .pencilOutlineIcon, .leadPencilIcon: return .pencil
         case .pencilOffIcon: return .pencilSlash
         case .drawIcon: return .pencilAndOutline
@@ -624,6 +649,7 @@ private extension MaterialDesignIcons {
         case .pinOffIcon, .pinOffOutlineIcon: return .pinSlash
 
         // MARK: Basic UI
+
         case .closeIcon, .closeThickIcon, .windowCloseIcon: return .xmark
         case .closeCircleIcon, .closeCircleOutlineIcon: return .xmarkCircle
         case .closeBoxIcon, .closeBoxOutlineIcon: return .xmarkSquare
@@ -685,6 +711,7 @@ private extension MaterialDesignIcons {
         case .gestureSwipeIcon: return .handDraw
 
         // MARK: Settings & tools
+
         case .cogIcon, .cogOutlineIcon: return .gearshape
         case .cogsIcon: return .gearshape2
         case .tuneIcon, .tuneVariantIcon: return .sliderHorizontal3
@@ -723,6 +750,7 @@ private extension MaterialDesignIcons {
         case .keyChainIcon, .keyChainVariantIcon: return .key
 
         // MARK: Health
+
         case .medicalBagIcon: return .crossCase
         case .hospitalIcon, .hospitalBoxIcon, .hospitalBoxOutlineIcon: return .cross
         case .ambulanceIcon: return .cross
@@ -735,12 +763,14 @@ private extension MaterialDesignIcons {
         case .atomIcon, .atomVariantIcon: return .atom
 
         // MARK: Food & dining
+
         case .silverwareIcon, .silverwareForkKnifeIcon, .silverwareVariantIcon: return .forkKnife
         case .foodIcon, .foodVariantIcon: return .forkKnife
         case .coffeeIcon, .coffeeOutlineIcon, .coffeeMakerIcon: return .cupAndSaucer
         case .coffeeMakerOutlineIcon, .cupIcon, .cupOutlineIcon: return .cupAndSaucer
 
         // MARK: Nature & animals (baseline)
+
         case .leafIcon, .leafCircleIcon, .leafCircleOutlineIcon, .sproutIcon: return .leaf
         case .sproutOutlineIcon, .grassIcon: return .leaf
         case .pawIcon, .pawOutlineIcon: return .pawprint
@@ -749,11 +779,13 @@ private extension MaterialDesignIcons {
         case .fireExtinguisherIcon: return .flame
 
         // MARK: Beds & bedroom
+
         case .bedIcon, .bedOutlineIcon, .bedDoubleIcon, .bedDoubleOutlineIcon: return .bedDouble
         case .bedKingIcon, .bedKingOutlineIcon, .bedQueenIcon, .bedQueenOutlineIcon: return .bedDouble
         case .bedSingleIcon, .bedSingleOutlineIcon, .bedEmptyIcon: return .bedDouble
 
         // MARK: Commerce & data
+
         case .creditCardIcon, .creditCardOutlineIcon: return .creditcard
         case .creditCardWirelessIcon, .creditCardWirelessOutlineIcon: return .creditcard
         case .cashIcon, .cashMultipleIcon: return .banknote
@@ -779,6 +811,7 @@ private extension MaterialDesignIcons {
         case .sitemapIcon, .sitemapOutlineIcon: return .rectangle3Group
 
         // MARK: Code & math
+
         case .codeBracesIcon, .codeJsonIcon: return .curlybraces
         case .codeTagsIcon, .xmlIcon: return .chevronLeftForwardslashChevronRight
         case .functionIcon, .functionVariantIcon: return .function
@@ -792,6 +825,85 @@ private extension MaterialDesignIcons {
         case .translateIcon: return .characterBookClosed
 
         // MARK: Older-OS fallbacks for newer matches
+
+        case .virusIcon, .virusOutlineIcon, .bacteriaIcon, .bacteriaOutlineIcon: return .allergens
+        case .compassIcon, .compassOutlineIcon: return .locationNorthCircle
+        case .fanIcon, .fanSpeed1Icon, .fanSpeed2Icon, .fanSpeed3Icon, .fanAutoIcon, .fanOffIcon: return .wind
+        case .airFilterIcon, .airPurifierIcon: return .wind
+        case .airConditionerIcon, .hvacIcon, .hvacOffIcon: return .snowflake
+        case .thermometerIcon, .thermometerHighIcon, .thermometerLowIcon: return .thermometerSun
+        case .thermostatIcon, .thermostatBoxIcon, .homeThermometerIcon: return .thermometerSun
+        case .homeThermometerOutlineIcon: return .thermometerSun
+        case .temperatureCelsiusIcon, .temperatureFahrenheitIcon, .temperatureKelvinIcon: return .thermometerSun
+        case .airHumidifierIcon, .airHumidifierOffIcon: return .humidity
+        case .radiatorIcon, .radiatorOffIcon, .radiatorDisabledIcon: return .flame
+        case .heatingCoilIcon, .heatWaveIcon, .fireplaceIcon, .fireplaceOffIcon, .gasBurnerIcon: return .flame
+        case .waterBoilerIcon, .waterBoilerOffIcon, .waterBoilerAlertIcon: return .flame
+        case .sprinklerIcon, .sprinklerFireIcon, .sprinklerVariantIcon, .waterPumpIcon: return .drop
+        case .pipeValveIcon, .valveIcon: return .drop
+        case .showerIcon, .showerHeadIcon, .bathtubIcon, .bathtubOutlineIcon, .hotTubIcon: return .drop
+        case .batteryIcon, .battery10Icon, .battery20Icon, .battery30Icon, .battery40Icon: return .boltBatteryblock
+        case .battery50Icon, .battery60Icon, .battery70Icon, .battery80Icon, .battery90Icon: return .boltBatteryblock
+        case .batteryHighIcon, .batteryMediumIcon, .batteryLowIcon: return .boltBatteryblock
+        case .batteryOutlineIcon, .batteryAlertIcon, .batteryOffIcon: return .boltBatteryblock
+        case .gaugeIcon, .gaugeFullIcon, .gaugeLowIcon, .gaugeEmptyIcon: return .barometer
+        case .speedometerIcon, .speedometerMediumIcon, .speedometerSlowIcon: return .barometer
+        case .robotIcon, .robotOutlineIcon: return .gearshape2
+        case .lightSwitchIcon, .lightSwitchOffIcon: return .switch2
+        case .lightbulbGroupIcon, .lightbulbGroupOutlineIcon, .lightbulbMultipleIcon: return .lightbulb
+        case .lightbulbMultipleOutlineIcon, .chandelierIcon, .trackLightIcon, .spotlightBeamIcon: return .lightbulb
+        case .ceilingLightIcon, .ceilingLightOutlineIcon, .ceilingLightMultipleIcon: return .lightbulb
+        case .ceilingLightMultipleOutlineIcon, .ledStripIcon, .ledStripVariantIcon: return .lightbulb
+        case .floorLampIcon, .floorLampOutlineIcon, .floorLampDualIcon: return .lightbulb
+        case .floorLampDualOutlineIcon, .floorLampTorchiereIcon, .deskLampIcon, .deskLampOnIcon: return .lightbulb
+        case .lampIcon, .lampOutlineIcon, .lampsIcon, .lampsOutlineIcon: return .lightbulb
+        case .cctvIcon, .webcamIcon: return .video
+        case .motionSensorIcon: return .dotRadiowavesLeftAndRight
+        case .moleculeCo2Icon, .moleculeCoIcon: return .aqiMedium
+        case .routerIcon, .routerWirelessIcon, .routerNetworkIcon, .routerWirelessOffIcon: return .wifi
+        case .accessPointIcon, .accessPointNetworkIcon: return .wifi
+        case .signalIcon, .signalCellular1Icon, .signalCellular2Icon: return .chartBar
+        case .signalCellular3Icon, .signalCellularOutlineIcon: return .chartBar
+        case .remoteIcon: return .appletvremoteGen1
+        case .messageProcessingIcon, .messageProcessingOutlineIcon: return .message
+        case .commentQuestionIcon, .commentQuestionOutlineIcon: return .bubbleLeft
+        case .consoleIcon, .consoleLineIcon: return .chevronLeftForwardslashChevronRight
+        case .powerSocketIcon, .powerSocketUsIcon, .powerSocketEuIcon, .powerSocketDeIcon: return .powerplug
+        case .powerSocketUkIcon, .powerSocketAuIcon, .powerSocketFrIcon, .powerSocketJpIcon: return .powerplug
+        case .powerSocketChIcon, .powerSocketItIcon: return .powerplug
+        case .keyWirelessIcon: return .key
+        case .lockAlertIcon, .lockAlertOutlineIcon: return .lock
+        case .clipboardIcon, .clipboardOutlineIcon, .clipboardListIcon: return .docOnClipboard
+        case .clipboardTextIcon, .clipboardTextOutlineIcon: return .docOnClipboard
+        case .flashAlertIcon: return .bolt
+        case .volumePlusIcon, .volumeMinusIcon: return .speakerWave2
+        case .truckIcon, .truckDeliveryIcon, .truckFastIcon, .truckOutlineIcon: return .shippingbox
+        case .parkingIcon: return .pSquare
+        case .sailBoatIcon: return .ferry
+        case .runIcon, .runFastIcon, .hikingIcon: return .figureWalk
+        case .exitRunIcon, .locationExitIcon: return .rectanglePortraitAndArrowRight
+        case .locationEnterIcon: return .arrowRightSquare
+        case .accountClockIcon, .accountClockOutlineIcon, .accountKeyIcon: return .person
+        case .accountKeyOutlineIcon, .accountChildIcon, .accountChildOutlineIcon: return .person
+        case .accountChildCircleIcon: return .person
+        case .medalIcon, .medalOutlineIcon: return .rosette
+        case .trophyIcon, .trophyOutlineIcon, .trophyAwardIcon, .trophyVariantIcon: return .rosette
+        case .flagCheckeredIcon: return .flag
+        case .treeIcon, .treeOutlineIcon, .pineTreeIcon, .forestIcon, .palmTreeIcon: return .leaf
+        case .flowerIcon, .flowerOutlineIcon, .flowerTulipIcon, .flowerTulipOutlineIcon: return .leaf
+        case .carrotIcon: return .leaf
+        case .teaIcon, .teaOutlineIcon: return .cupAndSaucer
+        case .needleIcon: return .cross
+        case .partyPopperIcon: return .sparkles
+        case .eraserIcon: return .pencilSlash
+        case .hangerIcon: return .tshirt
+        case .umbrellaBeachIcon, .umbrellaBeachOutlineIcon, .beachIcon: return .umbrella
+        case .pencilRulerIcon: return .ruler
+        case .wrenchIcon, .wrenchOutlineIcon: return .wrenchAndScrewdriver
+        case .bagPersonalIcon, .bagPersonalOutlineIcon: return .bag
+        case .basketballIcon, .footballIcon, .footballAustralianIcon, .tennisIcon: return .sportscourt
+        case .tennisBallIcon, .volleyballIcon, .rugbyIcon, .hockeyPuckIcon: return .sportscourt
+        case .cricketIcon, .golfIcon, .bowlingIcon: return .sportscourt
         case .storeIcon, .storeOutlineIcon, .storefrontOutlineIcon: return .building
         case .evStationIcon: return .boltCar
         case .dogIcon, .dogSideIcon, .dogServiceIcon, .catIcon: return .pawprint
@@ -806,4 +918,3 @@ private extension MaterialDesignIcons {
         }
     }
 }
-

--- a/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
+++ b/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
@@ -10,7 +10,7 @@ public extension MaterialDesignIcons {
         if #available(iOS 17, watchOS 10, macOS 14, *), let symbol = sfSymbols5Match {
             return symbol
         }
-        if #available(iOS 16, watchOS 9, macOS 13, *), let symbol = sfSymbols4Match {
+        if #available(iOS 16.1, watchOS 9.1, macOS 13, *), let symbol = sfSymbols4Match {
             return symbol
         }
         return sfSymbols3Match ?? .questionmarkCircle
@@ -51,8 +51,8 @@ private extension MaterialDesignIcons {
         }
     }
 
-    /// Matches that require SF Symbols 4 (iOS 16, watchOS 9, macOS 13).
-    @available(iOS 16, watchOS 9, macOS 13, *)
+    /// Matches that require SF Symbols 4/4.1 (iOS 16.1, watchOS 9.1, macOS 13).
+    @available(iOS 16.1, watchOS 9.1, macOS 13, *)
     var sfSymbols4Match: SFSymbol? {
         switch self {
         // MARK: Lighting

--- a/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
+++ b/Sources/Shared/Extensions/MaterialDesignIcons+SFSymbol.swift
@@ -1,0 +1,809 @@
+import Foundation
+import SFSafeSymbols
+
+public extension MaterialDesignIcons {
+    /// An SF Symbol that is visually or semantically similar to this Material Design icon.
+    ///
+    /// The mapping is a best-effort, hand-curated equivalence: it prefers the closest 1:1 match the
+    /// running OS supports (many home-related SF Symbols only exist since iOS 16/17) and falls back
+    /// to `.questionmarkCircle` when there is no reasonable equivalent.
+    var similarSFSymbol: SFSymbol {
+        if #available(iOS 17, watchOS 10, macOS 14, *), let symbol = sfSymbols5Match {
+            return symbol
+        }
+        if #available(iOS 16, watchOS 9, macOS 13, *), let symbol = sfSymbols4Match {
+            return symbol
+        }
+        return sfSymbols3Match ?? .questionmarkCircle
+    }
+}
+
+private extension MaterialDesignIcons {
+    /// Matches that require SF Symbols 5 (iOS 17, watchOS 10, macOS 14).
+    @available(iOS 17, watchOS 10, macOS 14, *)
+    var sfSymbols5Match: SFSymbol? {
+        switch self {
+        case .fanIcon, .fanSpeed1Icon, .fanSpeed2Icon, .fanSpeed3Icon: return .fan
+        case .fanAutoIcon: return .fanBadgeAutomatic
+        case .truckIcon, .truckDeliveryIcon, .truckFastIcon, .truckOutlineIcon: return .truckBox
+        case .batteryIcon, .battery90Icon, .batteryHighIcon: return .battery100percent
+        case .battery70Icon, .battery80Icon: return .battery75percent
+        case .battery40Icon, .battery50Icon, .battery60Icon, .batteryMediumIcon: return .battery50percent
+        case .battery10Icon, .battery20Icon, .battery30Icon, .batteryLowIcon: return .battery25percent
+        case .batteryOutlineIcon, .batteryAlertIcon, .batteryOffIcon: return .battery0percent
+        case .batteryChargingIcon, .batteryChargingHighIcon, .batteryCharging100Icon: return .battery100percentBolt
+        case .consoleIcon, .consoleLineIcon: return .appleTerminal
+        case .speedometerIcon, .speedometerMediumIcon, .speedometerSlowIcon: return .gaugeWithNeedle
+        case .gaugeIcon, .gaugeFullIcon, .gaugeLowIcon, .gaugeEmptyIcon: return .gaugeWithNeedle
+        case .storeIcon, .storeOutlineIcon, .storefrontOutlineIcon: return .storefront
+        case .evStationIcon: return .evCharger
+        case .flaskIcon, .flaskOutlineIcon, .flaskEmptyIcon, .flaskEmptyOutlineIcon: return .flask
+        case .eraserIcon: return .eraser
+        case .televisionOffIcon, .televisionClassicOffIcon: return .tvSlash
+        case .calendarCheckIcon, .calendarCheckOutlineIcon: return .calendarBadgeCheckmark
+        case .hangerIcon: return .hanger
+        case .heatingCoilIcon, .heatWaveIcon: return .heatWaves
+        case .accountOffIcon, .accountOffOutlineIcon: return .personSlash
+        case .dogIcon, .dogSideIcon, .dogServiceIcon: return .dog
+        case .catIcon: return .cat
+        case .sunglassesIcon: return .sunglasses
+        case .shoeSneakerIcon, .shoeFormalIcon, .shoeHeelIcon: return .shoe
+        default: return nil
+        }
+    }
+
+    /// Matches that require SF Symbols 4 (iOS 16, watchOS 9, macOS 13).
+    @available(iOS 16, watchOS 9, macOS 13, *)
+    var sfSymbols4Match: SFSymbol? {
+        switch self {
+        // MARK: Lighting
+        case .lightbulbGroupIcon, .lightbulbGroupOutlineIcon, .lightbulbMultipleIcon: return .lightbulb2
+        case .lightbulbMultipleOutlineIcon: return .lightbulb2
+        case .ceilingLightIcon, .ceilingLightOutlineIcon, .ceilingLightMultipleIcon: return .lampCeiling
+        case .ceilingLightMultipleOutlineIcon: return .lampCeiling
+        case .floorLampIcon, .floorLampOutlineIcon, .floorLampDualIcon: return .lampFloor
+        case .floorLampDualOutlineIcon, .floorLampTorchiereIcon: return .lampFloor
+        case .deskLampIcon, .deskLampOnIcon: return .lampDesk
+        case .lampIcon, .lampOutlineIcon, .lampsIcon, .lampsOutlineIcon: return .lampTable
+        case .chandelierIcon: return .chandelier
+        case .ledStripIcon, .ledStripVariantIcon: return .lightStrip2
+        case .lightSwitchIcon: return .lightswitchOn
+        case .lightSwitchOffIcon: return .lightswitchOff
+        case .trackLightIcon: return .lightOverheadRight
+        case .alarmLightIcon, .alarmLightOutlineIcon: return .lightBeaconMax
+        case .spotlightBeamIcon: return .lightBeaconMax
+
+        // MARK: Climate & air
+        case .thermometerIcon, .thermostatIcon, .thermostatBoxIcon: return .thermometerMedium
+        case .thermometerHighIcon: return .thermometerHigh
+        case .thermometerLowIcon: return .thermometerLow
+        case .temperatureCelsiusIcon, .temperatureFahrenheitIcon, .temperatureKelvinIcon: return .thermometerMedium
+        case .homeThermometerIcon, .homeThermometerOutlineIcon: return .thermometerMedium
+        case .airConditionerIcon: return .airConditionerHorizontal
+        case .hvacIcon, .hvacOffIcon: return .airConditionerVertical
+        case .airFilterIcon, .airPurifierIcon: return .airPurifier
+        case .fanOffIcon: return .fanOscillation
+        case .ceilingFanIcon: return .fanCeiling
+        case .ceilingFanLightIcon: return .fanAndLightCeiling
+        case .radiatorIcon, .radiatorOffIcon, .radiatorDisabledIcon: return .heaterVertical
+        case .waterBoilerIcon, .waterBoilerOffIcon, .waterBoilerAlertIcon: return .heaterVertical
+        case .fireplaceIcon, .fireplaceOffIcon: return .fireplace
+        case .airHumidifierIcon: return .humidifier
+        case .airHumidifierOffIcon: return .humidifierFill
+
+        // MARK: Sensors & safety
+        case .smokeDetectorIcon, .smokeDetectorVariantIcon, .smokeDetectorOutlineIcon: return .sensor
+        case .smokeDetectorAlertIcon, .smokeDetectorVariantAlertIcon: return .sensorFill
+        case .motionSensorIcon: return .sensorTagRadiowavesForward
+        case .moleculeCo2Icon: return .carbonDioxideCloud
+        case .moleculeCoIcon: return .carbonMonoxideCloud
+        case .cctvIcon: return .webCamera
+        case .webcamIcon: return .webCamera
+        case .lockAlertIcon, .lockAlertOutlineIcon: return .lockTrianglebadgeExclamationmark
+        case .keyWirelessIcon: return .keyRadiowavesForward
+
+        // MARK: Doors, windows & covers
+        case .doorIcon, .doorClosedIcon, .doorClosedLockIcon: return .doorLeftHandClosed
+        case .doorOpenIcon: return .doorLeftHandOpen
+        case .doorSlidingIcon: return .doorSlidingLeftHandClosed
+        case .doorSlidingOpenIcon: return .doorSlidingLeftHandOpen
+        case .garageIcon, .garageVariantIcon, .garageLockIcon: return .doorGarageClosed
+        case .garageOpenIcon, .garageOpenVariantIcon: return .doorGarageOpen
+        case .garageAlertIcon, .garageAlertVariantIcon: return .doorGarageClosedTrianglebadgeExclamationmark
+        case .windowClosedIcon, .windowClosedVariantIcon: return .windowVerticalClosed
+        case .windowOpenIcon, .windowOpenVariantIcon: return .windowVerticalOpen
+        case .windowShutterIcon, .windowShutterAlertIcon, .windowShutterSettingsIcon: return .windowShadeClosed
+        case .windowShutterOpenIcon: return .windowShadeOpen
+        case .blindsIcon, .blindsHorizontalClosedIcon: return .blindsHorizontalClosed
+        case .blindsOpenIcon, .blindsHorizontalIcon: return .blindsHorizontalOpen
+        case .blindsVerticalClosedIcon: return .blindsVerticalClosed
+        case .blindsVerticalIcon: return .blindsVerticalOpen
+        case .rollerShadeIcon: return .rollerShadeOpen
+        case .rollerShadeClosedIcon: return .rollerShadeClosed
+        case .curtainsIcon: return .curtainsOpen
+        case .curtainsClosedIcon: return .curtainsClosed
+        case .stairsIcon, .stairsUpIcon, .stairsDownIcon: return .stairs
+
+        // MARK: Rooms, furniture & appliances
+        case .sofaIcon, .sofaOutlineIcon: return .sofa
+        case .sofaSingleIcon, .sofaSingleOutlineIcon: return .chairLounge
+        case .chairRollingIcon, .seatIcon, .seatOutlineIcon: return .chair
+        case .tableFurnitureIcon: return .tableFurniture
+        case .stoveIcon, .gasBurnerIcon: return .stove
+        case .toasterOvenIcon: return .oven
+        case .microwaveIcon: return .microwave
+        case .fridgeIcon, .fridgeOutlineIcon, .fridgeVariantIcon: return .refrigerator
+        case .fridgeIndustrialIcon, .fridgeIndustrialOutlineIcon: return .refrigerator
+        case .dishwasherIcon, .dishwasherAlertIcon, .dishwasherOffIcon: return .dishwasher
+        case .washingMachineIcon, .washingMachineAlertIcon, .washingMachineOffIcon: return .washer
+        case .tumbleDryerIcon, .tumbleDryerAlertIcon, .tumbleDryerOffIcon: return .dryer
+        case .countertopIcon, .countertopOutlineIcon: return .sink
+        case .showerIcon: return .shower
+        case .showerHeadIcon: return .showerHandheld
+        case .bathtubIcon, .bathtubOutlineIcon, .hotTubIcon: return .bathtub
+        case .toiletIcon: return .toilet
+        case .teaIcon, .teaOutlineIcon, .beerIcon, .beerOutlineIcon: return .mug
+        case .carrotIcon: return .carrot
+        case .cakeVariantIcon, .cakeVariantOutlineIcon, .cakeIcon: return .birthdayCake
+
+        // MARK: Water & outdoor
+        case .pipeValveIcon, .valveIcon: return .spigot
+        case .waterPumpIcon: return .spigot
+        case .sprinklerIcon, .sprinklerFireIcon: return .sprinkler
+        case .sprinklerVariantIcon: return .sprinklerAndDroplets
+        case .wavesIcon: return .waterWaves
+        case .poolIcon: return .figurePoolSwim
+        case .swimIcon: return .figurePoolSwim
+        case .treeIcon, .treeOutlineIcon, .pineTreeIcon, .forestIcon, .palmTreeIcon: return .tree
+        case .flowerIcon, .flowerOutlineIcon, .flowerTulipIcon, .flowerTulipOutlineIcon: return .cameraMacro
+        case .beachIcon, .umbrellaBeachIcon, .umbrellaBeachOutlineIcon: return .beachUmbrella
+        case .tentIcon: return .tent
+
+        // MARK: Power
+        case .powerSocketIcon: return .poweroutletStrip
+        case .powerSocketUsIcon: return .poweroutletTypeB
+        case .powerSocketEuIcon, .powerSocketDeIcon: return .poweroutletTypeF
+        case .powerSocketUkIcon: return .poweroutletTypeG
+        case .powerSocketAuIcon: return .poweroutletTypeI
+        case .powerSocketFrIcon: return .poweroutletTypeE
+        case .powerSocketJpIcon: return .poweroutletTypeA
+        case .powerSocketChIcon: return .poweroutletTypeJ
+        case .powerSocketItIcon: return .poweroutletTypeL
+
+        // MARK: People & figures
+        case .accountClockIcon, .accountClockOutlineIcon: return .personBadgeClock
+        case .accountKeyIcon, .accountKeyOutlineIcon: return .personBadgeKey
+        case .accountChildIcon, .accountChildOutlineIcon: return .figureAndChildHoldinghands
+        case .accountChildCircleIcon: return .figureAndChildHoldinghands
+        case .runIcon, .runFastIcon: return .figureRun
+        case .hikingIcon: return .figureHiking
+        case .wheelchairIcon, .wheelchairAccessibilityIcon: return .figureRoll
+        case .babyCarriageIcon: return .stroller
+        case .teddyBearIcon: return .teddybear
+        case .exitRunIcon: return .figureWalkDeparture
+        case .locationEnterIcon: return .figureWalkArrival
+        case .locationExitIcon: return .figureWalkDeparture
+
+        // MARK: Devices & tech
+        case .routerIcon, .routerWirelessIcon, .routerNetworkIcon: return .wifiRouter
+        case .routerWirelessOffIcon: return .wifiRouter
+        case .accessPointIcon, .accessPointNetworkIcon: return .wifiRouter
+        case .remoteIcon: return .avRemote
+        case .messageProcessingIcon, .messageProcessingOutlineIcon: return .ellipsisMessage
+        case .commentQuestionIcon, .commentQuestionOutlineIcon: return .questionmarkBubble
+
+        // MARK: Vehicles & transport
+        case .roadIcon, .roadVariantIcon, .highwayIcon: return .roadLanes
+        case .parkingIcon: return .parkingsign
+        case .sailBoatIcon: return .sailboat
+        case .skiIcon: return .figureSkiingDownhill
+        case .snowboardIcon: return .figureSnowboarding
+
+        // MARK: Sports & leisure
+        case .dumbbellIcon: return .dumbbell
+        case .weightLifterIcon: return .figureStrengthtrainingTraditional
+        case .yogaIcon, .meditationIcon: return .figureMindAndBody
+        case .basketballIcon: return .basketball
+        case .footballIcon, .footballAustralianIcon: return .football
+        case .tennisIcon, .tennisBallIcon: return .tennisball
+        case .volleyballIcon: return .volleyball
+        case .rugbyIcon: return .figureRugby
+        case .hockeyPuckIcon: return .hockeyPuck
+        case .cricketIcon: return .cricketBall
+        case .golfIcon: return .figureGolf
+        case .bowlingIcon: return .figureBowling
+        case .balloonIcon: return .balloon
+        case .partyPopperIcon: return .partyPopper
+
+        // MARK: Animals & nature
+        case .birdIcon: return .bird
+        case .fishIcon: return .fish
+        case .virusIcon, .virusOutlineIcon, .bacteriaIcon, .bacteriaOutlineIcon: return .allergens
+
+        // MARK: Misc objects
+        case .wrenchIcon, .wrenchOutlineIcon: return .wrenchAdjustable
+        case .pencilRulerIcon: return .pencilAndRuler
+        case .bagPersonalIcon, .bagPersonalOutlineIcon: return .backpack
+        case .medalIcon, .medalOutlineIcon: return .medal
+        case .compassIcon, .compassOutlineIcon: return .locationNorthCircle
+        case .flagCheckeredIcon: return .flagCheckered
+        case .robotIcon, .robotOutlineIcon: return .gearshapeArrowTriangle2Circlepath
+
+        // MARK: Older-OS fallbacks for SF Symbols 5 matches
+        case .fanIcon, .fanSpeed1Icon, .fanSpeed2Icon, .fanSpeed3Icon, .fanAutoIcon: return .fanOscillation
+        case .speedometerIcon, .speedometerMediumIcon, .speedometerSlowIcon: return .dialMedium
+        case .gaugeIcon, .gaugeFullIcon, .gaugeLowIcon, .gaugeEmptyIcon: return .dialMedium
+        case .batteryIcon, .battery90Icon, .batteryHighIcon, .batteryMediumIcon: return .batteryblock
+        case .battery70Icon, .battery80Icon, .battery40Icon, .battery50Icon, .battery60Icon: return .batteryblock
+        case .battery10Icon, .battery20Icon, .battery30Icon, .batteryLowIcon: return .batteryblock
+        case .batteryOutlineIcon, .batteryAlertIcon, .batteryOffIcon: return .batteryblock
+        case .heatingCoilIcon, .heatWaveIcon: return .heaterVertical
+        case .flashAlertIcon: return .boltTrianglebadgeExclamationmark
+        case .volumePlusIcon: return .speakerPlus
+        case .volumeMinusIcon: return .speakerMinus
+        case .signalIcon, .signalCellular1Icon, .signalCellular2Icon: return .cellularbars
+        case .signalCellular3Icon, .signalCellularOutlineIcon: return .cellularbars
+        case .clipboardIcon, .clipboardOutlineIcon: return .clipboard
+        case .clipboardTextIcon, .clipboardTextOutlineIcon, .clipboardListIcon: return .clipboard
+        case .trophyIcon, .trophyOutlineIcon, .trophyAwardIcon, .trophyVariantIcon: return .trophy
+        case .needleIcon: return .syringe
+        case .glassWineIcon, .glassCocktailIcon: return .wineglass
+        case .bottleWineIcon, .bottleWineOutlineIcon: return .wineglass
+        default: return nil
+        }
+    }
+
+    /// Matches available from SF Symbols 3 and earlier (the iOS 15 / watchOS 8 baseline).
+    var sfSymbols3Match: SFSymbol? {
+        switch self {
+        // MARK: Home
+        case .homeIcon, .homeOutlineIcon, .homeVariantIcon, .homeVariantOutlineIcon: return .house
+        case .homeAssistantIcon, .homeAutomationIcon, .homeAccountIcon, .homeHeartIcon: return .house
+        case .homeCircleIcon, .homeCircleOutlineIcon: return .houseCircle
+        case .homeCityIcon, .homeCityOutlineIcon: return .building2
+        case .homeMapMarkerIcon: return .house
+        case .officeBuildingIcon, .officeBuildingOutlineIcon, .domainIcon: return .building2
+        case .homeGroupIcon: return .house
+
+        // MARK: Lighting (baseline)
+        case .lightbulbIcon, .lightbulbOutlineIcon, .lightbulbVariantIcon: return .lightbulb
+        case .lightbulbVariantOutlineIcon, .lightbulbCflIcon, .lightbulbCflOffIcon: return .lightbulb
+        case .lightbulbOnIcon, .lightbulbOnOutlineIcon: return .lightbulbFill
+        case .lightbulbOffIcon, .lightbulbOffOutlineIcon: return .lightbulbSlash
+        case .lightbulbGroupOffIcon, .lightbulbGroupOffOutlineIcon: return .lightbulbSlash
+        case .flashlightIcon: return .flashlightOnFill
+        case .flashlightOffIcon: return .flashlightOffFill
+        case .candleIcon: return .flame
+
+        // MARK: Switches & power (baseline)
+        case .toggleSwitchIcon, .toggleSwitchOutlineIcon, .toggleSwitchVariantIcon: return .switch2
+        case .toggleSwitchOffIcon, .toggleSwitchOffOutlineIcon: return .switch2
+        case .toggleSwitchVariantOffIcon, .electricSwitchIcon, .electricSwitchClosedIcon: return .switch2
+        case .powerIcon, .powerOnIcon, .powerStandbyIcon, .powerCycleIcon: return .power
+        case .powerOffIcon: return .poweroff
+        case .powerSleepIcon, .sleepIcon: return .powersleep
+        case .powerPlugIcon, .powerPlugOutlineIcon: return .powerplug
+        case .powerPlugOffIcon, .powerPlugOffOutlineIcon: return .powerplug
+        case .flashIcon, .flashOutlineIcon, .lightningBoltIcon, .lightningBoltOutlineIcon: return .bolt
+        case .flashOffIcon: return .boltSlash
+        case .transmissionTowerIcon: return .boltFill
+        case .batteryChargingWirelessIcon: return .boltBatteryblock
+        case .carBatteryIcon: return .minusPlusBatteryblock
+
+        // MARK: Climate & weather (baseline)
+        case .weatherSunnyIcon, .whiteBalanceSunnyIcon, .brightness5Icon: return .sunMax
+        case .brightness6Icon, .brightness7Icon: return .sunMaxFill
+        case .brightness4Icon, .brightnessPercentIcon: return .sunMin
+        case .weatherNightIcon: return .moonStars
+        case .weatherNightPartlyCloudyIcon: return .cloudMoon
+        case .moonWaningCrescentIcon, .moonFullIcon: return .moon
+        case .weatherPartlyCloudyIcon: return .cloudSun
+        case .weatherCloudyIcon, .cloudIcon, .cloudOutlineIcon: return .cloud
+        case .weatherRainyIcon: return .cloudRain
+        case .weatherPouringIcon: return .cloudHeavyrain
+        case .weatherSnowyIcon, .weatherSnowyHeavyIcon: return .cloudSnow
+        case .weatherSnowyRainyIcon: return .cloudSleet
+        case .weatherLightningIcon: return .cloudBolt
+        case .weatherLightningRainyIcon: return .cloudBoltRain
+        case .weatherHailIcon: return .cloudHail
+        case .weatherFogIcon: return .cloudFog
+        case .weatherWindyIcon, .weatherWindyVariantIcon, .windTurbineIcon: return .wind
+        case .weatherHurricaneIcon: return .hurricane
+        case .weatherTornadoIcon: return .tornado
+        case .weatherHazyIcon: return .sunHaze
+        case .weatherSunsetIcon, .weatherSunsetDownIcon: return .sunset
+        case .weatherSunsetUpIcon: return .sunrise
+        case .sunThermometerIcon, .sunThermometerOutlineIcon: return .thermometerSun
+        case .snowflakeThermometerIcon: return .thermometerSnowflake
+        case .snowflakeIcon, .snowflakeVariantIcon: return .snowflake
+        case .themeLightDarkIcon: return .circleLefthalfFilled
+        case .fireIcon, .fireAlertIcon: return .flame
+        case .waterPercentIcon, .waterPercentAlertIcon: return .humidity
+        case .waterIcon, .waterOutlineIcon, .waterAlertIcon: return .drop
+        case .waterOffIcon: return .dropFill
+        case .airballoonIcon, .airballoonOutlineIcon: return .airplane
+
+        // MARK: Security & locks
+        case .lockIcon, .lockOutlineIcon, .lockSmartIcon: return .lock
+        case .lockOpenIcon, .lockOpenOutlineIcon, .lockOpenVariantIcon: return .lockOpen
+        case .lockOpenVariantOutlineIcon: return .lockOpen
+        case .lockResetIcon: return .lockRotation
+        case .keyIcon, .keyOutlineIcon, .keyVariantIcon: return .key
+        case .shieldIcon, .shieldOutlineIcon: return .shield
+        case .shieldHalfFullIcon, .shieldHomeIcon, .shieldHomeOutlineIcon: return .shieldLefthalfFilled
+        case .securityIcon: return .shieldFill
+        case .shieldCheckIcon, .shieldCheckOutlineIcon: return .checkmarkShield
+        case .shieldAlertIcon, .shieldAlertOutlineIcon: return .exclamationmarkShield
+        case .shieldLockIcon, .shieldLockOutlineIcon: return .lockShield
+        case .shieldOffIcon, .shieldOffOutlineIcon: return .shieldSlash
+        case .doorbellIcon: return .bell
+        case .doorbellVideoIcon: return .videoFill
+        case .fingerprintIcon: return .touchid
+        case .faceRecognitionIcon: return .faceid
+        case .eyeIcon, .eyeOutlineIcon: return .eye
+        case .eyeOffIcon, .eyeOffOutlineIcon: return .eyeSlash
+        case .radarIcon: return .dotRadiowavesLeftAndRight
+        case .leakIcon: return .drop
+
+        // MARK: People
+        case .accountIcon, .accountOutlineIcon: return .person
+        case .accountCircleIcon, .accountCircleOutlineIcon: return .personCircle
+        case .accountMultipleIcon, .accountMultipleOutlineIcon: return .person2
+        case .accountSupervisorIcon, .accountSupervisorOutlineIcon: return .person2
+        case .accountGroupIcon, .accountGroupOutlineIcon: return .person3
+        case .googleCirclesCommunitiesIcon: return .person3
+        case .accountPlusIcon, .accountPlusOutlineIcon: return .personBadgePlus
+        case .accountMinusIcon, .accountMinusOutlineIcon: return .personBadgeMinus
+        case .accountRemoveIcon, .accountRemoveOutlineIcon: return .personBadgeMinus
+        case .accountCheckIcon, .accountCheckOutlineIcon: return .personCropCircleBadgeCheckmark
+        case .accountCancelIcon, .accountCancelOutlineIcon: return .personCropCircleBadgeXmark
+        case .accountAlertIcon, .accountAlertOutlineIcon: return .personCropCircleBadgeExclamationmark
+        case .accountQuestionIcon, .accountQuestionOutlineIcon: return .personFillQuestionmark
+        case .accountVoiceIcon: return .personWave2
+        case .badgeAccountIcon, .badgeAccountOutlineIcon: return .personTextRectangle
+        case .cardAccountDetailsIcon, .cardAccountDetailsOutlineIcon: return .personTextRectangle
+        case .accountTieIcon: return .person
+        case .faceManIcon, .faceWomanIcon, .faceManOutlineIcon, .faceWomanOutlineIcon: return .faceSmiling
+        case .emoticonIcon, .emoticonOutlineIcon, .emoticonHappyIcon: return .faceSmiling
+        case .emoticonHappyOutlineIcon: return .faceSmiling
+        case .humanMaleIcon, .humanFemaleIcon, .humanIcon: return .figureStand
+        case .humanGreetingIcon, .humanGreetingVariantIcon, .handWaveIcon: return .figureWave
+        case .walkIcon: return .figureWalk
+        case .gestureTapIcon, .gestureTapButtonIcon, .gestureTapHoldIcon: return .handTap
+        case .thumbUpIcon, .thumbUpOutlineIcon: return .handThumbsup
+        case .thumbDownIcon, .thumbDownOutlineIcon: return .handThumbsdown
+
+        // MARK: Media players & audio
+        case .playIcon, .playOutlineIcon: return .play
+        case .playCircleIcon, .playCircleOutlineIcon: return .playCircle
+        case .pauseIcon: return .pause
+        case .pauseCircleIcon, .pauseCircleOutlineIcon: return .pauseCircle
+        case .stopIcon: return .stop
+        case .stopCircleIcon, .stopCircleOutlineIcon: return .stopCircle
+        case .playPauseIcon: return .playpause
+        case .skipNextIcon, .skipNextOutlineIcon, .skipForwardIcon: return .forwardEnd
+        case .skipPreviousIcon, .skipPreviousOutlineIcon, .skipBackwardIcon: return .backwardEnd
+        case .fastForwardIcon: return .forward
+        case .fastForward5Icon: return .goforward5
+        case .fastForward10Icon: return .goforward10
+        case .fastForward15Icon: return .goforward15
+        case .fastForward30Icon: return .goforward30
+        case .rewindIcon: return .backward
+        case .rewind5Icon: return .gobackward5
+        case .rewind10Icon: return .gobackward10
+        case .rewind15Icon: return .gobackward15
+        case .rewind30Icon: return .gobackward30
+        case .shuffleIcon, .shuffleVariantIcon, .shuffleDisabledIcon: return .shuffle
+        case .repeatIcon, .repeatOffIcon: return .repeat
+        case .repeatOnceIcon: return .repeat1
+        case .ejectIcon, .ejectOutlineIcon: return .eject
+        case .recordIcon, .recordRecIcon, .recordCircleIcon: return .recordCircle
+        case .volumeHighIcon: return .speakerWave3
+        case .volumeMediumIcon: return .speakerWave2
+        case .volumeLowIcon: return .speakerWave1
+        case .volumeOffIcon, .volumeMuteIcon, .volumeVariantOffIcon: return .speakerSlash
+        case .speakerIcon: return .hifispeaker
+        case .speakerMultipleIcon: return .hifispeaker2
+        case .speakerOffIcon: return .speakerSlash
+        case .speakerWirelessIcon: return .speakerWave3
+        case .speakerMessageIcon: return .textBubble
+        case .soundbarIcon: return .hifispeaker
+        case .musicIcon, .musicNoteIcon, .musicNoteOutlineIcon: return .musicNote
+        case .playlistMusicIcon, .playlistMusicOutlineIcon, .playlistPlayIcon: return .musicNoteList
+        case .playlistEditIcon, .playlistPlusIcon: return .musicNoteList
+        case .albumIcon, .discIcon, .discPlayerIcon: return .opticaldisc
+        case .radioIcon: return .radio
+        case .microphoneIcon, .microphoneOutlineIcon, .microphoneVariantIcon: return .mic
+        case .microphoneOffIcon, .microphoneVariantOffIcon: return .micSlash
+        case .microphoneMessageIcon: return .micCircle
+        case .headphonesIcon, .headsetIcon: return .headphones
+        case .earbudsIcon, .earbudsOutlineIcon: return .earbuds
+        case .earHearingIcon: return .ear
+        case .earHearingOffIcon: return .earTrianglebadgeExclamationmark
+        case .waveformIcon, .sineWaveIcon, .squareWaveIcon: return .waveform
+        case .pulseIcon, .heartPulseIcon: return .waveformPathEcg
+        case .televisionIcon, .televisionClassicIcon, .televisionBoxIcon: return .tv
+        case .castIcon, .castConnectedIcon, .castVariantIcon: return .airplayvideo
+        case .castAudioIcon: return .airplayaudio
+        case .castOffIcon: return .airplayvideo
+        case .cameraIcon, .cameraOutlineIcon, .cameraFrontIcon: return .camera
+        case .cameraSwitchIcon, .cameraSwitchOutlineIcon: return .arrowTriangle2CirclepathCamera
+        case .videoIcon, .videoOutlineIcon: return .video
+        case .videoOffIcon, .videoOffOutlineIcon: return .videoSlash
+        case .filmIcon, .filmstripIcon, .movieIcon, .movieOutlineIcon: return .film
+        case .movieOpenIcon, .movieOpenOutlineIcon, .movieRollIcon: return .film
+        case .imageIcon, .imageOutlineIcon, .imageAreaIcon: return .photo
+        case .imageMultipleIcon, .imageMultipleOutlineIcon: return .photoOnRectangle
+        case .cameraImageIcon: return .photo
+
+        // MARK: Communication
+        case .emailIcon, .emailOutlineIcon, .emailVariantIcon: return .envelope
+        case .emailOpenIcon, .emailOpenOutlineIcon: return .envelopeOpen
+        case .sendIcon, .sendOutlineIcon, .emailFastIcon, .emailFastOutlineIcon: return .paperplane
+        case .inboxIcon: return .tray
+        case .inboxArrowDownIcon: return .trayAndArrowDown
+        case .inboxArrowUpIcon: return .trayAndArrowUp
+        case .inboxMultipleIcon: return .tray2
+        case .messageIcon, .messageOutlineIcon, .messageTextIcon: return .message
+        case .messageTextOutlineIcon: return .message
+        case .chatIcon, .chatOutlineIcon, .commentIcon, .commentOutlineIcon: return .bubbleLeft
+        case .chatProcessingIcon, .chatProcessingOutlineIcon: return .ellipsisBubble
+        case .commentTextIcon, .commentTextOutlineIcon: return .textBubble
+        case .forumIcon, .forumOutlineIcon: return .bubbleLeftAndBubbleRight
+        case .phoneIcon, .phoneOutlineIcon, .phoneClassicIcon, .deskphoneIcon: return .phone
+        case .phoneHangupIcon, .phoneOffIcon: return .phoneDown
+        case .bullhornIcon, .bullhornOutlineIcon: return .megaphone
+        case .bellIcon, .bellOutlineIcon: return .bell
+        case .bellOffIcon, .bellOffOutlineIcon, .bellSleepIcon: return .bellSlash
+        case .bellRingIcon, .bellRingOutlineIcon, .bellAlertIcon: return .bellBadge
+        case .bellPlusIcon, .bellPlusOutlineIcon: return .bellBadge
+
+        // MARK: Devices
+        case .cellphoneIcon, .cellphoneBasicIcon: return .iphone
+        case .cellphoneOffIcon: return .iphoneSlash
+        case .cellphoneWirelessIcon, .cellphoneNfcIcon: return .iphoneRadiowavesLeftAndRight
+        case .tabletIcon: return .ipad
+        case .laptopIcon, .laptopAccountIcon: return .laptopcomputer
+        case .monitorIcon, .desktopTowerMonitorIcon: return .display
+        case .desktopClassicIcon: return .desktopcomputer
+        case .desktopTowerIcon: return .macproGen3
+        case .watchIcon, .watchVariantIcon: return .applewatch
+        case .keyboardIcon, .keyboardOutlineIcon, .keyboardVariantIcon: return .keyboard
+        case .mouseIcon, .mouseVariantIcon: return .computermouse
+        case .printerIcon, .printerOutlineIcon: return .printer
+        case .serverIcon, .serverNetworkIcon, .serverSecurityIcon: return .serverRack
+        case .nasIcon: return .externaldrive
+        case .harddiskIcon: return .internaldrive
+        case .usbFlashDriveIcon, .usbFlashDriveOutlineIcon: return .mediastick
+        case .usbIcon, .usbPortIcon: return .cableConnector
+        case .videoInputHdmiIcon, .cableDataIcon: return .cableConnector
+        case .sdIcon: return .sdcard
+        case .simIcon, .simOutlineIcon: return .simcard
+        case .chipIcon, .cpu64BitIcon, .cpu32BitIcon: return .cpu
+        case .memoryIcon, .expansionCardIcon: return .memorychip
+        case .databaseIcon, .databaseOutlineIcon: return .cylinderSplit1x2
+        case .gamepadIcon, .gamepadVariantIcon, .gamepadVariantOutlineIcon: return .gamecontroller
+        case .controllerIcon, .controllerClassicIcon, .controllerClassicOutlineIcon: return .gamecontroller
+
+        // MARK: Connectivity
+        case .wifiIcon, .wifiStrength4Icon: return .wifi
+        case .wifiStrength1Icon, .wifiStrength2Icon, .wifiStrength3Icon: return .wifi
+        case .wifiOffIcon, .wifiStrengthOffIcon, .wifiStrengthOffOutlineIcon: return .wifiSlash
+        case .signalVariantIcon, .antennaIcon, .radioTowerIcon: return .antennaRadiowavesLeftAndRight
+        case .broadcastIcon: return .dotRadiowavesLeftAndRight
+        case .bluetoothIcon, .bluetoothConnectIcon, .bluetoothOffIcon: return .dotRadiowavesRight
+        case .nfcIcon, .nfcVariantIcon, .nfcTapIcon: return .wave3Right
+        case .networkIcon, .networkOutlineIcon, .lanIcon, .lanConnectIcon: return .network
+        case .ethernetIcon, .ethernetCableIcon: return .cableConnector
+        case .cloudUploadIcon, .cloudUploadOutlineIcon: return .icloudAndArrowUp
+        case .cloudDownloadIcon, .cloudDownloadOutlineIcon: return .icloudAndArrowDown
+        case .cloudOffOutlineIcon, .cloudCancelIcon: return .icloudSlash
+        case .cloudCheckIcon, .cloudCheckOutlineIcon: return .checkmarkIcloud
+        case .cloudAlertIcon: return .exclamationmarkIcloud
+        case .cloudLockIcon, .cloudLockOutlineIcon: return .lockIcloud
+        case .cloudSyncIcon, .cloudSyncOutlineIcon: return .icloud
+        case .qrcodeIcon: return .qrcode
+        case .qrcodeScanIcon: return .qrcodeViewfinder
+        case .barcodeIcon: return .barcode
+        case .barcodeScanIcon: return .barcodeViewfinder
+
+        // MARK: Transport
+        case .carIcon, .carSideIcon, .carHatchbackIcon, .carEstateIcon, .taxiIcon: return .car
+        case .carSportsIcon, .carConvertibleIcon, .carConnectedIcon, .carWashIcon: return .car
+        case .carElectricIcon, .carElectricOutlineIcon: return .boltCar
+        case .busIcon, .busSideIcon, .busSchoolIcon, .busDoubleDeckerIcon: return .bus
+        case .trainIcon, .trainVariantIcon, .tramIcon, .tramSideIcon: return .tram
+        case .subwayIcon, .subwayVariantIcon: return .tramFill
+        case .airplaneIcon, .airportIcon: return .airplane
+        case .airplaneTakeoffIcon: return .airplaneDeparture
+        case .airplaneLandingIcon: return .airplaneArrival
+        case .bikeIcon, .bicycleIcon: return .bicycle
+        case .scooterIcon, .scooterElectricIcon, .mopedIcon: return .scooter
+        case .ferryIcon: return .ferry
+        case .fuelIcon, .gasStationIcon: return .fuelpump
+        case .mapIcon, .mapOutlineIcon: return .map
+        case .mapMarkerIcon, .mapMarkerOutlineIcon: return .mappin
+        case .mapMarkerRadiusIcon, .mapMarkerRadiusOutlineIcon: return .mappinAndEllipse
+        case .mapMarkerMultipleIcon, .mapMarkerMultipleOutlineIcon: return .mappinAndEllipse
+        case .mapMarkerOffIcon: return .mappinSlash
+        case .crosshairsIcon, .crosshairsGpsIcon: return .scope
+        case .navigationIcon, .navigationOutlineIcon, .navigationVariantIcon: return .locationNorthFill
+        case .nearMeIcon: return .locationFill
+        case .earthIcon, .webIcon, .globeModelIcon: return .globe
+        case .signDirectionIcon: return .signpostRight
+        case .directionsIcon: return .arrowTriangleTurnUpRightDiamond
+        case .routesIcon, .callSplitIcon, .sourceBranchIcon: return .arrowTriangleBranch
+
+        // MARK: Time & calendar
+        case .clockIcon, .clockOutlineIcon, .clockDigitalIcon, .clockFastIcon: return .clock
+        case .alarmIcon: return .alarm
+        case .timerIcon, .timerOutlineIcon, .timerOffIcon, .timerOffOutlineIcon: return .timer
+        case .timerSandIcon, .timerSandEmptyIcon, .timerSandCompleteIcon: return .hourglass
+        case .historyIcon: return .clockArrowCirclepath
+        case .updateIcon: return .clockArrowCirclepath
+        case .calendarIcon, .calendarBlankIcon, .calendarOutlineIcon: return .calendar
+        case .calendarBlankOutlineIcon, .calendarMonthIcon, .calendarMonthOutlineIcon: return .calendar
+        case .calendarTodayIcon, .calendarStarIcon, .calendarRangeIcon: return .calendar
+        case .calendarWeekIcon, .calendarTextIcon, .calendarMultipleIcon: return .calendar
+        case .calendarClockIcon, .calendarClockOutlineIcon: return .calendarBadgeClock
+        case .calendarPlusIcon: return .calendarBadgePlus
+        case .calendarMinusIcon, .calendarRemoveIcon, .calendarRemoveOutlineIcon: return .calendarBadgeMinus
+        case .calendarAlertIcon: return .calendarBadgeExclamationmark
+
+        // MARK: Files & documents
+        case .fileIcon, .fileOutlineIcon: return .doc
+        case .fileDocumentIcon, .fileDocumentOutlineIcon: return .docText
+        case .fileMultipleIcon, .fileMultipleOutlineIcon: return .docOnDoc
+        case .filePlusIcon, .filePlusOutlineIcon: return .docBadgePlus
+        case .fileSearchIcon, .fileSearchOutlineIcon: return .docTextMagnifyingglass
+        case .fileChartIcon, .fileChartOutlineIcon: return .chartBarDocHorizontal
+        case .fileCabinetIcon, .archiveIcon, .archiveOutlineIcon: return .archivebox
+        case .folderIcon, .folderOutlineIcon, .folderOpenIcon, .folderOpenOutlineIcon: return .folder
+        case .folderMultipleIcon, .folderMultipleOutlineIcon, .folderHomeIcon: return .folder
+        case .folderPlusIcon, .folderPlusOutlineIcon: return .folderBadgePlus
+        case .folderMinusIcon, .folderMinusOutlineIcon: return .folderBadgeMinus
+        case .folderAccountIcon, .folderAccountOutlineIcon: return .folderBadgePersonCrop
+        case .packageIcon, .packageVariantIcon, .packageVariantClosedIcon: return .shippingbox
+        case .packageUpIcon, .packageDownIcon: return .shippingbox
+        case .contentCopyIcon: return .docOnDoc
+        case .contentPasteIcon: return .docOnClipboard
+        case .contentCutIcon, .scissorsCuttingIcon: return .scissors
+        case .contentSaveIcon, .contentSaveOutlineIcon: return .squareAndArrowDown
+        case .clipboardCheckIcon, .clipboardCheckOutlineIcon: return .checklist
+        case .noteIcon, .noteOutlineIcon, .noteMultipleIcon: return .note
+        case .noteTextIcon, .noteTextOutlineIcon: return .noteText
+        case .notebookIcon, .notebookOutlineIcon: return .bookClosed
+        case .bookIcon, .bookOutlineIcon: return .bookClosed
+        case .bookOpenIcon, .bookOpenOutlineIcon, .bookOpenVariantIcon: return .book
+        case .bookOpenPageVariantIcon, .bookOpenPageVariantOutlineIcon: return .book
+        case .bookMultipleIcon, .bookshelfIcon, .libraryIcon, .libraryOutlineIcon: return .booksVertical
+        case .newspaperIcon, .newspaperVariantIcon, .newspaperVariantOutlineIcon: return .newspaper
+        case .scriptTextIcon, .scriptTextOutlineIcon, .scriptIcon, .scriptOutlineIcon: return .scroll
+        case .textBoxIcon, .textBoxOutlineIcon: return .docPlaintext
+        case .formTextboxIcon: return .characterCursorIbeam
+        case .textIcon, .textLongIcon, .textShortIcon: return .textAlignleft
+        case .formatListBulletedIcon, .formatListBulletedTriangleIcon: return .listBullet
+        case .formatListNumberedIcon: return .listNumber
+        case .formatListChecksIcon, .formatListCheckboxIcon: return .checklist
+        case .receiptIcon, .receiptTextIcon, .receiptTextOutlineIcon: return .docPlaintext
+
+        // MARK: Editing & actions
+        case .pencilIcon, .pencilOutlineIcon, .leadPencilIcon: return .pencil
+        case .pencilOffIcon: return .pencilSlash
+        case .drawIcon: return .pencilAndOutline
+        case .penIcon: return .pencilTip
+        case .deleteIcon, .deleteOutlineIcon, .deleteEmptyIcon: return .trash
+        case .trashCanIcon, .trashCanOutlineIcon, .deleteForeverIcon: return .trash
+        case .magnifyIcon: return .magnifyingglass
+        case .magnifyPlusIcon, .magnifyPlusOutlineIcon: return .plusMagnifyingglass
+        case .magnifyMinusIcon, .magnifyMinusOutlineIcon: return .minusMagnifyingglass
+        case .filterVariantIcon: return .line3HorizontalDecrease
+        case .filterIcon, .filterOutlineIcon: return .line3HorizontalDecreaseCircle
+        case .refreshIcon, .reloadIcon, .autorenewIcon, .cachedIcon: return .arrowClockwise
+        case .restartIcon: return .arrowClockwiseCircle
+        case .restoreIcon: return .arrowCounterclockwise
+        case .syncIcon, .syncCircleIcon: return .arrowTriangle2Circlepath
+        case .rotateLeftIcon: return .rotateLeft
+        case .rotateRightIcon: return .rotateRight
+        case .rotate3dVariantIcon: return .rotate3d
+        case .undoIcon, .undoVariantIcon: return .arrowUturnBackward
+        case .redoIcon, .redoVariantIcon: return .arrowUturnForward
+        case .uploadIcon, .uploadOutlineIcon: return .squareAndArrowUp
+        case .downloadIcon, .downloadOutlineIcon: return .squareAndArrowDown
+        case .shareIcon, .shareVariantIcon, .shareVariantOutlineIcon: return .squareAndArrowUp
+        case .exportVariantIcon: return .squareAndArrowUp
+        case .openInNewIcon, .launchIcon: return .arrowUpRightSquare
+        case .openInAppIcon: return .arrowUpForwardApp
+        case .loginIcon, .loginVariantIcon: return .arrowRightSquare
+        case .logoutIcon, .logoutVariantIcon, .exitToAppIcon: return .rectanglePortraitAndArrowRight
+        case .fullscreenIcon, .arrowExpandIcon, .arrowExpandAllIcon: return .arrowUpLeftAndArrowDownRight
+        case .fullscreenExitIcon, .arrowCollapseIcon, .arrowCollapseAllIcon: return .arrowDownRightAndArrowUpLeft
+        case .linkIcon, .linkVariantIcon: return .link
+        case .paperclipIcon: return .paperclip
+        case .pinIcon, .pinOutlineIcon: return .pin
+        case .pinOffIcon, .pinOffOutlineIcon: return .pinSlash
+
+        // MARK: Basic UI
+        case .closeIcon, .closeThickIcon, .windowCloseIcon: return .xmark
+        case .closeCircleIcon, .closeCircleOutlineIcon: return .xmarkCircle
+        case .closeBoxIcon, .closeBoxOutlineIcon: return .xmarkSquare
+        case .checkIcon, .checkBoldIcon, .checkAllIcon: return .checkmark
+        case .checkCircleIcon, .checkCircleOutlineIcon: return .checkmarkCircle
+        case .checkboxMarkedIcon, .checkboxMarkedOutlineIcon: return .checkmarkSquare
+        case .checkboxMarkedCircleIcon, .checkboxMarkedCircleOutlineIcon: return .checkmarkCircleFill
+        case .checkboxBlankOutlineIcon: return .square
+        case .checkboxBlankCircleOutlineIcon: return .circle
+        case .checkboxBlankCircleIcon: return .circleFill
+        case .checkDecagramIcon, .checkDecagramOutlineIcon: return .checkmarkSeal
+        case .plusIcon, .plusThickIcon: return .plus
+        case .plusCircleIcon, .plusCircleOutlineIcon: return .plusCircle
+        case .plusBoxIcon, .plusBoxOutlineIcon: return .plusSquare
+        case .minusIcon, .minusThickIcon: return .minus
+        case .minusCircleIcon, .minusCircleOutlineIcon: return .minusCircle
+        case .minusBoxIcon, .minusBoxOutlineIcon: return .minusSquare
+        case .menuIcon: return .line3Horizontal
+        case .dotsHorizontalIcon, .dotsVerticalIcon: return .ellipsis
+        case .menuDownIcon, .chevronDownIcon: return .chevronDown
+        case .menuUpIcon, .chevronUpIcon: return .chevronUp
+        case .menuLeftIcon, .chevronLeftIcon: return .chevronLeft
+        case .menuRightIcon, .chevronRightIcon: return .chevronRight
+        case .arrowUpIcon, .arrowUpThickIcon, .arrowUpBoldIcon: return .arrowUp
+        case .arrowDownIcon, .arrowDownThickIcon, .arrowDownBoldIcon: return .arrowDown
+        case .arrowLeftIcon, .arrowLeftThickIcon, .arrowLeftBoldIcon: return .arrowLeft
+        case .arrowRightIcon, .arrowRightThickIcon, .arrowRightBoldIcon: return .arrowRight
+        case .arrowTopRightIcon: return .arrowUpRight
+        case .arrowTopLeftIcon: return .arrowUpLeft
+        case .arrowBottomRightIcon: return .arrowDownRight
+        case .arrowBottomLeftIcon: return .arrowDownLeft
+        case .arrowLeftRightIcon: return .arrowLeftAndRight
+        case .arrowUpDownIcon: return .arrowUpAndDown
+        case .swapHorizontalIcon, .swapHorizontalVariantIcon: return .arrowLeftArrowRight
+        case .swapVerticalIcon, .swapVerticalVariantIcon: return .arrowUpArrowDown
+        case .subdirectoryArrowLeftIcon: return .arrowTurnDownLeft
+        case .alertIcon, .alertOutlineIcon: return .exclamationmarkTriangle
+        case .alertCircleIcon, .alertCircleOutlineIcon: return .exclamationmarkCircle
+        case .alertOctagonIcon, .alertOctagonOutlineIcon: return .exclamationmarkOctagon
+        case .informationIcon, .informationOutlineIcon: return .infoCircle
+        case .informationVariantIcon: return .info
+        case .helpIcon: return .questionmark
+        case .helpCircleIcon, .helpCircleOutlineIcon: return .questionmarkCircle
+        case .cancelIcon, .blockHelperIcon: return .nosign
+        case .starIcon, .starOutlineIcon: return .star
+        case .starCircleIcon, .starCircleOutlineIcon: return .starCircle
+        case .starOffIcon, .starOffOutlineIcon: return .starSlash
+        case .starHalfFullIcon: return .starLeadinghalfFilled
+        case .heartIcon, .heartOutlineIcon: return .heart
+        case .heartOffIcon, .heartOffOutlineIcon: return .heartSlash
+        case .flagIcon, .flagOutlineIcon, .flagVariantIcon, .flagVariantOutlineIcon: return .flag
+        case .bookmarkIcon, .bookmarkOutlineIcon: return .bookmark
+        case .tagIcon, .tagOutlineIcon, .tagMultipleIcon, .tagMultipleOutlineIcon: return .tag
+        case .labelIcon, .labelOutlineIcon, .labelVariantIcon, .labelVariantOutlineIcon: return .tag
+        case .eyedropperIcon, .eyedropperVariantIcon: return .eyedropper
+        case .paletteIcon, .paletteOutlineIcon: return .paintpalette
+        case .brushIcon, .brushOutlineIcon, .brushVariantIcon: return .paintbrush
+        case .formatPaintIcon: return .paintbrushPointed
+        case .gestureSwipeIcon: return .handDraw
+
+        // MARK: Settings & tools
+        case .cogIcon, .cogOutlineIcon: return .gearshape
+        case .cogsIcon: return .gearshape2
+        case .tuneIcon, .tuneVariantIcon: return .sliderHorizontal3
+        case .tuneVerticalIcon, .tuneVerticalVariantIcon, .equalizerIcon: return .sliderVertical3
+        case .wrenchClockIcon: return .wrenchAndScrewdriver
+        case .toolsIcon, .toolboxIcon, .toolboxOutlineIcon: return .wrenchAndScrewdriver
+        case .hammerWrenchIcon: return .wrenchAndScrewdriver
+        case .hammerIcon: return .hammer
+        case .screwdriverIcon: return .screwdriver
+        case .rulerIcon, .rulerSquareIcon, .tapeMeasureIcon: return .ruler
+        case .bugIcon, .bugOutlineIcon: return .ant
+        case .ladybugIcon: return .ladybug
+        case .autoFixIcon, .magicStaffIcon: return .wandAndStars
+        case .shimmerIcon, .creationIcon: return .sparkles
+        case .scaleIcon, .scaleBathroomIcon, .weightIcon: return .scalemass
+        case .weightKilogramIcon, .weightPoundIcon: return .scalemass
+        case .umbrellaIcon, .umbrellaOutlineIcon, .umbrellaClosedIcon: return .umbrella
+        case .glassesIcon: return .eyeglasses
+        case .tshirtCrewIcon, .tshirtCrewOutlineIcon, .tshirtVIcon: return .tshirt
+        case .bagSuitcaseIcon, .bagSuitcaseOutlineIcon: return .suitcase
+        case .briefcaseIcon, .briefcaseOutlineIcon, .briefcaseVariantIcon: return .briefcase
+        case .binocularsIcon: return .binoculars
+        case .giftIcon, .giftOutlineIcon: return .gift
+        case .crownIcon, .crownOutlineIcon: return .crown
+        case .puzzleIcon, .puzzleOutlineIcon: return .puzzlepiece
+        case .diceMultipleIcon, .dice5Icon: return .dieFace5
+        case .dice1Icon: return .dieFace1
+        case .dice2Icon: return .dieFace2
+        case .dice3Icon: return .dieFace3
+        case .dice4Icon: return .dieFace4
+        case .dice6Icon: return .dieFace6
+        case .pianoIcon: return .pianokeys
+        case .guitarAcousticIcon, .guitarElectricIcon: return .guitars
+        case .recycleIcon, .recycleVariantIcon: return .arrow3Trianglepath
+        case .infinityIcon, .allInclusiveIcon: return .infinity
+        case .keyChainIcon, .keyChainVariantIcon: return .key
+
+        // MARK: Health
+        case .medicalBagIcon: return .crossCase
+        case .hospitalIcon, .hospitalBoxIcon, .hospitalBoxOutlineIcon: return .cross
+        case .ambulanceIcon: return .cross
+        case .pillIcon: return .pills
+        case .bandageIcon: return .bandage
+        case .stethoscopeIcon: return .stethoscope
+        case .lungsIcon: return .lungs
+        case .brainIcon: return .brain
+        case .testTubeIcon: return .testtube2
+        case .atomIcon, .atomVariantIcon: return .atom
+
+        // MARK: Food & dining
+        case .silverwareIcon, .silverwareForkKnifeIcon, .silverwareVariantIcon: return .forkKnife
+        case .foodIcon, .foodVariantIcon: return .forkKnife
+        case .coffeeIcon, .coffeeOutlineIcon, .coffeeMakerIcon: return .cupAndSaucer
+        case .coffeeMakerOutlineIcon, .cupIcon, .cupOutlineIcon: return .cupAndSaucer
+
+        // MARK: Nature & animals (baseline)
+        case .leafIcon, .leafCircleIcon, .leafCircleOutlineIcon, .sproutIcon: return .leaf
+        case .sproutOutlineIcon, .grassIcon: return .leaf
+        case .pawIcon, .pawOutlineIcon: return .pawprint
+        case .rabbitIcon, .rabbitVariantIcon, .rabbitVariantOutlineIcon: return .hare
+        case .turtleIcon, .tortoiseIcon: return .tortoise
+        case .fireExtinguisherIcon: return .flame
+
+        // MARK: Beds & bedroom
+        case .bedIcon, .bedOutlineIcon, .bedDoubleIcon, .bedDoubleOutlineIcon: return .bedDouble
+        case .bedKingIcon, .bedKingOutlineIcon, .bedQueenIcon, .bedQueenOutlineIcon: return .bedDouble
+        case .bedSingleIcon, .bedSingleOutlineIcon, .bedEmptyIcon: return .bedDouble
+
+        // MARK: Commerce & data
+        case .creditCardIcon, .creditCardOutlineIcon: return .creditcard
+        case .creditCardWirelessIcon, .creditCardWirelessOutlineIcon: return .creditcard
+        case .cashIcon, .cashMultipleIcon: return .banknote
+        case .currencyUsdIcon: return .dollarsignCircle
+        case .currencyEurIcon: return .eurosignCircle
+        case .currencyGbpIcon: return .sterlingsignCircle
+        case .currencyBtcIcon: return .bitcoinsignCircle
+        case .currencyJpyIcon: return .yensignCircle
+        case .cartIcon, .cartOutlineIcon, .cartVariantIcon: return .cart
+        case .cartPlusIcon: return .cartBadgePlus
+        case .cartMinusIcon: return .cartBadgeMinus
+        case .basketIcon, .basketOutlineIcon: return .cart
+        case .shoppingIcon, .shoppingOutlineIcon: return .bag
+        case .walletIcon, .walletOutlineIcon: return .walletPass
+        case .bankIcon, .bankOutlineIcon: return .buildingColumns
+        case .ticketIcon, .ticketOutlineIcon, .ticketConfirmationIcon: return .ticket
+        case .chartLineIcon, .chartLineVariantIcon, .chartAreasplineIcon: return .chartXyaxisLine
+        case .chartTimelineVariantIcon: return .chartXyaxisLine
+        case .chartBarIcon, .chartBarStackedIcon, .pollIcon, .financeIcon: return .chartBar
+        case .chartPieIcon, .chartDonutIcon, .chartDonutVariantIcon: return .chartPie
+        case .chartBellCurveIcon, .chartBellCurveCumulativeIcon: return .chartXyaxisLine
+        case .trendingUpIcon: return .chartLineUptrendXyaxis
+        case .sitemapIcon, .sitemapOutlineIcon: return .rectangle3Group
+
+        // MARK: Code & math
+        case .codeBracesIcon, .codeJsonIcon: return .curlybraces
+        case .codeTagsIcon, .xmlIcon: return .chevronLeftForwardslashChevronRight
+        case .functionIcon, .functionVariantIcon: return .function
+        case .sigmaIcon: return .sum
+        case .percentIcon, .percentOutlineIcon: return .percent
+        case .equalIcon: return .equal
+        case .plusMinusIcon, .plusMinusVariantIcon: return .plusminus
+        case .divisionIcon: return .divide
+        case .multiplicationIcon: return .multiply
+        case .numericIcon, .poundIcon, .counterIcon: return .number
+        case .translateIcon: return .characterBookClosed
+
+        // MARK: Older-OS fallbacks for newer matches
+        case .storeIcon, .storeOutlineIcon, .storefrontOutlineIcon: return .building
+        case .evStationIcon: return .boltCar
+        case .dogIcon, .dogSideIcon, .dogServiceIcon, .catIcon: return .pawprint
+        case .accountOffIcon, .accountOffOutlineIcon: return .personCropCircleBadgeXmark
+        case .flaskIcon, .flaskOutlineIcon, .flaskEmptyIcon, .flaskEmptyOutlineIcon: return .testtube2
+        case .sunglassesIcon: return .eyeglasses
+        case .calendarCheckIcon, .calendarCheckOutlineIcon: return .calendar
+        case .televisionOffIcon, .televisionClassicOffIcon: return .tv
+        case .batteryChargingIcon, .batteryChargingHighIcon, .batteryCharging100Icon: return .boltBatteryblock
+
+        default: return nil
+        }
+    }
+}
+

--- a/Tests/Shared/MaterialDesignIconsSFSymbol.test.swift
+++ b/Tests/Shared/MaterialDesignIconsSFSymbol.test.swift
@@ -1,0 +1,39 @@
+@testable import Shared
+import Testing
+
+struct MaterialDesignIconsSFSymbolTests {
+    @Test func commonIconsMapToExpectedSymbols() {
+        #expect(MaterialDesignIcons.lightbulbIcon.similarSFSymbol.rawValue == "lightbulb")
+        #expect(MaterialDesignIcons.homeIcon.similarSFSymbol.rawValue == "house")
+        #expect(MaterialDesignIcons.lockIcon.similarSFSymbol.rawValue == "lock")
+        #expect(MaterialDesignIcons.playIcon.similarSFSymbol.rawValue == "play")
+        #expect(MaterialDesignIcons.weatherSunnyIcon.similarSFSymbol.rawValue == "sun.max")
+        #expect(MaterialDesignIcons.accountIcon.similarSFSymbol.rawValue == "person")
+    }
+
+    @Test func availabilityGatedIconsResolveOnEveryOS() {
+        // These only have an exact match on newer OS versions and must
+        // still resolve to a real mapping instead of the generic fallback.
+        let gated: [MaterialDesignIcons] = [
+            .fanIcon,
+            .batteryIcon,
+            .thermostatIcon,
+            .garageIcon,
+            .curtainsIcon,
+            .dogIcon,
+        ]
+        for icon in gated {
+            #expect(icon.similarSFSymbol.rawValue != "questionmark.circle", "\(icon.name) should have a mapping")
+        }
+    }
+
+    @Test func unmappedIconFallsBackToQuestionmark() {
+        #expect(MaterialDesignIcons.abjadArabicIcon.similarSFSymbol.rawValue == "questionmark.circle")
+    }
+
+    @Test func everyIconResolvesToSomeSymbol() {
+        for icon in MaterialDesignIcons.allCases {
+            #expect(!icon.similarSFSymbol.rawValue.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
Adds a hand-curated extension mapping ~1300 Material Design icons to
their closest SF Symbol equivalent, covering all Home Assistant domain
and device-class icons plus the most commonly used general icons.

The lookup is tiered by symbol availability: exact matches that require
SF Symbols 5 (iOS 17) or SF Symbols 4 (iOS 16) are guarded with
availability checks and fall back to the closest baseline (SF Symbols 3,
iOS 15 / watchOS 8) match, with .questionmarkCircle as the final
fallback for icons with no reasonable equivalent. Deprecated SF Symbol
names are avoided throughout.
