### PR TITLE
Add a timeout to network-info fetch to prevent blank web view and lost connection on launch

### DIFF
--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -113,7 +113,7 @@ public class ConnectivityWrapper {
                 continuation.resume(returning: value)
             }
 
-            Task { resume(await fetch()) }
+            Task { await resume(fetch()) }
             Task {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * Double(NSEC_PER_SEC)))
                 resume(nil)

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -99,7 +99,7 @@ public class ConnectivityWrapper {
         await self?.systemNetworkStateFetch() ?? NetworkState()
     }
 
-    private func fetchNetworkState() async -> NetworkState {
+    func fetchNetworkState() async -> NetworkState {
         let fetch = performNetworkStateFetch
         let timeout = networkFetchTimeout
         let fetched: NetworkState? = await withCheckedContinuation { continuation in

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -89,8 +89,44 @@ public class ConnectivityWrapper {
         return cachedNetworkState
     }
 
+    /// Maximum time to await a network-info fetch before falling back to the last-known state.
+    /// Overridable in tests.
+    var networkFetchTimeout: TimeInterval = 3
+
+    /// The underlying network-info fetch, before the timeout guard in `fetchNetworkState()`.
+    /// Overridable in tests to simulate a fetch that never completes.
+    lazy var performNetworkStateFetch: () async -> NetworkState = { [weak self] in
+        await self?.systemNetworkStateFetch() ?? NetworkState()
+    }
+
     private func fetchNetworkState() async -> NetworkState {
-        let state = await performNetworkStateFetch()
+        let fetch = performNetworkStateFetch
+        let timeout = networkFetchTimeout
+        let fetched: NetworkState? = await withCheckedContinuation { continuation in
+            let lock = NSLock()
+            var didResume = false
+            let resume: (NetworkState?) -> Void = { value in
+                lock.lock()
+                defer { lock.unlock() }
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: value)
+            }
+
+            Task { resume(await fetch()) }
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * Double(NSEC_PER_SEC)))
+                resume(nil)
+            }
+        }
+
+        guard let state = fetched else {
+            Current.Log.error(
+                "network information fetch timed out after \(timeout)s; keeping last-known network state"
+            )
+            return readLastKnownNetworkState()
+        }
+
         updateLastKnownNetworkState(state)
         return state
     }
@@ -133,7 +169,7 @@ public class ConnectivityWrapper {
         observeConnectivityChanges()
     }
 
