### PR TITLE
Show our disconnected empty state instead of Cloudflare/proxy 5xx error pages

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -169,7 +169,7 @@ extension WebViewController {
             didHandleServerErrorResponse = true
             decisionHandler(.cancel)
             latestLoadError = Self.serverErrorLoadError(for: navigationResponse.response.url)
-            connectionState = .disconnected
+            connectionState = Self.connectionStateForInterceptedServerError(current: connectionState)
             showEmptyState()
         }
     }
@@ -311,6 +311,12 @@ extension WebViewController {
             return .allow
         }
         return .showEmptyState
+    }
+
+    static func connectionStateForInterceptedServerError(
+        current: FrontEndConnectionState
+    ) -> FrontEndConnectionState {
+        current == .authInvalid ? .authInvalid : .disconnected
     }
 
     static func serverErrorLoadError(for url: URL?) -> URLError {

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -11,6 +11,7 @@ extension WebViewController {
         // Deliberately does not mark disconnected: a navigation starting isn't a lost connection. Only the
         // frontend (via the external bus) or a hard reload (`reload()`/`refresh()`) sets disconnected.
         overlayState?.isLoading = true
+        didHandleServerErrorResponse = false
         webViewExternalMessageHandler.stopImprovScanIfNeeded()
     }
 
@@ -42,6 +43,10 @@ extension WebViewController {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         refreshControl.endRefreshing()
         overlayState?.isLoading = false
+        if didHandleServerErrorResponse {
+            didHandleServerErrorResponse = false
+            return
+        }
         if let err = error as? URLError {
             if err.code != .cancelled {
                 Current.Log.error("Failure during nav: \(err)")
@@ -57,6 +62,11 @@ extension WebViewController {
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         refreshControl.endRefreshing()
         overlayState?.isLoading = false
+
+        if didHandleServerErrorResponse {
+            didHandleServerErrorResponse = false
+            return
+        }
 
         let nsError = error as NSError
         let shouldShowError: Bool
@@ -127,16 +137,25 @@ extension WebViewController {
 
         lastNavigationWasServerError = true
 
-        // error response, let's inspect if it's restoring a page or normal navigation
-        if navigationResponse.response.url != initialURL {
-            // just a normal loading error
+        let cfMitigated = httpResponse.value(forHTTPHeaderField: "cf-mitigated")
+        let cfRay = httpResponse.value(forHTTPHeaderField: "cf-ray") ?? "-"
+        Current.Log.error(
+            "Main frame HTTP \(httpResponse.statusCode) at \(navigationResponse.response.url?.absoluteString ?? "?"), cf-ray=\(cfRay), cf-mitigated=\(cfMitigated ?? "-")"
+        )
+
+        switch Self.decisionForMainFrameErrorResponse(
+            statusCode: httpResponse.statusCode,
+            responseURL: navigationResponse.response.url,
+            initialURL: initialURL,
+            cfMitigated: cfMitigated
+        ) {
+        case .allow:
             decisionHandler(.allow)
-        } else {
+        case .reloadDefaultURL:
             // first: clear that saved url, it's bad
             initialURL = nil
 
             // it's for the restored page, let's load the default url
-
             Task { [weak self] in
                 if let self, let webviewURL = await server.webviewURL() {
                     decisionHandler(.cancel)
@@ -146,6 +165,12 @@ extension WebViewController {
                     decisionHandler(.allow)
                 }
             }
+        case .showEmptyState:
+            didHandleServerErrorResponse = true
+            decisionHandler(.cancel)
+            latestLoadError = Self.serverErrorLoadError(for: navigationResponse.response.url)
+            connectionState = .disconnected
+            showEmptyState()
         }
     }
 
@@ -260,5 +285,39 @@ extension WebViewController: UIGestureRecognizerDelegate {
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
         true
+    }
+}
+
+extension WebViewController {
+    enum MainFrameErrorResponseDecision: Equatable {
+        case allow
+        case reloadDefaultURL
+        case showEmptyState
+    }
+
+    static func decisionForMainFrameErrorResponse(
+        statusCode: Int,
+        responseURL: URL?,
+        initialURL: URL?,
+        cfMitigated: String?
+    ) -> MainFrameErrorResponseDecision {
+        if let initialURL, responseURL == initialURL {
+            return .reloadDefaultURL
+        }
+        if cfMitigated?.lowercased() == "challenge" {
+            return .allow
+        }
+        guard statusCode >= 500 else {
+            return .allow
+        }
+        return .showEmptyState
+    }
+
+    static func serverErrorLoadError(for url: URL?) -> URLError {
+        guard let url else { return URLError(.badServerResponse) }
+        return URLError(.badServerResponse, userInfo: [
+            NSURLErrorFailingURLErrorKey: url,
+            NSURLErrorFailingURLStringErrorKey: url.absoluteString,
+        ])
     }
 }

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -30,6 +30,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     var initialURL: URL?
     var statusBarButtonsStack: UIStackView?
     var lastNavigationWasServerError = false
+    var didHandleServerErrorResponse = false
     var reconnectBackgroundTimer: Timer? {
         willSet {
             if reconnectBackgroundTimer != newValue {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -216,6 +216,20 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(error.failingURL, url)
     }
 
+    func testInterceptedServerErrorMarksDisconnectedFromConnectedOrUnknown() {
+        for current in [FrontEndConnectionState.connected, .disconnected, .unknown] {
+            let resolved = WebViewController.connectionStateForInterceptedServerError(current: current)
+
+            XCTAssertEqual(resolved, .disconnected, "expected disconnected when current is \(current)")
+        }
+    }
+
+    func testInterceptedServerErrorPreservesAuthInvalid() {
+        let resolved = WebViewController.connectionStateForInterceptedServerError(current: .authInvalid)
+
+        XCTAssertEqual(resolved, .authInvalid)
+    }
+
     func testHandledServerErrorResponseSuppressesFollowUpProvisionalFailure() {
         let sut = makeSUT()
         let overlayState = WebFrontendOverlayState()

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -155,6 +155,80 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(handler.cleanCacheCallCount, 0)
     }
 
+    func testServerErrorResponseDecisionShowsEmptyStateForProxyServerErrors() {
+        for statusCode in [500, 502, 503, 521, 522, 523, 524] {
+            let decision = WebViewController.decisionForMainFrameErrorResponse(
+                statusCode: statusCode,
+                responseURL: URL(string: "https://example.com/lovelace"),
+                initialURL: nil,
+                cfMitigated: nil
+            )
+
+            XCTAssertEqual(decision, .showEmptyState, "expected empty state for HTTP \(statusCode)")
+        }
+    }
+
+    func testServerErrorResponseDecisionAllowsClientErrorsToRender() {
+        for statusCode in [400, 401, 403, 404, 429] {
+            let decision = WebViewController.decisionForMainFrameErrorResponse(
+                statusCode: statusCode,
+                responseURL: URL(string: "https://example.com/lovelace"),
+                initialURL: nil,
+                cfMitigated: nil
+            )
+
+            XCTAssertEqual(decision, .allow, "expected allow for HTTP \(statusCode)")
+        }
+    }
+
+    func testServerErrorResponseDecisionAllowsCloudflareChallengeToRender() {
+        let decision = WebViewController.decisionForMainFrameErrorResponse(
+            statusCode: 503,
+            responseURL: URL(string: "https://example.com/lovelace"),
+            initialURL: nil,
+            cfMitigated: "Challenge"
+        )
+
+        XCTAssertEqual(decision, .allow)
+    }
+
+    func testServerErrorResponseDecisionReloadsDefaultURLForRestoredPage() {
+        let restoredURL = URL(string: "https://example.com/history")!
+
+        for statusCode in [404, 500] {
+            let decision = WebViewController.decisionForMainFrameErrorResponse(
+                statusCode: statusCode,
+                responseURL: restoredURL,
+                initialURL: restoredURL,
+                cfMitigated: nil
+            )
+
+            XCTAssertEqual(decision, .reloadDefaultURL, "expected reload for restored page on HTTP \(statusCode)")
+        }
+    }
+
+    func testServerErrorLoadErrorCarriesFailingURL() {
+        let url = URL(string: "https://example.com/lovelace")!
+
+        let error = WebViewController.serverErrorLoadError(for: url)
+
+        XCTAssertEqual(error.code, .badServerResponse)
+        XCTAssertEqual(error.failingURL, url)
+    }
+
+    func testHandledServerErrorResponseSuppressesFollowUpProvisionalFailure() {
+        let sut = makeSUT()
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+        sut.didHandleServerErrorResponse = true
+        sut.latestLoadError = URLError(.badServerResponse)
+
+        sut.webView(WKWebView(), didFailProvisionalNavigation: nil, withError: URLError(.timedOut))
+
+        XCTAssertFalse(sut.didHandleServerErrorResponse)
+        XCTAssertEqual((sut.latestLoadError as? URLError)?.code, .badServerResponse)
+    }
+
     private func makeSUT(server: Server = .fake()) -> WebViewController {
         let sut = WebViewController(server: server)
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))


### PR DESCRIPTION
## Summary

When Home Assistant is behind a reverse proxy (e.g. **Cloudflare**) and the origin is unreachable, the proxy returns its own error page as a successfully-delivered HTTP 5xx response. The web view rendered that foreign page ("Web server is down", "Bad gateway", "Origin is unreachable", …) instead of our own disconnected empty state, leaving users staring at a Cloudflare page inside the app.

`decidePolicyFor navigationResponse` already inspected the main-frame HTTP status code, but the only case it acted on was the *restored-page* recovery. Every other error response fell through to `decisionHandler(.allow)`, so the proxy error page was rendered.

## What this changes

For a **main-frame** response:

- **5xx that is not an interactive challenge** → cancel the response, set a `badServerResponse` load error (carrying the failing URL, so *Error details* / connectivity checks work), mark the frontend disconnected, and show the existing empty state + auto-reconnect **immediately** (no 10s grace, since there is nothing to wait for).
- **Cloudflare/proxy interactive challenges** (detected via the `cf-mitigated: challenge` header, e.g. "Just a moment…", Under Attack Mode) → still **allowed to render** so the user can complete them. This is deliberate: blocking these would lock out anyone who has to solve a challenge.
- **4xx** → unchanged (still rendered), to avoid interfering with auth/login/WAF pages that the user may need to see.
- **Restored-page recovery** and sub-frame handling → unchanged.

The branch logic is extracted into a pure `decisionForMainFrameErrorResponse(statusCode:responseURL:initialURL:cfMitigated:)` so it can be unit-tested (`WKNavigationResponse` isn't instantiable in tests). A `didHandleServerErrorResponse` flag suppresses the follow-up "frame load interrupted" callback that WebKit fires after `.cancel`, so it doesn't clobber the richer error we surfaced.

A diagnostic `Current.Log.error` line records the status code + `cf-ray` + `cf-mitigated` on every main-frame error response, so real-world Cloudflare responses are captured in exported logs (useful before considering broadening interception to 4xx).

## Scope / follow-ups

This is intentionally the conservative option (5xx only). Once field logs confirm what codes/headers real Cloudflare error/challenge/WAF states emit, we could broaden to selected 4xx (e.g. WAF `cf-mitigated: block`) while keeping the challenge exemption.

## Tests

`WebViewControllerTests` covers the decision matrix (proxy 5xx → empty state, 4xx → allow, challenge → allow, restored page → reload default, failing-URL propagation, follow-up-failure suppression).

## How to verify manually

Point the app at a server behind a Cloudflare tunnel and stop the origin (521/522), or return a 502/503 from the proxy: the app now shows the "You're disconnected" empty state (with Retry / Error details / auto-reconnect) instead of Cloudflare's page. Enabling "Under Attack Mode" (challenge) should still render the challenge so it can be solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)