### PR TITLE
Camera player UI enhancements

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraMJPEGPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraMJPEGPlayerView.swift
@@ -9,14 +9,21 @@ struct CameraMJPEGPlayerView: View {
     private let server: Server
     private let cameraEntityId: String
     private let cameraName: String?
+    private let controlsVisible: Binding<Bool>?
 
     @State private var isLoading = true
     @State private var errorMessage: String?
 
-    init(server: Server, cameraEntityId: String, cameraName: String? = nil) {
+    init(
+        server: Server,
+        cameraEntityId: String,
+        cameraName: String? = nil,
+        controlsVisible: Binding<Bool>? = nil
+    ) {
         self.server = server
         self.cameraEntityId = cameraEntityId
         self.cameraName = cameraName
+        self.controlsVisible = controlsVisible
     }
 
     var body: some View {
@@ -51,6 +58,10 @@ struct CameraMJPEGPlayerView: View {
                         .padding(.horizontal)
                 }
             }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            controlsVisible?.wrappedValue.toggle()
         }
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)

--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -1,4 +1,5 @@
 import GRDB
+import PromiseKit
 import SFSafeSymbols
 import Shared
 import SwiftUI
@@ -8,12 +9,20 @@ import SwiftUI
 struct CameraPlayerView: View {
     @Environment(\.dismiss) private var dismiss
     private let server: Server
-    private let cameraEntityId: String
     private let cameraName: String?
 
+    @State private var cameraEntityId: String
     @State private var playerType: PlayerType = .webRTC
     @State private var appEntity: HAAppEntity?
     @State private var name: String?
+    @State private var subtitle: String?
+    @State private var cameras: [HAAppEntity] = []
+    /// Precomputed context subtitle per camera entity id, resolved once when the list is loaded so the
+    /// picker rows don't hit the database on every render.
+    @State private var cameraSubtitles: [String: String] = [:]
+    /// Snapshot thumbnail per camera entity id, fetched lazily so the picker can show a live still with an
+    /// SF Symbol placeholder until it arrives.
+    @State private var cameraSnapshots: [String: UIImage] = [:]
     @State private var controlsVisible = true
     @State private var showLoader = true
 
@@ -25,62 +34,106 @@ struct CameraPlayerView: View {
 
     init(server: Server, cameraEntityId: String, cameraName: String? = nil) {
         self.server = server
-        self.cameraEntityId = cameraEntityId
+        self._cameraEntityId = State(initialValue: cameraEntityId)
         self.cameraName = cameraName
     }
 
     var body: some View {
         ZStack {
-            ZStack(alignment: .topLeading) {
-                NavigationStack {
-                    content
-                        .toolbar {
-                            ToolbarItem(placement: .primaryAction) {
-                                if controlsVisible {
-                                    HStack(spacing: DesignSystem.Spaces.one) {
-                                        Button {
-                                            openMoreInfo()
-                                        } label: {
-                                            Image(systemSymbol: .safari)
-                                        }
-                                    }
-                                }
-                            }
+            navigationStack
 
-                            ToolbarItem(placement: .primaryAction) {
-                                CloseButton {
-                                    dismiss()
-                                }
-                            }
-                        }
-                        .modify { view in
-                            if #available(iOS 18.0, *) {
-                                view.toolbarVisibility(controlsVisible ? .automatic : .hidden, for: .navigationBar)
-                            } else {
-                                view
-                            }
-                        }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                nameBadge
-            }
             if showLoader {
-                HAProgressView(style: .extraLarge)
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.white)
+                    .scaleEffect(1.5)
             }
         }
         .onAppear {
-            appEntity = HAAppEntity.entity(id: cameraEntityId, serverId: server.identifier.rawValue)
-            name = appEntity?.name ?? cameraName
+            loadMetadata()
+            loadCameras()
         }
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)
     }
 
