### PR TITLE
Add Home summary models and entity-filter engine

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -648,7 +648,15 @@
 		423179802D54FADD0037A8A4 /* AppIntentHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4231797F2D54FADD0037A8A4 /* AppIntentHaptics.swift */; };
 		423179812D54FADD0037A8A4 /* AppIntentHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4231797F2D54FADD0037A8A4 /* AppIntentHaptics.swift */; };
 		42333ADB2D0B1771001E8408 /* EntityRegistryListForDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42333ADA2D0B1771001E8408 /* EntityRegistryListForDisplay.swift */; };
+		DE189D6FAC056A475B08745C /* EnergyPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E5D7CE3AD35E7B254FE056 /* EnergyPreferences.swift */; };
+		07B263BBEEC2F577F71F1072 /* HomeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3C8362C57D0B0954335578 /* HomeSummaryState.swift */; };
+		748F5B25B6B5FD6FC398D1B2 /* EntityFilterEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB1C17F4D824B2F3EFF8C9E /* EntityFilterEvaluator.swift */; };
+		D7B00AB3E685CC490E73E005 /* HomeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F20B7860E1D687C2A893A /* HomeSummary.swift */; };
 		42333ADC2D0B1771001E8408 /* EntityRegistryListForDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42333ADA2D0B1771001E8408 /* EntityRegistryListForDisplay.swift */; };
+		DADC72F561F7C9CD14817D35 /* EnergyPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E5D7CE3AD35E7B254FE056 /* EnergyPreferences.swift */; };
+		6E749C37B3AB638214E39EF6 /* HomeSummaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3C8362C57D0B0954335578 /* HomeSummaryState.swift */; };
+		EF561FB2B2AC06DBF58D2C1D /* EntityFilterEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB1C17F4D824B2F3EFF8C9E /* EntityFilterEvaluator.swift */; };
+		612B469B118519B3EF7BE522 /* HomeSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F20B7860E1D687C2A893A /* HomeSummary.swift */; };
 		4237E6392E5333370023B673 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 4237E6382E5333370023B673 /* ZIPFoundation */; };
 		42383F702D9576F700C745F2 /* AppTriggerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42383F6F2D9576F700C745F2 /* AppTriggerSource.swift */; };
 		42383F712D9576F700C745F2 /* AppTriggerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42383F6F2D9576F700C745F2 /* AppTriggerSource.swift */; };
@@ -2504,6 +2512,10 @@
 		423178492FBB000100814230 /* AllowedTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllowedTagsView.swift; sourceTree = "<group>"; };
 		4231797F2D54FADD0037A8A4 /* AppIntentHaptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentHaptics.swift; sourceTree = "<group>"; };
 		42333ADA2D0B1771001E8408 /* EntityRegistryListForDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityRegistryListForDisplay.swift; sourceTree = "<group>"; };
+		53E5D7CE3AD35E7B254FE056 /* EnergyPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnergyPreferences.swift; sourceTree = "<group>"; };
+		5A3C8362C57D0B0954335578 /* HomeSummaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSummaryState.swift; sourceTree = "<group>"; };
+		5FB1C17F4D824B2F3EFF8C9E /* EntityFilterEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityFilterEvaluator.swift; sourceTree = "<group>"; };
+		B34F20B7860E1D687C2A893A /* HomeSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSummary.swift; sourceTree = "<group>"; };
 		4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIconColorProvider.swift; sourceTree = "<group>"; };
 		42383F6F2D9576F700C745F2 /* AppTriggerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTriggerSource.swift; sourceTree = "<group>"; };
 		4238DCA32DD1F1E300126434 /* AppSessionValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionValues.swift; sourceTree = "<group>"; };
@@ -5607,6 +5619,10 @@
 			isa = PBXGroup;
 			children = (
 				42333ADA2D0B1771001E8408 /* EntityRegistryListForDisplay.swift */,
