### PR TITLE
Allow switching Apple Watch layout from Watch settings

### DIFF
--- a/Sources/Extensions/Watch/WatchSettingsView.swift
+++ b/Sources/Extensions/Watch/WatchSettingsView.swift
@@ -18,6 +18,7 @@ struct WatchSettingsView: View {
             List {
                 serversSection
                 configurationSection
+                layoutSection
                 performActionSection
                 troubleshootingSection
                 deleteLocalDataSection
@@ -82,6 +83,21 @@ struct WatchSettingsView: View {
             .onReceive(NotificationCenter.default.publisher(for: .watchConfigDidChange)) { _ in
                 viewModel.reload()
             }
+        }
+    }
+
+    private var layoutSection: some View {
+        Section {
+            Picker(L10n.Watch.Configuration.Layout.title, selection: Binding(
+                get: { viewModel.layout },
+                set: { viewModel.updateLayout($0) }
+            )) {
+                ForEach(WatchLayout.allCases, id: \.rawValue) { layout in
+                    Text(verbatim: layout.name).tag(layout)
+                }
+            }
+        } footer: {
+            Text(verbatim: L10n.Watch.Configuration.Layout.footer)
         }
     }
 

--- a/Sources/Extensions/Watch/WatchSettingsViewModel.swift
+++ b/Sources/Extensions/Watch/WatchSettingsViewModel.swift
@@ -6,6 +6,9 @@ final class WatchSettingsViewModel: ObservableObject {
     @Published private(set) var servers: [Server] = []
     @Published private(set) var lastUpdated: Date?
     @Published private(set) var assistPipelineTitle = L10n.Watch.Config.Assist.selectPipeline
+    /// The home-screen layout (list vs grid). Mirrors the iPhone watch-configuration editor so the user
+    /// can switch it directly on the watch. Edits persist locally first and sync to the phone.
+    @Published var layout: WatchLayout = WatchConfig().resolvedLayout
 
     init() {
         Current.servers.add(observer: self)
@@ -16,11 +19,69 @@ final class WatchSettingsViewModel: ObservableObject {
         let all = Current.servers.all
         let updatedAt = WatchUserDefaults.shared.date(for: .serversUpdatedAt)
         let assistPipelineTitle = Self.assistPipelineTitle()
+        let layout = (((try? WatchConfig.config()) ?? nil) ?? WatchConfig()).resolvedLayout
         DispatchQueue.main.async { [weak self] in
             self?.servers = all
             self?.lastUpdated = updatedAt
             self?.assistPipelineTitle = assistPipelineTitle
+            self?.layout = layout
         }
+    }
+
+    /// Change the home-screen layout. Follows the same offline-first flow as the Assist editor: persist
+    /// the edit locally so it survives without the phone nearby, then push it to the phone (source of
+    /// truth) when reachable; otherwise it syncs on the next reload.
+    func updateLayout(_ newValue: WatchLayout) {
+        layout = newValue
+        var config = ((try? WatchConfig.config()) ?? nil) ?? WatchConfig()
+        guard config.layout != newValue else { return }
+        config.layout = newValue
+        config.stampModified()
+        persistLocally(config)
+        NotificationCenter.default.post(name: .watchConfigDidChange, object: nil)
+        syncToPhone(config)
+    }
+
+    private func persistLocally(_ config: WatchConfig) {
+        do {
+            try Current.database().write { db in
+                var config = config
+                if config.id != WatchConfig.watchConfigId {
+                    try WatchConfig.deleteAll(db)
+                    config.id = WatchConfig.watchConfigId
+                }
+                try config.insert(db, onConflict: .replace)
+            }
+        } catch {
+            Current.Log.error("Failed to persist watch layout locally on watch: \(error.localizedDescription)")
+        }
+    }
+
+    private func syncToPhone(_ config: WatchConfig) {
+        guard Communicator.shared.currentReachability == .immediatelyReachable else { return }
+        Communicator.shared.send(.init(
+            identifier: InteractiveImmediateMessages.watchConfigUpdate.rawValue,
+            content: ["config": config.encodeForWatch()],
+            reply: { [weak self] message in
+                DispatchQueue.main.async { self?.handleLayoutSyncResponse(message) }
+            }
+        ), errorHandler: { error in
+            // The local copy is already saved; it'll sync on the next reload.
+            Current.Log.error("Failed to sync watch layout to phone: \(error.localizedDescription)")
+        })
+    }
+
+    private func handleLayoutSyncResponse(_ message: HAWatchConnectivity.ImmediateMessage) {
+        guard message.identifier == InteractiveImmediateResponses.watchConfigResponse.rawValue,
+              let configData = message.content["config"] as? Data,
+              let config = WatchConfig.decodeForWatch(configData) else {
+            // The local copy is already saved; it'll sync on the next reload.
+            return
+        }
+        persistLocally(config)
+        // The phone accepted our push, so this is now the synced baseline.
+        WatchUserDefaults.shared.lastSyncedModified = config.lastModified
+        NotificationCenter.default.post(name: .watchConfigDidChange, object: nil)
     }
 
     /// Wipe all data stored locally on this Watch: the offline GRDB database (mirrored servers,


### PR DESCRIPTION
The list/grid layout could only be changed from the iPhone watch
configuration editor. Add a Layout picker to the on-watch settings so
the user can toggle it directly on the Watch.

The change reuses the existing offline-first config flow: it persists
locally first, posts watchConfigDidChange so the home screen re-renders,
and pushes to the iPhone (source of truth) via watchConfigUpdate when
reachable — falling back to the next reload sync when offline.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P8s2UHfZX3EMj71tz7KYLD