### PR TITLE
Move support modules to SPM

### DIFF
--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "commander",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Commander.git",
+      "state" : {
+        "revision" : "4a1f2fb82fb6cef613c4a25d2e38f702e4d812c2",
+        "version" : "0.9.2"
+      }
+    },
+    {
+      "identity" : "kanna",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tid-kijyun/Kanna.git",
+      "state" : {
+        "revision" : "41c3d28ea0eac07e4551b28def9de1ede702e739",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "komondor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shibapm/Komondor.git",
+      "state" : {
+        "revision" : "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "packageconfig",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shibapm/PackageConfig.git",
+      "state" : {
+        "revision" : "58523193c26fb821ed1720dcd8a21009055c7cdb",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "shellout",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/ShellOut.git",
+      "state" : {
+        "revision" : "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "stencil",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Stencil.git",
+      "state" : {
+        "revision" : "973e190edf5d09274e4a6bc2e636c86899ed84c3",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "stencilswiftkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
+      "state" : {
+        "revision" : "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "402367fbe91d6a453bc608bfc0d93b14a301a519",
+        "version" : "0.53.1"
+      }
+    },
+    {
+      "identity" : "swiftgen",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftGen/SwiftGen",
+      "state" : {
+        "revision" : "d498d285867f42ef0c74c5ebd9ddced747831372",
+        "version" : "6.5.1"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "BuildTools",
+    platforms: [
+        .macOS(.v12),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.53.1"),
+        .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
+        // Pin SwiftGen's template engine to what 6.5.1 shipped with; newer Stencil
+        // changed whitespace trimming and corrupts the generated code.
+        .package(url: "https://github.com/kylef/Stencil.git", exact: "0.14.1"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.8.0"),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "SwiftLintBinary",
+            url: "https://github.com/realm/SwiftLint/releases/download/0.54.0/SwiftLintBinary-macos.artifactbundle.zip",
+            checksum: "963121d6babf2bf5fd66a21ac9297e86d855cbc9d28322790646b88dceca00f1"
+        ),
+        .target(name: "BuildTools"),
+    ]
+)

--- a/BuildTools/Sources/BuildTools/Empty.swift
+++ b/BuildTools/Sources/BuildTools/Empty.swift
@@ -1,0 +1,1 @@
+// Intentionally empty. This package pins command-line build tools.

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -8905,7 +8905,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/SwiftGen/bin/swiftgen\"\n";
+			shellScript = "env -u SDKROOT \"${SRCROOT}/Tools/build_tool\" swiftgen\n";
 		};
 		1132B378D7A9009C7692AFB9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8966,7 +8966,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    # swiftlint as of 2021-01-21 (0.42.0) can't handle spaces in paths\n    # for the config arg, so we rely on relative here\n    # https://github.com/realm/SwiftLint/issues/3471\n    \"${SRCROOT}/Pods/SwiftLint/swiftlint\" \\\n       --config \".swiftlint.yml\" \\\n       --quiet \\\n       \"${SRCROOT}\"\nfi\n";
+			shellScript = "if [ \"$CI\" != \"true\" ]\nthen \n    # swiftlint as of 2021-01-21 (0.42.0) can't handle spaces in paths\n    # for the config arg, so we rely on relative here\n    # https://github.com/realm/SwiftLint/issues/3471\n    \"${SRCROOT}/Tools/build_tool\" swiftlint \\\n       --config \".swiftlint.yml\" \\\n       --quiet \\\n       \"${SRCROOT}\"\nfi\n";
 		};
 		11A67358268D9E7B00D1AFD4 /* Fix Xcode 12.5+ Dependency Issues */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -9087,7 +9087,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Skip SwiftLint if flag is set in Build settings \"user-defined settings\"\nif [ \"${DISABLE_SWIFTLINT}\" = \"1\" ]; then\n  echo \"SwiftLint skipped because DISABLE_SWIFTLINT=1\"\n  exit 0\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint --strict --config \"${SRCROOT}/.swiftlint.yml\"\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Skip SwiftLint if flag is set in Build settings \"user-defined settings\"\nif [ \"${DISABLE_SWIFTLINT}\" = \"1\" ]; then\n  echo \"SwiftLint skipped because DISABLE_SWIFTLINT=1\"\n  exit 0\nfi\n\n\"${SRCROOT}/Tools/build_tool\" swiftlint --strict --config \"${SRCROOT}/.swiftlint.yml\"\n";
 		};
 		54C4A7F6CF3D179F18C3B480 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Podfile
+++ b/Podfile
@@ -3,22 +3,6 @@ inhibit_all_warnings!
 
 project 'HomeAssistant', 'Debug' => :debug, 'Release' => :release
 
-def support_modules
-  pod 'SwiftGen', '~> 6.5.0'
-  pod 'SwiftLint', '0.54.0' # also update ci.yml GHA
-  pod 'SwiftFormat/CLI', '0.53.1' # also update ci.yml GHA
-end
-
-if ENV['ONLY_SUPPORT_MODULES']
-  # some of our CI scripts only need e.g. SwiftLint
-  # this allows us to skip a lot of installation when unnecessary
-  platform :ios, '16.4'
-  support_modules
-  workspace 'abstract.workspace'
-
-  return self # rubocop:disable Lint/TopLevelReturnWithArgument
-end
-
 plugin 'cocoapods-acknowledgements'
 pod 'PromiseKit', '~> 8.1.1'
 
@@ -38,8 +22,6 @@ abstract_target 'iOS' do
   end
 
   target 'App' do
-    support_modules
-
     target 'Tests-App' do
       inherit! :search_paths
     end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,9 +18,6 @@ PODS:
   - PromiseKit/UIKit (8.1.2):
     - PromiseKit/CorePromise
   - Starscream (4.0.4)
-  - SwiftFormat/CLI (0.53.1)
-  - SwiftGen (6.5.1)
-  - SwiftLint (0.54.0)
 
 DEPENDENCIES:
   - HAKit (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.18`)
@@ -28,16 +25,10 @@ DEPENDENCIES:
   - HAKit/PromiseKit (from `https://github.com/home-assistant/HAKit.git`, tag `0.4.18`)
   - PromiseKit (~> 8.1.1)
   - Starscream (from `https://github.com/bgoncal/starscream`, tag `4.0.9`)
-  - SwiftFormat/CLI (= 0.53.1)
-  - SwiftGen (~> 6.5.0)
-  - SwiftLint (= 0.54.0)
 
 SPEC REPOS:
   trunk:
     - PromiseKit
-    - SwiftFormat
-    - SwiftGen
-    - SwiftLint
 
 EXTERNAL SOURCES:
   HAKit:
@@ -59,10 +50,7 @@ SPEC CHECKSUMS:
   HAKit: f6492dc50f8ba0113ff6845fcd07631ecdab9a91
   PromiseKit: e057b5b3c0ce9a0145674d633930924234104ee3
   Starscream: c5d70811b01d9ada7fdeb2132bc47fc893b6b0c9
-  SwiftFormat: a8623113c7adcbeb4289a013cac68ec801e1ed24
-  SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 7d10f0a29cf4d8aa81043b7d7b7c3022e899f520
+PODFILE CHECKSUM: 8ee6f4be5afbdd9fcf460b832942685762369348
 
 COCOAPODS: 1.15.2

--- a/Tools/BuildMaterialDesignIconsFont.sh
+++ b/Tools/BuildMaterialDesignIconsFont.sh
@@ -99,7 +99,7 @@ echo "Successfully built MaterialDesignIcons at version $MDI_VERSION"
 echo "Running Swiftgen..."
 
 pushd ..
-Pods/SwiftGen/bin/swiftgen
+Tools/build_tool swiftgen
 popd
 
 popd

--- a/Tools/build_tool
+++ b/Tools/build_tool
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: Tools/build_tool <swiftformat|swiftgen|swiftlint> [arguments...]" >&2
+  exit 64
+fi
+
+tool="$1"
+shift
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_path="$root_dir/BuildTools"
+cache_path="$root_dir/.build/swiftpm-cache"
+scratch_path="$package_path/.build"
+
+export CLANG_MODULE_CACHE_PATH="${CLANG_MODULE_CACHE_PATH:-$root_dir/.build/module-cache}"
+
+swift_package_resolve() {
+  swift package \
+    --disable-sandbox \
+    --package-path "$package_path" \
+    --cache-path "$cache_path" \
+    --scratch-path "$scratch_path" \
+    resolve
+}
+
+swift_package_run() {
+  swift run \
+    --disable-sandbox \
+    --package-path "$package_path" \
+    --cache-path "$cache_path" \
+    --scratch-path "$scratch_path" \
+    "$@"
+}
+
+case "$tool" in
+  swiftformat)
+    swift_package_run swiftformat "$@"
+    ;;
+  swiftgen)
+    swift_package_run swiftgen "$@"
+    ;;
+  swiftlint)
+    swiftlint_path="$scratch_path/artifacts/buildtools/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-0.54.0-macos/bin/swiftlint"
+    if [ ! -x "$swiftlint_path" ]; then
+      swift_package_resolve
+    fi
+    "$swiftlint_path" "$@"
+    ;;
+  *)
+    echo "error: unknown build tool '$tool'" >&2
+    exit 64
+    ;;
+esac

