### PR TITLE
Fix greyed-out About and Settings menu bar items on macOS

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -171,11 +171,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    @objc func openAbout() {
-        precondition(Current.sceneManager.supportsMultipleScenes)
-        sceneManager.activateAnyScene(for: .about)
-    }
-
     @objc func openMenuUrl(_ command: AnyObject) {
         guard let command = command as? UICommand, let url = MenuManager.url(from: command) else {
             return
@@ -186,18 +181,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         sceneManager.appCoordinator.done { coordinator in
             IncomingURLHandler(coordinator: coordinator).handle(url: url)
         }
-    }
-
-    @objc func openPreferences() {
-        precondition(Current.sceneManager.supportsMultipleScenes)
-        sceneManager.activateAnyScene(for: .settings)
-    }
-
-    @objc func openHelp() {
-        openURLInBrowser(
-            URL(string: "https://companion.home-assistant.io")!,
-            nil
-        )
     }
 
     func application(

--- a/Sources/App/HAApp.swift
+++ b/Sources/App/HAApp.swift
@@ -18,6 +18,7 @@ struct HAApp: App {
         .handlesExternalEvents(matching: [SceneActivity.webView.activityIdentifier])
         .commands {
             MainWindowGroupCommands()
+            AppMenuBarCommands()
         }
 
         // Mac Settings

--- a/Sources/App/MainWindowGroupCommands.swift
+++ b/Sources/App/MainWindowGroupCommands.swift
@@ -2,6 +2,42 @@ import Foundation
 import Shared
 import SwiftUI
 
+struct AppMenuBarCommands: Commands {
+    private var appName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Home Assistant"
+    }
+
+    var body: some Commands {
+        CommandGroup(replacing: .appInfo) {
+            Button(L10n.Menu.Application.about(appName)) {
+                Current.sceneManager.activateAnyScene(for: .about)
+            }
+        }
+
+        CommandGroup(after: .appInfo) {
+            if Current.updater.isSupported {
+                Button(L10n.Updater.CheckForUpdatesMenu.title) {
+                    guard let appDelegate = AppDelegate.shared else { return }
+                    appDelegate.checkForUpdate(appDelegate)
+                }
+            }
+        }
+
+        CommandGroup(replacing: .appSettings) {
+            Button(L10n.Menu.Application.preferences) {
+                Current.sceneManager.activateAnyScene(for: .settings)
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+
+        CommandGroup(replacing: .help) {
+            Button(L10n.Menu.Help.help(appName)) {
+                openURLInBrowser(URL(string: "https://companion.home-assistant.io")!, nil)
+            }
+        }
+    }
+}
+
 /// Controls macOS and iPadOS menu bar items for the main app window.
 struct MainWindowGroupCommands: Commands {
     @StateObject private var reloadObserver = MainWindowGroupCommandsReloadObserver()

--- a/Sources/App/Utilities/MenuManager.swift
+++ b/Sources/App/Utilities/MenuManager.swift
@@ -6,7 +6,6 @@ import Shared
 import UIKit
 
 private extension UIMenu.Identifier {
-    static var haHelp: Self { .init(rawValue: "ha.help") }
     static var haWebViewActions: Self { .init(rawValue: "ha.webViewActions") }
     static var haFile: Self { .init(rawValue: "ha.file") }
 }
@@ -206,17 +205,6 @@ class MenuManager {
     public func update() {
         builder.remove(menu: .format)
 
-        builder.replace(menu: .about, with: aboutMenu())
-
-        if builder.menu(for: .preferences) == nil {
-            // macOS prior to 11.3 doesn't have the preferences menu already and 11.3+ doesn't like it being inserted
-            builder.insertSibling(preferencesMenu(), afterMenu: .about)
-        } else {
-            builder.replace(menu: .preferences, with: preferencesMenu())
-        }
-
-        builder.replaceChildren(ofMenu: .help) { _ in helpMenus() }
-
         if builder.menu(for: .haWebViewActions) == nil {
             builder.insertSibling(webViewActionsMenu(), beforeMenu: .fullscreen)
         } else {
@@ -230,40 +218,6 @@ class MenuManager {
         }
 
         configureStatusItem()
-    }
-
-    private func aboutMenu() -> UIMenu {
-        let title = L10n.Menu.Application.about(appName)
-
-        let about = UICommand(
-            title: title,
-            image: nil,
-            action: #selector(AppDelegate.openAbout),
-            propertyList: nil
-        )
-
-        let checkForUpdates = UICommand(
-            title: L10n.Updater.CheckForUpdatesMenu.title,
-            image: nil,
-            action: #selector(AppDelegate.checkForUpdate(_:)),
-            propertyList: nil
-        )
-
-        var children: [UICommand] = [
-            about,
-        ]
-
-        if Current.updater.isSupported {
-            children.append(checkForUpdates)
-        }
-
-        return UIMenu(
-            title: title,
-            image: nil,
-            identifier: .about,
-            options: .displayInline,
-            children: children
-        )
     }
 
     private func aboutMenu() -> [AppMacBridgeStatusItemMenuItem] {
@@ -288,25 +242,6 @@ class MenuManager {
         ]
     }
 
-    private func preferencesMenu() -> UIMenu {
-        let command = UIKeyCommand(
-            title: L10n.Menu.Application.preferences,
-            image: nil,
-            action: #selector(AppDelegate.openPreferences),
-            input: ",",
-            modifierFlags: .command,
-            propertyList: nil
-        )
-
-        return UIMenu(
-            title: L10n.Menu.Application.preferences,
-            image: nil,
-            identifier: .preferences,
-            options: .displayInline,
-            children: [command]
-        )
-    }
-
     private func preferencesMenu() -> AppMacBridgeStatusItemMenuItem {
         .init(
             name: L10n.Menu.Application.preferences,
@@ -316,27 +251,6 @@ class MenuManager {
             Current.sceneManager.activateAnyScene(for: .settings)
             callbackInfo.activate()
         }
-    }
-
-    private func helpMenus() -> [UIMenu] {
-        let title = L10n.Menu.Help.help(appName)
-
-        let helpCommand = UICommand(
-            title: title,
-            image: nil,
-            action: #selector(AppDelegate.openHelp),
-            propertyList: nil
-        )
-
-        return [
-            UIMenu(
-                title: title,
-                image: nil,
-                identifier: .haHelp,
-                options: .displayInline,
-                children: [helpCommand]
-            ),
-        ]
     }
 
     private func webViewActionsMenu() -> UIMenu {


### PR DESCRIPTION
## Summary
On macOS the app-menu **About** and **Settings** items (and **Help** / **Check for Updates**) were greyed out. They were built as `UIMenuBuilder` `UICommand`s dispatched through the responder chain to `AppDelegate` selectors. Since the move to the SwiftUI app lifecycle, `AppDelegate` is no longer `UIApplication.shared.delegate` and therefore not in the responder chain, so UIKit found no valid target and disabled the items.

This moves those items to SwiftUI `CommandGroup` actions that trigger scene activation directly, and removes the now-unreachable `UIMenuBuilder` wiring.

Fixes #4958

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
