### PR TITLE
Sort in_zones by distance to zone center as a radius-tie tiebreaker

### DIFF
--- a/Sources/Shared/API/Models/RealmZone.swift
+++ b/Sources/Shared/API/Models/RealmZone.swift
@@ -265,7 +265,11 @@ public final class RLMZone: Object, UpdatableModel {
             .filter { $0.circularRegion.containsWithAccuracy(location) }
             .sorted { zoneA, zoneB in
                 // match the smaller zone over the larger
-                zoneA.Radius < zoneB.Radius
+                if zoneA.Radius != zoneB.Radius {
+                    return zoneA.Radius < zoneB.Radius
+                }
+                // tiebreaker: prefer the zone whose center is closer to the user
+                return location.distance(from: zoneA.location) < location.distance(from: zoneB.location)
             }
     }
 

--- a/Tests/Shared/RealmZone.test.swift
+++ b/Tests/Shared/RealmZone.test.swift
@@ -211,4 +211,45 @@ class RealmZoneTests: XCTestCase {
         )
         XCTAssertNil(insideDisabled, "zone with TrackingEnabled = false should be excluded")
     }
+
+    func testZonesOfLocationSortsEqualRadiusByDistanceToCenter() throws {
+        let executionIdentifier = UUID().uuidString
+
+        let realm = try Realm(configuration: .init(inMemoryIdentifier: executionIdentifier))
+        Current.realm = { realm }
+        addTeardownBlock { Current.realm = Realm.live }
+
+        let zones = [
+            with(RLMZone()) {
+                $0.entityId = "far_center"
+                $0.serverIdentifier = "fake1"
+                // gus's, mission bay
+                $0.Latitude = 37.774299403042754
+                $0.Longitude = -122.3914772411471
+                $0.Radius = 200.0
+            },
+            with(RLMZone()) {
+                $0.entityId = "near_center"
+                $0.serverIdentifier = "fake1"
+                // slightly to the south, so its center is closer to the user below
+                $0.Latitude = 37.773399403042754
+                $0.Longitude = -122.3914772411471
+                $0.Radius = 200.0
+            },
+        ]
+
+        try realm.write {
+            realm.add(zones)
+        }
+
+        let server1 = Server.fake(identifier: "fake1")
+
+        // user sits inside both equal-radius zones but nearer to near_center's center
+        let location = CLLocation(latitude: 37.773399403042754, longitude: -122.3914772411471)
+        XCTAssertEqual(
+            RLMZone.zones(of: location, in: server1).map(\.entityId),
+            ["near_center", "far_center"],
+            "equal-radius zones should be ordered by distance to the zone center"
+        )
+    }
 }


### PR DESCRIPTION
Resubmission of #4797, which was closed pending CLA - the CLA is now signed. Rebased onto current main.

## Summary

This adds the user's distance to each zone center as a secondary sort key for the `in_zones` array. Today the zones a user is inside are ordered so the smaller zone comes first. With this change, when two overlapping zones share the same radius, the zone whose center is closest to the user is ordered first. The existing smaller-zone-first behavior is unchanged; only equal-radius ties are reordered.

The change lives in the single ordering source, `RLMZone.zones(of:in:includingPassive:)` in `Sources/Shared/API/Models/RealmZone.swift`, which feeds both `RLMZone.zone(of:in:)` and the reported `in_zones` payload. It reuses the existing `RLMZone.location` accessor and `CLLocation.distance(from:)`, so no new geometry helper is introduced.

This resolves #4725, where ordering zones only by radius did not reflect how central the user actually is when sitting inside multiple overlapping zones of the same size. Adding distance-to-center as a tiebreaker makes the reported `in_zones` order better match the user's real position, which is useful for automations that key off the first reported zone.

Added `testZonesOfLocationSortsEqualRadiusByDistanceToCenter` to `Tests/Shared/RealmZone.test.swift`, which places the user inside two equal-radius overlapping zones and asserts the closer-center zone sorts first. The existing `testZoneOfLocation` still covers the unchanged radius-primary ordering and the passive/tracking filters.

Fixes #4725

## Screenshots

Not applicable. This changes the ordering of zone data reported to the integration; there is no user-facing UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes

The comparator keeps radius as the primary key and only consults distance-to-center on exact radius ties, matching the issue request to layer distance ordering on top of the existing zone-size sort.

