### PR TITLE
Fix watch home hanging forever when the iPhone config reply is dropped (2026.7.x backport)

### DIFF
--- a/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
@@ -56,7 +56,13 @@ final class WatchHomeViewModel: ObservableObject {
             reply: { [weak self] message in
                 self?.handleMessageResponse(message)
             }
-        ))
+        ), errorHandler: { [weak self] error in
+            // iPhone unreachable / slow / no reply within the system timeout: stop the spinner and
+            // fall back to the cached config so the screen never hangs on a dropped reply.
+            Current.Log.error("Watch config request failed: \(error)")
+            self?.loadCache()
+            self?.updateLoading(isLoading: false)
+        })
     }
 
     func info(for magicItem: MagicItem) -> MagicItem.Info {
@@ -133,7 +139,7 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func loadInformationCache(watchConfig: WatchConfig) {
         let magicItemsInfo = getItemsInfoFromCache()
-        if !magicItemsInfo.isEmpty {
+        if !magicItemsInfo.isEmpty || watchConfig.items.isEmpty {
             updateConfig(config: watchConfig, magicItemsInfo: magicItemsInfo)
             resetError()
         } else {


### PR DESCRIPTION
## Summary

Backport to the 2026.7 release line of the error handling introduced by the watch connectivity rework on `main` (#4921/#4933), targeting the failure mode seen in a user's log export where the watch never recovers from a dropped sync reply:

- Add an `errorHandler` to the `watchConfig` interactive request in `WatchHomeViewModel.requestConfig()`. Previously a dropped or timed-out reply left the loading spinner up forever with no fallback; now it logs the error, falls back to the config cached on the watch, and clears the loading state. WCSession delivers its own reply-timeout errors to this handler, so OS-level timeouts are covered as well.
- Treat an empty magic-items-info cache with an empty config as a valid state in `loadInformationCache` instead of showing a permanent "No information cached" error (same condition as `main`).

Diagnosis background: the affected user's iPhone logs show the phone correctly answering every `serversConfigSync`/`watchConfig` request (~26 retries in one evening, two watch app reinstalls, an app update — no recovery), meaning replies were being lost on the watch leg. On 2026.7.x a lost reply bricks the watch home screen; this change makes it degrade to the cached config instead.

## Screenshots

No visual changes; behavior change is only in the failure path (spinner stops and cached config is shown instead of hanging / a stuck error banner).

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

`main` already contains the full connectivity rewrite with reply timeouts and offline mirror, so this is intentionally **not** targeted at `main` — it is a minimal stop-gap for the 2026.7 release line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECVCeUMJ39bNLJEENacSoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECVCeUMJ39bNLJEENacSoV)_