### PR TITLE
Keep Watch sync error visible for 3s with clearer copy

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1850,7 +1850,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.home.sync.waiting" = "Waiting for iPhone…";
 "watch.sync.starting" = "Starting sync…";
 "watch.sync.progress" = "%1$d/%2$d";
-"watch.sync.error.unreachable" = "Can't reach your iPhone. Open Home Assistant on it, keep it nearby, and try again.";
+"watch.sync.error.connection_failed" = "We couldn't connect to your iPhone. Open the Home Assistant app on your iPhone, then tap the reload button here on your Watch.";
 "watch.sync.error.generic" = "Sync failed. Please try again.";
 "watch.sync.error.data" = "Received incomplete data from iPhone. Please try again.";
 "watch.sync.retry" = "Try Again";

--- a/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
+++ b/Sources/Extensions/Watch/Home/WatchHomeViewModel.swift
@@ -43,6 +43,13 @@ final class WatchHomeViewModel: ObservableObject {
     private var lastStatusChangeAt: Date?
     private var pendingStatusWork: DispatchWorkItem?
 
+    /// Minimum time the sync error banner stays on screen once shown. A failed sync immediately reloads
+    /// the local cache, whose completion would otherwise clear the banner within a fraction of a second —
+    /// too fast to read. Keep it up long enough to be legible.
+    private static let minErrorDisplay: TimeInterval = 3
+    private var errorShownAt: Date?
+    private var pendingErrorClearWork: DispatchWorkItem?
+
     /// Set the status text, but never faster than `minStatusDisplay`; rapid updates coalesce to the
     /// latest value once the minimum on-screen time for the previous one has elapsed. Must be called on
     /// the main thread (all call sites are).
@@ -304,7 +311,7 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func startDatabaseSync() {
         guard Communicator.shared.currentReachability == .immediatelyReachable else {
-            failSync(L10n.Watch.Sync.Error.unreachable)
+            failSync(L10n.Watch.Sync.Error.connectionFailed)
             return
         }
         resetSyncState()
@@ -316,7 +323,7 @@ final class WatchHomeViewModel: ObservableObject {
         ), errorHandler: { [weak self] error in
             Task { @MainActor in
                 Current.Log.error("Database sync start failed: \(error.localizedDescription)")
-                self?.failSync(L10n.Watch.Sync.Error.unreachable)
+                self?.failSync(L10n.Watch.Sync.Error.connectionFailed)
             }
         })
     }
@@ -407,8 +414,7 @@ final class WatchHomeViewModel: ObservableObject {
             text: "Apple Watch database sync failed: \(friendlyMessage)",
             type: .database
         ))
-        errorMessage = friendlyMessage
-        showError = true
+        presentError(friendlyMessage)
         updateLoading(isLoading: false)
         // Never leave the user with nothing: show whatever is cached locally.
         loadCache()
@@ -424,8 +430,57 @@ final class WatchHomeViewModel: ObservableObject {
 
     @MainActor
     private func clearError() {
+        // A brand-new sync attempt supersedes any previous error, so drop it right away.
+        pendingErrorClearWork?.cancel()
+        pendingErrorClearWork = nil
         errorMessage = ""
         showError = false
+        errorShownAt = nil
+    }
+
+    /// Show the sync error banner, cancelling any pending auto-dismiss and stamping when it appeared.
+    /// Must be called on the main thread (all call sites are).
+    private func presentError(_ message: String) {
+        pendingErrorClearWork?.cancel()
+        pendingErrorClearWork = nil
+        errorMessage = message
+        showError = true
+        errorShownAt = Current.date()
+    }
+
+    /// Hide the sync error banner, but never before it has been on screen for `minErrorDisplay`, so the
+    /// cache reload that follows a failed sync can't blink the message away before it can be read.
+    /// Must be called on the main thread (all call sites are).
+    private func dismissError() {
+        guard showError else {
+            pendingErrorClearWork?.cancel()
+            pendingErrorClearWork = nil
+            errorMessage = ""
+            errorShownAt = nil
+            return
+        }
+
+        let elapsed = errorShownAt.map { Current.date().timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+        if elapsed >= Self.minErrorDisplay {
+            pendingErrorClearWork?.cancel()
+            pendingErrorClearWork = nil
+            errorMessage = ""
+            showError = false
+            errorShownAt = nil
+            return
+        }
+
+        // Keep it up for the remainder of the minimum display window, coalescing repeated requests.
+        pendingErrorClearWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            errorMessage = ""
+            showError = false
+            errorShownAt = nil
+            pendingErrorClearWork = nil
+        }
+        pendingErrorClearWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + (Self.minErrorDisplay - elapsed), execute: work)
     }
 
     /// Render the home screen straight from the local GRDB — the config table plus names/icons/context
@@ -495,15 +550,13 @@ final class WatchHomeViewModel: ObservableObject {
 
     private func displayError(message: String) {
         DispatchQueue.main.async { [weak self] in
-            self?.errorMessage = message
-            self?.showError = true
+            self?.presentError(message)
         }
     }
 
     private func resetError() {
         DispatchQueue.main.async { [weak self] in
-            self?.errorMessage = ""
-            self?.showError = false
+            self?.dismissError()
         }
     }
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6295,12 +6295,12 @@ public enum L10n {
       /// Starting sync…
       public static var starting: String { return L10n.tr("Localizable", "watch.sync.starting") }
       public enum Error {
+        /// We couldn't connect to your iPhone. Open the Home Assistant app on your iPhone, then tap the reload button here on your Watch.
+        public static var connectionFailed: String { return L10n.tr("Localizable", "watch.sync.error.connection_failed") }
         /// Received incomplete data from iPhone. Please try again.
         public static var data: String { return L10n.tr("Localizable", "watch.sync.error.data") }
         /// Sync failed. Please try again.
         public static var generic: String { return L10n.tr("Localizable", "watch.sync.error.generic") }
-        /// Can't reach your iPhone. Open Home Assistant on it, keep it nearby, and try again.
-        public static var unreachable: String { return L10n.tr("Localizable", "watch.sync.error.unreachable") }
       }
     }
   }


### PR DESCRIPTION
## Summary
On the Apple Watch home view, the sync error banner shown when the Watch can't reach the iPhone only flashed for a fraction of a second — too fast to read. `failSync()` set the error, then the cache reload that immediately follows cleared it right away.

This PR makes two changes:

- **Keep the banner on screen for at least 3 seconds.** A `minErrorDisplay` window is introduced, mirroring the existing `loadingStatus` throttle: `presentError()` stamps when the banner appeared and `dismissError()` defers clearing until it has been visible long enough. Starting a fresh sync (`clearError`) still drops it immediately so a new attempt starts clean.
- **Clearer, actionable copy via a new localization key.** The old `watch.sync.error.unreachable` copy ("Can't reach your iPhone…") is replaced by a new key `watch.sync.error.connection_failed`: _"We couldn't connect to your iPhone. Open the Home Assistant app on your iPhone, then tap the reload button here on your Watch."_ — which tells the user exactly what to do.

## Screenshots
<!-- Not able to capture watchOS simulator screenshots in this environment. The change affects the existing orange sync-error banner on the Watch home view: same styling, longer visibility, new wording. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The old `watch.sync.error.unreachable` string is now unused and was removed; the remaining `en.lproj` translations are managed via Lokalise. Both `failSync` call sites for the unreachable case now point at the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAMVeBjG59jHvM9DtkeLk1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAMVeBjG59jHvM9DtkeLk1)_