### PR TITLE
Fix unresponsive Mac toolbar buttons after title bar re-appears

### DIFF
--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -15,21 +15,14 @@ struct MacWebViewTitleBar: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> UIViewController {
-        MacWebViewTitleBarViewController { [weak coordinator = context.coordinator] viewController in
-            coordinator?.configure(
-                windowScene: viewController.view.window?.windowScene,
-                server: server,
-                webViewController: webViewController
-            )
+        MacWebViewTitleBarViewController { [weak coordinator = context.coordinator] windowScene in
+            coordinator?.attach(to: windowScene)
         }
     }
 
     func updateUIViewController(_ viewController: UIViewController, context: Context) {
-        context.coordinator.configure(
-            windowScene: viewController.view.window?.windowScene,
-            server: server,
-            webViewController: webViewController
-        )
+        context.coordinator.update(server: server, webViewController: webViewController)
+        context.coordinator.attach(to: viewController.view.window?.windowScene)
     }
 
     static func dismantleUIViewController(_ viewController: UIViewController, coordinator: Coordinator) {
@@ -38,10 +31,10 @@ struct MacWebViewTitleBar: UIViewControllerRepresentable {
 }
 
 private final class MacWebViewTitleBarViewController: UIViewController {
-    private let updateToolbar: (MacWebViewTitleBarViewController) -> Void
+    private let attachToolbar: (UIWindowScene?) -> Void
 
-    init(updateToolbar: @escaping (MacWebViewTitleBarViewController) -> Void) {
-        self.updateToolbar = updateToolbar
+    init(attachToolbar: @escaping (UIWindowScene?) -> Void) {
+        self.attachToolbar = attachToolbar
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -58,7 +51,7 @@ private final class MacWebViewTitleBarViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        updateToolbar(self)
+        attachToolbar(view.window?.windowScene)
     }
 }
 
@@ -90,17 +83,17 @@ extension MacWebViewTitleBar {
         private var macToolbarItems: [MagicItem] = []
         private var macToolbarConfigObserver: NSObjectProtocol?
 
-        func configure(
-            windowScene: UIWindowScene?,
-            server: Server,
-            webViewController: WebViewController?
-        ) {
+        func update(server: Server, webViewController: WebViewController?) {
             self.server = server
             self.webViewController = webViewController
 
             loadMacToolbarItems()
             observeMacToolbarConfigChanges()
 
+            refreshToolbarState()
+        }
+
+        func attach(to windowScene: UIWindowScene?) {
             guard let titlebar = windowScene?.titlebar else { return }
             self.titlebar = titlebar
 
@@ -120,6 +113,11 @@ extension MacWebViewTitleBar {
                 self.toolbar = toolbar
             }
 
+            refreshToolbarState()
+        }
+
+        private func refreshToolbarState() {
+            guard let toolbar, titlebar?.toolbar === toolbar else { return }
             updateEnabledItems()
             updateServerPicker()
         }
@@ -572,12 +570,8 @@ private extension NSToolbarItem.Identifier {
 #else
 extension MacWebViewTitleBar {
     final class Coordinator: NSObject {
-        func configure(
-            windowScene: UIWindowScene?,
-            server: Server,
-            webViewController: WebViewController?
-        ) {}
-
+        func update(server: Server, webViewController: WebViewController?) {}
+        func attach(to windowScene: UIWindowScene?) {}
         func removeToolbar() {}
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Fixes the Mac (Catalyst) toolbar buttons becoming unresponsive after the web view title bar re-appears, for example after closing Settings, refocusing the window, or switching Spaces.

The `viewDidAppear` callback re-ran the toolbar setup using the web view controller captured when the SwiftUI representable was first created, which is always `nil` at that point (it is set asynchronously afterwards). Every re-appearance therefore reset the toolbar back to a `nil` controller, so back/forward/refresh/copy/paste/open-in-Safari and gesture buttons silently did nothing.

The coordinator now keeps the latest server and web view controller (updated from `updateUIViewController`) and re-applies that current state whenever the title bar re-appears, so the buttons keep working.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
