### PR TITLE
Reduce CI time: cache DerivedData and drop the dead size job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,15 +156,6 @@ jobs:
           ruby-version: .ruby-version
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        name: "Cache: Pods"
-        id: cache_pods
-        with:
-          path: Pods
-          key: >-
-            ${{ runner.os }}-pods-${{ env.DEVELOPER_DIR }}-
-            ${{ hashFiles('**/Gemfile.lock', '**/Podfile.lock') }}
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         name: "Cache: Gems"
         id: cache_gems
         with:
@@ -175,6 +166,22 @@ jobs:
             env.ImageVersion,
             env.DEVELOPER_DIR,
             hashFiles('.ruby-version', '**/Gemfile.lock')) }}
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        name: "Cache: DerivedData"
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: >-
+            ${{ format('{0}-deriveddata-{1}-{2}-{3}',
+            runner.os,
+            env.DEVELOPER_DIR,
+            hashFiles('**/Package.resolved'),
+            github.run_id) }}
+          restore-keys: >-
+            ${{ format('{0}-deriveddata-{1}-{2}-',
+            runner.os,
+            env.DEVELOPER_DIR,
+            hashFiles('**/Package.resolved')) }}
 
       - name: Install Brews
         # right now, we don't need anything from brew for tests, so save some time
@@ -209,63 +216,3 @@ jobs:
         with:
           name: ios-simulator
           path: ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/Build/Products/Debug-iphonesimulator/*.app
-
-  size:
-    needs: check-swiftlint-disables
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == 'home-assistant/iOS'
-    runs-on: macos-26
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9  # v1.316.0
-        with:
-          ruby-version: .ruby-version
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v4.6.2
-        name: "Cache: Pods"
-        id: cache_pods
-        with:
-          path: Pods
-          key: >-
-            ${{ runner.os }}-pods-${{ env.DEVELOPER_DIR }}-
-            ${{ hashFiles('**/Gemfile.lock', '**/Podfile.lock') }}
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        name: "Cache: Gems"
-        id: cache_gems
-        with:
-          path: vendor/bundle
-          key: >-
-            ${{ format('{0}-gems-{1}-{2}-{3}',
-            runner.os,
-            env.ImageVersion,
-            env.DEVELOPER_DIR,
-            hashFiles('.ruby-version', '**/Gemfile.lock')) }}
-
-      - name: Install Brews
-        # right now, we don't need anything from brew for sizing, so save some time
-        if: ${{ false }}
-        run: brew bundle
-
-      - name: Install Gems
-        if: steps.cache_gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
-
-      - name: Build app
-        run: bundle exec fastlane ios size
-        env:
-          P12_KEY_DISTRIBUTION: ${{ secrets.P12_KEY_DISTRIBUTION }}
-          P12_VALUE_DISTRIBUTION: ${{ secrets.P12_VALUE_DISTRIBUTION }}
-          P12_KEY_MAC_DEVELOPER_ID: ${{ secrets.P12_KEY_MAC_DEVELOPER_ID }}
-          P12_KEY_MAC_DEVELOPER_INSTALLER: ${{ secrets.P12_KEY_MAC_DEVELOPER_INSTALLER }}
-          P12_VALUE_MAC_DEVELOPER_ID: ${{ secrets.P12_VALUE_MAC_DEVELOPER_ID }}
-          P12_VALUE_MAC_DEVELOPER_INSTALLER: ${{ secrets.P12_VALUE_MAC_DEVELOPER_INSTALLER }}
-          EMERGE_API_TOKEN: ${{ secrets.EMERGE_API_TOKEN }}
-          EMERGE_REPO_NAME: ${{ github.repository }}
-          EMERGE_PR_NUMBER: ${{ github.event.number }}
-          EMERGE_SHA: ${{ github.event.pull_request.head.sha }}
-          EMERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HOMEASSISTANT_APP_STORE_CONNECT_PASSWORD: ${{ secrets.HOMEASSISTANT_APP_STORE_CONNECT_PASSWORD }}
-          HOMEASSISTANT_APPLE_ID: ${{ secrets.HOMEASSISTANT_APPLE_ID }}
-          HOMEASSISTANT_FASTLANE_SESSION: ${{ secrets.HOMEASSISTANT_FASTLANE_SESSION }}


### PR DESCRIPTION
## Summary

