### PR TITLE
Add pre-commit hook running fastlane autocorrect

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,15 +10,23 @@ set -e
 
 cd "$(git rev-parse --show-toplevel)"
 
-if git diff --cached --quiet --diff-filter=ACMR; then
-  exit 0
-fi
-
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
+
+[ -n "$staged" ] || exit 0
+
+partial=$(git diff --name-only --diff-filter=ACMR -- $staged)
+if [ -n "$partial" ]; then
+  echo "pre-commit: these staged files also have unstaged changes:" >&2
+  echo "$partial" | sed 's/^/  /' >&2
+  echo "pre-commit: stage the whole file, or run 'bundle exec fastlane autocorrect' and stage it yourself." >&2
+  exit 1
+fi
 
 echo "pre-commit: running bundle exec fastlane autocorrect"
 bundle exec fastlane autocorrect
 
-printf '%s\n' "$staged" | while IFS= read -r file; do
-  [ -n "$file" ] && [ -e "$file" ] && git add -- "$file"
+IFS='
+'
+for file in $staged; do
+  [ -e "$file" ] && git add -- "$file"
 done

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Pre-commit hook: auto-format the code before committing.
+# Runs `bundle exec fastlane autocorrect` and re-stages the files it changed.
+#
+# Install with: bundle exec fastlane install_git_hooks
+#
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+if git diff --cached --quiet --diff-filter=ACMR; then
+  exit 0
+fi
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+
+echo "pre-commit: running bundle exec fastlane autocorrect"
+bundle exec fastlane autocorrect
+
+printf '%s\n' "$staged" | while IFS= read -r file; do
+  [ -n "$file" ] && [ -e "$file" ] && git add -- "$file"
+done

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ bundle exec fastlane lint
 bundle exec fastlane autocorrect
 ```
 
+To run `autocorrect` automatically before each commit, install the git pre-commit hook once:
+
+```bash
+bundle exec fastlane install_git_hooks
+```
+
 In the Xcode project, the autocorrectable linters will not modify your source code but will provide warnings. This project uses several linters:
 
 - [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)

--- a/fastlane/lanes/quality.rb
+++ b/fastlane/lanes/quality.rb
@@ -10,3 +10,9 @@ lane :autocorrect do
   sh('../Tools/build_tool swiftformat ..')
   sh('bundle exec rubocop -a ..')
 end
+
+desc 'Install the git pre-commit hook that runs autocorrect before each commit'
+lane :install_git_hooks do
+  sh('cd .. ; git config core.hooksPath .githooks')
+  UI.success('Installed git hooks. `bundle exec fastlane autocorrect` will run before each commit.')
+end

--- a/fastlane/lanes/quality.rb
+++ b/fastlane/lanes/quality.rb
@@ -12,7 +12,20 @@ lane :autocorrect do
 end
 
 desc 'Install the git pre-commit hook that runs autocorrect before each commit'
-lane :install_git_hooks do
+lane :install_git_hooks do |options|
+  current = sh('cd .. ; git config --default "" core.hooksPath', log: false).strip
+
+  if current == '.githooks'
+    UI.success('Git hooks already installed (core.hooksPath is .githooks).')
+    next
+  end
+
+  unless current.empty? || options[:force]
+    message = "core.hooksPath is already set to '#{current}'. " \
+              'Re-run with `install_git_hooks force:true` to override it.'
+    UI.user_error!(message)
+  end
+
   sh('cd .. ; git config core.hooksPath .githooks')
   UI.success('Installed git hooks. `bundle exec fastlane autocorrect` will run before each commit.')
 end


### PR DESCRIPTION
## Summary

Adds an opt-in git pre-commit hook that runs `bundle exec fastlane autocorrect` before each commit, so formatting fixes land automatically instead of being caught later in CI or in review.

## Changes

- **`.githooks/pre-commit`** (new, executable): runs `bundle exec fastlane autocorrect` and re-stages the files that were part of the commit so the formatting fixes are included. No-ops when nothing is staged.
- **`fastlane/lanes/quality.rb`**: new `install_git_hooks` lane that points `core.hooksPath` at `.githooks`.
- **`README.md`**: documents the one-time `bundle exec fastlane install_git_hooks` setup step under *Code style*.

## Usage

The hook is not active until a contributor opts in once:

```bash
bundle exec fastlane install_git_hooks
```

After that, `autocorrect` runs on every `git commit`. The hook is committed to the repo (rather than living in `.git/hooks`) so it stays in sync for everyone who installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)