+				53E5D7CE3AD35E7B254FE056 /* EnergyPreferences.swift */,
+				5A3C8362C57D0B0954335578 /* HomeSummaryState.swift */,
+				5FB1C17F4D824B2F3EFF8C9E /* EntityFilterEvaluator.swift */,
+				B34F20B7860E1D687C2A893A /* HomeSummary.swift */,
 				42F1DA6F2B4EE2E8002729BC /* HAAreasRegistryResponse.swift */,
 				42F1DA702B4EE2E8002729BC /* HAFloorRegistryResponse.swift */,
 				429C33C12F17A7010033EF5E /* HAUsagePredictionCommonControl.swift */,
@@ -9837,6 +9853,10 @@
 				11AF4D17249C8083006C74C0 /* With.swift in Sources */,
 				42C5E5AB2F7C20EA004797B5 /* EntityColorAttributesParser.swift in Sources */,
 				42333ADB2D0B1771001E8408 /* EntityRegistryListForDisplay.swift in Sources */,
+				DE189D6FAC056A475B08745C /* EnergyPreferences.swift in Sources */,
+				07B263BBEEC2F577F71F1072 /* HomeSummaryState.swift in Sources */,
+				748F5B25B6B5FD6FC398D1B2 /* EntityFilterEvaluator.swift in Sources */,
+				D7B00AB3E685CC490E73E005 /* HomeSummary.swift in Sources */,
 				11B38EF7275C54A300205C7B /* UpdateSensorsIntentHandler.swift in Sources */,
 				1141182B24AFA10900E6525C /* WebhookResponseHandler.swift in Sources */,
 				426266462C11B02C0081A818 /* InteractiveImmediateMessages.swift in Sources */,
@@ -10192,6 +10212,10 @@
 				D03D893620E0AEFA00D4F28D /* Environment.swift in Sources */,
 				D0EEF2CE214D8AE200D1D360 /* RealmZone.swift in Sources */,
 				42333ADC2D0B1771001E8408 /* EntityRegistryListForDisplay.swift in Sources */,
+				DADC72F561F7C9CD14817D35 /* EnergyPreferences.swift in Sources */,
+				6E749C37B3AB638214E39EF6 /* HomeSummaryState.swift in Sources */,
+				EF561FB2B2AC06DBF58D2C1D /* EntityFilterEvaluator.swift in Sources */,
+				612B469B118519B3EF7BE522 /* HomeSummary.swift in Sources */,
 				11C65CC0249838EB00D07FC7 /* StreamCameraResponse.swift in Sources */,
 				B6A258452232485300ADD202 /* Alamofire+EncryptedResponses.swift in Sources */,
 				1182620424F9C453000795C6 /* HACoreMediaObjectSystem.swift in Sources */,

--- a/Sources/Shared/HATypedRequest+App.swift
+++ b/Sources/Shared/HATypedRequest+App.swift
@@ -167,6 +167,12 @@ public extension HATypedRequest {
         ))
     }
 
+    static func energyPreferences() -> HATypedRequest<EnergyPreferences> {
+        HATypedRequest<EnergyPreferences>(request: .init(
+            type: .webSocket("energy/get_prefs")
+        ))
+    }
+
     static func fetchCurrentUser() -> HATypedRequest<HAResponseCurrentUser> {
         HATypedRequest<HAResponseCurrentUser>.currentUser()
     }

--- a/Sources/Shared/Models/EnergyPreferences.swift
+++ b/Sources/Shared/Models/EnergyPreferences.swift
@@ -1,0 +1,39 @@
+import Foundation
+import HAKit
+
+public struct EnergyPreferences: HADataDecodable, Codable, Equatable, Sendable {
+    public let energySources: [EnergySource]
+
+    public init(data: HAData) throws {
+        self.energySources = (try? data.decode("energy_sources")) ?? []
+    }
+
+    public init(energySources: [EnergySource]) {
+        self.energySources = energySources
+    }
+
+    public var hasGridSource: Bool {
+        energySources.contains { $0.type == "grid" && !($0.statEnergyFrom ?? "").isEmpty }
+    }
+}
+
+public struct EnergySource: HADataDecodable, Codable, Equatable, Sendable {
+    public let type: String
+    public let statEnergyFrom: String?
+    public let statEnergyTo: String?
+    public let name: String?
+
+    public init(data: HAData) throws {
+        self.type = try data.decode("type")
+        self.statEnergyFrom = try? data.decode("stat_energy_from")
+        self.statEnergyTo = try? data.decode("stat_energy_to")
+        self.name = try? data.decode("name")
+    }
+
+    public init(type: String, statEnergyFrom: String? = nil, statEnergyTo: String? = nil, name: String? = nil) {
+        self.type = type
+        self.statEnergyFrom = statEnergyFrom
+        self.statEnergyTo = statEnergyTo
+        self.name = name
+    }
+}

