### PR TITLE
Add minimum scale factor to Live Activity expanded trailing value

### DIFF
--- a/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
@@ -16,6 +16,10 @@ struct HALockScreenView: View {
     /// Icon size for the MDI icon in the header row.
     private static let iconSize: CGFloat = 28
 
+    /// Lets the trailing value (e.g. "100%") shrink to fit on one line instead of
+    /// wrapping the "%" onto a second line when horizontal space is tight.
+    private static let trailingValueMinimumScaleFactor: CGFloat = 0.7
+
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spaces.oneAndHalf) {
             HStack(alignment: .top, spacing: DesignSystem.Spaces.oneAndHalf) {
@@ -99,11 +103,14 @@ struct HALockScreenView: View {
             Text(HAActivityVisualStyle.percentString(for: fraction))
                 .font(.headline.monospacedDigit())
                 .foregroundStyle(primaryTextColor)
+                .lineLimit(1)
+                .minimumScaleFactor(Self.trailingValueMinimumScaleFactor)
         } else if let critical = state.criticalText {
             Text(critical)
                 .font(.headline)
                 .foregroundStyle(primaryTextColor)
                 .lineLimit(1)
+                .minimumScaleFactor(Self.trailingValueMinimumScaleFactor)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
In the expanded (Lock Screen / banner) presentation of a Live Activity, the trailing `critical_text` (and the progress percent) could wrap when horizontal space was tight — e.g. "100%" rendered with the "%" broken onto a second line.

This applies `.lineLimit(1)` together with a `0.7` minimum scale factor to the trailing value in `HALockScreenView`, so the text shrinks to fit on a single line instead of wrapping or truncating. This matches the behavior already in place for the expanded Dynamic Island trailing region (`HAExpandedTrailingView`).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Visual fix only — no functional or documentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUgVmpPRHkFnfTkHHEYPX9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUgVmpPRHkFnfTkHHEYPX9)_