### PR TITLE
Remove folder chevron on Apple Watch grid layout

### DIFF
--- a/Sources/Extensions/Watch/Home/MagicItemRow/WatchFolderRow.swift
+++ b/Sources/Extensions/Watch/Home/MagicItemRow/WatchFolderRow.swift
@@ -137,5 +137,6 @@ struct WatchFolderRow: View {
             ) {}
         }
         .listRowBackground(Color.clear)
+        .listRowInsets(EdgeInsets())
     }
 }

--- a/Sources/Extensions/Watch/Home/MagicItemRow/WatchFolderRow.swift
+++ b/Sources/Extensions/Watch/Home/MagicItemRow/WatchFolderRow.swift
@@ -64,19 +64,12 @@ struct WatchFolderRow: View {
     }
 
     private var gridIcon: some View {
-        ZStack(alignment: .topTrailing) {
-            Image(uiImage: item.icon(info: itemInfo).image(
-                ofSize: .init(width: 28, height: 28),
-                color: iconColor
-            ))
-            .foregroundStyle(Color(uiColor: iconColor))
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            Image(systemSymbol: .chevronRight)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .padding(DesignSystem.Spaces.half)
-                .accessibilityHidden(true)
-        }
+        Image(uiImage: item.icon(info: itemInfo).image(
+            ofSize: .init(width: 28, height: 28),
+            color: iconColor
+        ))
+        .foregroundStyle(Color(uiColor: iconColor))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .accessibilityLabel(Text(item.name(info: itemInfo)))
     }
@@ -98,7 +91,7 @@ struct WatchFolderRow: View {
     }
 }
 
-#Preview {
+#Preview("List") {
     MaterialDesignIcons.register()
     return List {
         WatchFolderRow(
@@ -116,5 +109,33 @@ struct WatchFolderRow: View {
                 customization: .init(iconColor: "#03A9F4")
             )
         ) {}
+    }
+}
+
+#Preview("Grid") {
+    MaterialDesignIcons.register()
+    return List {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 60), spacing: DesignSystem.Spaces.one)],
+            spacing: DesignSystem.Spaces.one
+        ) {
+            WatchFolderRow(
+                item: .init(
+                    id: "folder1",
+                    serverId: "",
+                    type: .folder,
+                    customization: .init(iconColor: "#03A9F4"),
+                    displayText: "Living Room"
+                ),
+                itemInfo: .init(
+                    id: "folder1",
+                    name: "Living Room",
+                    iconName: "mdi:folder",
+                    customization: .init(iconColor: "#03A9F4")
+                ),
+                layout: .grid
+            ) {}
+        }
+        .listRowBackground(Color.clear)
     }
 }


### PR DESCRIPTION
## Summary

Remove the chevron from folder tiles in the Apple Watch home screen **grid** layout.

In grid layout the chevron was pinned to the corner of the small tile, where it looked cramped and could sit in the region the tile's 16pt rounded corner rounds away (so it visually got lost). The folder icon on its own already signals that the item is a folder, so the chevron is dropped on grid tiles.

The **list** layout is unchanged and keeps its trailing chevron.

## Changes

- `WatchFolderRow.gridIcon`: drop the corner chevron overlay; the grid tile now shows just the folder icon.
- Added a `Grid` `#Preview` alongside the existing (now named `List`) preview so the grid folder tile can be checked in Xcode.

## Testing

- Verified via Xcode previews (List and Grid). List layout behavior is unchanged.

> Note: `fastlane autocorrect` could not be run locally in this worktree (BuildTools SPM resolution issue), but the change was hand-checked against the SwiftFormat/SwiftLint rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)