--- a/Sources/Shared/Models/EntityFilterEvaluator.swift
+++ b/Sources/Shared/Models/EntityFilterEvaluator.swift
@@ -1,0 +1,167 @@
+import Foundation
+import HAKit
+
+public struct EntityFilterEvaluator {
+    public struct ResolvedEntity: Sendable {
+        public let areaId: String?
+        public let deviceId: String?
+        public let category: EntityCategory
+        public let hidden: Bool
+        public let labels: [String]
+        public let platform: String?
+    }
+
+    public let states: [String: HAEntity]
+    private let entities: [String: ResolvedEntity]
+    private let deviceAreas: [String: String?]
+    private let areaFloors: [String: String?]
+    private let floorIds: Set<String>
+    private let entitiesByDevice: [String: [String]]
+
+    public init(
+        states: [String: HAEntity],
+        entityRegistry: EntityRegistryListForDisplay,
+        devices: [DeviceRegistryEntry],
+        areas: [HAAreasRegistryResponse],
+        floors: [HAFloorRegistryResponse]
+    ) {
+        self.states = states
+
+        var resolved: [String: ResolvedEntity] = [:]
+        var byDevice: [String: [String]] = [:]
+        for entity in entityRegistry.entities {
+            resolved[entity.entityId] = ResolvedEntity(
+                areaId: entity.areaId,
+                deviceId: entity.deviceId,
+                category: Self.category(for: entity.entityCategory, in: entityRegistry.entityCategories),
+                hidden: entity.isHidden,
+                labels: entity.labels ?? [],
+                platform: entity.platform
+            )
+            if let deviceId = entity.deviceId {
+                byDevice[deviceId, default: []].append(entity.entityId)
+            }
+        }
+        self.entities = resolved
+        self.entitiesByDevice = byDevice
+        self.deviceAreas = Dictionary(devices.map { ($0.id, $0.areaId) }, uniquingKeysWith: { first, _ in first })
+        self.areaFloors = Dictionary(areas.map { ($0.areaId, $0.floorId) }, uniquingKeysWith: { first, _ in first })
+        self.floorIds = Set(floors.map(\.floorId))
+    }
+
+    private static func category(for index: Int?, in categories: [String: String]) -> EntityCategory {
+        guard let index, let name = categories[String(index)] else { return .none }
+        return EntityCategory(rawValue: name) ?? .none
+    }
+
+    public var entityIds: [String] { Array(states.keys) }
+
+    public func deviceClass(of entityId: String) -> String {
+        states[entityId]?.attributes.dictionary["device_class"] as? String ?? "none"
+    }
+
+    public func findEntities(matching filters: [EntityFilter]) -> [String] {
+        let ids = entityIds
+        var seen = Set<String>()
+        var results: [String] = []
+        for filter in filters {
+            for id in ids where !seen.contains(id) && matches(entityId: id, filter: filter) {
+                seen.insert(id)
+                results.append(id)
+            }
+        }
+        return results
+    }
+
+    public func matches(entityId: String, filter: EntityFilter) -> Bool {
+        guard states[entityId] != nil else { return false }
+        guard passesDomain(Self.domain(of: entityId), filter: filter) else { return false }
+        guard passesDeviceClass(entityId: entityId, filter: filter) else { return false }
+        return passesContext(entityId: entityId, filter: filter)
+    }
+
+    private func passesDomain(_ domain: String, filter: EntityFilter) -> Bool {
+        if let domains = filter.domain, !domains.contains(domain) { return false }
+        if let hiddenDomains = filter.hiddenDomains, hiddenDomains.contains(domain) { return false }
+        return true
+    }
+
+    private func passesDeviceClass(entityId: String, filter: EntityFilter) -> Bool {
+        guard let deviceClasses = filter.deviceClass else { return true }
+        return deviceClasses.contains(deviceClass(of: entityId))
+    }
+
+    private func passesContext(entityId: String, filter: EntityFilter) -> Bool {
+        let resolved = entities[entityId]
+        if resolved?.hidden == true { return false }
+        let areaId = resolveAreaId(for: resolved)
+        let floorId = resolveFloorId(forArea: areaId)
+        guard passesLocation(resolved: resolved, areaId: areaId, floorId: floorId, filter: filter) else {
+            return false
+        }
+        return passesMetadata(resolved: resolved, filter: filter)
+    }
+
+    private func passesLocation(
+        resolved: ResolvedEntity?,
+        areaId: String?,
+        floorId: String?,
+        filter: EntityFilter
+    ) -> Bool {
+        if let floors = filter.floor, !floors.contains(floorId) { return false }
+        if let areas = filter.area, !areas.contains(areaId) { return false }
+        if let devices = filter.device, !devices.contains(resolved?.deviceId) { return false }
+        return true
+    }
+
+    private func passesMetadata(resolved: ResolvedEntity?, filter: EntityFilter) -> Bool {
+        if let labels = filter.label {
+            guard let resolved, resolved.labels.contains(where: labels.contains) else { return false }
+        }
+        if let categories = filter.entityCategory, !categories.contains(resolved?.category ?? .none) {
+            return false
+        }
+        return passesHiddenPlatform(resolved: resolved, filter: filter)
+    }
+
+    private func passesHiddenPlatform(resolved: ResolvedEntity?, filter: EntityFilter) -> Bool {
+        guard let hiddenPlatforms = filter.hiddenPlatform else { return true }
+        guard let resolved else { return false }
+        if let platform = resolved.platform, hiddenPlatforms.contains(platform) { return false }
+        return true
+    }
+
+    private func resolveAreaId(for resolved: ResolvedEntity?) -> String? {
+        if let areaId = resolved?.areaId { return areaId }
+        if let deviceId = resolved?.deviceId { return deviceAreas[deviceId] ?? nil }
+        return nil
+    }
+
+    private func resolveFloorId(forArea areaId: String?) -> String? {
+        guard let areaId, let floorId = areaFloors[areaId] ?? nil, floorIds.contains(floorId) else {
+            return nil
+        }
+        return floorId
+    }
+
+    public func isLowBattery(entityId: String, threshold: Double = 20) -> Bool {
+        guard let state = states[entityId]?.state else { return false }
+        if Self.domain(of: entityId) == Domain.binarySensor.rawValue {
+            return state == "on"
+        }
+        if isBatteryCharging(entityId: entityId) { return false }
+        guard let value = Double(state) else { return false }
+        return value <= threshold
+    }
+
+    private func isBatteryCharging(entityId: String) -> Bool {
+        guard let deviceId = entities[entityId]?.deviceId, let siblings = entitiesByDevice[deviceId] else {
+            return false
+        }
+        return siblings.contains { deviceClass(of: $0) == "battery_charging" && states[$0]?.state == "on" }
+    }
+
+    private static func domain(of entityId: String) -> String {
+        String(entityId.split(separator: ".", maxSplits: 1).first ?? "")
+    }
+}

