### PR TITLE
Hide empty state close button behind a 5-tap dismiss

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -93,6 +93,7 @@ struct HomeAssistantView: View, WebFrontendView {
             WebViewEmptyStateView(
                 style: emptyState.style,
                 server: emptyState.server,
+                isLoading: overlayState.isLoading,
                 showsErrorDetailsButton: emptyState.showsErrorDetailsButton,
                 availableReauthURLTypes: emptyState.availableReauthURLTypes,
                 retryAction: emptyState.retryAction,

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
@@ -8,7 +8,7 @@ enum WebViewEmptyStateStyle: Equatable {
     enum HeaderAccessory {
         case none
         case settings
-        case close
+        case hiddenDismiss
     }
 
     var title: String {
@@ -65,7 +65,7 @@ enum WebViewEmptyStateStyle: Equatable {
     var trailingHeaderAccessory: HeaderAccessory {
         switch self {
         case .disconnected:
-            .close
+            .hiddenDismiss
         case .unauthenticated:
             .none
         case .recoveredServerNeedingReauthentication:

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -3,15 +3,19 @@ import Shared
 import SwiftUI
 
 struct WebViewEmptyStateView: View {
+    static let dismissTapThreshold = 5
+
     @State private var selectedReauthURLType: ConnectionInfo.URLType
     @State private var showURLPicker = false
     @State private var isPerformingPrimaryAction = false
     @State private var errorMessage: String?
+    @State private var dismissTapCount = 0
 
     private let headerAccessorySize = CGSize(width: 44, height: 44)
 
     let style: WebViewEmptyStateStyle
     let server: Server
+    let isLoading: Bool
     let showsErrorDetailsButton: Bool
     let availableReauthURLTypes: [ConnectionInfo.URLType]
     let retryAction: (() -> Void)?
@@ -25,6 +29,7 @@ struct WebViewEmptyStateView: View {
     init(
         style: WebViewEmptyStateStyle,
         server: Server,
+        isLoading: Bool = false,
         showsErrorDetailsButton: Bool = false,
         availableReauthURLTypes: [ConnectionInfo.URLType] = [],
         retryAction: (() -> Void)? = nil,
@@ -40,6 +45,7 @@ struct WebViewEmptyStateView: View {
     ) {
         self.style = style
         self.server = server
+        self.isLoading = isLoading
         self.showsErrorDetailsButton = showsErrorDetailsButton
         self.availableReauthURLTypes = availableReauthURLTypes
         self._selectedReauthURLType = State(initialValue: availableReauthURLTypes.first ?? .external)
@@ -186,11 +192,25 @@ struct WebViewEmptyStateView: View {
                 }
             )
             .accessibilityLabel(L10n.WebView.EmptyState.openSettingsButton)
-        case .close:
-            ModalCloseButton {
-                dismissAction?()
-            }
+        case .hiddenDismiss:
+            Color.clear
+                .frame(width: headerAccessorySize.width, height: headerAccessorySize.height)
+                .overlay {
+                    if isLoading {
+                        ProgressView()
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture(perform: registerDismissTap)
+                .accessibilityHidden(true)
         }
+    }
+
+    private func registerDismissTap() {
+        dismissTapCount += 1
+        guard dismissTapCount >= Self.dismissTapThreshold else { return }
+        dismissTapCount = 0
+        dismissAction?()
     }
 
     @ViewBuilder
@@ -341,6 +361,10 @@ struct WebViewEmptyStateView: View {
     WebViewEmptyStatePreview.view(style: .disconnected)
 }
 
+#Preview("Disconnected Loading") {
+    WebViewEmptyStatePreview.view(style: .disconnected, isLoading: true)
+}
+
 #Preview("Disconnected With Error Details") {
     WebViewEmptyStatePreview.view(
         style: .disconnected,
@@ -393,6 +417,7 @@ struct WebViewEmptyStateView: View {
 private enum WebViewEmptyStatePreview {
     static func view(
         style: WebViewEmptyStateStyle,
+        isLoading: Bool = false,
         showsErrorDetailsButton: Bool = false,
         availableReauthURLTypes: [ConnectionInfo.URLType] = [],
         errorDetailsAction: (() -> Void)? = nil,
@@ -405,6 +430,7 @@ private enum WebViewEmptyStatePreview {
         WebViewEmptyStateView(
             style: style,
             server: ServerFixture.standard,
+            isLoading: isLoading,
             showsErrorDetailsButton: showsErrorDetailsButton,
             availableReauthURLTypes: availableReauthURLTypes,
             retryAction: {},

--- a/Sources/App/Frontend/WebView/WebFrontendOverlayState.swift
+++ b/Sources/App/Frontend/WebView/WebFrontendOverlayState.swift
@@ -13,6 +13,8 @@ final class WebFrontendOverlayState: ObservableObject {
     /// Non-nil while the disconnected/unauthenticated empty state should be shown.
     @Published var emptyState: EmptyStateContent?
 
+    @Published var isLoading = false
+
     /// Theme color for the top status-bar inset, drawn by `HomeAssistantView` over the (always edge-to-edge)
     /// web view. Nil when there should be no themed bar — i.e. edge-to-edge / full-screen is enabled, or on
     /// Catalyst (where the native status-bar view handles it).

--- a/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+WebKitDelegates.swift
@@ -10,6 +10,7 @@ extension WebViewController {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         // Deliberately does not mark disconnected: a navigation starting isn't a lost connection. Only the
         // frontend (via the external bus) or a hard reload (`reload()`/`refresh()`) sets disconnected.
+        overlayState?.isLoading = true
         webViewExternalMessageHandler.stopImprovScanIfNeeded()
     }
 
@@ -40,6 +41,7 @@ extension WebViewController {
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         refreshControl.endRefreshing()
+        overlayState?.isLoading = false
         if let err = error as? URLError {
             if err.code != .cancelled {
                 Current.Log.error("Failure during nav: \(err)")
@@ -54,6 +56,7 @@ extension WebViewController {
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         refreshControl.endRefreshing()
+        overlayState?.isLoading = false
 
         let nsError = error as NSError
         let shouldShowError: Bool
@@ -84,6 +87,7 @@ extension WebViewController {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         refreshControl.endRefreshing()
+        overlayState?.isLoading = false
         latestLoadError = nil
 
         // in case the view appears again, don't reload


### PR DESCRIPTION
## Summary

The disconnected web view empty state showed a visible close button that was only ever meant as a safeguard. This removes the visible button and replaces it with an **invisible tap target** in the same spot (the trailing header accessory): tapping it **5 times** dismisses the empty state.

While the web view has a navigation in flight, that same spot renders a `ProgressView` instead of nothing, so the user gets a loading indicator. The spinner is also a 5-tap dismiss target.

The tap threshold is a constant: `WebViewEmptyStateView.dismissTapThreshold` (`5`).

## Changes

- `WebViewEmptyStateStyle`: renamed the `.close` header accessory to `.hiddenDismiss` (the trailing accessory for `.disconnected`).
- `WebViewEmptyStateView`: the `.hiddenDismiss` accessory is a clear, tappable 44×44 region that overlays a `ProgressView` when `isLoading`; taps accumulate and call the dismiss action on the 5th. Added an `isLoading` input and a `Disconnected Loading` preview.
- `WebFrontendOverlayState`: added `isLoading`, published from the web view's navigation delegate callbacks.
- `WebViewController+WebKitDelegates`: set `isLoading` on provisional-navigation start and clear it on finish/fail.
- `HomeAssistantView`: passes `overlayState.isLoading` into the empty state.

## Notes

The loading spinner surfaces whenever a navigation is in flight while the empty state is visible (e.g. a load in progress when the frontend signals a disconnect). The retry/auto-reconnect path still hard-resets the frontend, which tears the empty state down; if we'd rather keep the empty state up with the spinner during a reconnect, that's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)