+    private var navigationStack: some View {
+        NavigationStack {
+            content
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        if controlsVisible {
+                            HStack(spacing: DesignSystem.Spaces.one) {
+                                Button {
+                                    openMoreInfo()
+                                } label: {
+                                    Image(systemSymbol: .safari)
+                                }
+                            }
+                        }
+                    }
+
+                    ToolbarItem(placement: .cancellationAction) {
+                        CloseButton {
+                            dismiss()
+                        }
+                    }
+
+                    ToolbarItem(placement: .principal) {
+                        nameBadge
+                    }
+                }
+                .modify { view in
+                    if #available(iOS 18.0, *) {
+                        view.toolbarVisibility(controlsVisible ? .automatic : .hidden, for: .navigationBar)
+                    } else {
+                        view
+                    }
+                }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     @ViewBuilder
     private var nameBadge: some View {
         if let name, controlsVisible {
-            Text(name)
-                .font(.headline)
+            Menu {
+                ForEach(cameras) { camera in
+                    Button {
+                        switchCamera(to: camera.entityId)
+                    } label: {
+                        if let snapshot = cameraSnapshots[camera.entityId] {
+                            Image(uiImage: snapshot)
+                                .renderingMode(.original)
+                                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.one))
+                        } else {
+                            Image(systemSymbol: .videoFill)
+                        }
+                        Text(camera.name)
+                        if let subtitle = cameraSubtitles[camera.entityId], !subtitle.isEmpty {
+                            Text(subtitle)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: DesignSystem.Spaces.one) {
+                    VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+                        Text(name)
+                            .font(DesignSystem.Font.caption.bold())
+                            .foregroundStyle(.primary)
+                            .truncationMode(.middle)
+                        if let subtitle, !subtitle.isEmpty {
+                            Text(subtitle)
+                                .font(DesignSystem.Font.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    if cameras.count > 1 {
+                        Image(systemSymbol: .chevronUpChevronDown)
+                            .font(DesignSystem.Font.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 .padding(.horizontal, DesignSystem.Spaces.two)
                 .padding(.vertical, DesignSystem.Spaces.one)
                 .modify { view in
@@ -93,9 +146,10 @@ struct CameraPlayerView: View {
                             .clipShape(.capsule)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.leading, DesignSystem.Spaces.two)
-                .padding(.top, DesignSystem.Spaces.half)
+            }
+            .menuOrder(.fixed)
+            .disabled(cameras.count <= 1)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -106,7 +160,7 @@ struct CameraPlayerView: View {
                 WebRTCVideoPlayerView(
                     server: server,
                     cameraEntityId: cameraEntityId,
-                    cameraName: cameraName,
+                    cameraName: name ?? cameraName,
                     controlsVisible: $controlsVisible,
                     showLoader: $showLoader,
                     onWebRTCUnsupported: {
@@ -117,7 +171,8 @@ struct CameraPlayerView: View {
                 CameraStreamHLSView(
                     server: server,
                     cameraEntityId: cameraEntityId,
-                    cameraName: cameraName,
+                    cameraName: name ?? cameraName,
+                    controlsVisible: $controlsVisible,
                     onHLSUnsupported: {
                         fallbackToMJPEG()
                     }
@@ -126,10 +181,15 @@ struct CameraPlayerView: View {
                 CameraMJPEGPlayerView(
                     server: server,
                     cameraEntityId: cameraEntityId,
-                    cameraName: cameraName
+                    cameraName: name ?? cameraName,
+                    controlsVisible: $controlsVisible
                 )
             }
         }
+        // Rebuild the whole player subtree when the camera changes so the previous stream is torn
+        // down cleanly (the WebRTC controller closes its connection in `viewWillDisappear`) before a
+        // new one starts, rather than reusing the existing player/view model.
+        .id(cameraEntityId)
     }
 
     private func fallbackToHLS() {
@@ -144,6 +204,59 @@ struct CameraPlayerView: View {
         withAnimation {
             playerType = .mjpeg
         }
+    }
+
+    private func loadMetadata() {
+        appEntity = HAAppEntity.entity(id: cameraEntityId, serverId: server.identifier.rawValue)
+        name = appEntity?.name ?? cameraName
+        subtitle = appEntity?.contextualSubtitle
+    }
+
+    private func loadCameras() {
+        do {
+            let loaded = try HAAppEntity.config()
+                .filter { $0.serverId == server.identifier.rawValue && $0.domain == Domain.camera.rawValue }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            cameras = loaded
+            cameraSubtitles = Dictionary(
+                uniqueKeysWithValues: loaded.compactMap { camera in
+                    camera.contextualSubtitle.map { (camera.entityId, $0) }
+                }
+            )
+            Task { await loadSnapshots(for: loaded) }
+        } catch {
+            Current.Log.error("Failed to load cameras for picker: \(error)")
+        }
+    }
+
+    /// Fetches a still thumbnail for each camera to show as its picker icon. Failures are logged and
+    /// simply leave that camera on its SF Symbol placeholder.
+    @MainActor
+    private func loadSnapshots(for cameras: [HAAppEntity]) async {
+        guard let api = Current.api(for: server) else { return }
+        for camera in cameras where cameraSnapshots[camera.entityId] == nil {
+            do {
+                let image: UIImage = try await withCheckedThrowingContinuation { continuation in
+                    api.getCameraSnapshot(cameraEntityID: camera.entityId)
+                        .done { continuation.resume(returning: $0) }
+                        .catch { continuation.resume(throwing: $0) }
+                }
+                let thumbnail = await image.byPreparingThumbnail(ofSize: CGSize(width: 120, height: 120))
+                cameraSnapshots[camera.entityId] = thumbnail ?? image
+            } catch {
+                Current.Log.error("Failed to load snapshot for \(camera.entityId): \(error)")
+            }
+        }
+    }
+
+    private func switchCamera(to entityId: String) {
+        guard entityId != cameraEntityId else { return }
+        // Restart from the top of the fallback chain and show the loader while the new stream connects.
+        // Changing `cameraEntityId` re-identifies `content`, tearing down the current player first.
+        showLoader = true
+        playerType = .webRTC
+        cameraEntityId = entityId
+        loadMetadata()
     }
 
     private func openMoreInfo() {

--- a/Sources/App/Cameras/CameraPlayer/CameraStreamHLSView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraStreamHLSView.swift
@@ -10,6 +10,7 @@ struct CameraStreamHLSView: View {
     private let cameraEntityId: String
     private let cameraName: String?
     private let onHLSUnsupported: (() -> Void)?
+    private let controlsVisible: Binding<Bool>?
 
     @State private var player: AVPlayer?
     @State private var isLoading = true
@@ -20,11 +21,13 @@ struct CameraStreamHLSView: View {
         server: Server,
         cameraEntityId: String,
         cameraName: String? = nil,
+        controlsVisible: Binding<Bool>? = nil,
         onHLSUnsupported: (() -> Void)? = nil
     ) {
         self.server = server
         self.cameraEntityId = cameraEntityId
         self.cameraName = cameraName
+        self.controlsVisible = controlsVisible
         self.onHLSUnsupported = onHLSUnsupported
     }
 
@@ -56,6 +59,10 @@ struct CameraStreamHLSView: View {
                         .padding(.horizontal)
                 }
             }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            controlsVisible?.wrappedValue.toggle()
         }
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
@@ -23,7 +23,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
     @State private var isVideoPlaying: Bool = false
     var controlsVisible: Binding<Bool>
     var showLoader: Binding<Bool>
-    @State var hideControlsWorkItem: DispatchWorkItem?
 
     private let server: Server
     private let cameraEntityId: String
@@ -44,7 +43,11 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
         self.onWebRTCUnsupported = onWebRTCUnsupported
         self.controlsVisible = controlsVisible
         self.showLoader = showLoader
-        self._viewModel = .init(wrappedValue: WebRTCViewPlayerViewModel(server: server, cameraEntityId: cameraEntityId))
+        self._viewModel = .init(wrappedValue: WebRTCViewPlayerViewModel(
+            server: server,
+            cameraEntityId: cameraEntityId,
+            supportsTalkback: true
+        ))
     }
 
     var body: some View {
@@ -68,18 +71,33 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                 )
             }
             .background(.black)
-            .onAppear {
-                showControlsTemporarily()
-            }
-            .onDisappear {
-                hideControlsWorkItem?.cancel()
-                hideControlsWorkItem = nil
+            .overlay {
+                // Fade shade behind the bottom controls so the talkback (mic) button keeps contrast
+                // against a bright camera image. Only shown when the mic button is present. The
+                // container ignores the safe area so the shade extends under the mic button/home
+                // indicator rather than stopping above it.
+                if controlsVisible.wrappedValue, viewModel.isTalkbackSupported {
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        LinearGradient(
+                            colors: [.clear, .black.opacity(0.6)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 180)
+                    }
+                    .allowsHitTesting(false)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                }
             }
             .simultaneousGesture(
                 dragGesture(geometry: geometry)
             )
             .onTapGesture {
-                showControlsTemporarily()
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    controlsVisible.wrappedValue.toggle()
+                }
             }
             .onChange(of: viewModel.isWebRTCUnsupported) { isUnsupported in
                 if isUnsupported {
@@ -91,6 +109,40 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
             }
         }
         .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                if controlsVisible.wrappedValue, viewModel.isTalkbackSupported {
+                    Button(action: {
+                        viewModel.toggleTalkback()
+                    }) {
+                        HStack {
+                            if viewModel.isTalking {
+                                Text(L10n.CameraPlayer.Talkback.stop)
+                            }
+                            Image(systemSymbol: viewModel.isTalking ? .micSlash : .micFill)
+                        }
+                        .transition(.opacity.combined(with: .scale))
+                    }
+                    .controlSize({
+                        if #available(iOS 17.0, *) {
+                            return .extraLarge
+                        } else {
+                            return .large
+                        }
+                    }())
+                    .modify({ view in
+                        if #available(iOS 26.0, *) {
+                            view
+                                .buttonStyle(.glassProminent)
+                                .tint(viewModel.isTalking ? Color.orange : Color.haPrimary)
+                        } else {
+                            view
+                        }
+                    })
+                    .accessibilityLabel(
+                        viewModel.isTalking ? L10n.CameraPlayer.Talkback.stop : L10n.CameraPlayer.Talkback.start
+                    )
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 if controlsVisible.wrappedValue {
                     Button(action: {
@@ -134,13 +186,11 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
         scale = proposedScale
         offset = clampedOffset(for: newOffset, in: containerSize)
         previousFrameScale = proposedScale
-        showControlsTemporarily()
     }
 
     private func handlePinchEnded(in containerSize: CGSize) {
         lastScale = scale
         previousFrameScale = scale
-        showControlsTemporarily()
         if scale <= 1.0 {
             withAnimation {
                 offset = .zero
@@ -173,7 +223,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                 offset = clampedOffset(for: newOffset, in: containerSize)
                 lastOffset = offset
             }
-            showControlsTemporarily()
         }
     }
 
@@ -186,7 +235,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                     height: lastOffset.height + value.translation.height
                 )
                 offset = clampedOffset(for: newOffset, in: geometry.size)
-                showControlsTemporarily()
             }
             .onEnded { value in
                 // If user is not zoomed in, allow dismissing the view with a swipe down
@@ -200,7 +248,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                     offset = clampedOffset(for: offset, in: geometry.size)
                     lastOffset = offset
                 }
-                showControlsTemporarily()
             }
     }
 
@@ -212,16 +259,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
         .edgesIgnoringSafeArea(.all)
         .scaleEffect(.init(floatLiteral: scale >= 1.0 ? scale : 1.0))
         .offset(offset)
-    }
-
-    private func showControlsTemporarily() {
-        controlsVisible.wrappedValue = true
-        hideControlsWorkItem?.cancel()
-        let workItem = DispatchWorkItem {
-            controlsVisible.wrappedValue = false
-        }
-        hideControlsWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
     }
 
     /// Clamps the dragging offset to prevent the zoomed content from being moved

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
@@ -27,20 +27,26 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
     private var pendingCandidates: [RTCIceCandidate] = []
     private let server: Server
     private let cameraEntityId: String
+    private let supportsTalkback: Bool
 
     @Published var failureReason: String?
     @Published var showLoader: Bool = true
     @Published var isMuted: Bool = true
     @Published var isWebRTCUnsupported: Bool = false
+    @Published var isTalkbackSupported: Bool = false
+    @Published var isTalking: Bool = false
 
     /// Invoked on offer rejection or ICE failure. Used by the notification extension to fall back;
     /// the SwiftUI player leaves it `nil` and observes the published properties instead.
     var onFailure: (() -> Void)?
 
-    init(server: Server, cameraEntityId: String) {
+    init(server: Server, cameraEntityId: String, supportsTalkback: Bool = false) {
         self.server = server
         self.cameraEntityId = cameraEntityId
+        self.supportsTalkback = supportsTalkback
     }
+
+    func toggleTalkback() {}
 
     func toggleMute() {
         guard let webRTCClient else { return }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -198,6 +198,9 @@
 "camera_player.errors.unable_to_connect_to_server" = "Unable to connect to Home Assistant";
 "camera_player.errors.unknown" = "Unknown error";
 "camera_player.notification.body" = "Tap to open camera";
+"camera_player.talkback.microphone_denied" = "Microphone access is required for two-way audio. Enable it in Settings.";
+"camera_player.talkback.start" = "Start talking";
+"camera_player.talkback.stop" = "Stop talking";
 "cameras.no_server_found" = "No server found for camera: %@";
 "cancel_label" = "Cancel";
 "carPlay.action.execute.in_progress" = "Executing...";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -815,6 +815,14 @@ public enum L10n {
       /// Tap to open camera
       public static var body: String { return L10n.tr("Localizable", "camera_player.notification.body") }
     }
+    public enum Talkback {
+      /// Microphone access is required for two-way audio. Enable it in Settings.
+      public static var microphoneDenied: String { return L10n.tr("Localizable", "camera_player.talkback.microphone_denied") }
+      /// Start talking
+      public static var start: String { return L10n.tr("Localizable", "camera_player.talkback.start") }
+      /// Stop talking
+      public static var stop: String { return L10n.tr("Localizable", "camera_player.talkback.stop") }
+    }
   }
 
   public enum Cameras {


### PR DESCRIPTION
## Summary

Camera player UI/UX enhancements for the in-app player (MJPEG / HLS / WebRTC):
- Reworked player controls (tap-to-toggle visibility) and layout.
- Introduces the talkback (microphone) button and its contrast shade, but **gated off** behind `isTalkbackSupported` (always `false` here) so it is present in the UI yet never shown or functional.

The two-way-audio engine that actually drives `isTalkbackSupported` and unhides the button lands in a **stacked follow-up PR** based on this branch, so this can be reviewed and merged first.

## Notes
- No functional talkback here — the ViewModel exposes only an inert shell (`isTalkbackSupported`/`isTalking`/empty `toggleTalkback()`).