### PR TITLE
Reference the '+' button in watch no-config-add copy

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1826,7 +1826,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.labels.complication_text_areas.trailing.description" = "The text to display on the trailing edge of the gauge.";
 "watch.labels.complication_text_areas.trailing.label" = "Trailing";
 "watch.labels.no_config" = "No watch configuration available, open the iOS App and create your configuration under companion app settings.";
-"watch.labels.no_config_add" = "With your iPhone nearby, you can add compatible entities to your Apple Watch using the button below, or from your companion app settings on iPhone.";
+"watch.labels.no_config_add_plus" = "With your iPhone nearby, you can add compatible entities to your Apple Watch using the '+' button, or from your companion app settings on iPhone.";
 "watch.labels.selected_pipeline.title" = "Pipeline";
 "watch.placeholder_complication_name" = "Placeholder";
 "watch.settings.auto" = "Auto";

--- a/Sources/Extensions/Watch/Home/WatchHomeView.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeView.swift
@@ -178,7 +178,7 @@ struct WatchHomeView: View {
     @ViewBuilder
     private var listContent: some View {
         if viewModel.watchConfig.items.isEmpty {
-            Text(verbatim: L10n.Watch.Labels.noConfigAdd)
+            Text(verbatim: L10n.Watch.Labels.noConfigAddPlus)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .listRowBackground(Color.clear)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -5694,8 +5694,8 @@ public enum L10n {
     public enum Labels {
       /// No watch configuration available, open the iOS App and create your configuration under companion app settings.
       public static var noConfig: String { return L10n.tr("Localizable", "watch.labels.no_config") }
-      /// With your iPhone nearby, you can add compatible entities to your Apple Watch using the button below, or from your companion app settings on iPhone.
-      public static var noConfigAdd: String { return L10n.tr("Localizable", "watch.labels.no_config_add") }
+      /// With your iPhone nearby, you can add compatible entities to your Apple Watch using the '+' button, or from your companion app settings on iPhone.
+      public static var noConfigAddPlus: String { return L10n.tr("Localizable", "watch.labels.no_config_add_plus") }
       public enum ComplicationGroup {
         public enum CircularSmall {
           /// Use circular small complications to display content in the corners of the Color watch face.


### PR DESCRIPTION
## Summary

Updates the Apple Watch empty-state copy so it points users at the **'+' button** instead of the vaguer "the button below".

Before:
> With your iPhone nearby, you can add compatible entities to your Apple Watch using the button below, or from your companion app settings on iPhone.

After:
> With your iPhone nearby, you can add compatible entities to your Apple Watch using the '+' button, or from your companion app settings on iPhone.

## Details

- Introduces a **new** localization key `watch.labels.no_config_add_plus` rather than editing the existing `watch.labels.no_config_add` value, per the repo convention that copy changes get a new key (so Lokalise doesn't ship stale translations for the old wording).
- Only `en.lproj/Localizable.strings` is touched; other locales are managed via Lokalise.
- Updated the usage in `WatchHomeView` and regenerated the SwiftGen `Strings.swift` accessor (`L10n.Watch.Labels.noConfigAddPlus`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)