### PR TITLE
Reset frontend asset cache when the server version changes

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -27,9 +27,29 @@ extension WebViewController {
             object: nil
         )
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(serverVersionDidChange(_:)),
+            name: HomeAssistantAPI.serverVersionDidChangeNotification,
+            object: nil
+        )
+
         tokens.append(server.observe { [weak self] _ in
             self?.connectionInfoDidChange()
         })
+    }
+
+    @objc func serverVersionDidChange(_ notification: Notification) {
+        guard let changedServer = notification.object as? Server,
+              changedServer.identifier == server.identifier else { return }
+
+        Current.Log.info("Resetting frontend cache for \(server.identifier) after server version change")
+        Current.websiteDataStoreHandler
+            .cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) { [weak self] in
+                DispatchQueue.main.async {
+                    self?.reload()
+                }
+            }
     }
 
     @objc func connectionInfoDidChange() {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -43,6 +43,8 @@ public class HomeAssistantAPI {
     }
 
     public static let didConnectNotification = Notification.Name(rawValue: "HomeAssistantAPIConnected")
+    public static let serverVersionDidChangeNotification =
+        Notification.Name(rawValue: "HomeAssistantServerVersionDidChange")
 
     public private(set) var manager: Alamofire.Session!
     public static let unauthenticatedManager: Alamofire.Session = configureSessionManager()
@@ -456,15 +458,27 @@ public class HomeAssistantAPI {
         )
 
         return promise.done { [self] config in
+            let previousVersion = server.info.version
+            let fetchedVersion = try? Version(hassVersion: config.Version)
+
             server.update { serverInfo in
                 serverInfo.connection.cloudhookURL = config.CloudhookURL
                 serverInfo.connection.set(address: config.RemoteUIURL, for: .remoteUI)
                 serverInfo.remoteName = config.LocationName ?? ServerInfo.defaultName
                 serverInfo.hassDeviceId = config.hassDeviceId
 
-                if let version = try? Version(hassVersion: config.Version) {
-                    serverInfo.version = version
+                if let fetchedVersion {
+                    serverInfo.version = fetchedVersion
                 }
+            }
+
+            if let fetchedVersion, fetchedVersion != previousVersion {
+                Current.Log
+                    .info("Server \(server.identifier) version changed from \(previousVersion) to \(fetchedVersion)")
+                NotificationCenter.default.post(
+                    name: Self.serverVersionDidChangeNotification,
+                    object: server
+                )
             }
 
             Current.crashReporter.setUserProperty(value: config.Version, name: "HA_Version")

--- a/Sources/Shared/WebsiteDataStoreHandler.swift
+++ b/Sources/Shared/WebsiteDataStoreHandler.swift
@@ -2,16 +2,22 @@ import Foundation
 import WebKit
 
 public protocol WebsiteDataStoreHandlerProtocol {
-    func cleanCache(completion: (() -> Void)?)
+    func cleanCache(dataTypes: Set<String>, completion: (() -> Void)?)
+}
+
+public extension WebsiteDataStoreHandlerProtocol {
+    func cleanCache(completion: (() -> Void)? = nil) {
+        cleanCache(dataTypes: WKWebsiteDataStore.allWebsiteDataTypes(), completion: completion)
+    }
 }
 
 final class WebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
-    public func cleanCache(completion: (() -> Void)? = nil) {
+    func cleanCache(dataTypes: Set<String>, completion: (() -> Void)? = nil) {
         WKWebsiteDataStore.default().removeData(
-            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            ofTypes: dataTypes,
             modifiedSince: Date(timeIntervalSince1970: 0),
             completionHandler: {
-                Current.Log.verbose("Cleaned browser cache")
+                Current.Log.verbose("Cleaned browser cache for data types: \(dataTypes)")
                 completion?()
             }
         )
@@ -22,4 +28,11 @@ public enum WebsiteDataStoreHandlerImpl {
     static func build() -> WebsiteDataStoreHandlerProtocol {
         WebsiteDataStoreHandler()
     }
+
+    public static let frontendAssetDataTypes: Set<String> = [
+        WKWebsiteDataTypeDiskCache,
+        WKWebsiteDataTypeMemoryCache,
+        WKWebsiteDataTypeFetchCache,
+        WKWebsiteDataTypeServiceWorkerRegistrations,
+    ]
 }


### PR DESCRIPTION
## Summary

Detects when the connected server's Home Assistant version changes and proactively resets the stale frontend asset cache before the web view keeps serving old bundles.

When a server is upgraded, the on-disk frontend assets (hashed JS/HTML, service worker) cached by `WKWebView` can become stale and occasionally get stuck, leaving the user on an outdated frontend. Today the only recovery is a manual double pull-to-refresh or the debug "Reset web cache" button.

## What changed

- **Detection** — `getConfig()` compares the currently stored `ServerInfo.version` (the base) against the version reported by `get_config`. On any difference it posts a new `HomeAssistantAPI.serverVersionDidChangeNotification` (with the `Server` as its object).
- **Reaction** — `WebViewController` observes that notification, filters to its own server, drops the frontend asset caches, and reloads.
- **Scoped cache clear** — `WebsiteDataStoreHandler` gains a `cleanCache(dataTypes:completion:)` variant; the existing full-wipe `cleanCache(completion:)` is kept as a convenience. A new `WebsiteDataStoreHandlerImpl.frontendAssetDataTypes` set clears only disk/memory/fetch caches and service-worker registrations.

## Why the scoped clear matters

The automatic reset deliberately **does not** touch cookies, localStorage or IndexedDB, so the frontend stays logged in and keeps its local preferences. Only the asset caches are dropped. The nuclear full wipe remains reserved for the explicit user actions (debug button, double pull-to-refresh).

## Behaviour notes

- Runs on every connect (`getConfig` is part of the connect flow) and when Settings opens, so an upgrade that happened while the app was open is also caught.
- No spurious resets on normal launches: the web view is created with the current version already stored, so a matching `get_config` posts nothing. Self-terminating (the new version is stored before the notification fires), so there is no reload loop.
- Reactive by design (a brief reload after the initial paint) rather than blocking launch on a pre-fetch.

## Testing

- Verified formatting/lint via the pre-commit `fastlane autocorrect` (SwiftFormat + Rubocop, no changes needed).
- Manual verification of the upgrade path pending on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
