### PR TITLE
Fix top iOS crashes: GRDB suspension (0xdead10cc) and ServerManager lock reentrancy

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import PromiseKit
 import Shared
 import UIKit
@@ -80,6 +81,7 @@ class LifecycleManager {
 
     @objc private func willEnterForeground() {
         isActive = true
+        NotificationCenter.default.post(name: Database.resumeNotification, object: self)
         refreshNetworkInformation()
         syncLiveActivities()
     }
@@ -96,6 +98,7 @@ class LifecycleManager {
 
     @objc private func didEnterBackground() {
         isActive = false
+        NotificationCenter.default.post(name: Database.suspendNotification, object: self)
         Current.backgroundTask(withName: BackgroundTask.lifecycleManagerDidEnterBackground.rawValue) { _ in
             when(fulfilled: Current.apis.map { api in
                 api.CreateEvent(

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -92,38 +92,8 @@ private extension Identifier where ObjectType == Server {
 
 private struct ServerCache {
     var restrictCaching: Bool = false
-    var deletedServers: Set<Identifier<Server>> {
-        get {
-            let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
-            return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
-        }
-        set {
-            Current.settingsStore.prefs.set(newValue.map(\.rawValue), forKey: "deletedServers")
-        }
-    }
-
-    var info: [Identifier<Server>: ServerInfo] = [:] {
-        didSet {
-            if !deletedServers.isDisjoint(with: info.keys) {
-                Current.Log
-                    .error(
-                        "Stale server(s) in info cache overlapping with deleted servers, info keys: \(info.keys), deleted servers: \(deletedServers)"
-                    )
-            }
-        }
-    }
-
-    var server: [Identifier<Server>: Server] = [:] {
-        didSet {
-            if !deletedServers.isDisjoint(with: server.keys) {
-                Current.Log
-                    .error(
-                        "There are server(s) in cache that are deleted also in deleted servers set, servers: \(server.keys), deleted servers: \(deletedServers)"
-                    )
-            }
-        }
-    }
-
+    var info: [Identifier<Server>: ServerInfo] = [:]
+    var server: [Identifier<Server>: Server] = [:]
     var all: [Server]?
 
     mutating func remove(identifier: Identifier<Server>) {
@@ -164,6 +134,16 @@ final class ServerManagerImpl: ServerManager {
 
     private let cache = HAProtected<ServerCache>(value: .init())
 
+    private var deletedServers: Set<Identifier<Server>> {
+        get {
+            let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
+            return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
+        }
+        set {
+            Current.settingsStore.prefs.set(newValue.map(\.rawValue), forKey: "deletedServers")
+        }
+    }
+
     // MARK: Lifecycle
 
     init(
@@ -202,10 +182,10 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public var all: [Server] {
+        let deletedServers = deletedServers
         let snapshot = cache.read { cache in
             (
                 restrictCaching: cache.restrictCaching,
-                deletedServers: cache.deletedServers,
                 cachedServers: cache.all
             )
         }
@@ -216,17 +196,18 @@ final class ServerManagerImpl: ServerManager {
 
         // Read from Keychain and GRDB outside the cache lock so persistence I/O
         // does not block unrelated server-manager operations.
-        let persistedServers = mergedServerInfo(deletedServers: snapshot.deletedServers)
+        let persistedServers = mergedServerInfo(deletedServers: deletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
             })
 
+        let deletedServersUnchanged = self.deletedServers == deletedServers
         if let cachedOrFreshServers = cache.mutate(using: { cache -> [Server]? in
             if !cache.restrictCaching, let cachedServers = cache.all {
                 return cachedServers
             }
 
-            guard cache.deletedServers == snapshot.deletedServers else {
+            guard deletedServersUnchanged else {
                 return nil
             }
 
@@ -241,7 +222,7 @@ final class ServerManagerImpl: ServerManager {
 
         // Avoid retrying forever when another thread keeps mutating the server set.
         // In that case we return a best-effort fresh view and let a later access cache it.
-        let latestDeletedServers = cache.read(\.deletedServers)
+        let latestDeletedServers = self.deletedServers
         let latestPersistedServers = mergedServerInfo(deletedServers: latestDeletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
@@ -272,8 +253,12 @@ final class ServerManagerImpl: ServerManager {
             }
         }
 
+        var deletedServers = deletedServers
+        if deletedServers.remove(identifier) != nil {
+            self.deletedServers = deletedServers
+        }
+
         let result = cache.mutate { cache -> Server in
-            cache.deletedServers.remove(identifier)
             keychain.set(serverInfo: setValue, key: identifier.keychainKey, encoder: encoder)
             cache.info[identifier] = setValue
             cache.all = nil
@@ -293,8 +278,11 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public func remove(identifier: Identifier<Server>) {
+        var deletedServers = deletedServers
+        deletedServers.insert(identifier)
+        self.deletedServers = deletedServers
+
         cache.mutate { cache in
-            cache.deletedServers.insert(identifier)
             keychain.deleteServerInfo(key: identifier.keychainKey)
             cache.remove(identifier: identifier)
         }
@@ -310,8 +298,11 @@ final class ServerManagerImpl: ServerManager {
 
     public func removeAll() {
         let allKeys = Set(keychain.allKeys() + mirrorStore.allKeys())
+        var deletedServers = deletedServers
+        deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
+        self.deletedServers = deletedServers
+
         cache.mutate { cache in
-            cache.deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
             cache.reset()
             _ = try? keychain.removeAll()
         }
@@ -344,7 +335,14 @@ final class ServerManagerImpl: ServerManager {
         fallback: ServerInfo
     ) -> () -> ServerInfo {
         {
-            cache.mutate { cache -> ServerInfo in
+            if let cached = cache.read({ cache -> ServerInfo? in
+                cache.restrictCaching ? nil : cache.info[identifier]
+            }) {
+                return cached
+            }
+
+            let deletedServers = self.deletedServers
+            return cache.mutate { cache -> ServerInfo in
                 if !cache.restrictCaching, let info = cache.info[identifier] {
                     return info
                 } else {
@@ -357,7 +355,7 @@ final class ServerManagerImpl: ServerManager {
                     let info = keychainInfo
                         ?? (shouldUseMirrorFallback ? mirroredInfo : nil)
                         ?? fallback
-                    if !cache.deletedServers.contains(identifier) {
+                    if !deletedServers.contains(identifier) {
                         cache.info[identifier] = info
                     }
                     return info
@@ -373,15 +371,16 @@ final class ServerManagerImpl: ServerManager {
         encoder: JSONEncoder,
         notify: @escaping () -> Void
     ) -> (ServerInfo) -> Bool {
-        { baseServerInfo in
+        { [weak self] baseServerInfo in
             var serverInfo = baseServerInfo
 
             // update active URL so we can update just once if it's different than the save is doing
             // intentionally not in the lock
             _ = serverInfo.connection.evaluateActiveURL()
 
+            let deletedServers = self?.deletedServers ?? []
             return cache.mutate { cache in
-                guard !cache.deletedServers.contains(identifier) else {
+                guard !deletedServers.contains(identifier) else {
                     Current.Log.verbose("ignoring update to deleted server \(identifier)")
                     return false
                 }
@@ -491,7 +490,7 @@ final class ServerManagerImpl: ServerManager {
     }
 
     private func pruneDeletedMirroredServers() {
-        let deletedKeys = Set(cache.read(\.deletedServers).map(\.keychainKey))
+        let deletedKeys = Set(deletedServers.map(\.keychainKey))
         guard !deletedKeys.isEmpty else { return }
 
         let mirrorKeys = Set(mirrorStore.allKeys())
@@ -506,7 +505,7 @@ final class ServerManagerImpl: ServerManager {
     }
 
     private func restorableMirroredServers(excludingPreviouslyRestored: Bool = false) -> [(String, ServerInfo)] {
-        let deletedServers = cache.read(\.deletedServers)
+        let deletedServers = deletedServers
         let restoredMirroredServers = excludingPreviouslyRestored ? restoredMirroredServers : []
         return mirrorStore.allServerInfo().filter { key, _ in
             !deletedServers.contains(.init(keychainKey: key)) && !restoredMirroredServers.contains(key)
@@ -578,7 +577,7 @@ final class ServerManagerImpl: ServerManager {
     public func restorableState() -> Data {
         var state = [String: ServerInfo]()
 
-        for (id, info) in mergedServerInfo(deletedServers: cache.read({ $0.deletedServers })) {
+        for (id, info) in mergedServerInfo(deletedServers: deletedServers) {
             state[id] = info
         }
 

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -92,6 +92,8 @@ private extension Identifier where ObjectType == Server {
 
 private struct ServerCache {
     var restrictCaching: Bool = false
+    var deletedServersLoaded = false
+    var deletedServers: Set<Identifier<Server>> = []
     var info: [Identifier<Server>: ServerInfo] = [:]
     var server: [Identifier<Server>: Server] = [:]
     var all: [Server]?
@@ -135,12 +137,26 @@ final class ServerManagerImpl: ServerManager {
     private let cache = HAProtected<ServerCache>(value: .init())
 
     private var deletedServers: Set<Identifier<Server>> {
-        get {
-            let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
-            return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
-        }
-        set {
-            Current.settingsStore.prefs.set(newValue.map(\.rawValue), forKey: "deletedServers")
+        hydrateDeletedServersIfNeeded()
+        return cache.read(\.deletedServers)
+    }
+
+    private func loadPersistedDeletedServers() -> Set<Identifier<Server>> {
+        let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
+        return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
+    }
+
+    private func persist(deletedServers: Set<Identifier<Server>>) {
+        Current.settingsStore.prefs.set(deletedServers.map(\.rawValue), forKey: "deletedServers")
+    }
+
+    private func hydrateDeletedServersIfNeeded() {
+        guard !cache.read(\.deletedServersLoaded) else { return }
+        let persisted = loadPersistedDeletedServers()
+        cache.mutate { cache in
+            guard !cache.deletedServersLoaded else { return }
+            cache.deletedServers = persisted
+            cache.deletedServersLoaded = true
         }
     }
 
@@ -182,10 +198,11 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public var all: [Server] {
-        let deletedServers = deletedServers
+        hydrateDeletedServersIfNeeded()
         let snapshot = cache.read { cache in
             (
                 restrictCaching: cache.restrictCaching,
+                deletedServers: cache.deletedServers,
                 cachedServers: cache.all
             )
         }
@@ -196,18 +213,17 @@ final class ServerManagerImpl: ServerManager {
 
         // Read from Keychain and GRDB outside the cache lock so persistence I/O
         // does not block unrelated server-manager operations.
-        let persistedServers = mergedServerInfo(deletedServers: deletedServers)
+        let persistedServers = mergedServerInfo(deletedServers: snapshot.deletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
             })
 
-        let deletedServersUnchanged = self.deletedServers == deletedServers
         if let cachedOrFreshServers = cache.mutate(using: { cache -> [Server]? in
             if !cache.restrictCaching, let cachedServers = cache.all {
                 return cachedServers
             }
 
-            guard deletedServersUnchanged else {
+            guard cache.deletedServers == snapshot.deletedServers else {
                 return nil
             }
 
@@ -222,7 +238,7 @@ final class ServerManagerImpl: ServerManager {
 
         // Avoid retrying forever when another thread keeps mutating the server set.
         // In that case we return a best-effort fresh view and let a later access cache it.
-        let latestDeletedServers = self.deletedServers
+        let latestDeletedServers = cache.read(\.deletedServers)
         let latestPersistedServers = mergedServerInfo(deletedServers: latestDeletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
@@ -253,18 +269,17 @@ final class ServerManagerImpl: ServerManager {
             }
         }
 
-        var deletedServers = deletedServers
-        if deletedServers.remove(identifier) != nil {
-            self.deletedServers = deletedServers
-        }
-
-        let result = cache.mutate { cache -> Server in
+        hydrateDeletedServersIfNeeded()
+        let (result, deletedServers) = cache.mutate { cache -> (Server, Set<Identifier<Server>>) in
+            cache.deletedServers.remove(identifier)
             keychain.set(serverInfo: setValue, key: identifier.keychainKey, encoder: encoder)
             cache.info[identifier] = setValue
             cache.all = nil
 
-            return server(key: identifier.keychainKey, value: setValue, currentCache: &cache)
+            let server = server(key: identifier.keychainKey, value: setValue, currentCache: &cache)
+            return (server, cache.deletedServers)
         }
+        persist(deletedServers: deletedServers)
 
         mirrorStore.set(setValue, key: identifier.keychainKey)
         var restoredMirroredServers = restoredMirroredServers
@@ -278,14 +293,14 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public func remove(identifier: Identifier<Server>) {
-        var deletedServers = deletedServers
-        deletedServers.insert(identifier)
-        self.deletedServers = deletedServers
-
-        cache.mutate { cache in
+        hydrateDeletedServersIfNeeded()
+        let deletedServers = cache.mutate { cache -> Set<Identifier<Server>> in
+            cache.deletedServers.insert(identifier)
             keychain.deleteServerInfo(key: identifier.keychainKey)
             cache.remove(identifier: identifier)
+            return cache.deletedServers
         }
+        persist(deletedServers: deletedServers)
 
         mirrorStore.remove(identifier.keychainKey)
         var restoredMirroredServers = restoredMirroredServers
@@ -298,14 +313,14 @@ final class ServerManagerImpl: ServerManager {
 
     public func removeAll() {
         let allKeys = Set(keychain.allKeys() + mirrorStore.allKeys())
-        var deletedServers = deletedServers
-        deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
-        self.deletedServers = deletedServers
-
-        cache.mutate { cache in
+        hydrateDeletedServersIfNeeded()
+        let deletedServers = cache.mutate { cache -> Set<Identifier<Server>> in
+            cache.deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
             cache.reset()
             _ = try? keychain.removeAll()
+            return cache.deletedServers
         }
+        persist(deletedServers: deletedServers)
 
         mirrorStore.removeAll()
         restoredMirroredServers = []
@@ -341,7 +356,7 @@ final class ServerManagerImpl: ServerManager {
                 return cached
             }
 
-            let deletedServers = self.deletedServers
+            self.hydrateDeletedServersIfNeeded()
             return cache.mutate { cache -> ServerInfo in
                 if !cache.restrictCaching, let info = cache.info[identifier] {
                     return info
@@ -355,7 +370,7 @@ final class ServerManagerImpl: ServerManager {
                     let info = keychainInfo
                         ?? (shouldUseMirrorFallback ? mirroredInfo : nil)
                         ?? fallback
-                    if !deletedServers.contains(identifier) {
+                    if !cache.deletedServers.contains(identifier) {
                         cache.info[identifier] = info
                     }
                     return info
@@ -378,9 +393,9 @@ final class ServerManagerImpl: ServerManager {
             // intentionally not in the lock
             _ = serverInfo.connection.evaluateActiveURL()
 
-            let deletedServers = self?.deletedServers ?? []
+            self?.hydrateDeletedServersIfNeeded()
             return cache.mutate { cache in
-                guard !deletedServers.contains(identifier) else {
+                guard !cache.deletedServers.contains(identifier) else {
                     Current.Log.verbose("ignoring update to deleted server \(identifier)")
                     return false
                 }

--- a/Sources/Shared/API/ServerManager.swift
+++ b/Sources/Shared/API/ServerManager.swift
@@ -92,8 +92,6 @@ private extension Identifier where ObjectType == Server {
 
 private struct ServerCache {
     var restrictCaching: Bool = false
-    var deletedServersLoaded = false
-    var deletedServers: Set<Identifier<Server>> = []
     var info: [Identifier<Server>: ServerInfo] = [:]
     var server: [Identifier<Server>: Server] = [:]
     var all: [Server]?
@@ -137,26 +135,12 @@ final class ServerManagerImpl: ServerManager {
     private let cache = HAProtected<ServerCache>(value: .init())
 
     private var deletedServers: Set<Identifier<Server>> {
-        hydrateDeletedServersIfNeeded()
-        return cache.read(\.deletedServers)
-    }
-
-    private func loadPersistedDeletedServers() -> Set<Identifier<Server>> {
-        let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
-        return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
-    }
-
-    private func persist(deletedServers: Set<Identifier<Server>>) {
-        Current.settingsStore.prefs.set(deletedServers.map(\.rawValue), forKey: "deletedServers")
-    }
-
-    private func hydrateDeletedServersIfNeeded() {
-        guard !cache.read(\.deletedServersLoaded) else { return }
-        let persisted = loadPersistedDeletedServers()
-        cache.mutate { cache in
-            guard !cache.deletedServersLoaded else { return }
-            cache.deletedServers = persisted
-            cache.deletedServersLoaded = true
+        get {
+            let identifiers = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String] ?? []
+            return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
+        }
+        set {
+            Current.settingsStore.prefs.set(newValue.map(\.rawValue), forKey: "deletedServers")
         }
     }
 
@@ -198,11 +182,10 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public var all: [Server] {
-        hydrateDeletedServersIfNeeded()
+        let deletedServers = deletedServers
         let snapshot = cache.read { cache in
             (
                 restrictCaching: cache.restrictCaching,
-                deletedServers: cache.deletedServers,
                 cachedServers: cache.all
             )
         }
@@ -213,17 +196,18 @@ final class ServerManagerImpl: ServerManager {
 
         // Read from Keychain and GRDB outside the cache lock so persistence I/O
         // does not block unrelated server-manager operations.
-        let persistedServers = mergedServerInfo(deletedServers: snapshot.deletedServers)
+        let persistedServers = mergedServerInfo(deletedServers: deletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
             })
 
+        let deletedServersUnchanged = self.deletedServers == deletedServers
         if let cachedOrFreshServers = cache.mutate(using: { cache -> [Server]? in
             if !cache.restrictCaching, let cachedServers = cache.all {
                 return cachedServers
             }
 
-            guard cache.deletedServers == snapshot.deletedServers else {
+            guard deletedServersUnchanged else {
                 return nil
             }
 
@@ -238,7 +222,7 @@ final class ServerManagerImpl: ServerManager {
 
         // Avoid retrying forever when another thread keeps mutating the server set.
         // In that case we return a best-effort fresh view and let a later access cache it.
-        let latestDeletedServers = cache.read(\.deletedServers)
+        let latestDeletedServers = self.deletedServers
         let latestPersistedServers = mergedServerInfo(deletedServers: latestDeletedServers)
             .sorted(by: { lhs, rhs -> Bool in
                 lhs.1.sortOrder < rhs.1.sortOrder
@@ -269,17 +253,18 @@ final class ServerManagerImpl: ServerManager {
             }
         }
 
-        hydrateDeletedServersIfNeeded()
-        let (result, deletedServers) = cache.mutate { cache -> (Server, Set<Identifier<Server>>) in
-            cache.deletedServers.remove(identifier)
+        var deletedServers = deletedServers
+        if deletedServers.remove(identifier) != nil {
+            self.deletedServers = deletedServers
+        }
+
+        let result = cache.mutate { cache -> Server in
             keychain.set(serverInfo: setValue, key: identifier.keychainKey, encoder: encoder)
             cache.info[identifier] = setValue
             cache.all = nil
 
-            let server = server(key: identifier.keychainKey, value: setValue, currentCache: &cache)
-            return (server, cache.deletedServers)
+            return server(key: identifier.keychainKey, value: setValue, currentCache: &cache)
         }
-        persist(deletedServers: deletedServers)
 
         mirrorStore.set(setValue, key: identifier.keychainKey)
         var restoredMirroredServers = restoredMirroredServers
@@ -293,14 +278,14 @@ final class ServerManagerImpl: ServerManager {
     }
 
     public func remove(identifier: Identifier<Server>) {
-        hydrateDeletedServersIfNeeded()
-        let deletedServers = cache.mutate { cache -> Set<Identifier<Server>> in
-            cache.deletedServers.insert(identifier)
+        var deletedServers = deletedServers
+        deletedServers.insert(identifier)
+        self.deletedServers = deletedServers
+
+        cache.mutate { cache in
             keychain.deleteServerInfo(key: identifier.keychainKey)
             cache.remove(identifier: identifier)
-            return cache.deletedServers
         }
-        persist(deletedServers: deletedServers)
 
         mirrorStore.remove(identifier.keychainKey)
         var restoredMirroredServers = restoredMirroredServers
@@ -313,14 +298,14 @@ final class ServerManagerImpl: ServerManager {
 
     public func removeAll() {
         let allKeys = Set(keychain.allKeys() + mirrorStore.allKeys())
-        hydrateDeletedServersIfNeeded()
-        let deletedServers = cache.mutate { cache -> Set<Identifier<Server>> in
-            cache.deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
+        var deletedServers = deletedServers
+        deletedServers.formUnion(Set(allKeys.map { Identifier<Server>(keychainKey: $0) }))
+        self.deletedServers = deletedServers
+
+        cache.mutate { cache in
             cache.reset()
             _ = try? keychain.removeAll()
-            return cache.deletedServers
         }
-        persist(deletedServers: deletedServers)
 
         mirrorStore.removeAll()
         restoredMirroredServers = []
@@ -356,7 +341,7 @@ final class ServerManagerImpl: ServerManager {
                 return cached
             }
 
-            self.hydrateDeletedServersIfNeeded()
+            let deletedServers = self.deletedServers
             return cache.mutate { cache -> ServerInfo in
                 if !cache.restrictCaching, let info = cache.info[identifier] {
                     return info
@@ -370,7 +355,7 @@ final class ServerManagerImpl: ServerManager {
                     let info = keychainInfo
                         ?? (shouldUseMirrorFallback ? mirroredInfo : nil)
                         ?? fallback
-                    if !cache.deletedServers.contains(identifier) {
+                    if !deletedServers.contains(identifier) {
                         cache.info[identifier] = info
                     }
                     return info
@@ -393,9 +378,9 @@ final class ServerManagerImpl: ServerManager {
             // intentionally not in the lock
             _ = serverInfo.connection.evaluateActiveURL()
 
-            self?.hydrateDeletedServersIfNeeded()
+            let deletedServers = self?.deletedServers ?? []
             return cache.mutate { cache in
-                guard !cache.deletedServers.contains(identifier) else {
+                guard !deletedServers.contains(identifier) else {
                     Current.Log.verbose("ignoring update to deleted server \(identifier)")
                     return false
                 }

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -5,9 +5,12 @@ public extension DatabaseQueue {
     // Following GRDB cocnurrency rules, we have just one database instance
     // https://swiftpackageindex.com/groue/grdb.swift/v6.29.3/documentation/grdb/concurrency#Concurrency-Rules
     static var appDatabase: DatabaseQueue = {
+        var configuration = Configuration()
+        configuration.observesSuspensionNotifications = true
+
         let database: DatabaseQueue
         do {
-            database = try DatabaseQueue(path: databasePath())
+            database = try DatabaseQueue(path: databasePath(), configuration: configuration)
             #if targetEnvironment(simulator)
             print("GRDB App database is stored at \(AppConstants.appGRDBFile.description)")
             #endif
@@ -15,7 +18,7 @@ public extension DatabaseQueue {
             Current.Log.error("Failed to initialize GRDB, error: \(error.localizedDescription)")
             // Fallback to in-memory database so extensions don't crash
             do {
-                database = try DatabaseQueue()
+                database = try DatabaseQueue(configuration: configuration)
                 Current.Log.error("Using in-memory GRDB database as fallback")
             } catch {
                 fatalError("Failed to create even an in-memory GRDB database: \(error.localizedDescription)")
@@ -89,6 +92,8 @@ public extension DatabaseQueue {
         ]
         for tableName in obsoleteTables {
             do {
+                let exists = try database.read { try $0.tableExists(tableName) }
+                guard exists else { continue }
                 try database.write { db in
                     try db.drop(table: tableName)
                 }
@@ -115,24 +120,27 @@ protocol DatabaseTableProtocol {
 extension DatabaseTableProtocol {
     /// Migrates the table by adding new columns and removing obsolete columns
     func migrateColumns(database: DatabaseQueue) throws {
-        try database.write { db in
-            let existingColumns = try db.columns(in: tableName)
+        let (columnsToAdd, columnsToDrop) = try database.read { db -> ([String], [String]) in
+            let existingColumnNames = try db.columns(in: tableName).map(\.name)
+            let existingColumnSet = Set(existingColumnNames)
             let definedColumnSet = Set(definedColumns)
 
-            // Add new columns that don't exist yet
-            for columnName in definedColumns {
-                let shouldCreateColumn = !existingColumns.contains { $0.name == columnName }
-                if shouldCreateColumn {
-                    try db.alter(table: tableName) { tableAlteration in
-                        tableAlteration.add(column: columnName)
-                    }
+            let toAdd = definedColumns.filter { !existingColumnSet.contains($0) }
+            let toDrop = existingColumnNames.filter { !definedColumnSet.contains($0) }
+            return (toAdd, toDrop)
+        }
+
+        guard !columnsToAdd.isEmpty || !columnsToDrop.isEmpty else { return }
+
+        try database.write { db in
+            for columnName in columnsToAdd {
+                try db.alter(table: tableName) { tableAlteration in
+                    tableAlteration.add(column: columnName)
                 }
             }
-
-            // Remove columns that are no longer defined
-            for existingColumn in existingColumns where !definedColumnSet.contains(existingColumn.name) {
+            for columnName in columnsToDrop {
                 try db.alter(table: tableName) { tableAlteration in
-                    tableAlteration.drop(column: existingColumn.name)
+                    tableAlteration.drop(column: columnName)
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes the top crashes on 2026.7.0.

**`0xdead10cc` (SQLite lock held during suspension)** — the shared App Group database was opened without a GRDB configuration, so the process kept SQLite locks when iOS suspended it and got killed. Now:
- The database is opened with `observesSuspensionNotifications`, and `LifecycleManager` posts `Database.suspendNotification` / `resumeNotification` on background/foreground, so locks are released (in-flight work throws a caught `SQLITE_INTERRUPT`) before suspension.
- The GRDB init path is now read-mostly: `migrateColumns` and `deleteOldTables` only open a write transaction when a schema change is actually needed, so a normal launch (including the widgets extension) no longer holds a write lock during setup.

**Recursive `os_unfair_lock` abort in `ServerManager`** — `deletedServers` was read from `UserDefaults` while holding the `cache` lock; a `UserDefaults` read can synchronously deliver KVO notifications whose observer re-entered `ServerManager` and re-acquired the non-reentrant lock. `deletedServers` is now always read and written outside the lock.

## Screenshots
N/A — no user-facing UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behavior change intended; existing `ServerManager` tests still use the same `deletedServers` UserDefaults key. The intentional CarPlay "Force close" `fatalError` is left as-is.
