### PR TITLE
Revert #5013 (tabFocusesLinks breaks Mac Catalyst build)

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -205,9 +205,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         config.mediaTypesRequiringUserActionForPlayback = Current.settingsStore
             .mediaTypesRequiringUserActionForPlayback
             .wkMediaTypes
-        #if targetEnvironment(macCatalyst)
-        config.preferences.tabFocusesLinks = true
-        #endif
         return config
     }
 

--- a/Sources/App/Onboarding/API/OnboardingAuthLoginViewController.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthLoginViewController.swift
@@ -22,9 +22,6 @@ class OnboardingAuthLoginViewControllerImpl: UIViewController, OnboardingAuthLog
         let configuration = WKWebViewConfiguration()
         configuration.applicationNameForUserAgent = HomeAssistantAPI.applicationNameForUserAgent
         configuration.defaultWebpagePreferences.preferredContentMode = Current.isCatalyst ? .desktop : .mobile
-        #if targetEnvironment(macCatalyst)
-        configuration.preferences.tabFocusesLinks = true
-        #endif
 
         return WKWebView(frame: .zero, configuration: configuration)
     }()


### PR DESCRIPTION
## Summary

Reverts #5013 (`Fix Tab key not moving between web view form fields on Mac Catalyst`), which broke the **Mac Catalyst archive** in the Distribute workflow ([failing run](https://github.com/home-assistant/iOS/actions/runs/29085384349/job/86337754549)):

```
WebViewController.swift:209: error: value of type 'WKPreferences' has no member 'tabFocusesLinks'
OnboardingAuthLoginViewController.swift:26: error: value of type 'WKPreferences' has no member 'tabFocusesLinks'
** ARCHIVE FAILED **
```

## Root cause

#5013 set `WKPreferences.tabFocusesLinks = true` inside a `#if targetEnvironment(macCatalyst)` block. But that property is **macOS/AppKit-only** — WebKit's `WKPreferences.h` declares it under `#if !TARGET_OS_IPHONE`:

```objc
#if !TARGET_OS_IPHONE
@property (nonatomic) BOOL tabFocusesLinks API_AVAILABLE(macos(10.12.4));
#endif
```

Mac Catalyst is an iOS-derived environment (`TARGET_OS_IPHONE == 1`), so the symbol is stripped from the Catalyst SDK. The `#if targetEnvironment(macCatalyst)` guard wrapped the call in exactly the one environment where it can't compile.

## Why it wasn't caught earlier

The PR pipeline (`ci.yml`) only builds the iOS simulator and runs tests; it never compiles Mac Catalyst. The Catalyst archive is compiled only by the Distribute workflow on push to `main`, so `main`'s mac build has been broken since #5013 merged (2026-07-09).

Reverting to unblock Mac distribution. The original Tab-focus improvement can be revisited with an approach that actually compiles on Catalyst (e.g. a KVC/dynamic set), validated against a real Mac build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)