### PR TITLE
Stop widget extension from wedging the shared database

### DIFF
--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -5,9 +5,13 @@ public extension DatabaseQueue {
     // Following GRDB cocnurrency rules, we have just one database instance
     // https://swiftpackageindex.com/groue/grdb.swift/v6.29.3/documentation/grdb/concurrency#Concurrency-Rules
     static var appDatabase: DatabaseQueue = {
+        var configuration = Configuration()
+        configuration.busyMode = .timeout(3)
+
         let database: DatabaseQueue
+        var isInMemoryFallback = false
         do {
-            database = try DatabaseQueue(path: databasePath())
+            database = try DatabaseQueue(path: databasePath(), configuration: configuration)
             #if targetEnvironment(simulator)
             print("GRDB App database is stored at \(AppConstants.appGRDBFile.description)")
             #endif
@@ -16,13 +20,16 @@ public extension DatabaseQueue {
             // Fallback to in-memory database so extensions don't crash
             do {
                 database = try DatabaseQueue()
+                isInMemoryFallback = true
                 Current.Log.error("Using in-memory GRDB database as fallback")
             } catch {
                 fatalError("Failed to create even an in-memory GRDB database: \(error.localizedDescription)")
             }
         }
 
-        setupSchema(database: database)
+        if !Current.isAppExtension || isInMemoryFallback {
+            setupSchema(database: database)
+        }
         return database
     }()
 

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -206,7 +206,8 @@ public enum AppConstants {
         let groupDir = fileManager.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID)
 
         guard let groupDir else {
-            fatalError("Unable to get groupDir.")
+            Current.Log.error("Unable to get app group container URL; falling back to temporary directory")
+            return URL(fileURLWithPath: NSTemporaryDirectory())
         }
 
         return groupDir

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -60,6 +60,10 @@ final class MagicItemProvider: MagicItemProviderProtocol {
     }
 
     func migrateCarPlayConfig(completion: @escaping () -> Void) {
+        guard !Current.isAppExtension else {
+            completion()
+            return
+        }
         guard var carPlayConfig = try? Current.carPlayConfig() else {
             completion()
             return
@@ -79,6 +83,10 @@ final class MagicItemProvider: MagicItemProviderProtocol {
     }
 
     func migrateWatchConfig(completion: @escaping () -> Void) {
+        guard !Current.isAppExtension else {
+            completion()
+            return
+        }
         guard var watchConfig = try? Current.watchConfig() else {
             completion()
             return
@@ -97,6 +105,10 @@ final class MagicItemProvider: MagicItemProviderProtocol {
     }
 
     func migrateAppIconShortcutConfig(completion: @escaping () -> Void) {
+        guard !Current.isAppExtension else {
+            completion()
+            return
+        }
         guard var appIconShortcutConfig = try? Current.appIconShortcutConfig() else {
             completion()
             return
@@ -125,6 +137,10 @@ final class MagicItemProvider: MagicItemProviderProtocol {
      The completion handler is always called at the end of the process.
      */
     func migrateWidgetsConfig(completion: @escaping () -> Void) {
+        guard !Current.isAppExtension else {
+            completion()
+            return
+        }
         guard let customWidgets = try? Current.customWidgets() else {
             completion()
             return

--- a/Sources/Shared/Panels/PanelsUpdater.swift
+++ b/Sources/Shared/Panels/PanelsUpdater.swift
@@ -25,6 +25,7 @@ final class PanelsUpdater: PanelsUpdaterProtocol {
     }
 
     public func update() {
+        guard !Current.isAppExtension else { return }
         if let lastUpdate, lastUpdate.timeIntervalSinceNow > -5 {
             Current.Log.verbose("Skipping panels update, last update was \(lastUpdate)")
             return


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Widgets extension shares one on-disk SQLite database with the app. Crash logs show the extension being killed with `0xdead10cc` (RunningBoard suspending it while it holds a SQLite write lock) inside GRDB schema setup, column migration, and panel writes. A kill mid-write can leave the file wedged, after which the extension crash-loops or renders blank on every reload. None of the in-app resets touch that file, so today the only user recovery is reinstalling the app.

This makes the extension a read-only consumer of the shared database so it can no longer take the write lock that triggers the kill:

- Skip GRDB schema creation and column migrations in extensions; only the main app performs them. The private in-memory fallback is still set up so reads return empty instead of throwing.
- Skip the per-refresh `MagicItem` config migrations and `PanelsUpdater` writes in extensions (both are writes that ran on every timeline reload).
- Open the database with a 3s busy timeout so contended access waits briefly instead of dropping to an empty in-memory database.
- Replace the reachable `fatalError` on a nil app group container with a logged temporary-directory fallback.

Interactive widget writes (AppIntents) are unaffected. Follow-ups can add extension-side self-heal (quarantine-and-retry) and a user-facing "reset widget data" action.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Addresses the same class of crash as #4518, generalized: unhandled/automatic writes from the extension against shared app-group state that no in-app reset can clear.