### PR TITLE
Fix stale Live Activity when progress is a floating point value

### DIFF
--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -240,10 +240,10 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             _ container: KeyedDecodingContainer<CodingKeys>,
             forKey key: CodingKeys
         ) -> Int? {
-            if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
-                return value.map { Int($0.rounded()) }
+            guard let value = try? container.decodeIfPresent(Double.self, forKey: key) else {
+                return nil
             }
-            return nil
+            return Int(exactly: value.rounded())
         }
     }
 

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -189,8 +189,8 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             }
             self.message = try container.decode(String.self, forKey: .message)
             self.criticalText = try container.decodeIfPresent(String.self, forKey: .criticalText)
-            self.progress = try container.decodeIfPresent(Int.self, forKey: .progress)
-            self.progressMax = try container.decodeIfPresent(Int.self, forKey: .progressMax)
+            self.progress = Self.decodeRoundedInt(container, forKey: .progress)
+            self.progressMax = Self.decodeRoundedInt(container, forKey: .progressMax)
             self.chronometer = try container.decodeIfPresent(Bool.self, forKey: .chronometer)
             if let timestamp = try container.decodeIfPresent(Double.self, forKey: .countdownEnd) {
                 self.countdownEnd = Date(timeIntervalSince1970: timestamp)
@@ -230,6 +230,20 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             try container.encodeIfPresent(backgroundColor, forKey: .backgroundColor)
             try container.encodeIfPresent(textColor, forKey: .textColor)
             try container.encodeIfPresent(progressBarColor, forKey: .progressBarColor)
+        }
+
+        // HA may send progress/progress_max as a JSON float (e.g. 20.1234). ActivityKit decodes
+        // content-state OS-side with a strict JSONDecoder, so decoding those keys as Int would throw
+        // and drop the whole remote update (stale activity) or reject a push-to-start. Decode as
+        // Double and round so both integer and fractional values map to the nearest Int.
+        private static func decodeRoundedInt(
+            _ container: KeyedDecodingContainer<CodingKeys>,
+            forKey key: CodingKeys
+        ) -> Int? {
+            if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+                return value.map { Int($0.rounded()) }
+            }
+            return nil
         }
     }
 

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -136,8 +136,8 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
         let criticalText = payload["critical_text"] as? String
         // Round so both Int and Double JSON values (e.g. 50 vs 50.9) map to the nearest Int, matching
         // the OS-side content-state decoder in HALiveActivityAttributes.ContentState.