--- a/Sources/Shared/Models/HAAreasRegistryResponse.swift
+++ b/Sources/Shared/Models/HAAreasRegistryResponse.swift
@@ -10,6 +10,8 @@ public struct HAAreasRegistryResponse: HADataDecodable {
     public let icon: String?
     // Identifier of the floor this area belongs to, if any.
     public let floorId: String?
+    public let temperatureEntityId: String?
+    public let humidityEntityId: String?
     public init(data: HAData) throws {
         try self.init(
             aliases: data.decode("aliases"),
@@ -17,7 +19,9 @@ public struct HAAreasRegistryResponse: HADataDecodable {
             name: data.decode("name"),
             picture: try? data.decode("picture"),
             icon: try? data.decode("icon"),
-            floorId: try? data.decode("floor_id")
+            floorId: try? data.decode("floor_id"),
+            temperatureEntityId: try? data.decode("temperature_entity_id"),
+            humidityEntityId: try? data.decode("humidity_entity_id")
         )
     }
 
@@ -27,7 +31,9 @@ public struct HAAreasRegistryResponse: HADataDecodable {
         name: String,
         picture: String? = nil,
         icon: String? = nil,
-        floorId: String? = nil
+        floorId: String? = nil,
+        temperatureEntityId: String? = nil,
+        humidityEntityId: String? = nil
     ) {
         self.aliases = aliases
         self.areaId = areaId
@@ -35,5 +41,7 @@ public struct HAAreasRegistryResponse: HADataDecodable {
         self.picture = picture
         self.icon = icon
         self.floorId = floorId
+        self.temperatureEntityId = temperatureEntityId
+        self.humidityEntityId = humidityEntityId
     }
 }

--- a/Sources/Shared/Models/HomeSummary.swift
+++ b/Sources/Shared/Models/HomeSummary.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+public enum EntityCategory: String, Codable, Sendable, CaseIterable {
+    case none
+    case config
+    case diagnostic
+}
+
+public struct EntityFilter: Equatable, Sendable {
+    public var domain: [String]?
+    public var deviceClass: [String]?
+    public var device: [String?]?
+    public var area: [String?]?
+    public var floor: [String?]?
+    public var label: [String]?
+    public var entityCategory: [EntityCategory]?
+    public var hiddenPlatform: [String]?
+    public var hiddenDomains: [String]?
+
+    public init(
+        domain: [String]? = nil,
+        deviceClass: [String]? = nil,
+        device: [String?]? = nil,
+        area: [String?]? = nil,
+        floor: [String?]? = nil,
+        label: [String]? = nil,
+        entityCategory: [EntityCategory]? = nil,
+        hiddenPlatform: [String]? = nil,
+        hiddenDomains: [String]? = nil
+    ) {
+        self.domain = domain
+        self.deviceClass = deviceClass
+        self.device = device
+        self.area = area
+        self.floor = floor
+        self.label = label
+        self.entityCategory = entityCategory
+        self.hiddenPlatform = hiddenPlatform
+        self.hiddenDomains = hiddenDomains
+    }
+}
+
+public enum HomeSummary: String, CaseIterable, Sendable {
+    case light
+    case climate
+    case security
+    case mediaPlayers = "media_players"
+    case maintenance
+    case energy
+    case persons
+
+    public var iconName: String {
+        switch self {
+        case .light: return "lamps"
+        case .climate: return "home-thermometer"
+        case .security: return "security"
+        case .mediaPlayers: return "multimedia"
+        case .maintenance: return "wrench"
+        case .energy: return "lightning-bolt"
+        case .persons: return "account-multiple"
+        }
+    }
+
+    public var icon: MaterialDesignIcons {
+        MaterialDesignIcons(named: iconName.replacingOccurrences(of: "-", with: "_"))
+    }
+
+    public var themeColor: String {
+        switch self {
+        case .light: return "amber"
+        case .climate: return "deep-orange"
+        case .security: return "blue-grey"
+        case .mediaPlayers: return "blue"
+        case .maintenance: return "grey"
+        case .energy: return "amber"
+        case .persons: return "green"
+        }
+    }
+
+    public var filters: [EntityFilter] {
+        switch self {
+        case .light: return Self.lightEntityFilters
+        case .climate: return Self.climateEntityFilters
+        case .security: return Self.securityEntityFilters
+        case .mediaPlayers: return Self.mediaPlayerEntityFilters
+        case .maintenance: return Self.maintenanceEntityFilters
+        case .energy: return []
+        case .persons: return Self.personEntityFilters
+        }
+    }
+}
+
+public extension HomeSummary {
+    static let lightEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.light.rawValue], entityCategory: [.none]),
+    ]
+
+    static let climateEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.climate.rawValue], entityCategory: [.none]),
+        EntityFilter(domain: [Domain.humidifier.rawValue], entityCategory: [.none]),
+        EntityFilter(domain: [Domain.fan.rawValue], entityCategory: [.none]),
+        EntityFilter(domain: [Domain.waterHeater.rawValue], entityCategory: [.none]),
+        EntityFilter(
+            domain: [Domain.cover.rawValue],
+            deviceClass: ["awning", "blind", "curtain", "shade", "shutter", "window", "none"],
+            entityCategory: [.none]
+        ),
+        EntityFilter(domain: [Domain.binarySensor.rawValue], deviceClass: ["window"], entityCategory: [.none]),
+    ]
+
+    static let securityEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.camera.rawValue], entityCategory: [.none]),
+        EntityFilter(domain: [Domain.alarmControlPanel.rawValue], entityCategory: [.none]),
+        EntityFilter(domain: [Domain.lock.rawValue], entityCategory: [.none]),
+        EntityFilter(
+            domain: [Domain.cover.rawValue],
+            deviceClass: ["door", "garage", "gate", "window"],
+            entityCategory: [.none]
+        ),
+        EntityFilter(
+            domain: [Domain.binarySensor.rawValue],
+            deviceClass: [
+                "lock",
+                "door",
+                "window",
+                "garage_door",
+                "opening",
+                "carbon_monoxide",
+                "gas",
+                "moisture",
+                "safety",
+                "smoke",
+                "tamper",
+            ],
+            entityCategory: [.none]
+        ),
+        EntityFilter(domain: [Domain.binarySensor.rawValue], deviceClass: ["tamper"], entityCategory: [.diagnostic]),
+    ]
+
+    static let maintenanceEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.sensor.rawValue], deviceClass: ["battery"]),
+        EntityFilter(domain: [Domain.binarySensor.rawValue], deviceClass: ["battery"]),
+    ]
+
+    static let mediaPlayerEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.mediaPlayer.rawValue], entityCategory: [.none]),
+    ]
+
+    static let personEntityFilters: [EntityFilter] = [
+        EntityFilter(domain: [Domain.person.rawValue]),
+    ]
+}
+
+public extension HomeSummary {
+    static func applicableSummaries(
+        evaluator: EntityFilterEvaluator,
+        panelPaths: Set<String>? = nil,
+        energyPreferences: EnergyPreferences? = nil
+    ) -> [HomeSummary] {
+        allCases.filter {
+            $0.isApplicable(evaluator: evaluator, panelPaths: panelPaths, energyPreferences: energyPreferences)
+        }
+    }
+
+    func isApplicable(
+        evaluator: EntityFilterEvaluator,
+        panelPaths: Set<String>?,
+        energyPreferences: EnergyPreferences?
+    ) -> Bool {
+        switch self {
+        case .energy:
+            let hasPanel = panelPaths?.contains(rawValue) ?? true
+            return hasPanel && (energyPreferences?.hasGridSource ?? false)
+        case .light, .climate, .security, .maintenance:
+            let hasPanel = panelPaths?.contains(rawValue) ?? true
+            return hasPanel && !evaluator.findEntities(matching: filters).isEmpty
+        case .mediaPlayers, .persons:
+            return !evaluator.findEntities(matching: filters).isEmpty
+        }
+    }
+}

