### PR TITLE
Prefer direct Watch-to-HA execution for magic items, fall back to iPhone

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1836,6 +1836,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.settings.no_servers" = "No servers synced yet. Open Home Assistant on your paired iPhone, then refresh from the Home screen.";
 "watch.settings.perform_action.apple_watch" = "Apple Watch";
 "watch.settings.perform_action.footer" = "Where actions run. Auto uses your iPhone when it's nearby, otherwise the Apple Watch connects directly to Home Assistant.";
+"watch.settings.perform_action.footer_prefer_watch" = "Where actions run. Auto connects directly from the Apple Watch to Home Assistant when it can, otherwise it relays through your iPhone.";
 "watch.settings.perform_action.iphone" = "iPhone";
 "watch.settings.perform_action.title" = "Perform action using";
 "watch.settings.refresh" = "Refresh";

--- a/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NetworkExtension
 import PromiseKit
 import Shared
 
@@ -72,13 +71,6 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         }
     }
 
-    private func fetchNetworkInfo(completion: (() -> Void)? = nil) {
-        Current.networkInformation { hotspotNetwork in
-            WatchUserDefaults.shared.set(hotspotNetwork?.ssid, key: .watchSSID)
-            completion?()
-        }
-    }
-
     private func executeMagicItemUsingiPhone(magicItem: MagicItem, completion: @escaping (Bool) -> Void) {
         Current.Log.verbose("Signaling magic item pressed via phone")
         let itemMessage = HAWatchConnectivity.InteractiveImmediateMessage(
@@ -87,6 +79,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
                 "itemId": magicItem.id,
                 "serverId": magicItem.serverId,
                 "itemType": magicItem.type.rawValue,
+                "triggeredAt": Current.date().timeIntervalSince1970,
             ],
             reply: { message in
                 Current.Log.verbose("Received reply dictionary \(message)")
@@ -135,51 +128,74 @@ final class WatchMagicViewRowViewModel: ObservableObject {
     }
 
     private func executeMagicItem(completion: @escaping (MagicItemResponse) -> Void) {
-        let timeTriggered = Date()
+        let timeTriggered = Current.date()
         let magicItem = item
         Current.Log.verbose("Selected magic item id: \(magicItem.id)")
-        fetchNetworkInfo { [weak self] in
+        startTimeoutTimerWhichResetsState(completion: completion)
+        Task { [weak self] in
             guard let self else { return }
-            if shouldUsePhone {
-                executeMagicItemUsingiPhone(magicItem: magicItem) { success in
-                    // Avoid haptics in background
-                    guard self.isLessThan30Seconds(from: timeTriggered) else {
-                        completion(.tookLonger)
-                        return
-                    }
-                    if success {
-                        self.cancelTimeout()
-                        completion(success ? .success : .failed)
-                    } else {
-                        completion(.failed)
-                    }
-                }
-            } else {
-                executeMagicItemUsingAPI(magicItem: magicItem) { success in
-                    self.cancelTimeout()
-                    completion(success ? .success : .failed)
-                }
-            }
-            startTimeoutTimerWhichResetsState(completion: completion)
+            await Current.connectivity.refreshNetworkInformation()
+            await routeExecution(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         }
     }
 
     /// Resolve where to run the action from the user's "Perform action using" preference: always the
-    /// iPhone, always the Watch (direct), or automatically (iPhone when reachable, else direct).
-    private var shouldUsePhone: Bool {
+    /// iPhone, always the Watch (direct), or automatically. In `auto` the Watch is preferred: it pings
+    /// Home Assistant directly and runs the action itself when reachable, otherwise it relays through
+    /// the paired iPhone (which errors if the iPhone isn't reachable either).
+    private func routeExecution(
+        magicItem: MagicItem,
+        timeTriggered: Date,
+        completion: @escaping (MagicItemResponse) -> Void
+    ) async {
         switch WatchUserDefaults.shared.performActionTarget {
         case .iPhone:
-            return true
+            executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         case .appleWatch:
-            return false
+            executeViaWatch(magicItem: magicItem, completion: completion)
         case .auto:
-            return Communicator.shared.currentReachability == .immediatelyReachable
+            if let server = Current.servers.all.first(where: { $0.identifier.rawValue == magicItem.serverId }),
+               await HomeAssistantAPI.apiAvailabilityCheck(for: server) {
+                Current.Log.info("Auto: Watch can reach Home Assistant directly, executing on watch")
+                executeViaWatch(magicItem: magicItem, completion: completion)
+            } else {
+                Current.Log.info("Auto: Watch cannot reach Home Assistant directly, relaying via iPhone")
+                executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+            }
+        }
+    }
+
+    private func executeViaWatch(magicItem: MagicItem, completion: @escaping (MagicItemResponse) -> Void) {
+        executeMagicItemUsingAPI(magicItem: magicItem) { [weak self] success in
+            self?.cancelTimeout()
+            completion(success ? .success : .failed)
+        }
+    }
+
+    private func executeViaiPhone(
+        magicItem: MagicItem,
+        timeTriggered: Date,
+        completion: @escaping (MagicItemResponse) -> Void
+    ) {
+        executeMagicItemUsingiPhone(magicItem: magicItem) { [weak self] success in
+            guard let self else { return }
+            // Avoid haptics in background
+            guard isLessThan30Seconds(from: timeTriggered) else {
+                completion(.tookLonger)
+                return
+            }
+            if success {
+                cancelTimeout()
+                completion(.success)
+            } else {
+                completion(.failed)
+            }
         }
     }
 
     // Given date returns if is less than 30 seconds from now
     private func isLessThan30Seconds(from date: Date) -> Bool {
-        Date().timeIntervalSince(date) < 30
+        Current.date().timeIntervalSince(date) < 30
     }
 
     private func startTimeoutTimerWhichResetsState(completion: @escaping (MagicItemResponse) -> Void) {

--- a/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/Extensions/Watch/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -133,9 +133,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         Current.Log.verbose("Selected magic item id: \(magicItem.id)")
         startTimeoutTimerWhichResetsState(completion: completion)
         Task { [weak self] in
-            guard let self else { return }
-            await Current.connectivity.refreshNetworkInformation()
-            await routeExecution(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+            await self?.routeExecution(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         }
     }
 
@@ -152,12 +150,13 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         case .iPhone:
             executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         case .appleWatch:
-            executeViaWatch(magicItem: magicItem, completion: completion)
+            await Current.connectivity.refreshNetworkInformation()
+            executeViaWatch(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         case .auto:
             if let server = Current.servers.all.first(where: { $0.identifier.rawValue == magicItem.serverId }),
                await HomeAssistantAPI.apiAvailabilityCheck(for: server) {
                 Current.Log.info("Auto: Watch can reach Home Assistant directly, executing on watch")
-                executeViaWatch(magicItem: magicItem, completion: completion)
+                executeViaWatch(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
             } else {
                 Current.Log.info("Auto: Watch cannot reach Home Assistant directly, relaying via iPhone")
                 executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
@@ -165,10 +164,13 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         }
     }
 
-    private func executeViaWatch(magicItem: MagicItem, completion: @escaping (MagicItemResponse) -> Void) {
+    private func executeViaWatch(
+        magicItem: MagicItem,
+        timeTriggered: Date,
+        completion: @escaping (MagicItemResponse) -> Void
+    ) {
         executeMagicItemUsingAPI(magicItem: magicItem) { [weak self] success in
-            self?.cancelTimeout()
-            completion(success ? .success : .failed)
+            self?.finishExecution(success: success, timeTriggered: timeTriggered, completion: completion)
         }
     }
 
@@ -178,19 +180,22 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         completion: @escaping (MagicItemResponse) -> Void
     ) {
         executeMagicItemUsingiPhone(magicItem: magicItem) { [weak self] success in
-            guard let self else { return }
-            // Avoid haptics in background
-            guard isLessThan30Seconds(from: timeTriggered) else {
-                completion(.tookLonger)
-                return
-            }
-            if success {
-                cancelTimeout()
-                completion(.success)
-            } else {
-                completion(.failed)
-            }
+            self?.finishExecution(success: success, timeTriggered: timeTriggered, completion: completion)
         }
+    }
+
+    private func finishExecution(
+        success: Bool,
+        timeTriggered: Date,
+        completion: @escaping (MagicItemResponse) -> Void
+    ) {
+        // Avoid haptics in background
+        guard isLessThan30Seconds(from: timeTriggered) else {
+            completion(.tookLonger)
+            return
+        }
+        cancelTimeout()
+        completion(success ? .success : .failed)
     }
 
     // Given date returns if is less than 30 seconds from now

--- a/Sources/Extensions/Watch/Home/WatchHomeFooterView.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeFooterView.swift
@@ -67,6 +67,7 @@ struct WatchHomeFooterView: View {
             }
             .font(DesignSystem.Font.caption2)
             .foregroundStyle(.secondary.opacity(0.5))
+            .padding(.vertical, DesignSystem.Spaces.one)
         }
     }
 }

--- a/Sources/Extensions/Watch/Home/WatchHomeView.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeView.swift
@@ -97,6 +97,7 @@ struct WatchHomeView: View {
         }
         .onAppear {
             guard autoLoad else { return }
+            viewModel.startNetworkMonitoring()
             Task {
                 await viewModel.fetchNetworkInfo()
                 viewModel.initialRoutine()

--- a/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NetworkExtension
+import Network
 import PromiseKit
 import Shared
 import SwiftUI
@@ -27,11 +27,29 @@ final class WatchHomeViewModel: ObservableObject {
     /// user to choose which to keep.
     @Published var pendingConflict: ConfigConflict?
 
+    private var networkPathMonitor: NWPathMonitor?
+    private let networkMonitorQueue = DispatchQueue(label: "WatchHomeNetworkPathMonitor")
+
+    deinit {
+        networkPathMonitor?.cancel()
+    }
+
+    func startNetworkMonitoring() {
+        guard networkPathMonitor == nil else { return }
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] _ in
+            Task { @MainActor in
+                await self?.fetchNetworkInfo()
+            }
+        }
+        monitor.start(queue: networkMonitorQueue)
+        networkPathMonitor = monitor
+    }
+
     @MainActor
     func fetchNetworkInfo() async {
-        let networkInformation = await Current.networkInformation
-        WatchUserDefaults.shared.set(networkInformation?.ssid, key: .watchSSID)
-        currentSSID = networkInformation?.ssid ?? ""
+        await Current.connectivity.refreshNetworkInformation()
+        currentSSID = Current.connectivity.currentWiFiSSID() ?? ""
     }
 
     @MainActor

--- a/Sources/Extensions/Watch/WatchSettingsView.swift
+++ b/Sources/Extensions/Watch/WatchSettingsView.swift
@@ -56,7 +56,7 @@ struct WatchSettingsView: View {
                 WatchUserDefaults.shared.performActionTarget = newValue
             }
         } footer: {
-            Text(verbatim: L10n.Watch.Settings.PerformAction.footer)
+            Text(verbatim: L10n.Watch.Settings.PerformAction.footerPreferWatch)
         }
     }
 

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -203,7 +203,7 @@ public class HomeAssistantAPI {
             let (_, response) = try await session.data(for: request)
             return response is HTTPURLResponse
         } catch {
-            Current.Log.info("Watch reachability probe failed, relaying via iPhone (\(error.localizedDescription))")
+            Current.Log.info("API availability check failed for \(server.info.name): \(error.localizedDescription)")
             return false
         }
     }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -192,6 +192,26 @@ public class HomeAssistantAPI {
         }
     }
 
+    public static func apiAvailabilityCheck(for server: Server, timeout: TimeInterval = 5) async -> Bool {
+        var connectionInfo = server.info.connection
+        guard let baseURL = await connectionInfo.activeURL() else {
+            return false
+        }
+
+        var request = URLRequest(url: baseURL.appendingPathComponent("api"))
+        request.timeoutInterval = timeout
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        defer { session.finishTasksAndInvalidate() }
+        do {
+            let (_, response) = try await session.data(for: request)
+            return response is HTTPURLResponse
+        } catch {
+            Current.Log.info("Watch reachability probe failed, relaying via iPhone (\(error.localizedDescription))")
+            return false
+        }
+    }
+
     convenience init?() {
         if let server = Current.servers.all.first {
             self.init(server: server, urlConfig: .default)

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -83,11 +83,7 @@ public class ConnectivityWrapper {
     #else
     init() {
         self.hasWiFi = { true }
-        self.currentWiFiSSID = {
-            let ssid = WatchUserDefaults.shared.string(for: .watchSSID)
-            Current.Log.verbose("Watch current WiFi SSID: \(String(describing: ssid))")
-            return ssid
-        }
+        self.currentWiFiSSID = { nil }
         self.currentWiFiBSSID = { nil }
         self.connectivityDidChangeNotification = { .init(rawValue: "_noop_") }
         self.simpleNetworkType = { .unknown }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -4,7 +4,6 @@ import CoreMotion
 import Foundation
 import GRDB
 import HAKit
-import NetworkExtension
 import PromiseKit
 import RealmSwift
 import UserNotifications
@@ -570,22 +569,6 @@ public class AppEnvironment {
 
     public var userNotificationCenter: UNUserNotificationCenter {
         UNUserNotificationCenter.current()
-    }
-
-    public var networkInformation: NEHotspotNetwork? {
-        get async {
-            await withCheckedContinuation { continuation in
-                NEHotspotNetwork.fetchCurrent { hotspotNetwork in
-                    continuation.resume(returning: hotspotNetwork)
-                }
-            }
-        }
-    }
-
-    public func networkInformation(completion: @escaping (NEHotspotNetwork?) -> Void) {
-        NEHotspotNetwork.fetchCurrent { hotspotNetwork in
-            completion(hotspotNetwork)
-        }
     }
 
     #if !os(watchOS)

--- a/Sources/Shared/Environment/WatchUserDefaults.swift
+++ b/Sources/Shared/Environment/WatchUserDefaults.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public enum WatchUserDefaultsKey: String {
-    case watchSSID
     /// When the watch last received the server configuration from the paired iPhone.
     case serversUpdatedAt
     /// Where the watch runs actions (magic items): automatically, always via iPhone, or directly.
@@ -15,7 +14,7 @@ public enum WatchUserDefaultsKey: String {
 
 /// Where the Apple Watch performs actions such as executing magic items.
 public enum WatchActionTarget: String, CaseIterable {
-    /// Use the iPhone when it's immediately reachable, otherwise connect directly from the Watch.
+    /// Connect directly from the Watch when it can reach Home Assistant, otherwise relay via the iPhone.
     case auto
     /// Always route through the paired iPhone.
     case iPhone

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6189,6 +6189,8 @@ public enum L10n {
         public static var appleWatch: String { return L10n.tr("Localizable", "watch.settings.perform_action.apple_watch") }
         /// Where actions run. Auto uses your iPhone when it's nearby, otherwise the Apple Watch connects directly to Home Assistant.
         public static var footer: String { return L10n.tr("Localizable", "watch.settings.perform_action.footer") }
+        /// Where actions run. Auto connects directly from the Apple Watch to Home Assistant when it can, otherwise it relays through your iPhone.
+        public static var footerPreferWatch: String { return L10n.tr("Localizable", "watch.settings.perform_action.footer_prefer_watch") }
         /// iPhone
         public static var iphone: String { return L10n.tr("Localizable", "watch.settings.perform_action.iphone") }
         /// Perform action using

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -374,6 +374,16 @@ final class WatchCommunicatorService {
 
     private func magicItemPressed(message: HAWatchConnectivity.InteractiveImmediateMessage) {
         let responseIdentifier = InteractiveImmediateResponses.magicItemRowPressedResponse.rawValue
+
+        if let triggeredAt = message.content["triggeredAt"] as? TimeInterval {
+            let age = Current.date().timeIntervalSince1970 - triggeredAt
+            if age > 30 {
+                Current.Log.warning("Discarding stale magic item press received \(Int(age))s after it was triggered")
+                message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+                return
+            }
+        }
+
         guard let itemType = message.content["itemType"] as? String,
               let itemId = message.content["itemId"] as? String,
               let type = MagicItem.ItemType(rawValue: itemType) else {


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On Apple Watch, running a magic item in "auto" mode now prefers the Watch's own connection: it checks whether Home Assistant is reachable directly and runs the action on the Watch when it is, relaying through the paired iPhone only when the Watch can't reach the server (and surfacing an error when the iPhone isn't reachable either). The iPhone ignores any relayed request older than 30 seconds, so a message that got stuck in transit never fires late. The Watch's current SSID is now updated in real time and refreshed right before an action runs (so the correct internal/external URL is chosen), and the legacy SSID cache in UserDefaults was replaced with live network information.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
