### PR TITLE
Fix Use Anyway button and mTLS in connection URL test

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionURLView.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLView.swift
@@ -34,7 +34,7 @@ struct ConnectionURLView: View {
         .alert(L10n.Settings.ConnectionSection.ValidateError.title, isPresented: $viewModel.showError) {
             if viewModel.canCommitAnyway {
                 Button(L10n.Settings.ConnectionSection.ValidateError.useAnyway) {
-                    viewModel.save(onSuccess: {
+                    viewModel.commitAnyway(onSuccess: {
                         dismiss()
                     })
                 }

--- a/Sources/App/Settings/Connection/ConnectionURLViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionURLViewModel.swift
@@ -146,6 +146,11 @@ final class ConnectionURLViewModel: ObservableObject {
         }
     }
 
+    func commitAnyway(onSuccess: @escaping () -> Void) {
+        commit()
+        onSuccess()
+    }
+
     private func commit() {
         let givenURL = url.isEmpty ? nil : URL(string: url)
 

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -470,8 +470,25 @@ public class WebhookManager: NSObject {
                 server: server,
                 baseURL: baseURL
             )
-        }.then(on: dataQueue) { urlRequest, data in
-            self.currentRegularSessionInfo.session.uploadTask(.promise, with: urlRequest, from: data)
+        }.then(on: dataQueue) { [self] urlRequest, data -> Promise<(Data, URLResponse)> in
+            let (promise, seal) = Promise<(Data, URLResponse)>.pending()
+            let task = currentRegularSessionInfo.session.uploadTask(
+                with: urlRequest,
+                from: data,
+                completionHandler: { data, response, error in
+                    if let data, let response {
+                        seal.fulfill((data, response))
+                    } else {
+                        seal.resolve(nil, error)
+                    }
+                }
+            )
+            let taskKey = TaskKey(sessionInfo: currentRegularSessionInfo, task: task)
+            serverForEphemeralTask[taskKey] = server
+            task.resume()
+            return promise.ensure(on: dataQueue) { [self] in
+                serverForEphemeralTask[taskKey] = nil
+            }
         }.then { data, response in
             Promise.value(data).webhookJson(
                 on: DispatchQueue.global(qos: .utility),


### PR DESCRIPTION
## Summary
Fixes two issues in the internal/external connection URL settings:

- The **Use Anyway** button in the validation error alert did nothing: it re-ran the full save flow, including the reachability test that had just failed, so the same alert reappeared. It now commits the entered values directly and dismisses.
- The connection **test request did not present the mTLS client certificate**, so validating a URL against a server that requires client certs always failed. The test upload task is now associated with its server (like other webhook requests), so the authentication challenge handler supplies the client certificate.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
