### PR TITLE
Fix Intents extension crashes from concurrent sensor updates

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -40,9 +40,9 @@ public struct SensorResponse {
 }
 
 public class SensorContainer {
-    private var providers = [SensorProvider.Type]()
-    private var observers = NSHashTable<AnyObject>(options: .weakMemory)
-    private var providerDependencies: SensorProviderDependencies
+    private let providers = HAProtected<[SensorProvider.Type]>(value: [])
+    private let observers = HAProtected<NSHashTable<AnyObject>>(value: .init(options: .weakMemory))
+    private let providerDependencies: SensorProviderDependencies
 
     init() {
         self.providerDependencies = SensorProviderDependencies()
@@ -52,19 +52,19 @@ public class SensorContainer {
     }
 
     public func register(provider: SensorProvider.Type) {
-        providers.append(provider)
+        providers.mutate { $0.append(provider) }
     }
 
     public func register(observer: SensorObserver) {
-        observers.add(observer)
+        observers.mutate { $0.add(observer) }
 
-        if let lastUpdate {
+        if let lastUpdate = lastUpdate.read({ $0 }) {
             observer.sensorContainer(self, didUpdate: lastUpdate)
         }
     }
 
     public func unregister(observer: SensorObserver) {
-        observers.remove(observer)
+        observers.mutate { $0.remove(observer) }
     }
 
     private var disabledSensorIDs: Set<String> {
@@ -108,14 +108,15 @@ public class SensorContainer {
         }
     }
 
-    private var lastUpdate: SensorObserverUpdate? {
-        didSet {
-            guard let lastUpdate else { return }
-            observers
-                .allObjects
-                .compactMap { $0 as? SensorObserver }
-                .forEach { $0.sensorContainer(self, didUpdate: lastUpdate) }
-        }
+    private let lastUpdate = HAProtected<SensorObserverUpdate?>(value: nil)
+
+    private func currentObservers() -> [SensorObserver] {
+        observers.read { $0.allObjects.compactMap { $0 as? SensorObserver } }
+    }
+
+    private func setLastUpdate(_ update: SensorObserverUpdate) {
+        lastUpdate.mutate { $0 = update }
+        currentObservers().forEach { $0.sensorContainer(self, didUpdate: update) }
     }
 
     private struct LastSentSensors {
@@ -158,7 +159,7 @@ public class SensorContainer {
         )
 
         let generatedSensors = firstly {
-            let promises = providers
+            let promises = providers.read { $0 }
                 .filter { providerType in
                     if let limitedTo {
                         return limitedTo.contains(where: { ObjectIdentifier($0) == ObjectIdentifier(providerType) })
@@ -181,7 +182,7 @@ public class SensorContainer {
             }.flatMap { $0 }
         }
 
-        lastUpdate = .init(sensors: generatedSensors.map { [lastSentSensors] new in
+        setLastUpdate(.init(sensors: generatedSensors.map { [lastSentSensors] new in
             // doesn't store the sent values, that happens when the network request ends
             // this is just what's presented to the user, so we always have the latest version
             let ignoringExisting: Bool
@@ -206,7 +207,7 @@ public class SensorContainer {
                 case (false, true): return false
                 }
             })
-        })
+        }))
 
         return generatedSensors.mapValues { [weak self] sensor -> WebhookSensor in
             guard let self else { return sensor }
@@ -220,10 +221,10 @@ public class SensorContainer {
     }
 
     private func notifySignal(reason: SensorContainerUpdateReason) {
-        observers
-            .allObjects
-            .compactMap { $0 as? SensorObserver }
-            .forEach { $0.sensorContainer(self, didSignalForUpdateBecause: reason, lastUpdate: lastUpdate) }
+        let update = lastUpdate.read { $0 }
+        currentObservers().forEach {
+            $0.sensorContainer(self, didSignalForUpdateBecause: reason, lastUpdate: update)
+        }
     }
 
     private func updateSignaled(from type: SensorProvider.Type) {

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -116,7 +116,9 @@ public class SensorContainer {
 
     private func setLastUpdate(_ update: SensorObserverUpdate) {
         lastUpdate.mutate { $0 = update }
-        currentObservers().forEach { $0.sensorContainer(self, didUpdate: update) }
+        for observer in currentObservers() {
+            observer.sensorContainer(self, didUpdate: update)
+        }
     }
 
     private struct LastSentSensors {
@@ -222,8 +224,8 @@ public class SensorContainer {
 
     private func notifySignal(reason: SensorContainerUpdateReason) {
         let update = lastUpdate.read { $0 }
-        currentObservers().forEach {
-            $0.sensorContainer(self, didSignalForUpdateBecause: reason, lastUpdate: update)
+        for observer in currentObservers() {
+            observer.sensorContainer(self, didSignalForUpdateBecause: reason, lastUpdate: update)
         }
     }
 

--- a/Sources/Shared/API/Webhook/Sensors/SensorProviderDependencies.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorProviderDependencies.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HAKit
 
 public protocol SensorProviderUpdateSignaler: AnyObject {
     init(signal: @escaping () -> Void)
@@ -6,7 +7,7 @@ public protocol SensorProviderUpdateSignaler: AnyObject {
 
 public class SensorProviderDependencies {
     var updateSignalHandler: (SensorProvider.Type) -> Void = { _ in }
-    private var updateSignalers: [String: [SensorProviderUpdateSignaler]] = [:]
+    private let updateSignalers = HAProtected<[String: [SensorProviderUpdateSignaler]]>(value: [:])
 
     private func key(for sensorProvider: SensorProvider) -> String {
         String(describing: type(of: sensorProvider))
@@ -16,7 +17,7 @@ public class SensorProviderDependencies {
         for sensorProvider: SensorProvider
     ) -> SignalerType? {
         let key = key(for: sensorProvider)
-        return updateSignalers[key]?.compactMap({ $0 as? SignalerType }).first
+        return updateSignalers.read { $0[key]?.compactMap { $0 as? SignalerType }.first }
     }
 
     public func updateSignaler<SignalerType: SensorProviderUpdateSignaler>(
@@ -26,12 +27,18 @@ public class SensorProviderDependencies {
             return existing
         }
 
+        let key = key(for: sensorProvider)
         let sensorType = type(of: sensorProvider)
         let created = SignalerType(signal: { [weak self] in
             self?.updateSignalHandler(sensorType)
         })
 
-        updateSignalers[key(for: sensorProvider), default: []] += [created]
-        return created
+        return updateSignalers.mutate { signalers in
+            if let existing = signalers[key]?.compactMap({ $0 as? SignalerType }).first {
+                return existing
+            }
+            signalers[key, default: []].append(created)
+            return created
+        }
     }
 }

--- a/Tests/Shared/Sensors/SensorProviderDependencies.test.swift
+++ b/Tests/Shared/Sensors/SensorProviderDependencies.test.swift
@@ -73,6 +73,27 @@ class SensorProviderDependenciesTests: XCTestCase {
         XCTAssertTrue(info1_2 !== info2_2)
         XCTAssertTrue(info2_1 === info2_2)
     }
+
+    func testUpdateSignalerConcurrentAccessIsThreadSafe() {
+        let dependencies = SensorProviderDependencies()
+
+        func makeProvider() -> MockSensorProvider1 {
+            MockSensorProvider1(request: .init(
+                reason: .trigger("unit-test"),
+                dependencies: dependencies,
+                location: nil,
+                serverVersion: Version()
+            ))
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            let _: MockUpdateSignaler = dependencies.updateSignaler(for: makeProvider())
+        }
+
+        let info1: MockUpdateSignaler = dependencies.updateSignaler(for: makeProvider())
+        let info2: MockUpdateSignaler = dependencies.updateSignaler(for: makeProvider())
+        XCTAssertTrue(info1 === info2)
+    }
 }
 
 private class MockSensorProvider1: SensorProvider {


### PR DESCRIPTION
## Summary
Fixes the top crashes in the Intents extension.

`SensorContainer` (the `Current.sensors` singleton) and `SensorProviderDependencies` were accessed concurrently from multiple threads with no synchronization: the intent handler triggers a sensor update at the same time as sensor-update signals / GRDB observations, and both funnel into `SensorContainer.sensors(...)`. This corrupted their shared collections and produced `EXC_BAD_ACCESS` crashes in three places:

- `register(observer:)` mutating an `NSHashTable` from two threads
- `updateSignaler(for:)` mutating its dictionary concurrently
- downstream heap corruption surfacing inside PromiseKit box resolution

The shared mutable state (`providers`, `observers`, `lastUpdate`, and the `updateSignalers` dictionary) is now guarded with `HAProtected`. Observers are snapshotted before their callbacks run, so no lock is held across a callout. Public API and behavior are unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Added a regression test that hammers `updateSignaler(for:)` from concurrent iterations.
