### PR TITLE
Remove target-level automatic signing from Extensions-WatchWidgets

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -11121,7 +11121,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = "Configuration/Entitlements/Extension-ios.entitlements";
-				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2026;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -11209,7 +11208,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = "Configuration/Entitlements/Extension-ios.entitlements";
-				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2026;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";


### PR DESCRIPTION
## Summary

Follow-up to #5032. Committing the provisioning profile was necessary but not sufficient: the **Distribute** workflow's `App-Release` archive still fails with the same error ([latest failing run](https://github.com/home-assistant/iOS/actions/runs/29084034712/job/86333386325)):

> `Extensions-WatchWidgets has conflicting provisioning settings. Extensions-WatchWidgets is automatically signed, but provisioning profile iOS App Store - Extensions-WatchWidgets has been manually specified.`

`Extensions-WatchWidgets` (added in #5027) was created via the Xcode new-target wizard, which hard-coded `CODE_SIGN_STYLE = Automatic` into its Debug **and** Release build configs. Every other shipping target (`App`, `WatchApp`, all `Extensions-*`) leaves `CODE_SIGN_STYLE` unset at the target level and inherits it from the xcconfigs:

- `Configuration/HomeAssistant.xcconfig` → `Automatic` for Debug
- `Configuration/HomeAssistant.release.xcconfig` → `Manual` for the archive, plus `PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*] = iOS App Store - $(TARGET_NAME)`

The target-level `Automatic` overrode the xcconfig's `Manual` while the manual profile specifier was still inherited. xcodebuild rejects that combination at signing-settings resolution — **before** the profile is even used — which is why adding the profile in #5032 didn't clear it.

Removing the two lines lets WatchWidgets resolve signing exactly like `WatchApp`: `Manual` + the `iOS App Store - Extensions-WatchWidgets` profile for the release archive, `Automatic` for local Debug builds.

## Changes
- Remove target-level `CODE_SIGN_STYLE = Automatic` from `Extensions-WatchWidgets` (Debug + Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)