### PR TITLE
Surface Mac App Store upload-limit (90382) in the Distribute CI summary

### DIFF
--- a/fastlane/lanes/build_utils.rb
+++ b/fastlane/lanes/build_utils.rb
@@ -1,22 +1,64 @@
 # Build and deployment utilities
 
 private_lane :upload_binary_to_apple do |options|
+  command = [
+    'xcrun', 'altool', '--upload-app', '--type', options[:type],
+    '--file', options[:path],
+    '--username', ENV.fetch('DELIVER_USERNAME', nil),
+    '--password', '@env:FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
+  ]
+
   attempts = 0
 
-  begin
-    sh(
-      'xcrun', 'altool', '--upload-app', '--type', options[:type],
-      '--file', options[:path],
-      '--username', ENV.fetch('DELIVER_USERNAME', nil),
-      '--password', '@env:FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
-    )
-  rescue StandardError => e
-    puts "Failed with #{e}; retrying upload..."
+  loop do
+    succeeded = false
+    output = +''
 
-    # retry a few times, then give up
+    sh(*command) do |status, result, _command|
+      succeeded = status.success?
+      output = result.to_s
+    end
+
+    break if succeeded
+
+    if output.include?('90382') || output.include?('Upload limit reached')
+      report_upload_limit_reached(type: options[:type])
+      UI.user_error!('App Store upload limit reached (error 90382). See the job summary for details.')
+    end
+
     attempts += 1
+    UI.user_error!("altool upload failed after #{attempts} attempts.") if attempts > 3
 
-    retry if attempts <= 3
-    raise e
+    puts 'Failed to upload; retrying upload...'
   end
+end
+
+def report_upload_limit_reached(type:)
+  store = type == 'osx' ? 'Mac App Store' : 'App Store'
+  message = "#{store} upload failed: Apple daily upload limit reached (error 90382). " \
+            'The app built, notarized and stapled fine; this is an App Store Connect ' \
+            'per-app daily quota, not a build failure. Wait ~24h for the reset, then re-run.'
+
+  UI.error(message)
+  puts "::error title=#{store} upload limit reached (90382)::#{message}"
+  append_job_summary(upload_limit_summary(store, type))
+end
+
+def upload_limit_summary(store, type)
+  [
+    "## :x: #{store} upload failed: daily upload limit reached (90382)",
+    '',
+    "Apple returned **error 90382 (\"Upload limit reached\")** for the `#{type}` package.",
+    '',
+    '- The app **built, notarized and stapled successfully**, so this is not a build or code failure.',
+    '- App Store Connect enforces a **per-app daily upload quota**, which has now been exhausted.',
+    "- **Action:** wait ~24h for Apple's window to reset, then re-run. Re-running sooner hits the same limit."
+  ].join("\n")
+end
+
+def append_job_summary(text)
+  summary_path = ENV.fetch('GITHUB_STEP_SUMMARY', nil)
+  return if summary_path.nil? || summary_path.empty?
+
+  File.write(summary_path, "#{text}\n", mode: 'a')
 end

--- a/fastlane/lanes/build_utils.rb
+++ b/fastlane/lanes/build_utils.rb
@@ -23,7 +23,7 @@ private_lane :upload_binary_to_apple do |options|
 
     if output.include?('90382') || output.include?('Upload limit reached')
       report_upload_limit_reached(type: options[:type])
-      UI.user_error!('App Store upload limit reached (error 90382). See the job summary for details.')
+      UI.user_error!('Apple upload limit reached (error 90382). See the job summary for details.')
     end
 
     attempts += 1


### PR DESCRIPTION
## Problem

The `Distribute` job for Mac has been failing on `main` (e.g. [run 28991505329](https://github.com/home-assistant/iOS/actions/runs/28991505329)). The app **builds, notarizes and staples successfully**, but the final `xcrun altool --upload-app` step is rejected by Apple with:

> **Error 90382 — "Upload limit reached. The upload limit for your application has been reached. Please wait 1 day and try again."**

This is App Store Connect's **per-app daily upload quota**, not a build or code failure. It gets exhausted because Distribute uploads to the Mac App Store on every `main` push, and several runs can land in a day.

Two annoyances made this hard to diagnose:

1. The reason was buried deep in the xcodebuild log; the run page just showed a generic Ruby `FastlaneShellError` / "exit code 1".
2. `upload_binary_to_apple` blindly retried **any** error 3× before re-raising, so a rate-limit that can never succeed on retry wasted ~6 minutes each run.

## Change

In `fastlane/lanes/upload_binary_to_apple`:

- Detect `90382` / "Upload limit reached" in `altool`'s output.
- Write a clear **GitHub Actions job-summary** section and emit an `::error::` **annotation** stating it was the daily upload limit and that the build itself succeeded, with the action to take (wait ~24h, re-run).
- **Skip the futile retries** for this specific error. Other (transient) errors still retry 3× as before.

The job still fails red, but now the run page explains *why* at a glance instead of hiding it in the log.

## Notes

- Ruby-only change; `rubocop` and `ruby -c` pass. No Swift touched.
- The summary uses the `:x:` markdown shortcode rather than a literal emoji so the lane file stays ASCII (fastlane `eval`s lane files under the runner's locale, which can be US-ASCII).
- This does **not** stop the daily cap from being hit. If we also want to prevent it, a follow-up could gate the Mac App Store upload to tags/manual dispatch instead of every `main` push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)