### PR TITLE
Reduce web view empty-state timeout to 5s and make it debug-configurable

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+ProtocolConformance.swift
@@ -76,8 +76,9 @@ extension WebViewController: WebViewControllerProtocol {
         case .authInvalid:
             showEmptyState()
         case .disconnected, .unknown:
-            // Start a 10-second timer. If not interrupted by a 'connected' state, set alpha to 1.
-            emptyStateTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { [weak self] _ in
+            // Start a timer. If not interrupted by a 'connected' state, show the empty state.
+            let timeout = TimeInterval(Current.settingsStore.webViewEmptyStateTimeout)
+            emptyStateTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
                 self?.showEmptyState()
             }
         }

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -71,7 +71,8 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     /// Handler for script messages sent from the webview to the app
     let webViewScriptMessageHandler = WebViewScriptMessageHandler()
 
-    /// Defer showing the empty state until disconnected for 10 seconds (used by
+    /// Defer showing the empty state until the frontend has been disconnected for
+    /// `Current.settingsStore.webViewEmptyStateTimeout` seconds (used by
     /// updateFrontendConnectionState in WebViewController+ProtocolConformance.swift)
     var emptyStateTimer: Timer?
 

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -439,6 +439,18 @@ struct DebugView: View {
                 Text("Receive debug notifications")
             }
 
+            Picker(selection: Binding(
+                get: { Current.settingsStore.webViewEmptyStateTimeout },
+                set: { Current.settingsStore.webViewEmptyStateTimeout = $0 }
+            )) {
+                ForEach([5, 10, 15, 20, 30, 60], id: \.self) { seconds in
+                    Text(verbatim: "\(seconds)s").tag(seconds)
+                }
+            } label: {
+                Text(verbatim: "Web view empty state timeout")
+            }
+            .pickerStyle(.menu)
+
         } header: {
             Text(verbatim: L10n.Settings.Developer.header)
         } footer: {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -555,6 +555,18 @@ public class SettingsStore {
         }
     }
 
+    public static let defaultWebViewEmptyStateTimeout = 5
+
+    /// Seconds the frontend can stay disconnected before the web view shows its empty state
+    public var webViewEmptyStateTimeout: Int {
+        get {
+            (prefs.object(forKey: "webViewEmptyStateTimeout") as? Int) ?? Self.defaultWebViewEmptyStateTimeout
+        }
+        set {
+            prefs.set(newValue, forKey: "webViewEmptyStateTimeout")
+        }
+    }
+
     public var mediaTypesRequiringUserActionForPlayback: Set<MediaTypeRequiringUserActionForPlayback> {
         get {
             let rawValues = prefs.stringArray(forKey: "mediaTypesRequiringUserActionForPlayback") ?? [


### PR DESCRIPTION
## Summary

When the frontend reports a disconnected/unknown connection state, `WebViewController` waits before showing its empty-state overlay to avoid flashing it during brief reconnects. That grace period was hardcoded to **10 seconds**.

This PR:
- **Reduces the default timeout to 5 seconds** so users see the empty state (and reconnect UI) sooner when connectivity is genuinely lost.
- **Adds a Debug setting** (Settings → Debug → Developer) with a number picker to change the timeout on the fly (5, 10, 15, 20, 30, 60 seconds), backed by a new `SettingsStore.webViewEmptyStateTimeout` preference.

## Changes

- `SettingsStore.webViewEmptyStateTimeout: Int` — persisted in the app-group `UserDefaults`, defaults to `5` (`SettingsStore.defaultWebViewEmptyStateTimeout`).
- `WebViewController+ProtocolConformance.updateFrontendConnectionState(state:)` now reads the timeout from the setting instead of the hardcoded `10`.
- A menu-style `Picker` in `DebugView`'s developer section to select the timeout.
- Updated the stale doc comment on `emptyStateTimer`.

## Testing

- Existing `WebViewControllerTests` still hold: they assert the timer is scheduled (non-nil) on disconnect, which remains true regardless of the interval.
- `bundle exec fastlane autocorrect` is clean (SwiftFormat + Rubocop, no changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)