--- a/fastlane/lanes/assets.rb
+++ b/fastlane/lanes/assets.rb
@@ -20,6 +20,6 @@ end
 desc 'Update switftgen input/output files'
 lane :update_swiftgen_config do
   # rubocop:disable Layout/LineLength
-  sh('cd ../ && ./Pods/SwiftGen/bin/swiftgen config generate-xcfilelists --inputs swiftgen.yml.file-list.in --outputs swiftgen.yml.file-list.out')
+  sh('cd ../ && ./Tools/build_tool swiftgen config generate-xcfilelists --inputs swiftgen.yml.file-list.in --outputs swiftgen.yml.file-list.out')
   # rubocop:enable Layout/LineLength
 end

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -516,7 +516,7 @@ lane :update_strings do
     )
   end
 
-  sh('cd ../ && ./Pods/SwiftGen/bin/swiftgen')
+  sh('cd ../ && ./Tools/build_tool swiftgen')
 end
 
 desc 'Upload localized strings to Lokalise'
@@ -669,7 +669,7 @@ lane :delete_local_strings do
   missing = key_names - removed
   UI.important("Not found in any Localizable.strings: #{missing.join(', ')}") unless missing.empty?
 
-  sh('cd ../ && ./Pods/SwiftGen/bin/swiftgen')
+  sh('cd ../ && ./Tools/build_tool swiftgen')
 end
 
 desc 'Find unused localized strings'