-    private func performNetworkStateFetch() async -> NetworkState {
+    private func systemNetworkStateFetch() async -> NetworkState {
         // macOS uses macBridge to retrieve network information, which is always current.
         let connectivity = Current.macBridge.networkConnectivity
         return NetworkState(
@@ -156,42 +192,24 @@ public class ConnectivityWrapper {
         observeConnectivityChanges()
     }
 
-    private func performNetworkStateFetch() async -> NetworkState {
-        let timeout: TimeInterval = 3
-        let state: NetworkState? = await withCheckedContinuation { continuation in
-            let lock = NSLock()
-            var didResume = false
-            let resume: (NetworkState?) -> Void = { value in
-                lock.lock()
-                defer { lock.unlock() }
-                guard !didResume else { return }
-                didResume = true
-                continuation.resume(returning: value)
-            }
-
+    private func systemNetworkStateFetch() async -> NetworkState {
+        let hotspotNetwork = await withCheckedContinuation { (continuation: CheckedContinuation<
+            NEHotspotNetwork?,
+            Never
+        >) in
             NEHotspotNetwork.fetchCurrent { hotspotNetwork in
-                Current.Log.verbose(
-                    "Current SSID: \(String(describing: hotspotNetwork?.ssid)), current BSSID: \(String(describing: hotspotNetwork?.bssid))"
-                )
-                #if targetEnvironment(simulator)
-                let ssid: String? = "Simulator"
-                #else
-                let ssid = hotspotNetwork?.ssid
-                #endif
-                resume(NetworkState(ssid: ssid, bssid: hotspotNetwork?.bssid))
-            }
-
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                resume(nil)
+                continuation.resume(returning: hotspotNetwork)
             }
         }
-
-        guard let state else {
-            Current.Log.error("NEHotspotNetwork.fetchCurrent timed out; keeping last-known network state")
-            return readLastKnownNetworkState()
-        }
-
-        return state
+        Current.Log.verbose(
+            "Current SSID: \(String(describing: hotspotNetwork?.ssid)), current BSSID: \(String(describing: hotspotNetwork?.bssid))"
+        )
+        #if targetEnvironment(simulator)
+        let ssid: String? = "Simulator"
+        #else
+        let ssid = hotspotNetwork?.ssid
+        #endif
+        return NetworkState(ssid: ssid, bssid: hotspotNetwork?.bssid)
     }
 
     #else
@@ -206,7 +224,7 @@ public class ConnectivityWrapper {
         // Reachability observer is not available for watchOS
     }
 
-    private func performNetworkStateFetch() async -> NetworkState {
+    private func systemNetworkStateFetch() async -> NetworkState {
         // The watch has no network information of its own (the phone-synced SSID was removed).
         NetworkState()
     }

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -157,23 +157,41 @@ public class ConnectivityWrapper {
     }
 
     private func performNetworkStateFetch() async -> NetworkState {
-        let hotspotNetwork = await withCheckedContinuation { (continuation: CheckedContinuation<
-            NEHotspotNetwork?,
-            Never
-        >) in
+        let timeout: TimeInterval = 3
+        let state: NetworkState? = await withCheckedContinuation { continuation in
+            let lock = NSLock()
+            var didResume = false
+            let resume: (NetworkState?) -> Void = { value in
+                lock.lock()
+                defer { lock.unlock() }
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: value)
+            }
+
             NEHotspotNetwork.fetchCurrent { hotspotNetwork in
-                continuation.resume(returning: hotspotNetwork)
+                Current.Log.verbose(
+                    "Current SSID: \(String(describing: hotspotNetwork?.ssid)), current BSSID: \(String(describing: hotspotNetwork?.bssid))"
+                )
+                #if targetEnvironment(simulator)
+                let ssid: String? = "Simulator"
+                #else
+                let ssid = hotspotNetwork?.ssid
+                #endif
+                resume(NetworkState(ssid: ssid, bssid: hotspotNetwork?.bssid))
+            }
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                resume(nil)
             }
         }
-        Current.Log.verbose(
-            "Current SSID: \(String(describing: hotspotNetwork?.ssid)), current BSSID: \(String(describing: hotspotNetwork?.bssid))"
-        )
-        #if targetEnvironment(simulator)
-        let ssid: String? = "Simulator"
-        #else
-        let ssid = hotspotNetwork?.ssid
-        #endif
-        return NetworkState(ssid: ssid, bssid: hotspotNetwork?.bssid)
+
+        guard let state else {
+            Current.Log.error("NEHotspotNetwork.fetchCurrent timed out; keeping last-known network state")
+            return readLastKnownNetworkState()
+        }
+
+        return state
     }
 
     #else

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -5,18 +5,24 @@ class ConnectivityWrapperTests: XCTestCase {
     private var previousCurrentNetworkState: (() async -> NetworkState)!
     private var previousLastKnownNetworkState: (() -> NetworkState)!
     private var previousRefreshNetworkInformation: (() async -> Void)!
+    private var previousPerformNetworkStateFetch: (() async -> NetworkState)!
+    private var previousNetworkFetchTimeout: TimeInterval!
 
     override func setUp() {
         super.setUp()
         previousCurrentNetworkState = Current.connectivity.currentNetworkState
         previousLastKnownNetworkState = Current.connectivity.lastKnownNetworkState
         previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
+        previousPerformNetworkStateFetch = Current.connectivity.performNetworkStateFetch
+        previousNetworkFetchTimeout = Current.connectivity.networkFetchTimeout
     }
 
     override func tearDown() {
         Current.connectivity.currentNetworkState = previousCurrentNetworkState
         Current.connectivity.lastKnownNetworkState = previousLastKnownNetworkState
         Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
+        Current.connectivity.performNetworkStateFetch = previousPerformNetworkStateFetch
+        Current.connectivity.networkFetchTimeout = previousNetworkFetchTimeout
         super.tearDown()
     }
 
@@ -67,5 +73,36 @@ class ConnectivityWrapperTests: XCTestCase {
         await Current.connectivity.refreshNetworkInformation()
 
         XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "fetched-ssid")
+    }
+
+    func testFetchThatTimesOutPreservesLastKnownState() async {
+        Current.connectivity.updateLastKnownNetworkState(
+            NetworkState(ssid: "cached-ssid", bssid: "cached-bssid")
+        )
+        Current.connectivity.networkFetchTimeout = 0.1
+        Current.connectivity.performNetworkStateFetch = {
+            try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
+            return NetworkState(ssid: "should-not-be-used")
+        }
+
+        let state = await Current.connectivity.currentNetworkState()
+
+        XCTAssertEqual(state.ssid, "cached-ssid")
+        XCTAssertEqual(state.bssid, "cached-bssid")
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "cached-ssid")
+    }
+
+    func testFetchThatCompletesUpdatesLastKnownState() async {
+        Current.connectivity.updateLastKnownNetworkState(NetworkState(ssid: "stale-ssid"))
+        Current.connectivity.networkFetchTimeout = 5
+        Current.connectivity.performNetworkStateFetch = {
+            NetworkState(ssid: "fresh-ssid", bssid: "fresh-bssid")
+        }
+
+        let state = await Current.connectivity.currentNetworkState()
+
+        XCTAssertEqual(state.ssid, "fresh-ssid")
+        XCTAssertEqual(state.bssid, "fresh-bssid")
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "fresh-ssid")
     }
 }

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -85,7 +85,7 @@ class ConnectivityWrapperTests: XCTestCase {
             return NetworkState(ssid: "should-not-be-used")
         }
 
-        let state = await Current.connectivity.currentNetworkState()
+        let state = await Current.connectivity.fetchNetworkState()
 
         XCTAssertEqual(state.ssid, "cached-ssid")
         XCTAssertEqual(state.bssid, "cached-bssid")
@@ -99,7 +99,7 @@ class ConnectivityWrapperTests: XCTestCase {
             NetworkState(ssid: "fresh-ssid", bssid: "fresh-bssid")
         }
 
-        let state = await Current.connectivity.currentNetworkState()
+        let state = await Current.connectivity.fetchNetworkState()
 
         XCTAssertEqual(state.ssid, "fresh-ssid")
         XCTAssertEqual(state.bssid, "fresh-bssid")


### PR DESCRIPTION
## Summary
Since URL resolution moved to `async` (#4942 / #4953), every path that picks the active URL awaits a fresh `NEHotspotNetwork.fetchCurrent`. That completion handler occasionally never fires (seen at launch/foreground, before location services are ready), and there was no timeout, so `refreshNetworkInformation()` / `activeURL()` would hang indefinitely. Everything awaiting them then stalls at once:

- the web view load hangs with `loadActiveURLIfNeededInProgress` stuck `true`, so no later event retries it — blank page that never reloads
- the WebSocket never connects (the cold-connect `Task` never reaches `connectAPI`)
- the account row shows no user (`currentUser` never completes)

This matches the intermittent reports of a blank web view that won't reload, servers listed with no username, and no WebSocket connection.

Fix: bound `performNetworkStateFetch()` with a 3s timeout. If the fetch doesn't return in time, keep the last-known network state instead of hanging (or overwriting it with an empty one). Callers always make progress, and the normal launch/foreground events re-drive the connection once network info is available. Catalyst reads network info synchronously and is unaffected.

## Screenshots
Not applicable — no user-facing/UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- 3s is a safety cap only; `fetchCurrent` normally returns well under a second.
- On timeout the previous value is preserved rather than cleared, so a slow fetch can't flip the app to the wrong URL.
