### PR TITLE
Speed up CI by warming a shared DerivedData cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
             ```
 
   test:
-    needs: check-swiftlint-disables
+    needs: lint
     runs-on: macos-26
     timeout-minutes: 45
     steps:
@@ -167,21 +167,23 @@ jobs:
             env.DEVELOPER_DIR,
             hashFiles('.ruby-version', '**/Gemfile.lock')) }}
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        name: "Cache: DerivedData"
+      # DerivedData is warmed on `main` (the save step below) and only restored
+      # on PRs, so pinned SPM dependencies are compiled once per Package.resolved
+      # and reused instead of recompiled from scratch on every run.
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        name: "Restore: DerivedData"
+        id: derived_data
         with:
           path: ~/Library/Developer/Xcode/DerivedData
           key: >-
-            ${{ format('{0}-deriveddata-{1}-{2}-{3}',
-            runner.os,
-            env.DEVELOPER_DIR,
-            hashFiles('**/Package.resolved'),
-            github.run_id) }}
-          restore-keys: >-
-            ${{ format('{0}-deriveddata-{1}-{2}-',
+            ${{ format('{0}-deriveddata-{1}-{2}',
             runner.os,
             env.DEVELOPER_DIR,
             hashFiles('**/Package.resolved')) }}
+          restore-keys: >-
+            ${{ format('{0}-deriveddata-{1}-',
+            runner.os,
+            env.DEVELOPER_DIR) }}
 
       - name: Install Brews
         # right now, we don't need anything from brew for tests, so save some time
@@ -194,9 +196,25 @@ jobs:
 
       - name: Run tests
         run: bundle exec fastlane test
+        env:
+          CI_ENABLE_COVERAGE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+
+      # Save the warmed DerivedData only from `main`, and only on a fresh key,
+      # so PR runs never evict the shared base cache other PRs restore from.
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        name: "Save: DerivedData"
+        if: github.ref == 'refs/heads/main' && steps.derived_data.outputs.cache-hit != 'true'
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: >-
+            ${{ format('{0}-deriveddata-{1}-{2}',
+            runner.os,
+            env.DEVELOPER_DIR,
+            hashFiles('**/Package.resolved')) }}
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         name: "Upload Code Coverage"
+        if: github.ref == 'refs/heads/main'
         with:
           xcode: true
           xcode_archive_path: fastlane/test_output/Tests-Unit.xcresult

--- a/fastlane/lanes/testing.rb
+++ b/fastlane/lanes/testing.rb
@@ -34,12 +34,15 @@ end
 
 desc 'Run tests'
 lane :test do
+  code_coverage = ENV.key?('CI_ENABLE_COVERAGE') ? (ENV['CI_ENABLE_COVERAGE'] == 'true') : nil
   run_tests(
     project: 'HomeAssistant.xcodeproj',
     scheme: 'Tests-Unit',
     result_bundle: true,
     skip_package_dependencies_resolution: true,
     skip_detect_devices: true,
+    code_coverage: code_coverage,
+    xcargs: 'COMPILER_INDEX_STORE_ENABLE=NO',
     destination: 'platform=iOS Simulator,name=iPhone 17,OS=latest'
   )
 end


### PR DESCRIPTION
## Problem

The `test` job is the CI long pole. Everything else finishes in under ~2 min; `test` runs **~30–42 min**, and per #4993 it's **~95% compilation** (app + every SPM dependency; the 552 tests then run in ~31s).

The DerivedData cache added in #4993 helps *when it hits* (~18 min) but usually misses (~42 min). Two reasons:

1. Each save was keyed on `github.run_id`, so every run wrote a fresh multi-GB entry. Under GitHub's **10 GB per-repo cache limit** these thrash and evict each other, so most PRs get a cold cache.
2. The `test` job only ran on PRs, so **`main` never produced a stable base** for PRs to restore from.

## Changes

- **Warm DerivedData from `main`, restore-only on PRs.** `test` now runs on `main` too (`needs: lint` instead of the PR-only `check-swiftlint-disables`) and saves DerivedData under a key scoped to `Package.resolved` (no `run_id`). PRs restore that shared base via `actions/cache/restore` and **never save**, so entries stop evicting each other and pinned dependencies are compiled **once per dependency set** and reused. Running tests on `main` also closes the gap where merges ran no tests at all.
- **Disable the compiler index store in CI** (`COMPILER_INDEX_STORE_ENABLE=NO`). The index only matters for interactive Xcode; skipping it speeds the build and shrinks DerivedData so it fits under the 10 GB limit.
- **Skip code coverage on PR runs.** Coverage instrumentation is only needed for the codecov upload, which now runs on `main` only. The lane reads `CI_ENABLE_COVERAGE` and falls back to the scheme setting locally.
- **Revert the runner to `macos-26`.** (The earlier `macos-*-xlarge` attempt is a paid larger runner the org's billing doesn't currently permit — it failed instantly with a spending-limit error.)

## Expected impact

Once `main` has run once and warmed the cache, PR `test` should drop from the common **~30–42 min cold build toward the ~10–14 min dependency-cache-hit path**, at **no change in per-minute runner cost**.

## Notes for review

- **This PR's own `test` run will still be slow.** The shared base only exists after this merges and the first `main` run saves it; PRs opened afterward get the speedup. The green check here just confirms the workflow + build still work.
- **`test` now runs on every push to `main`**, adding one macOS job per merge (this is the cache-warming mechanism, and it restores post-merge test coverage). PRs, which are far more frequent, get faster in return.
- **Per-PR codecov visibility changes:** coverage is now reported from `main`, not from PR runs. If per-PR coverage deltas are wanted, we can re-enable coverage on PRs (small compile cost) — the dependency-cache win is independent of this.
- Cross-machine Xcode incremental can occasionally over-rebuild; keying on `Package.resolved` + deterministic runner paths is the standard mitigation. If app-source incrementals prove flaky, we can scope the cache to SPM `SourcePackages` + module cache only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)