### PR TITLE
Fix Tab key not moving between web view form fields on Mac Catalyst

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -194,6 +194,9 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         config.mediaTypesRequiringUserActionForPlayback = Current.settingsStore
             .mediaTypesRequiringUserActionForPlayback
             .wkMediaTypes
+        #if targetEnvironment(macCatalyst)
+        config.preferences.tabFocusesLinks = true
+        #endif
         return config
     }
 

--- a/Sources/App/Onboarding/API/OnboardingAuthLoginViewController.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthLoginViewController.swift
@@ -22,6 +22,9 @@ class OnboardingAuthLoginViewControllerImpl: UIViewController, OnboardingAuthLog
         let configuration = WKWebViewConfiguration()
         configuration.applicationNameForUserAgent = HomeAssistantAPI.applicationNameForUserAgent
         configuration.defaultWebpagePreferences.preferredContentMode = Current.isCatalyst ? .desktop : .mobile
+        #if targetEnvironment(macCatalyst)
+        configuration.preferences.tabFocusesLinks = true
+        #endif
 
         return WKWebView(frame: .zero, configuration: configuration)
     }()


### PR DESCRIPTION
## Summary

On Mac Catalyst, pressing **Tab** did not move focus between form fields in the onboarding login web view (and the same limitation applied to the main frontend web view). WebKit gates sequential focus traversal behind the `tabsToLinks` preference (exposed as `WKPreferences.tabFocusesLinks`), which **defaults to off**, so Tab was effectively a no-op on Catalyst. The classic tell for this is that **Option+Tab worked but plain Tab did not**.

The app was not intercepting the key itself: `WebViewController.keyCommands` (Catalyst-only) registers only Cmd-modified shortcuts (Cmd+C/V/X/R/F), with no bare Tab command.

## Fix

Enable `WKPreferences.tabFocusesLinks` on the `WKWebViewConfiguration`, gated to Mac Catalyst, in two places:

- `OnboardingAuthLoginViewControllerImpl` — the onboarding auth login web view
- `WebViewController.makeWebViewConfiguration()` — the main frontend web view

```swift
#if targetEnvironment(macCatalyst)
config.preferences.tabFocusesLinks = true
#endif
```

WebKit's native focus controller traverses the frontend's shadow-DOM form components (`ha-authorize` / `ha-textfield`) correctly, so no JavaScript workaround is needed. `tabFocusesLinks` is `API_AVAILABLE(macos(10.12.4))`, available on Mac Catalyst (macOS deployment floor is well above that), so no availability guard is required.

## Testing

- Mac Catalyst: on the onboarding login screen, Tab now moves between the username/password fields and on to the sign-in control; verified the same in the main frontend.

> Note: a separate, unrelated Ventura-era Catalyst regression can swallow `keyDown` entirely (Tab produces nothing at all, and Option+Tab also does nothing). That is an Apple-side bug outside app control and is not what this change addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)