--- a/fastlane/lanes/quality.rb
+++ b/fastlane/lanes/quality.rb
@@ -1,12 +1,12 @@
 # Code quality and linting lanes
 
 lane :lint do
-  sh('cd .. ; Pods/SwiftFormat/CommandLineTool/swiftformat --config .swiftformat --lint --quiet .')
-  sh('cd .. ; Pods/SwiftLint/swiftlint lint --config .swiftlint.yml --quiet .')
+  sh('cd .. ; Tools/build_tool swiftformat --config .swiftformat --lint --quiet .')
+  sh('cd .. ; Tools/build_tool swiftlint lint --config .swiftlint.yml --quiet .')
   sh('cd .. ; bundle exec rubocop --config .rubocop.yml')
 end
 
 lane :autocorrect do
-  sh('../Pods/SwiftFormat/CommandLineTool/swiftformat ..')
+  sh('../Tools/build_tool swiftformat ..')
   sh('bundle exec rubocop -a ..')
 end


### PR DESCRIPTION
Moves the build support modules (SwiftGen, SwiftLint, SwiftFormat) from CocoaPods to an SPM `BuildTools` package invoked via `Tools/build_tool`.

Supersedes #4986, which GitHub auto-closed when its stacked base branch was deleted during the pod→SPM merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)