> **Stacked on #4990 (Remove cocoapods).** This PR targets `pode-deintegrate` and its diff assumes that merges first. When #4990 lands, GitHub will auto-retarget this to `main`.

CI time on PRs is dominated by two `macos-26` jobs that run in parallel, `test` and `size`. Profiling the last ~100 runs plus the raw log of a full run showed:

- Full PR runs: median **~33 min** wall-clock, each burning **~60–75 macOS‑runner‑minutes** (billed 10× Linux).
- The `test` job (~32 min) is **~95% compilation**: it recompiles the whole app plus every dependency (Realm, GRDB, Firebase, gRPC, abseil, SwiftSyntax, WebRTC, …) for **both iOS and watchOS**, then runs its **552 unit tests in ~31 seconds**.
- CI caches only Ruby gems (and, before #4990, Pods *source*) — **never build products** — so every job of every run compiles everything from scratch.

Root cause: no compiled‑artifact caching, plus a second full compile (`size`) whose output is thrown away.

## Changes

**1. Cache `DerivedData` in the `test` job.**
Adds an `actions/cache` for `~/Library/Developer/Xcode/DerivedData`, keyed on `Package.resolved` (+ `github.run_id` so each run saves a fresh entry). Since #4990 makes dependencies 100% SPM, `Package.resolved` is the right cache key. `restore-keys` only falls back **within the same dependency set**, which is safe alongside the lane's `skip_package_dependencies_resolution: true` (never restores SourcePackages that don't match the pinned versions). Unchanged dependencies — the common case for most PRs — are reused instead of recompiled.

**2. Drop the dead `Cache: Pods` step.**
#4990 removed `pod install` but left the `Cache: Pods` step behind. With no Pods, it caches an empty `Pods/` path and its `cache-hit` output is no longer referenced, so it's removed.

**3. Remove the `size` job.**
It built a full app‑store release archive purely to feed Emerge size analysis, but the `emerge` action was removed in #3853 ("Remove emerge from CI while we dont have the updated API token") and never restored. The lane now only calls `create_archive`; the archive is uploaded nowhere and the `EMERGE_*` env vars are vestigial. The job cost **~30–44 min and a whole macOS runner on every PR** for no consumable output.

## Expected impact

- `test`: from ~32 min toward **~8–12 min** on cache‑hit PRs (dependency compile skipped; ~31 s of tests unchanged).
- Removing `size`: eliminates the usual **wall‑clock long pole** and frees **one macOS runner per PR**.
- Net: median PR CI plausibly **~33 min → ~10–12 min**, roughly halving macOS‑minute spend.

## Notes / risks for review

- **Branch protection**: if `size` is a *required* status check, it must be removed from the required list or PRs will hang waiting for a check that no longer reports. (I couldn't read protection settings.)
- **Loss of pre‑merge release‑build verification**: `size` was the only per‑PR release/app‑store‑signed compile. The post‑merge `Distribute` workflow already does a full release build on `main`, so the gap is small, but a release‑config‑only break would now surface post‑merge rather than on the PR. If that's not acceptable, the alternative is to keep a release **build** check gated behind a label or path filter instead of on every PR.
- **DerivedData cache size vs the 10 GB repo cache limit**: a big project's DerivedData can be several GB, so entries may churn/evict. The key/restore‑keys design degrades gracefully (miss ⇒ today's full build), but hit rate may need tuning (e.g. scoping the cached paths).
- **Cross‑machine incremental builds** can occasionally be stale; keying on `Package.resolved` and letting Xcode invalidate changed sources is the standard mitigation. If flakiness appears, scope the cache to SPM `SourcePackages` + module cache only.

## Proposed follow‑ups (not in this PR)

- **Re‑enable Emerge** if size tracking is still wanted, instead of a discarded archive.
- **Bigger runners** (`macos-latest-xlarge`) for the compile‑bound `test` job — more cores parallelize `xcodebuild` well; benchmark cost/wall‑clock.
- **Trim watchOS targets from `Tests-Unit`** if watch code isn't under test (watch variants are a large slice of the compile).
- **`clean true` in `fastlane/Gymfile`** forces from‑scratch archives; removing it (plus a DerivedData cache on `Distribute`) would speed the release build too.
- **Tests don't run on merge to `main`** (`test` needs the PR‑gated `check-swiftlint-disables`, so it's skipped on push). Worth a deliberate decision on post‑merge coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
