### PR TITLE
Fix area name shown twice in the camera player subtitle

### DIFF
--- a/Sources/Extensions/EntityProvider+Details.swift
+++ b/Sources/Extensions/EntityProvider+Details.swift
@@ -14,7 +14,8 @@ public enum EntityContextSubtitle {
     ///     configured — it's prepended as the first segment; pass `nil` to omit it (single-server).
     ///   - floorName: The floor the entity's area belongs to. Pass this only when it's needed to
     ///     disambiguate two areas that share the same name; pass `nil` to omit it otherwise.
-    ///   - areaName: The area the entity belongs to, if any.
+    ///   - areaName: The area the entity belongs to, if any. Omitted when the entity name already
+    ///     contains it (e.g. a camera named after its location), to avoid echoing it in the subtitle.
     ///   - deviceName: The device the entity belongs to, if any. Omitted when it merely repeats the entity name.
     ///   - entityName: The entity's resolved display name (used to avoid echoing it as the device name).
     ///   - entityId: The entity id, used as a last-resort context when no other context is available.
@@ -40,7 +41,8 @@ public enum EntityContextSubtitle {
         if let floorName, !floorName.isEmpty {
             parts.append(floorName)
         }
-        if let areaName, !areaName.isEmpty {
+        if let areaName, !areaName.isEmpty,
+           entityName.range(of: areaName, options: [.caseInsensitive, .diacriticInsensitive]) == nil {
             parts.append(areaName)
         }
         if let deviceName, !deviceName.isEmpty,

--- a/Sources/Extensions/EntityProvider+Details.swift
+++ b/Sources/Extensions/EntityProvider+Details.swift
@@ -34,6 +34,7 @@ public enum EntityContextSubtitle {
         domain: Domain?,
         fallbackToEntityId: Bool = true
     ) -> String? {
+        let normalizedEntityName = entityName.normalizedForAreaComparison
         var parts: [String] = []
         if let serverName, !serverName.isEmpty {
             parts.append(serverName)
@@ -41,9 +42,14 @@ public enum EntityContextSubtitle {
         if let floorName, !floorName.isEmpty {
             parts.append(floorName)
         }
-        if let areaName, !areaName.isEmpty,
-           entityName.range(of: areaName, options: [.caseInsensitive, .diacriticInsensitive]) == nil {
-            parts.append(areaName)
+        if let areaName {
+            // Drop the area when the name already conveys it (e.g. a camera named after its location).
+            // Compared in the trimmed, case-/diacritic-insensitive form used everywhere area names are
+            // matched, so "Bedroom " and "Bedroom" count as the same and whitespace-only areas are ignored.
+            let normalizedAreaName = areaName.normalizedForAreaComparison
+            if !normalizedAreaName.isEmpty, normalizedEntityName.range(of: normalizedAreaName) == nil {
+                parts.append(areaName)
+            }
         }
         if let deviceName, !deviceName.isEmpty,
            deviceName.range(of: entityName, options: [.caseInsensitive, .diacriticInsensitive]) == nil {

--- a/Sources/Extensions/EntityProvider+Details.swift
+++ b/Sources/Extensions/EntityProvider+Details.swift
@@ -14,8 +14,7 @@ public enum EntityContextSubtitle {
     ///     configured — it's prepended as the first segment; pass `nil` to omit it (single-server).
     ///   - floorName: The floor the entity's area belongs to. Pass this only when it's needed to
     ///     disambiguate two areas that share the same name; pass `nil` to omit it otherwise.
-    ///   - areaName: The area the entity belongs to, if any. Omitted when the entity name already
-    ///     contains it (e.g. a camera named after its location), to avoid echoing it in the subtitle.
+    ///   - areaName: The area the entity belongs to, if any.
     ///   - deviceName: The device the entity belongs to, if any. Omitted when it merely repeats the entity name.
     ///   - entityName: The entity's resolved display name (used to avoid echoing it as the device name).
     ///   - entityId: The entity id, used as a last-resort context when no other context is available.
@@ -34,7 +33,6 @@ public enum EntityContextSubtitle {
         domain: Domain?,
         fallbackToEntityId: Bool = true
     ) -> String? {
-        let normalizedEntityName = entityName.normalizedForAreaComparison
         var parts: [String] = []
         if let serverName, !serverName.isEmpty {
             parts.append(serverName)
@@ -42,18 +40,22 @@ public enum EntityContextSubtitle {
         if let floorName, !floorName.isEmpty {
             parts.append(floorName)
         }
-        if let areaName {
-            // Drop the area when the name already conveys it (e.g. a camera named after its location).
-            // Compared in the trimmed, case-/diacritic-insensitive form used everywhere area names are
-            // matched, so "Bedroom " and "Bedroom" count as the same and whitespace-only areas are ignored.
-            let normalizedAreaName = areaName.normalizedForAreaComparison
-            if !normalizedAreaName.isEmpty, normalizedEntityName.range(of: normalizedAreaName) == nil {
-                parts.append(areaName)
-            }
+        if let areaName, !areaName.isEmpty {
+            parts.append(areaName)
         }
         if let deviceName, !deviceName.isEmpty,
            deviceName.range(of: entityName, options: [.caseInsensitive, .diacriticInsensitive]) == nil {
             parts.append(deviceName)
+        }
+        // Collapse segments that resolve to the same label so the line doesn't repeat one twice — a
+        // device named after its area is common (e.g. a "Sala" camera in the "Sala" area) and would
+        // otherwise render as "Sala • Sala". Compared in the trimmed, case-/diacritic-insensitive form,
+        // which also drops whitespace-only segments that would show as a blank piece.
+        var seenNormalizedParts = Set<String>()
+        parts = parts.filter { part in
+            let normalized = part.normalizedForAreaComparison
+            guard !normalized.isEmpty else { return false }
+            return seenNormalizedParts.insert(normalized).inserted
         }
         guard parts.isEmpty else {
             return parts.joined(separator: " • ")

--- a/Tests/App/Area/EntityContextSubtitle.test.swift
+++ b/Tests/App/Area/EntityContextSubtitle.test.swift
@@ -68,58 +68,42 @@ struct EntityContextSubtitleTests {
         #expect(subtitle == "Living Room")
     }
 
-    @Test func areaIsOmittedWhenEntityNameMatchesIt() {
-        // A camera named after its location (entity name == area) would otherwise repeat the area in
-        // its subtitle, so the area segment is dropped and only the entity id fallback remains.
+    @Test func deviceRepeatingTheAreaIsCollapsedToOneSegment() {
+        // A camera device named after its area (common in Home Assistant) would otherwise render the
+        // same label twice, e.g. "Sala • Sala".
         let subtitle = EntityContextSubtitle.make(
-            areaName: "Front Door",
-            deviceName: nil,
-            entityName: "Front Door",
-            entityId: "camera.front_door",
+            areaName: "Sala",
+            deviceName: "Sala",
+            entityName: "Camera",
+            entityId: "camera.sala",
             domain: .camera
         )
-        #expect(subtitle == "camera.front_door")
+        #expect(subtitle == "Sala")
     }
 
-    @Test func areaIsOmittedWhenEntityNameContainsItCaseAndDiacriticInsensitive() {
+    @Test func duplicateSegmentsAreCollapsedIgnoringCaseDiacriticsAndWhitespace() {
         let subtitle = EntityContextSubtitle.make(
-            areaName: "café",
-            deviceName: "Cafe Camera",
-            entityName: "Cafe Camera",
-            entityId: "camera.cafe",
+            areaName: "Escritório do Bruno",
+            deviceName: "escritorio do bruno ",
+            entityName: "Camera",
+            entityId: "camera.office",
             domain: .camera
         )
-        // Area "café" is contained (case/diacritic-insensitively) in the entity name, and the device
-        // repeats the entity name, so both are omitted — leaving only the entity id fallback.
-        #expect(subtitle == "camera.cafe")
+        #expect(subtitle == "Escritório do Bruno")
     }
 
-    @Test func areaIsKeptWhenEntityNameDoesNotContainIt() {
+    @Test func distinctAreaAndDeviceAreBothKept() {
         let subtitle = EntityContextSubtitle.make(
-            areaName: "Living Room",
-            deviceName: nil,
-            entityName: "Front Door",
-            entityId: "camera.front_door",
+            areaName: "Meter cupboard",
+            deviceName: "C100",
+            entityName: "C100 mainStream",
+            entityId: "camera.c100",
             domain: .camera
         )
-        #expect(subtitle == "Living Room")
+        #expect(subtitle == "Meter cupboard • C100")
     }
 
-    @Test func areaIsOmittedWhenEntityNameMatchesItIgnoringSurroundingWhitespace() {
-        // Area names are compared in their trimmed, folded form, so trailing whitespace on the area
-        // (which core/frontend treat as equivalent) must not prevent the duplication from being removed.
-        let subtitle = EntityContextSubtitle.make(
-            areaName: "Bedroom ",
-            deviceName: nil,
-            entityName: "Bedroom",
-            entityId: "camera.bedroom",
-            domain: .camera
-        )
-        #expect(subtitle == "camera.bedroom")
-    }
-
-    @Test func whitespaceOnlyAreaIsIgnored() {
-        // A whitespace-only area name carries no meaning and must not render as a blank subtitle segment.
+    @Test func whitespaceOnlyAreaIsDroppedRatherThanShownBlank() {
         let subtitle = EntityContextSubtitle.make(
             areaName: "   ",
             deviceName: nil,

--- a/Tests/App/Area/EntityContextSubtitle.test.swift
+++ b/Tests/App/Area/EntityContextSubtitle.test.swift
@@ -67,6 +67,43 @@ struct EntityContextSubtitleTests {
         )
         #expect(subtitle == "Living Room")
     }
+
+    @Test func areaIsOmittedWhenEntityNameMatchesIt() {
+        // A camera named after its location (entity name == area) would otherwise repeat the area in
+        // its subtitle, so the area segment is dropped and only the entity id fallback remains.
+        let subtitle = EntityContextSubtitle.make(
+            areaName: "Front Door",
+            deviceName: nil,
+            entityName: "Front Door",
+            entityId: "camera.front_door",
+            domain: .camera
+        )
+        #expect(subtitle == "camera.front_door")
+    }
+
+    @Test func areaIsOmittedWhenEntityNameContainsItCaseAndDiacriticInsensitive() {
+        let subtitle = EntityContextSubtitle.make(
+            areaName: "café",
+            deviceName: "Cafe Camera",
+            entityName: "Cafe Camera",
+            entityId: "camera.cafe",
+            domain: .camera
+        )
+        // Area "café" is contained (case/diacritic-insensitively) in the entity name, and the device
+        // repeats the entity name, so both are omitted — leaving only the entity id fallback.
+        #expect(subtitle == "camera.cafe")
+    }
+
+    @Test func areaIsKeptWhenEntityNameDoesNotContainIt() {
+        let subtitle = EntityContextSubtitle.make(
+            areaName: "Living Room",
+            deviceName: nil,
+            entityName: "Front Door",
+            entityId: "camera.front_door",
+            domain: .camera
+        )
+        #expect(subtitle == "Living Room")
+    }
 }
 
 struct AppAreaFloorDisambiguationTests {

--- a/Tests/App/Area/EntityContextSubtitle.test.swift
+++ b/Tests/App/Area/EntityContextSubtitle.test.swift
@@ -104,6 +104,31 @@ struct EntityContextSubtitleTests {
         )
         #expect(subtitle == "Living Room")
     }
+
+    @Test func areaIsOmittedWhenEntityNameMatchesItIgnoringSurroundingWhitespace() {
+        // Area names are compared in their trimmed, folded form, so trailing whitespace on the area
+        // (which core/frontend treat as equivalent) must not prevent the duplication from being removed.
+        let subtitle = EntityContextSubtitle.make(
+            areaName: "Bedroom ",
+            deviceName: nil,
+            entityName: "Bedroom",
+            entityId: "camera.bedroom",
+            domain: .camera
+        )
+        #expect(subtitle == "camera.bedroom")
+    }
+
+    @Test func whitespaceOnlyAreaIsIgnored() {
+        // A whitespace-only area name carries no meaning and must not render as a blank subtitle segment.
+        let subtitle = EntityContextSubtitle.make(
+            areaName: "   ",
+            deviceName: nil,
+            entityName: "Backyard",
+            entityId: "camera.backyard",
+            domain: .camera
+        )
+        #expect(subtitle == "camera.backyard")
+    }
 }
 
 struct AppAreaFloorDisambiguationTests {


### PR DESCRIPTION
## Summary
In the camera player, each camera shows a **name** plus a secondary context line built from `Floor • Area • Device` (via the shared `EntityContextSubtitle.make`). When a camera's **device is named after its area** — very common, e.g. a "Sala" camera whose device is also "Sala" in the "Sala" area — the area label rendered **twice**: `Sala • Sala`. This is independent of the entity name (in the reported case the entity is just "Camera"), so it also affected the name badge and every picker row.

The fix deduplicates the assembled segments by their trimmed, case-/diacritic-insensitive form (the same normalization already used to compare area names elsewhere in this file), so a repeated label collapses to a single segment. It also drops whitespace-only segments that would otherwise render as a blank piece. Distinct area/device pairs are unaffected — e.g. `Meter cupboard • C100` stays as-is. Because `make` is the single source of truth for these subtitles, the fix applies consistently across the camera player and the other pickers.

- `Sources/Extensions/EntityProvider+Details.swift`: collapse duplicate/blank segments after assembling `Server • Floor • Area • Device`.
- `Tests/App/Area/EntityContextSubtitle.test.swift`: cover the device==area collapse (incl. case/diacritic/whitespace differences), the distinct-pair case, and whitespace-only area.

## Screenshots
Reported case (from the camera picker): rows such as `Camera — Sala • Sala`, `Camera — Lavanderia • Lavanderia`, `Camera — Escritório do Bruno • Escritório do Bruno`. After the fix each collapses to a single `Sala` / `Lavanderia` / `Escritório do Bruno`, while `C100 mainStream — Meter cupboard • C100` is unchanged.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No user-facing strings changed. When collapsing leaves no other context, the subtitle falls back to the entity id exactly as before — that existing fallback behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnnKx798FwR1WPra9JxZeR