### PR TITLE
Fix launch crash: embed RealmSwift framework in app and watch extension bundles

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -445,8 +445,8 @@
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
 		177E4B39B7BA296CCB68A27D /* Pods-iOS-Extensions-Widgets-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
-		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A0BF50187A921289B3BA4AE /* Pods-Tests-App-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B67C3F1DA02199833DA64AF8 /* Pods-Tests-App-metadata.plist */; };
 		1A3CC1D75E8EEF7294146BD1 /* ControlFanValueProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A34A5417D650BBBE9D2D7C0 /* ControlFanValueProvider.swift */; };
 		1AA7D3A6102D7CC4601EEC6F /* KioskSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70F7D3E8E4B489FA1514E7C /* KioskSettingsViewModel.swift */; };

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -445,6 +445,8 @@
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
 		177E4B39B7BA296CCB68A27D /* Pods-iOS-Extensions-Widgets-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6723A4E97E50C3C9141428D0 /* Pods-iOS-Extensions-Widgets-metadata.plist */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
+		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		1A0BF50187A921289B3BA4AE /* Pods-Tests-App-metadata.plist in Resources */ = {isa = PBXBuildFile; fileRef = B67C3F1DA02199833DA64AF8 /* Pods-Tests-App-metadata.plist */; };
 		1A3CC1D75E8EEF7294146BD1 /* ControlFanValueProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A34A5417D650BBBE9D2D7C0 /* ControlFanValueProvider.swift */; };
 		1AA7D3A6102D7CC4601EEC6F /* KioskSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70F7D3E8E4B489FA1514E7C /* KioskSettingsViewModel.swift */; };
@@ -1920,6 +1922,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				110EC9FE251708D5009C9A1B /* Shared.framework in Embed Frameworks */,
+				1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1975,6 +1978,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				B67CE82C22200D420034C1D0 /* Shared.framework in Embed Frameworks */,
+				1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary

Fixes the dead-on-arrival launch crash in the first TestFlight build (2026.8.0 / 2026.2243) after #4968:

```
Termination Reason: DYLD 1 Library missing
Library not loaded: @rpath/RealmSwift.framework/RealmSwift
Referenced from: … Home Assistant.app/Home Assistant
(terminated at launch; ignore backtrace)
```

**Root cause:** #4968 moved Realm from CocoaPods to SPM using `bgoncal/xcode27-realm-swift`, whose `Package.swift` declares the `Realm`/`RealmSwift` library products as explicitly `type: .dynamic`. Xcode builds those as a plain `RealmSwift.framework`, and it fails to embed such explicitly-dynamic package frameworks into archived/exported builds — so the framework the app binary links against is missing from the shipped bundle, and dyld aborts before `main()`.

The crash log's Binary Images list shows the contrast: every *automatic*-type SPM product linked by multiple targets (Alamofire, KeychainAccess, SFSafeSymbols, SharedPush) was correctly built and embedded as `<Name>_<hash>_PackageProduct.framework`; RealmSwift — the only explicitly-dynamic product — is absent.

Debug/simulator runs don't reproduce this because dyld resolves the framework from the build products directory via rpath, which is why #4968 looked fine before merge.

**Fix:** mark `RealmSwift` as *Embed & Sign* (copy-files phase, Frameworks destination) on the `App` target and on `WatchExtension-Watch` — the same way the CocoaPods-built Realm dynamic framework shipped before #4968. The iOS app extensions need no change: they resolve the app-embedded copy through their existing `@executable_path/../../Frameworks` runpath, exactly as they already do for the remaining CocoaPods frameworks (PromiseKit, XCGLogger, …).

## Screenshots

N/A — build/packaging fix, no UI change.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

- **Verification needs an archive, not a simulator run:** export an IPA (or upload a TestFlight build) and confirm `Home Assistant.app/Frameworks/RealmSwift.framework` is present and the app launches on device. Also check the watch extension bundle contains it.
- **Cleaner long-term fix (recommended follow-up):** drop `type: .dynamic` from both library products in `bgoncal/xcode27-realm-swift`'s `Package.swift` so Realm rides the same automatic `_PackageProduct` pipeline that demonstrably embeds correctly for Alamofire & co., then re-pin the package revision here. That would make this manual embed phase unnecessary. (`fruitcoder/realm-core`'s products are already automatic, so the change is only needed in the realm-swift fork.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJLzNatPzGYpw9mGwJhpJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJLzNatPzGYpw9mGwJhpJK)_