### PR TITLE
Run the CI test job on the self-hosted macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
   test:
     needs: check-swiftlint-disables
-    runs-on: macos-26
+    runs-on: self-hosted
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -166,22 +166,6 @@ jobs:
             env.ImageVersion,
             env.DEVELOPER_DIR,
             hashFiles('.ruby-version', '**/Gemfile.lock')) }}
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        name: "Cache: DerivedData"
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: >-
-            ${{ format('{0}-deriveddata-{1}-{2}-{3}',
-            runner.os,
-            env.DEVELOPER_DIR,
-            hashFiles('**/Package.resolved'),
-            github.run_id) }}
-          restore-keys: >-
-            ${{ format('{0}-deriveddata-{1}-{2}-',
-            runner.os,
-            env.DEVELOPER_DIR,
-            hashFiles('**/Package.resolved')) }}
 
       - name: Install Brews
         # right now, we don't need anything from brew for tests, so save some time


### PR DESCRIPTION
## Summary

Alternative to #5002. Moves the compile-bound `test` job off the GitHub-hosted `macos-26` runner (~30–42 min, mostly recompiling the app + every SPM dependency from a cold cache) and onto the org's **self-hosted** runner ("Bruno's Mac Mini", labels `self-hosted, macOS, ARM64`).

The win: a persistent machine keeps `~/Library/Developer/Xcode/DerivedData` warm between runs, so builds are incremental for free — no per-run cache upload/download, and only changed sources recompile.

## Changes

- `test` job `runs-on: macos-26` → `runs-on: self-hosted`.
- **Removed the GitHub Actions DerivedData cache step.** On a persistent runner it's redundant (the disk already holds warm DerivedData) and counterproductive (it would upload/download multi-GB caches to a machine that already has the data). The gem cache stays, since the per-job workspace is cleaned.
- Only the macOS `test` job moves; `lint` and the PR-check jobs stay on GitHub-hosted `ubuntu-latest`.