### PR TITLE
Deprecate synchronous activeURL() in favor of async variant that refreshes network information

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraStreamHLSView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraStreamHLSView.swift
@@ -102,7 +102,7 @@ struct CameraStreamHLSView: View {
         let response = api.StreamCamera(entityId: cameraEntityId).value
 
         if let hlsPath = response?.hlsPath,
-           let baseURL = api.server.info.connection.activeURL() {
+           let baseURL = await api.server.activeURL() {
             return baseURL.appendingPathComponent(hlsPath)
         } else {
             throw StreamError.noHLSAvailable

--- a/Sources/Shared/API/ConnectionInfo.swift
+++ b/Sources/Shared/API/ConnectionInfo.swift
@@ -227,7 +227,32 @@ public struct ConnectionInfo: Codable, Equatable {
     }
 
     /// Returns the url that should be used at this moment to access the Home Assistant instance.
+    ///
+    /// This evaluates against the network information (e.g. current SSID) cached at the time of the
+    /// call, which may be stale.
+    @available(
+        *,
+        deprecated,
+        message: "Use the async activeURL() instead, which refreshes network information before returning"
+    )
     public mutating func activeURL() -> URL? {
+        evaluateActiveURL()
+    }
+
+    /// Returns the url that should be used at this moment to access the Home Assistant instance,
+    /// refreshing network information (e.g. current SSID) before evaluating which URL is active.
+    public mutating func activeURL() async -> URL? {
+        await Current.connectivity.refreshNetworkInformation()
+        return evaluateActiveURL()
+    }
+
+    /// Evaluates the url that should be used at this moment to access the Home Assistant instance,
+    /// based on the currently cached network information.
+    ///
+    /// Not meant for general use: prefer the async `activeURL()`, which refreshes network
+    /// information first. This exists for callers that must stay synchronous and accept
+    /// potentially stale network information.
+    mutating func evaluateActiveURL() -> URL? {
         if let overrideActiveURLType {
             let overrideURL: URL?
 
@@ -300,7 +325,7 @@ public struct ConnectionInfo: Codable, Equatable {
 
     /// Returns the activeURL with /api appended.
     public mutating func activeAPIURL() -> URL? {
-        if let activeURL = activeURL() {
+        if let activeURL = evaluateActiveURL() {
             return activeURL.appendingPathComponent("api", isDirectory: false)
         } else {
             return nil
@@ -312,7 +337,7 @@ public struct ConnectionInfo: Codable, Equatable {
             return cloudhookURL
         }
 
-        if let activeURL = activeURL() {
+        if let activeURL = evaluateActiveURL() {
             return activeURL.appendingPathComponent(webhookPath, isDirectory: false)
         } else {
             return nil
@@ -417,7 +442,7 @@ class ServerRequestAdapter: RequestAdapter {
         var updatedRequest: URLRequest = urlRequest
 
         if let currentURL = urlRequest.url {
-            if let activeURL = server.info.connection.activeURL() {
+            if let activeURL = server.info.connection.evaluateActiveURL() {
                 let expectedURL = activeURL.adapting(url: currentURL)
                 if currentURL != expectedURL {
                     Current.Log.verbose("Changing request URL from \(currentURL) to \(expectedURL)")

--- a/Sources/Shared/API/Server+Fakes.swift
+++ b/Sources/Shared/API/Server+Fakes.swift
@@ -30,7 +30,7 @@ extension ServerInfo {
                 build: nil
             )
         )
-        _ = value.connection.activeURL()
+        _ = value.connection.evaluateActiveURL()
         return value
     }
 }

--- a/Sources/Shared/API/Server.swift
+++ b/Sources/Shared/API/Server.swift
@@ -332,6 +332,23 @@ public final class Server: Hashable, Comparable, CustomStringConvertible {
     }
 }
 
+public extension Server {
+    /// Returns the url that should be used at this moment to access this server, refreshing
+    /// network information (e.g. current SSID) before evaluating which URL is active.
+    ///
+    /// The re-evaluated active URL type is written back to `info`, matching the behavior of the
+    /// synchronous `ConnectionInfo.activeURL()` when called through `Server.info`.
+    func activeURL() async -> URL? {
+        await Current.connectivity.refreshNetworkInformation()
+
+        var url: URL?
+        update { info in
+            url = info.connection.evaluateActiveURL()
+        }
+        return url
+    }
+}
+
 #if !os(watchOS)
 public extension Server {
     /// Triggers a refresh of this server's data from Home Assistant

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -379,7 +379,7 @@ final class ServerManagerImpl: ServerManager {
 
             // update active URL so we can update just once if it's different than the save is doing
             // intentionally not in the lock
-            _ = serverInfo.connection.activeURL()
+            _ = serverInfo.connection.evaluateActiveURL()
 
             return cache.mutate { cache in
                 guard !cache.deletedServers.contains(identifier) else {

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -16,6 +16,11 @@ public class ConnectivityWrapper {
     public var simpleNetworkType: () -> NetworkType
     public var cellularNetworkType: () -> NetworkType
     public var networkAttributes: () -> [String: Any]
+    /// Refreshes the cached network information (e.g. current SSID/BSSID), returning once the
+    /// values are up to date. Defaults to `syncNetworkInformation()`; replaceable in tests.
+    public var refreshNetworkInformation: () async -> Void = {
+        await Current.connectivity.syncNetworkInformation()
+    }
 
     #if targetEnvironment(macCatalyst)
     init() {

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -18,8 +18,8 @@ public class ConnectivityWrapper {
     public var networkAttributes: () -> [String: Any]
     /// Refreshes the cached network information (e.g. current SSID/BSSID), returning once the
     /// values are up to date. Defaults to `syncNetworkInformation()`; replaceable in tests.
-    public var refreshNetworkInformation: () async -> Void = {
-        await Current.connectivity.syncNetworkInformation()
+    public lazy var refreshNetworkInformation: () async -> Void = { [weak self] in
+        await self?.syncNetworkInformation()
     }
 
     #if targetEnvironment(macCatalyst)

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -757,10 +757,9 @@ class ConnectionInfoTests: XCTestCase {
             connectionAccessSecurityLevel: .undefined
         )
 
+        let previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
         addTeardownBlock {
-            Current.connectivity.refreshNetworkInformation = {
-                await Current.connectivity.syncNetworkInformation()
-            }
+            Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
         }
 
         // Cached network information does not know about the internal network yet;
@@ -793,10 +792,9 @@ class ConnectionInfoTests: XCTestCase {
             connectionAccessSecurityLevel: .undefined
         )
 
+        let previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
         addTeardownBlock {
-            Current.connectivity.refreshNetworkInformation = {
-                await Current.connectivity.syncNetworkInformation()
-            }
+            Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
         }
 
         // Cached network information still says we are on the internal network,
@@ -816,10 +814,9 @@ class ConnectionInfoTests: XCTestCase {
         let internalURL = URL(string: "http://internal.example.com:8123")
         let externalURL = URL(string: "http://external.example.com:8123")
 
+        let previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
         addTeardownBlock {
-            Current.connectivity.refreshNetworkInformation = {
-                await Current.connectivity.syncNetworkInformation()
-            }
+            Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
         }
 
         Current.connectivity.currentWiFiSSID = { nil }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -739,4 +739,104 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(info.activeURL(), internalURL)
         XCTAssertEqual(info.activeURLType, .internal)
     }
+
+    func testAsyncActiveURLRefreshesNetworkInformationBeforeEvaluating() async {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: ["unit_tests"],
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined
+        )
+
+        addTeardownBlock {
+            Current.connectivity.refreshNetworkInformation = {
+                await Current.connectivity.syncNetworkInformation()
+            }
+        }
+
+        // Cached network information does not know about the internal network yet;
+        // the refresh performed by the async activeURL discovers it.
+        Current.connectivity.currentWiFiSSID = { nil }
+        Current.connectivity.refreshNetworkInformation = {
+            Current.connectivity.currentWiFiSSID = { "unit_tests" }
+        }
+
+        let url = await info.activeURL()
+
+        XCTAssertEqual(url, internalURL)
+        XCTAssertEqual(info.activeURLType, .internal)
+    }
+
+    func testAsyncActiveURLFallsBackToExternalURLWhenRefreshLeavesInternalNetwork() async {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+        var info = ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: ["unit_tests"],
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined
+        )
+
+        addTeardownBlock {
+            Current.connectivity.refreshNetworkInformation = {
+                await Current.connectivity.syncNetworkInformation()
+            }
+        }
+
+        // Cached network information still says we are on the internal network,
+        // but the refresh performed by the async activeURL discovers we left it.
+        Current.connectivity.currentWiFiSSID = { "unit_tests" }
+        Current.connectivity.refreshNetworkInformation = {
+            Current.connectivity.currentWiFiSSID = { nil }
+        }
+
+        let url = await info.activeURL()
+
+        XCTAssertEqual(url, externalURL)
+        XCTAssertEqual(info.activeURLType, .external)
+    }
+
+    func testServerAsyncActiveURLRefreshesNetworkInformationAndUpdatesInfo() async {
+        let internalURL = URL(string: "http://internal.example.com:8123")
+        let externalURL = URL(string: "http://external.example.com:8123")
+
+        addTeardownBlock {
+            Current.connectivity.refreshNetworkInformation = {
+                await Current.connectivity.syncNetworkInformation()
+            }
+        }
+
+        Current.connectivity.currentWiFiSSID = { nil }
+
+        let server = Server.fake { info in
+            info.connection.set(address: internalURL, for: .internal)
+            info.connection.set(address: externalURL, for: .external)
+            info.connection.internalSSIDs = ["unit_tests"]
+        }
+
+        Current.connectivity.refreshNetworkInformation = {
+            Current.connectivity.currentWiFiSSID = { "unit_tests" }
+        }
+
+        let url = await server.activeURL()
+
+        XCTAssertEqual(url, internalURL)
+        XCTAssertEqual(server.info.connection.activeURLType, .internal)
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
The synchronous `ConnectionInfo.activeURL()` evaluates against network information (current SSID / hardware address) that was cached at some earlier point, so right after a network change it can resolve the wrong URL — e.g. still returning the internal URL after leaving the home network. Several call sites work around this by manually calling `Current.connectivity.syncNetworkInformation()` first.

This PR deprecates the synchronous API and introduces an async `activeURL()` that refreshes network information before evaluating which URL is active:

- **`ConnectionInfo.activeURL() async`** — awaits a network-information refresh, then evaluates the active URL. The synchronous `activeURL()` is now marked `@available(*, deprecated, ...)`.
- **`Server.activeURL() async`** — convenience that refreshes and writes the re-evaluated `activeURLType` back through `Server.info` (persisting it), matching what the synchronous mutation did for callers going through `server.info.connection`.
- **`Current.connectivity.refreshNetworkInformation`** — new World-pattern closure (defaults to `syncNetworkInformation()`) so tests can control the refresh step.
- The URL evaluation itself moved to the internal `evaluateActiveURL()`, used by machinery that must stay synchronous and knowingly accepts cached network information: `activeAPIURL()`, `webhookURL()`, `ServerRequestAdapter`, the `ServerManager` save path, and `ServerInfo.fake()`.
- `CameraStreamHLSView.fetchStreamURL` was migrated to `await api.server.activeURL()` — it is the one call site inside an async context, where the new overload takes precedence in resolution.
- New tests in `ConnectionInfoTests` cover both directions (refresh discovers the internal network / discovers it was left) and the `Server` convenience.

Remaining synchronous call sites keep compiling and now emit deprecation warnings; migrating them to the async variant is intended as follow-up work.

## Screenshots
Not applicable — no user-facing/UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- No behavior change for existing callers: the deprecated function performs exactly the same evaluation as before.
- Follow-ups: migrate the remaining deprecated call sites, and consider async variants of `activeAPIURL()`/`webhookURL()` (the latter also reads `isOnInternalNetwork` from cached data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StXKmmfEiUx7S8p1stT4bd

---
_Generated by [Claude Code](https://claude.ai/code/session_01StXKmmfEiUx7S8p1stT4bd)_