-        let progress = (payload["progress"] as? NSNumber).map { Int($0.doubleValue.rounded()) }
-        let progressMax = (payload["progress_max"] as? NSNumber).map { Int($0.doubleValue.rounded()) }
+        let progress = (payload["progress"] as? NSNumber).flatMap { Int(exactly: $0.doubleValue.rounded()) }
+        let progressMax = (payload["progress_max"] as? NSNumber).flatMap { Int(exactly: $0.doubleValue.rounded()) }
         let chronometer = payload["chronometer"] as? Bool
         let icon = payload["notification_icon"] as? String
         let color = payload["notification_icon_color"] as? String

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -134,9 +134,10 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
         let title = (payload["title"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         let message = payload["message"] as? String ?? ""
         let criticalText = payload["critical_text"] as? String
-        // Use NSNumber coercion so both Int and Double JSON values (e.g. 50 vs 50.0) decode correctly.
-        let progress = (payload["progress"] as? NSNumber).map { Int(truncating: $0) }
-        let progressMax = (payload["progress_max"] as? NSNumber).map { Int(truncating: $0) }
+        // Round so both Int and Double JSON values (e.g. 50 vs 50.9) map to the nearest Int, matching
+        // the OS-side content-state decoder in HALiveActivityAttributes.ContentState.
+        let progress = (payload["progress"] as? NSNumber).map { Int($0.doubleValue.rounded()) }
+        let progressMax = (payload["progress_max"] as? NSNumber).map { Int($0.doubleValue.rounded()) }
         let chronometer = payload["chronometer"] as? Bool
         let icon = payload["notification_icon"] as? String
         let color = payload["notification_icon_color"] as? String

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -134,6 +134,16 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertEqual(state.progressMax, 100)
     }
 
+    func testContentState_progressNonFinite_isNil() {
+        let payload: [String: Any] = [
+            "progress": NSNumber(value: Double.nan),
+            "progress_max": NSNumber(value: Double.infinity),
+        ]
+        let state = HandlerStartOrUpdateLiveActivity.contentState(from: payload)
+        XCTAssertNil(state.progress)
+        XCTAssertNil(state.progressMax)
+    }
+
     func testContentState_whenAbsolute_usesEpochTimestamp() {
         let timestamp: Double = 1_700_000_000
         let payload: [String: Any] = ["when": NSNumber(value: timestamp), "when_relative": false]

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -126,11 +126,12 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNil(state.countdownEnd)
     }
 
-    func testContentState_progressAsDouble_truncatesToInt() {
-        // JSON may send progress as 50.0 (Double) rather than 50 (Int)
-        let payload: [String: Any] = ["progress": NSNumber(value: 50.9)]
+    func testContentState_progressAsDouble_roundsToInt() {
+        // JSON may send progress as a float (e.g. 20.1234) rather than an Int; round to the nearest.
+        let payload: [String: Any] = ["progress": NSNumber(value: 50.9), "progress_max": NSNumber(value: 100.4)]
         let state = HandlerStartOrUpdateLiveActivity.contentState(from: payload)
-        XCTAssertEqual(state.progress, 50)
+        XCTAssertEqual(state.progress, 51)
+        XCTAssertEqual(state.progressMax, 100)
     }
 
     func testContentState_whenAbsolute_usesEpochTimestamp() {

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -164,6 +164,35 @@ final class LiveActivityContractTests: XCTestCase {
         XCTAssertEqual(decoded, original)
     }
 
+    /// HA sends `progress`/`progress_max` as JSON numbers that may be fractional (e.g. 20.1234).
+    /// ActivityKit decodes content-state OS-side with a strict JSONDecoder, so a float must not make
+    /// the decode throw — that would silently drop the remote update (stale activity) or reject a
+    /// push-to-start. It must decode, rounded to the nearest Int.
+    func testContentState_progressAsFloat_decodesRounded() throws {
+        let decoded = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress":20.1234,"progress_max":100}"#.utf8)
+        )
+        XCTAssertEqual(decoded.progress, 20)
+        XCTAssertEqual(decoded.progressMax, 100)
+
+        let rounding = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress":20.6}"#.utf8)
+        )
+        XCTAssertEqual(rounding.progress, 21)
+    }
+
+    /// A content-state payload without progress keys still decodes, with nil progress.
+    func testContentState_missingProgress_decodesAsNil() throws {
+        let decoded = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m"}"#.utf8)
+        )
+        XCTAssertNil(decoded.progress)
+        XCTAssertNil(decoded.progressMax)
+    }
+
     // MARK: - LiveActivityRegistry (webhook contracts)
 
     /// The Keychain key for the push-to-start token. Changing it would lose stored tokens.

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -193,6 +193,16 @@ final class LiveActivityContractTests: XCTestCase {
         XCTAssertNil(decoded.progressMax)
     }
 
+    /// An out-of-Int-range progress value must degrade to nil rather than trap the OS-side decoder.
+    func testContentState_progressOutOfIntRange_decodesAsNil() throws {
+        let decoded = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress":1e19,"progress_max":100}"#.utf8)
+        )
+        XCTAssertNil(decoded.progress)
+        XCTAssertEqual(decoded.progressMax, 100)
+    }
+
     // MARK: - LiveActivityRegistry (webhook contracts)
 
     /// The Keychain key for the push-to-start token. Changing it would lose stored tokens.


### PR DESCRIPTION
## Summary

Fixes [#4936](https://github.com/home-assistant/iOS/issues/4936). Sending a non-integer `progress` (e.g. `progress: 20.1234`) froze a running Live Activity and prevented a new one from starting.

## Root cause

`HALiveActivityAttributes.ContentState.init(from:)` decoded `progress` and `progress_max` strictly as `Int`. That initializer runs OS-side inside ActivityKit for every remote content-state push and push-to-start, so a JSON float made `decodeIfPresent(Int.self, ...)` throw and fail the whole content-state decode. The result was a silently dropped update (the activity keeps its last state and goes stale, showing the spinner) or a rejected push-to-start (the activity never appears).

The in-app command handler parsed the payload manually with `NSNumber` coercion, so the initial start survived, but subsequent updates HA sends directly to the activity push token bypass that handler and hit the strict decoder. That split is why the bug looked intermittent.

## Fix

- Decode `progress`/`progress_max` as `Double` and round to the nearest `Int`. Integers still decode, floats now round instead of throwing, and a missing or non-numeric value degrades to `nil` rather than failing the whole decode.
- Change the in-app handler from truncation to rounding so both decode paths agree and match the expected behavior of rounding to the closest integer (e.g. `50.9` becomes `51`).

Both delivery flows are covered: remote push (in-app handler and the OS-side ActivityKit decode) and local push (the parser already promotes these fields into the handler). No relay change is needed since the failing decode is on-device.

## Tests

- Added a contract test that decodes a raw `{"progress":20.1234,...}` payload exactly as ActivityKit would, proving it no longer throws and rounds correctly, plus a missing-progress case.
- Updated the handler test to assert rounding instead of truncation.