### PR TITLE
Add SwiftUI view conventions to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,13 @@ public lazy var webhooks = with(WebhookManager()) {
 - View models are annotated with `@MainActor`
 - Support both light and dark mode
 
+#### SwiftUI View Conventions
+
+- **One struct per file**: whenever a new `View` struct is introduced, put it in its own file. Do not stack multiple view structs in one file.
+- **Keep everything in `body`**: build the view's content inline inside `body`. Do not abstract portions out into separate reusable subviews (helper view structs or computed `some View` properties) just to break `body` up. Extract a new struct only when it is genuinely reused elsewhere, and when you do, it gets its own file (see above).
+- **Always add a `#Preview`**: every SwiftUI view must ship with a preview so it can be checked quickly in Xcode.
+- **Snapshot tests for new features**: any new feature that adds UI must include snapshot tests (see [Snapshot Testing](#snapshot-testing)).
+
 ### Assets
 
 - SF Symbols via `SFSafeSymbols` library (`Image(systemSymbol: .house)`), never the string-based API


### PR DESCRIPTION
## Summary
Documents four SwiftUI conventions in the agent instructions (`AGENTS.md`, symlinked as `CLAUDE.md`) so AI coding agents and contributors follow a consistent structure for new SwiftUI code:

- **One struct per file** — a new `View` struct always goes in its own file, never stacked with others.
- **Keep everything in `body`** — build content inline rather than extracting helper subviews or computed `some View` properties just to split `body`; extract a struct only when genuinely reused (and then it gets its own file).
- **Always add a `#Preview`** — every SwiftUI view ships with a preview for quick Xcode checks.
- **Snapshot tests for new features** — any new feature adding UI must include snapshot tests, linking to the existing Snapshot Testing section.

These are added as a new "SwiftUI View Conventions" subsection under UI Patterns.

## Screenshots
N/A — documentation-only change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Docs-only change to `AGENTS.md`; no code or user-facing behavior affected.