### PR TITLE
Use standard ProgressView for onboarding loader below iOS 17

### DIFF
--- a/Sources/App/Onboarding/Views/SearchingServersAnimationView.swift
+++ b/Sources/App/Onboarding/Views/SearchingServersAnimationView.swift
@@ -25,9 +25,13 @@ struct SearchingServersAnimationView: View {
 
     var body: some View {
         VStack(spacing: DesignSystem.Spaces.three) {
-            ZStack {
-                dots
-                logo
+            if #available(iOS 17, *) {
+                ZStack {
+                    dots
+                    logo
+                }
+            } else {
+                ProgressView()
             }
 
             Text(text ?? "")
@@ -39,9 +43,9 @@ struct SearchingServersAnimationView: View {
                 .animation(.easeInOut, value: showText)
         }
         .onAppear {
-            animateLogoPulse()
-            withAnimation(Animation.linear(duration: Constants.animationDuration).repeatForever(autoreverses: false)) {
-                rotation = direction * Constants.rotationDegrees
+            if #available(iOS 17, *) {
+                animateLogoPulse()
+                animateRotation()
             }
             if text != nil {
                 scheduleText()
@@ -78,6 +82,12 @@ struct SearchingServersAnimationView: View {
     private func animateLogoPulse() {
         withAnimation(Animation.easeInOut(duration: Constants.logoPulseDuration).repeatForever(autoreverses: true)) {
             logoScale = Constants.logoPulseScale
+        }
+    }
+
+    private func animateRotation() {
+        withAnimation(Animation.linear(duration: Constants.animationDuration).repeatForever(autoreverses: false)) {
+            rotation = direction * Constants.rotationDegrees
         }
     }
 }


### PR DESCRIPTION
## Summary

On iOS 15 and 16 the custom `SearchingServersAnimationView` (rotating dots + pulsing logo) breaks the onboarding layout. This change gates the custom animation behind `#available(iOS 17, *)` and falls back to a standard `ProgressView` on older versions.

The informative "still searching" text (revealed after a delay) is preserved on all versions; only the spinner visual differs.

## Scope

The fix is applied at the shared component level, so it covers both onboarding screens that use this view:
- The servers list (`OnboardingServersListView` center loader) — the reported broken screen.
- The recovered servers import screen (`RecoveredServersImportView`), which uses the same animation.

## Testing

- iOS 17+: unchanged, custom animated loader.
- iOS 15/16: standard `ProgressView` renders in place of the custom animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)