--- a/Sources/Shared/Models/HomeSummaryState.swift
+++ b/Sources/Shared/Models/HomeSummaryState.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public enum HomeSummaryState: Equatable, Sendable {
+    case lights(onCount: Int)
+    case climate(minTemperature: Double, maxTemperature: Double)
+    case climateUnavailable
+    case security(SecuritySummary)
+    case mediaPlayers(playingCount: Int)
+    case maintenance(lowBattery: Int, unavailableBattery: Int)
+    case energy(totalConsumption: Double?)
+    case persons(homeCount: Int)
+}
+
+public struct SecuritySummary: Equatable, Sendable {
+    public let hasSecurityEntities: Bool
+    public let unlockedLocks: Int
+    public let disarmedAlarms: Int
+
+    public init(hasSecurityEntities: Bool, unlockedLocks: Int, disarmedAlarms: Int) {
+        self.hasSecurityEntities = hasSecurityEntities
+        self.unlockedLocks = unlockedLocks
+        self.disarmedAlarms = disarmedAlarms
+    }
+}
+
+public extension HomeSummary {
+    func state(using evaluator: EntityFilterEvaluator, areas: [HAAreasRegistryResponse]) -> HomeSummaryState {
+        switch self {
+        case .light:
+            let matched = evaluator.findEntities(matching: filters)
+            return .lights(onCount: matched.filter { evaluator.states[$0]?.state == "on" }.count)
+        case .climate:
+            let temperatures = areas
+                .compactMap(\.temperatureEntityId)
+                .compactMap { evaluator.states[$0]?.state }
+                .compactMap(Double.init)
+            guard let minimum = temperatures.min(), let maximum = temperatures.max() else {
+                return .climateUnavailable
+            }
+            return .climate(minTemperature: minimum, maxTemperature: maximum)
+        case .security:
+            let matched = evaluator.findEntities(matching: filters)
+            let locks = matched.filter { $0.hasPrefix("\(Domain.lock.rawValue).") }
+            let alarms = matched.filter { $0.hasPrefix("\(Domain.alarmControlPanel.rawValue).") }
+            guard !locks.isEmpty || !alarms.isEmpty else {
+                return .security(SecuritySummary(hasSecurityEntities: false, unlockedLocks: 0, disarmedAlarms: 0))
+            }
+            let unlockedStates: Set<String> = ["unlocked", "jammed", "open"]
+            return .security(SecuritySummary(
+                hasSecurityEntities: true,
+                unlockedLocks: locks.filter { unlockedStates.contains(evaluator.states[$0]?.state ?? "") }.count,
+                disarmedAlarms: alarms.filter { evaluator.states[$0]?.state == "disarmed" }.count
+            ))
+        case .mediaPlayers:
+            let matched = evaluator.findEntities(matching: filters)
+            return .mediaPlayers(playingCount: matched.filter { evaluator.states[$0]?.state == "playing" }.count)
+        case .maintenance:
+            let matched = evaluator.findEntities(matching: filters)
+            return .maintenance(
+                lowBattery: matched.filter { evaluator.isLowBattery(entityId: $0) }.count,
+                unavailableBattery: matched.filter { evaluator.states[$0]?.state == "unavailable" }.count
+            )
+        case .energy:
+            return .energy(totalConsumption: nil)
+        case .persons:
+            let matched = evaluator.findEntities(matching: filters)
+            return .persons(homeCount: matched.filter { evaluator.states[$0]?.state == "home" }.count)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds the model and request layer for the default-dashboard **summaries** (light, climate, security, media players, maintenance, energy, people) so they can be reused natively. These are derived client-side from entity states and registries, matching the frontend's `home` strategy.

- `EntityFilter` plus `EntityFilterEvaluator` — a Swift port of the frontend entity-filter engine (`generateEntityFilter` / `findEntities`).
- `HomeSummary` enum — each summary's entity filters, icon, colour, and applicability.
- `HomeSummaryState` — computes each summary's value (lights on, temperature range, lock/alarm status, media playing, low/unavailable batteries, people home).
- New `energy/get_prefs` request + `EnergyPreferences` model, and `temperature_entity_id` / `humidity_entity_id` added to the area registry model.

No UI yet — this is groundwork for a native summaries view. Energy's live value is left for a follow-up (needs the energy statistics collection).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
