### PR TITLE
Recover from hung URL load attempts instead of leaving the web view blank until force-kill

### DIFF
--- a/Sources/App/Frontend/Extensions/ConnectionInfo+WebView.swift
+++ b/Sources/App/Frontend/Extensions/ConnectionInfo+WebView.swift
@@ -25,6 +25,19 @@ extension Server {
         await webviewURLComponents()?.url
     }
 
+    /// Like `webviewURL()`, but evaluated synchronously against the last-known network state.
+    ///
+    /// Only for fallback paths that cannot await (e.g. recovering after an async load attempt
+    /// hung): the network information may be stale, so prefer `webviewURL()` everywhere else.
+    func webviewURLUsingLastKnownNetworkState() -> URL? {
+        guard let activeURL = activeURLUsingLastKnownNetworkState(),
+              var components = URLComponents(url: activeURL, resolvingAgainstBaseURL: true) else {
+            return nil
+        }
+        components.queryItems = [URLQueryItem(name: "external_auth", value: "1")]
+        return components.url
+    }
+
     func webviewURL(from raw: String) async -> URL? {
         guard let baseURLComponents = await webviewURLComponents(), let baseURL = baseURLComponents.url else {
             return nil

--- a/Sources/App/Frontend/Extensions/ConnectionInfo+WebView.swift
+++ b/Sources/App/Frontend/Extensions/ConnectionInfo+WebView.swift
@@ -3,22 +3,15 @@ import Shared
 
 extension Server {
     func webviewURLComponents() async -> URLComponents? {
-        if Current.appConfiguration == .fastlaneSnapshot, prefs.object(forKey: "useDemo") != nil {
-            return URLComponents(string: "https://companion.home-assistant.io/app/ios/demo")!
+        if let demoComponents = demoModeURLComponents() {
+            return demoComponents
         }
         guard let activeURL = await activeURL() else {
             Current.Log.error("No activeURL available while webviewURLComponents was called")
             return nil
         }
 
-        guard var components = URLComponents(url: activeURL, resolvingAgainstBaseURL: true) else {
-            return nil
-        }
-
-        let queryItem = URLQueryItem(name: "external_auth", value: "1")
-        components.queryItems = [queryItem]
-
-        return components
+        return webviewURLComponents(for: activeURL)
     }
 
     func webviewURL() async -> URL? {
@@ -30,12 +23,28 @@ extension Server {
     /// Only for fallback paths that cannot await (e.g. recovering after an async load attempt
     /// hung): the network information may be stale, so prefer `webviewURL()` everywhere else.
     func webviewURLUsingLastKnownNetworkState() -> URL? {
-        guard let activeURL = activeURLUsingLastKnownNetworkState(),
-              var components = URLComponents(url: activeURL, resolvingAgainstBaseURL: true) else {
+        if let demoComponents = demoModeURLComponents() {
+            return demoComponents.url
+        }
+        guard let activeURL = activeURLUsingLastKnownNetworkState() else {
+            return nil
+        }
+        return webviewURLComponents(for: activeURL)?.url
+    }
+
+    private func demoModeURLComponents() -> URLComponents? {
+        guard Current.appConfiguration == .fastlaneSnapshot, prefs.object(forKey: "useDemo") != nil else {
+            return nil
+        }
+        return URLComponents(string: "https://companion.home-assistant.io/app/ios/demo")!
+    }
+
+    private func webviewURLComponents(for activeURL: URL) -> URLComponents? {
+        guard var components = URLComponents(url: activeURL, resolvingAgainstBaseURL: true) else {
             return nil
         }
         components.queryItems = [URLQueryItem(name: "external_auth", value: "1")]
-        return components.url
+        return components
     }
 
     func webviewURL(from raw: String) async -> URL? {

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -56,28 +56,68 @@ extension WebViewController {
         }
     }
 
+    /// How long an in-flight `loadActiveURLIfNeeded()` attempt may run before a new call treats it
+    /// as hung and replaces it. Attempts normally finish in well under a second; the network-info
+    /// fetch they depend on is itself bounded by `ConnectivityWrapper.networkFetchTimeout`.
+    static let loadActiveURLStaleInterval: TimeInterval = 5
+
     @objc func loadActiveURLIfNeeded() {
-        guard !loadActiveURLIfNeededInProgress else {
-            Current.Log.info("loadActiveURLIfNeeded already in progress, skipping")
+        var previousAttemptHung = false
+        if let inFlightTask = loadActiveURLTask {
+            let startDate = loadActiveURLTaskStartDate ?? .distantPast
+            guard Current.date().timeIntervalSince(startDate) >= Self.loadActiveURLStaleInterval else {
+                Current.Log.info("loadActiveURLIfNeeded already in progress, skipping")
+                return
+            }
+
+            // The attempt hung mid-flight (e.g. the app was suspended while it refreshed network
+            // information during a background launch). Cancel it so it can't apply a stale result
+            // later, and start over -- otherwise the web view stays blank until the app is killed.
+            Current.Log.error("loadActiveURLIfNeeded in progress since \(startDate), assuming hung and restarting")
+            inFlightTask.cancel()
+            loadActiveURLTask = nil
+            loadActiveURLTaskStartDate = nil
+            previousAttemptHung = true
+        }
+
+        guard !isAppInBackground() else {
+            // Loading would bail anyway, and starting async work while backgrounded risks hanging
+            // mid-flight on suspension; didBecomeActive triggers another call once loading can work.
+            Current.Log.info("not loading, in background")
             return
         }
 
-        loadActiveURLIfNeededInProgress = true
-        Current.Log.info("loadActiveURLIfNeeded called")
+        // The async path hung once already, so don't depend on it recovering: if the web view is
+        // still empty, load the last-known URL synchronously right away -- a possibly stale URL
+        // beats a blank screen -- and let the fresh attempt below correct it if the network changed.
+        if previousAttemptHung, webView.url == nil,
+           let fallbackURL = server.webviewURLUsingLastKnownNetworkState() {
+            Current.Log.info("loading fallback URL after hung attempt")
+            load(request: URLRequest(url: fallbackURL))
+        }
 
-        Task { [weak self] in
+        Current.Log.info("loadActiveURLIfNeeded called")
+        loadActiveURLTaskStartDate = Current.date()
+        loadActiveURLTask = Task { [weak self] in
             defer {
-                self?.loadActiveURLIfNeededInProgress = false
+                // A cancelled attempt has already been replaced; it must not clear its replacement.
+                if !Task.isCancelled {
+                    self?.loadActiveURLTask = nil
+                    self?.loadActiveURLTaskStartDate = nil
+                }
             }
 
             guard let self else { return }
             // `webviewURL()` refreshes the network information (e.g. current SSID) before
             // evaluating which URL is active.
             guard let webviewURL = await server.webviewURL() else {
+                guard !Task.isCancelled else { return }
                 Current.Log.info("not loading, no url")
                 showNoActiveURLError()
                 return
             }
+
+            guard !Task.isCancelled else { return }
 
             hideNoActiveURLError()
 
@@ -87,13 +127,10 @@ extension WebViewController {
                 return
             }
 
-            guard UIApplication.shared.applicationState != .background else {
-                Current.Log.info("not loading, in background")
-                return
-            }
-
             // if we aren't showing a url or it's an incorrect url, update it -- otherwise, leave it alone
-            await load(request: URLRequest(url: resolvedLoadURL(for: webviewURL)))
+            let request = URLRequest(url: await resolvedLoadURL(for: webviewURL))
+            guard !Task.isCancelled else { return }
+            load(request: request)
         }
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -57,11 +57,22 @@ extension WebViewController {
     }
 
     /// How long an in-flight `loadActiveURLIfNeeded()` attempt may run before a new call treats it
-    /// as hung and replaces it. Attempts normally finish in well under a second; the network-info
-    /// fetch they depend on is itself bounded by `ConnectivityWrapper.networkFetchTimeout`.
-    static let loadActiveURLStaleInterval: TimeInterval = 5
+    /// as hung and replaces it. Attempts normally finish in well under a second; the worst healthy
+    /// case is two sequential network-info fetches (`webviewURL()` plus the kiosk dashboard URL),
+    /// each bounded by `ConnectivityWrapper.networkFetchTimeout` (3s), so 10s means only a truly
+    /// stuck attempt gets replaced.
+    static let loadActiveURLStaleInterval: TimeInterval = 10
 
     @objc func loadActiveURLIfNeeded() {
+        // Checked before the stale handling below so a hung attempt is only ever replaced while
+        // active, when the fallback load and the fresh attempt can both actually run.
+        guard !isAppInBackground() else {
+            // Loading would bail anyway, and starting async work while backgrounded risks hanging
+            // mid-flight on suspension; didBecomeActive triggers another call once loading can work.
+            Current.Log.info("not loading, in background")
+            return
+        }
+
         var previousAttemptHung = false
         if let inFlightTask = loadActiveURLTask {
             let startDate = loadActiveURLTaskStartDate ?? .distantPast
@@ -78,13 +89,6 @@ extension WebViewController {
             loadActiveURLTask = nil
             loadActiveURLTaskStartDate = nil
             previousAttemptHung = true
-        }
-
-        guard !isAppInBackground() else {
-            // Loading would bail anyway, and starting async work while backgrounded risks hanging
-            // mid-flight on suspension; didBecomeActive triggers another call once loading can work.
-            Current.Log.info("not loading, in background")
-            return
         }
 
         // The async path hung once already, so don't depend on it recovering: if the web view is
@@ -129,7 +133,10 @@ extension WebViewController {
 
             // if we aren't showing a url or it's an incorrect url, update it -- otherwise, leave it alone
             let request = URLRequest(url: await resolvedLoadURL(for: webviewURL))
-            guard !Task.isCancelled else { return }
+            // Re-check the background state too: backgrounding mid-flight could otherwise start a
+            // navigation that stalls on suspension, leaving webView.url pointing at a page that
+            // never loaded (which would defeat the empty-web-view checks above and the fallback).
+            guard !Task.isCancelled, !isAppInBackground() else { return }
             load(request: request)
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -138,7 +138,7 @@ extension WebViewController {
         }
 
         // if we aren't showing a url or it's an incorrect url, update it -- otherwise, leave it alone
-        let request = URLRequest(url: await resolvedLoadURL(for: webviewURL))
+        let request = await URLRequest(url: resolvedLoadURL(for: webviewURL))
         // Re-check the background state too: backgrounding mid-flight could otherwise start a
         // navigation that stalls on suspension, leaving webView.url pointing at a page that
         // never loaded (which would defeat the empty-web-view checks above and the fallback).

--- a/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+URLLoading.swift
@@ -111,34 +111,39 @@ extension WebViewController {
                 }
             }
 
-            guard let self else { return }
-            // `webviewURL()` refreshes the network information (e.g. current SSID) before
-            // evaluating which URL is active.
-            guard let webviewURL = await server.webviewURL() else {
-                guard !Task.isCancelled else { return }
-                Current.Log.info("not loading, no url")
-                showNoActiveURLError()
-                return
-            }
-
-            guard !Task.isCancelled else { return }
-
-            hideNoActiveURLError()
-
-            guard webView.url == nil || webView.url?.baseIsEqual(to: webviewURL) == false else {
-                // we also tell the webview -- maybe it failed to connect itself? -- to refresh if needed
-                webView.evaluateJavaScript("checkForMissingHassConnectionAndReload()", completionHandler: nil)
-                return
-            }
-
-            // if we aren't showing a url or it's an incorrect url, update it -- otherwise, leave it alone
-            let request = URLRequest(url: await resolvedLoadURL(for: webviewURL))
-            // Re-check the background state too: backgrounding mid-flight could otherwise start a
-            // navigation that stalls on suspension, leaving webView.url pointing at a page that
-            // never loaded (which would defeat the empty-web-view checks above and the fallback).
-            guard !Task.isCancelled, !isAppInBackground() else { return }
-            load(request: request)
+            await self?.performLoadActiveURL()
         }
+    }
+
+    /// The async body of `loadActiveURLIfNeeded()`; only ever runs as `loadActiveURLTask`, and
+    /// re-checks cancellation after every await so a replaced attempt cannot apply stale results.
+    private func performLoadActiveURL() async {
+        // `webviewURL()` refreshes the network information (e.g. current SSID) before
+        // evaluating which URL is active.
+        guard let webviewURL = await server.webviewURL() else {
+            guard !Task.isCancelled else { return }
+            Current.Log.info("not loading, no url")
+            showNoActiveURLError()
+            return
+        }
+
+        guard !Task.isCancelled else { return }
+
+        hideNoActiveURLError()
+
+        guard webView.url == nil || webView.url?.baseIsEqual(to: webviewURL) == false else {
+            // we also tell the webview -- maybe it failed to connect itself? -- to refresh if needed
+            webView.evaluateJavaScript("checkForMissingHassConnectionAndReload()", completionHandler: nil)
+            return
+        }
+
+        // if we aren't showing a url or it's an incorrect url, update it -- otherwise, leave it alone
+        let request = URLRequest(url: await resolvedLoadURL(for: webviewURL))
+        // Re-check the background state too: backgrounding mid-flight could otherwise start a
+        // navigation that stalls on suspension, leaving webView.url pointing at a page that
+        // never loaded (which would defeat the empty-web-view checks above and the fallback).
+        guard !Task.isCancelled, !isAppInBackground() else { return }
+        load(request: request)
     }
 
     /// Determines which URL to load for the active server: the kiosk dashboard (when applicable), the

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -50,7 +50,15 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     /// Owns disconnected empty-state recovery timing. Kept in `HomeAssistantView` so attempts survive reset.
     var reconnectManager: WebViewReconnectManager?
 
-    var loadActiveURLIfNeededInProgress = false
+    /// In-flight `loadActiveURLIfNeeded()` attempt and when it started. Repeat calls are skipped
+    /// while a recent attempt is running, but an attempt older than
+    /// `WebViewController.loadActiveURLStaleInterval` is assumed hung, cancelled, and replaced —
+    /// a hung attempt must never block URL loading until the app is killed.
+    var loadActiveURLTask: Task<Void, Never>?
+    var loadActiveURLTaskStartDate: Date?
+
+    /// Wrapper around the application state; replaceable in tests.
+    var isAppInBackground: @MainActor () -> Bool = { UIApplication.shared.applicationState == .background }
 
     /// Track the timestamp of the last pull-to-refresh action
     var lastPullToRefreshTimestamp: Date?
@@ -186,6 +194,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         self.urlObserver = nil
         self.tokens.forEach { $0.cancel() }
         autoReloadTimer?.invalidate()
+        loadActiveURLTask?.cancel()
     }
 
     static func makeWebViewConfiguration() -> WKWebViewConfiguration {

--- a/Sources/Shared/API/Authentication/AuthenticationAPI.swift
+++ b/Sources/Shared/API/Authentication/AuthenticationAPI.swift
@@ -55,49 +55,49 @@ public class AuthenticationAPI {
 
     public func refreshTokenWith(tokenInfo: TokenInfo) -> Promise<TokenInfo> {
         Promise { seal in
-            Task { [self] in
-                guard let activeUrl = await server.activeURL() else {
-                    seal.reject(ServerConnectionError.noActiveURL(server.info.name))
-                    return
-                }
-                let token = tokenInfo.refreshToken
-                let routeInfo = RouteInfo(
-                    route: AuthenticationRoute.refreshToken(token: token),
-                    baseURL: activeUrl
-                )
-                let request = session.request(routeInfo)
-
-                let context = TokenInfo.TokenInfoContext(oldTokenInfo: tokenInfo)
-                request.validateAuth()
-                    .responseObject(context: context) { (response: DataResponse<TokenInfo, AFError>) in
-                        switch response.result {
-                        case let .failure(error):
-                            seal.reject(error)
-                        case let .success(value):
-                            seal.fulfill(value)
-                        }
-                    }
+            // Like HAKit's connectionInfo closure, evaluate against cached network information:
+            // websocket auth waits on token refresh, so this must stay off the async network-info
+            // path, which can hang mid-flight (the cache is refreshed on connectivity changes).
+            guard let activeUrl = server.activeURLUsingLastKnownNetworkState() else {
+                seal.reject(ServerConnectionError.noActiveURL(server.info.name))
+                return
             }
+            let token = tokenInfo.refreshToken
+            let routeInfo = RouteInfo(
+                route: AuthenticationRoute.refreshToken(token: token),
+                baseURL: activeUrl
+            )
+            let request = session.request(routeInfo)
+
+            let context = TokenInfo.TokenInfoContext(oldTokenInfo: tokenInfo)
+            request.validateAuth()
+                .responseObject(context: context) { (response: DataResponse<TokenInfo, AFError>) in
+                    switch response.result {
+                    case let .failure(error):
+                        seal.reject(error)
+                    case let .success(value):
+                        seal.fulfill(value)
+                    }
+                }
         }
     }
 
     public func revokeToken(tokenInfo: TokenInfo) -> Promise<Bool> {
         Promise { seal in
-            Task { [self] in
-                guard let activeUrl = await server.activeURL() else {
-                    seal.reject(ServerConnectionError.noActiveURL(server.info.name))
-                    return
-                }
-                let token = tokenInfo.accessToken
-                let routeInfo = RouteInfo(
-                    route: AuthenticationRoute.revokeToken(token: token),
-                    baseURL: activeUrl
-                )
-                let request = session.request(routeInfo)
+            // Evaluated against cached network information for the same reason as refreshTokenWith.
+            guard let activeUrl = server.activeURLUsingLastKnownNetworkState() else {
+                seal.reject(ServerConnectionError.noActiveURL(server.info.name))
+                return
+            }
+            let token = tokenInfo.accessToken
+            let routeInfo = RouteInfo(
+                route: AuthenticationRoute.revokeToken(token: token),
+                baseURL: activeUrl
+            )
+            let request = session.request(routeInfo)
 
-                request.validateAuth().response { _ in
-                    seal.fulfill(true)
-                }
+            request.validateAuth().response { _ in
+                seal.fulfill(true)
             }
         }
     }

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -114,8 +114,10 @@ public class ConnectivityWrapper {
             }
 
             Task { await resume(fetch()) }
-            Task {
-                try? await Task.sleep(nanoseconds: UInt64(timeout * Double(NSEC_PER_SEC)))
+            // The timeout must run on GCD, not on a `Task`: the scenario it guards against is the
+            // fetch hanging because Swift concurrency's shared thread pool is starved (seen during
+            // background launches), and a `Task.sleep`-based timeout would be starved with it.
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
                 resume(nil)
             }
         }
@@ -241,6 +243,13 @@ public class ConnectivityWrapper {
     #endif
 
     private func observeConnectivityChanges() {
+        // Touch the lazy closures while init is still single-threaded: `lazy var` initialization
+        // is not thread-safe, and at app launch these are first hit concurrently from many tasks.
+        _ = currentNetworkState
+        _ = refreshNetworkInformation
+        _ = lastKnownNetworkState
+        _ = performNetworkStateFetch
+
         // Prime the last-known network state so synchronous consumers have a value early.
         Task { [weak self] in
             await self?.refreshNetworkInformation()

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -172,3 +172,226 @@ private final class FakeWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol
         lastDataTypes = dataTypes
     }
 }
+
+@MainActor
+final class WebViewControllerURLLoadingTests: XCTestCase {
+    private var previousRefreshNetworkInformation: (() async -> Void)!
+
+    override func setUp() {
+        super.setUp()
+        previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
+        Current.connectivity.refreshNetworkInformation = {}
+    }
+
+    override func tearDown() {
+        Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
+        super.tearDown()
+    }
+
+    func testLoadActiveURLSkipsWhileRecentAttemptIsInFlight() {
+        let sut = makeSUT()
+        let inFlight = neverFinishingTask()
+        sut.loadActiveURLTask = inFlight
+        sut.loadActiveURLTaskStartDate = Current.date()
+
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertEqual(sut.loadActiveURLTask, inFlight)
+        XCTAssertFalse(inFlight.isCancelled)
+        inFlight.cancel()
+    }
+
+    func testLoadActiveURLCancelsAndReplacesStaleAttempt() async {
+        let sut = makeSUT()
+        let stale = neverFinishingTask()
+        sut.loadActiveURLTask = stale
+        sut.loadActiveURLTaskStartDate = Current.date()
+            .addingTimeInterval(-WebViewController.loadActiveURLStaleInterval)
+
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertTrue(stale.isCancelled)
+        XCTAssertNotNil(sut.loadActiveURLTask)
+        XCTAssertNotEqual(sut.loadActiveURLTask, stale)
+
+        await sut.loadActiveURLTask?.value
+        XCTAssertNil(sut.loadActiveURLTask)
+    }
+
+    func testLoadActiveURLDoesNothingWhileAppIsInBackground() {
+        let sut = makeSUT()
+        sut.isAppInBackground = { true }
+
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
+    func testLoadActiveURLRequestsNavigationAndClearsInFlightState() async {
+        let sut = makeSUT()
+
+        sut.loadActiveURLIfNeeded()
+        XCTAssertNotNil(sut.loadActiveURLTask)
+        await sut.loadActiveURLTask?.value
+
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+        // Server.fake()'s active URL; set when the provisional navigation starts.
+        await waitUntil { sut.webView.url != nil }
+        XCTAssertEqual(sut.webView.url?.host, "homeassistant.local")
+    }
+
+    func testLoadActiveURLShowsNoActiveURLOverlayWhenNoURLIsAvailable() async {
+        let sut = makeSUT(server: .fake(update: { info in
+            info.connection.set(address: nil, for: .external)
+        }))
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.loadActiveURLIfNeeded()
+        await sut.loadActiveURLTask?.value
+
+        XCTAssertTrue(overlayState.showsNoActiveURL)
+        XCTAssertNil(sut.loadActiveURLTask)
+    }
+
+    /// When an attempt hung and the web view is still blank, the last-known URL must load
+    /// synchronously -- without waiting for any async work, which just hung once already.
+    func testStaleAttemptTriggersImmediateFallbackLoadFromLastKnownState() async {
+        let gate = AsyncGate()
+        Current.connectivity.refreshNetworkInformation = { await gate.holdIfNeeded() }
+        let sut = makeSUT()
+
+        gate.shouldHold = true
+        sut.loadActiveURLIfNeeded()
+        let hungAttempt = sut.loadActiveURLTask
+        await waitUntil { gate.waiterCount == 1 }
+        sut.loadActiveURLTaskStartDate = Current.date()
+            .addingTimeInterval(-WebViewController.loadActiveURLStaleInterval)
+
+        sut.loadActiveURLIfNeeded()
+
+        // The replacement attempt is itself parked at the gate, so only the synchronous
+        // fallback can have loaded anything.
+        await waitUntil { sut.webView.url != nil }
+        XCTAssertEqual(sut.webView.url?.host, "homeassistant.local")
+
+        await waitUntil { gate.waiterCount == 2 }
+        gate.releaseNext()
+        gate.releaseNext()
+        await hungAttempt?.value
+        await sut.loadActiveURLTask?.value
+        XCTAssertNil(sut.loadActiveURLTask)
+    }
+
+    /// Regression test for the stuck blank web view: an attempt that hung, was declared stale, and
+    /// was replaced must not clear (or otherwise affect) the attempt that replaced it when it
+    /// eventually resumes.
+    func testCancelledStaleAttemptDoesNotClearItsReplacement() async {
+        let gate = AsyncGate()
+        Current.connectivity.refreshNetworkInformation = { await gate.holdIfNeeded() }
+        let sut = makeSUT()
+
+        // First attempt hangs refreshing network information.
+        gate.shouldHold = true
+        sut.loadActiveURLIfNeeded()
+        let hungAttempt = sut.loadActiveURLTask
+        XCTAssertNotNil(hungAttempt)
+        await waitUntil { gate.waiterCount == 1 }
+
+        // Once stale, a new call cancels it and the replacement completes normally.
+        sut.loadActiveURLTaskStartDate = Current.date()
+            .addingTimeInterval(-WebViewController.loadActiveURLStaleInterval)
+        gate.shouldHold = false
+        sut.loadActiveURLIfNeeded()
+        XCTAssertEqual(hungAttempt?.isCancelled, true)
+        await sut.loadActiveURLTask?.value
+        XCTAssertNil(sut.loadActiveURLTask)
+
+        // A third attempt is in flight when the hung attempt finally wakes up.
+        gate.shouldHold = true
+        sut.loadActiveURLIfNeeded()
+        let inFlightAttempt = sut.loadActiveURLTask
+        XCTAssertNotNil(inFlightAttempt)
+        await waitUntil { gate.waiterCount == 2 }
+
+        gate.releaseNext() // resumes only the hung (cancelled) attempt
+        await hungAttempt?.value
+
+        XCTAssertEqual(sut.loadActiveURLTask, inFlightAttempt)
+
+        gate.releaseNext()
+        await inFlightAttempt?.value
+        XCTAssertNil(sut.loadActiveURLTask)
+    }
+
+    private func makeSUT(server: Server = .fake()) -> WebViewController {
+        let sut = WebViewController(server: server)
+        let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+        sut.setValue(containerView, forKey: "view")
+        sut.webView = WKWebView(frame: containerView.bounds)
+        sut.isAppInBackground = { false }
+        return sut
+    }
+
+    private func neverFinishingTask() -> Task<Void, Never> {
+        Task { try? await Task.sleep(nanoseconds: 60 * 1_000_000_000) }
+    }
+
+    private func waitUntil(
+        _ condition: @escaping () -> Bool,
+        timeout: TimeInterval = 2,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(condition(), "condition not met within \(timeout)s", file: file, line: line)
+    }
+}
+
+/// Parks `refreshNetworkInformation` calls while `shouldHold` is set, releasing them one at a
+/// time in arrival order so tests can interleave hung and healthy load attempts deterministically.
+private final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters = [CheckedContinuation<Void, Never>]()
+    private var holding = false
+
+    var shouldHold: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return holding
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            holding = newValue
+        }
+    }
+
+    var waiterCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return waiters.count
+    }
+
+    func holdIfNeeded() async {
+        guard shouldHold else { return }
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    func releaseNext() {
+        lock.lock()
+        let waiter = waiters.isEmpty ? nil : waiters.removeFirst()
+        lock.unlock()
+        waiter?.resume()
+    }
+}

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -245,6 +245,9 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
     func testLoadActiveURLShowsNoActiveURLOverlayWhenNoURLIsAvailable() async {
         let sut = makeSUT(server: .fake(update: { info in
             info.connection.set(address: nil, for: .external)
+            // Re-evaluate now so the load attempt doesn't change the stored active URL type,
+            // which would fire the server observer and enqueue a stray load into later tests.
+            _ = info.connection.evaluateActiveURL()
         }))
         let overlayState = WebFrontendOverlayState()
         sut.overlayState = overlayState
@@ -329,8 +332,8 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
     private func makeSUT(server: Server = .fake()) -> WebViewController {
         let sut = WebViewController(server: server)
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+        // Setting the view triggers viewDidLoad, which creates the real webView.
         sut.setValue(containerView, forKey: "view")
-        sut.webView = WKWebView(frame: containerView.bounds)
         sut.isAppInBackground = { false }
         return sut
     }

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -332,8 +332,10 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
     private func makeSUT(server: Server = .fake()) -> WebViewController {
         let sut = WebViewController(server: server)
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
-        // Setting the view triggers viewDidLoad, which creates the real webView.
+        // KVC-setting the view bypasses loadView/viewDidLoad, so the webView the URL-loading
+        // paths dereference must be provided explicitly.
         sut.setValue(containerView, forKey: "view")
+        sut.webView = WKWebView(frame: containerView.bounds)
         sut.isAppInBackground = { false }
         return sut
     }

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -92,6 +92,36 @@ class ConnectivityWrapperTests: XCTestCase {
         XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "cached-ssid")
     }
 
+    func testFetchThatNeverCompletesTimesOutToLastKnownState() async {
+        Current.connectivity.updateLastKnownNetworkState(NetworkState(ssid: "cached-ssid"))
+        Current.connectivity.networkFetchTimeout = 0.1
+        Current.connectivity.performNetworkStateFetch = {
+            // Simulates NEHotspotNetwork never calling back (seen during background launches).
+            try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+            return NetworkState(ssid: "should-not-be-used")
+        }
+
+        let state = await Current.connectivity.fetchNetworkState()
+
+        XCTAssertEqual(state.ssid, "cached-ssid")
+    }
+
+    func testFetchCompletingAfterTimeoutDoesNotOverrideLastKnownState() async throws {
+        Current.connectivity.updateLastKnownNetworkState(NetworkState(ssid: "cached-ssid"))
+        Current.connectivity.networkFetchTimeout = 0.1
+        Current.connectivity.performNetworkStateFetch = {
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            return NetworkState(ssid: "late-ssid")
+        }
+
+        let state = await Current.connectivity.fetchNetworkState()
+        XCTAssertEqual(state.ssid, "cached-ssid")
+
+        // The fetch that lost the race must be dropped entirely, not applied after the fact.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "cached-ssid")
+    }
+
     func testFetchThatCompletesUpdatesLastKnownState() async {
         Current.connectivity.updateLastKnownNetworkState(NetworkState(ssid: "stale-ssid"))
         Current.connectivity.networkFetchTimeout = 5

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -1,8 +1,34 @@
 import Alamofire
 import HAKit
 import HAKit_Mocks
+import PromiseKit
 @testable import Shared
 import XCTest
+
+class AuthenticationAPIActiveURLTests: XCTestCase {
+    /// Websocket auth waits on token refresh, so token refresh must never depend on the async
+    /// network-info path: here that path hangs outright, and the refresh must still settle.
+    func testRefreshTokenSettlesEvenWhenNetworkInfoRefreshHangs() {
+        let previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
+        defer { Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation }
+        Current.connectivity.refreshNetworkInformation = {
+            try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+        }
+
+        let server = Server.fake(update: { info in
+            info.connection.set(address: nil, for: .external)
+        })
+        let api = AuthenticationAPI(server: server)
+
+        let rejected = expectation(description: "refresh rejected without an active URL")
+        api.refreshTokenWith(tokenInfo: server.info.token).catch { error in
+            XCTAssertTrue(error is ServerConnectionError)
+            rejected.fulfill()
+        }
+
+        wait(for: [rejected], timeout: 1)
+    }
+}
 
 class HAAPITokenFetchFailureTests: XCTestCase {
     private func drainMainQueue(cycles: Int = 2) {

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -181,13 +181,13 @@ private final class RejectingMockConnection: HAConnection {
 
     private func noopCancellable() -> HACancellable { HAMockCancellable {} }
 
-    func send(_ request: HARequest, completion: @escaping (Result<HAData, HAError>) -> Void) -> HACancellable {
+    func send(_ request: HARequest, completion: @escaping (Swift.Result<HAData, HAError>) -> Void) -> HACancellable {
         noopCancellable()
     }
 
     func send<T>(
         _ request: HATypedRequest<T>,
-        completion: @escaping (Result<T, HAError>) -> Void
+        completion: @escaping (Swift.Result<T, HAError>) -> Void
     ) -> HACancellable {
         noopCancellable()
     }
@@ -201,7 +201,7 @@ private final class RejectingMockConnection: HAConnection {
 
     func subscribe(
         to request: HARequest,
-        initiated: @escaping (Result<HAData, HAError>) -> Void,
+        initiated: @escaping (Swift.Result<HAData, HAError>) -> Void,
         handler: @escaping (HACancellable, HAData) -> Void
     ) -> HACancellable {
         noopCancellable()
@@ -216,7 +216,7 @@ private final class RejectingMockConnection: HAConnection {
 
     func subscribe<T>(
         to request: HATypedSubscription<T>,
-        initiated: @escaping (Result<HAData, HAError>) -> Void,
+        initiated: @escaping (Swift.Result<HAData, HAError>) -> Void,
         handler: @escaping (HACancellable, T) -> Void
     ) -> HACancellable {
         noopCancellable()


### PR DESCRIPTION
## Summary

Fixes the "app has no connection at all" incident: blank web view, pull-to-refresh doing nothing, app websockets dead, only a force-kill recovering. Device logs showed the exact mechanism:

1. The app was cold-launched into the background. `loadActiveURLIfNeeded()` set its `loadActiveURLIfNeededInProgress` flag and its Task hung awaiting the network-info refresh — the flag is only cleared when the Task finishes, so it stayed latched for the process lifetime. Every recovery trigger (`didBecomeActive`, connection changes) then logged "already in progress, skipping" and did nothing. The web view never received a URL.
2. The 3s network-info fetch timeout added in #5017 never fired in the incident logs: it slept on a `Task`, which is starved by exactly the condition it guards against (a starved cooperative thread pool).
3. Token refresh awaited the async `activeURL()` inside an unstructured `Task`. The websockets TCP-connected, entered the auth phase, and never sent the auth message because the bearer-token promise hung on that await — the server dropped them and they reconnected forever.

Changes:

- **`WebViewController`**: track the in-flight load as a `Task` handle plus start date. Calls are deduplicated while a recent attempt runs; an attempt older than 10s is assumed hung, cancelled, and replaced. When replacing a hung attempt with the web view still empty, the last-known URL loads synchronously first (no async infrastructure needed — a possibly stale URL beats a blank screen) and the fresh attempt corrects it if the network changed. The cancelled attempt re-checks `Task.isCancelled` after every await so it cannot apply stale results or clear its replacement.
- **Background handling**: the background check now runs before any async work starts (a background launch can no longer park an attempt mid-flight; `didBecomeActive` retriggers), and is re-checked before `webView.load` so backgrounding mid-attempt cannot start a navigation that stalls on suspension.
- **`ConnectivityWrapper`**: the fetch timeout now fires from `DispatchQueue.global().asyncAfter`, which works even when Swift concurrency's shared pool is starved. The lazy closures are primed during single-threaded init since `lazy var` initialization is not thread-safe and they were first hit concurrently at app launch.
- **`AuthenticationAPI`**: token refresh/revocation evaluate the active URL against the last-known network state, synchronously — the same trade-off HAKit's `connectionInfo` closure already documents — so websocket auth can never hang behind a stuck network-info fetch.

Tests: new coverage for the fetch timeout (never-completing fetch, late-completing fetch dropped), the load lifecycle (skip while recent, cancel-and-replace when stale, background no-op, no-active-URL overlay, synchronous fallback, and a gate-based regression test that a resumed cancelled attempt cannot clobber its replacement), and that token refresh settles even when the network-info refresh hangs outright.

## Screenshots

No UI changes — behavior fix only (the web view now recovers instead of staying blank).

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

- The incident logs also show the cooperative thread pool never running anything again after the process resumed from suspension. These changes make URL loading, pull-to-refresh, and websocket auth independent of (or bounded against) that state, but auditing launch-time blocking work on the cooperative pool (Realm opens, Keychain reads) is worth a follow-up.
- `refresh()` (pull-to-refresh) is now indirectly bounded by the GCD-based fetch timeout; it shares the recovery behavior via `loadActiveURLIfNeeded` when the frontend reports disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r1iemSLA9gjz2AJTgC3Un