### PR TITLE
Fade HomeAssistantView in and out on appear/disappear

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -73,15 +73,13 @@ struct HomeAssistantView: View, WebFrontendView {
         .animation(DesignSystem.Animation.easeInOutFaster, value: overlayState.showsNoActiveURL)
         .statusBarHidden(chrome.statusBarHidden)
         .persistentSystemOverlays(chrome.homeIndicatorHidden ? .hidden : .automatic)
-        .onAppear {
-            withAnimation(DesignSystem.Animation.easeInOutSlowest) {
-                contentOpacity = 1
-            }
-        }
-        .onDisappear {
-            withAnimation(DesignSystem.Animation.easeInOutSlowest) {
-                contentOpacity = 0
-            }
+        .onAppear { fade(to: 1) }
+        .onDisappear { fade(to: 0) }
+    }
+
+    private func fade(to opacity: Double) {
+        withAnimation(DesignSystem.Animation.easeInOutSlowest) {
+            contentOpacity = opacity
         }
     }
 

--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -74,12 +74,12 @@ struct HomeAssistantView: View, WebFrontendView {
         .statusBarHidden(chrome.statusBarHidden)
         .persistentSystemOverlays(chrome.homeIndicatorHidden ? .hidden : .automatic)
         .onAppear {
-            withAnimation(.easeInOut(duration: 1.5)) {
+            withAnimation(DesignSystem.Animation.easeInOutSlowest) {
                 contentOpacity = 1
             }
         }
         .onDisappear {
-            withAnimation(.easeInOut(duration: 1.5)) {
+            withAnimation(DesignSystem.Animation.easeInOutSlowest) {
                 contentOpacity = 0
             }
         }

--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -26,6 +26,8 @@ struct HomeAssistantView: View, WebFrontendView {
     @State private var webViewResetID = UUID()
     @State private var webViewController: WebViewController?
 
+    @State private var contentOpacity: Double = 0
+
     init(server: Server, onWebViewController: @escaping (WebViewController) -> Void) {
         self.server = server
         self.onWebViewController = onWebViewController
@@ -65,11 +67,22 @@ struct HomeAssistantView: View, WebFrontendView {
             }
             emptyStates
         }
+        .opacity(contentOpacity)
         .background(themedStatusBar)
         .animation(DesignSystem.Animation.easeInOutFaster, value: overlayState.emptyState != nil)
         .animation(DesignSystem.Animation.easeInOutFaster, value: overlayState.showsNoActiveURL)
         .statusBarHidden(chrome.statusBarHidden)
         .persistentSystemOverlays(chrome.homeIndicatorHidden ? .hidden : .automatic)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.5)) {
+                contentOpacity = 1
+            }
+        }
+        .onDisappear {
+            withAnimation(.easeInOut(duration: 1.5)) {
+                contentOpacity = 0
+            }
+        }
     }
 
     @ViewBuilder

--- a/Sources/App/Frontend/WebView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView.swift
@@ -28,6 +28,8 @@ struct HomeAssistantView: View, WebFrontendView {
 
     @State private var contentOpacity: Double = 0
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     init(server: Server, onWebViewController: @escaping (WebViewController) -> Void) {
         self.server = server
         self.onWebViewController = onWebViewController
@@ -65,9 +67,9 @@ struct HomeAssistantView: View, WebFrontendView {
                 .ignoresSafeArea(edges: webViewIgnoredSafeAreaEdges)
                 macTitleBar
             }
+            .opacity(contentOpacity)
             emptyStates
         }
-        .opacity(contentOpacity)
         .background(themedStatusBar)
         .animation(DesignSystem.Animation.easeInOutFaster, value: overlayState.emptyState != nil)
         .animation(DesignSystem.Animation.easeInOutFaster, value: overlayState.showsNoActiveURL)
@@ -78,6 +80,10 @@ struct HomeAssistantView: View, WebFrontendView {
     }
 
     private func fade(to opacity: Double) {
+        guard !reduceMotion else {
+            contentOpacity = opacity
+            return
+        }
         withAnimation(DesignSystem.Animation.easeInOutSlowest) {
             contentOpacity = opacity
         }

--- a/Sources/Shared/DesignSystem/DesignSystem.swift
+++ b/Sources/Shared/DesignSystem/DesignSystem.swift
@@ -83,5 +83,6 @@ public enum DesignSystem {
         public static let `default`: SwiftUICore.Animation = .easeInOut(duration: 0.3)
         public static let easeInOutFaster: SwiftUICore.Animation = .easeInOut(duration: 0.1)
         public static let easeInOutSlower: SwiftUICore.Animation = .easeInOut(duration: 0.8)
+        public static let easeInOutSlowest: SwiftUICore.Animation = .easeInOut(duration: 1.5)
     }
 }


### PR DESCRIPTION
## Summary

Adds a fade transition to `HomeAssistantView`: the frontend content animates its opacity from 0 → 1 on `onAppear` and back to 0 on `onDisappear`, using a 1.5s ease-in-out.

## Changes

- Added `@State private var contentOpacity` driving `.opacity(contentOpacity)` on the root `ZStack`.
- `onAppear` animates opacity to 1; `onDisappear` animates it back to 0, both with `.easeInOut(duration: 1.5)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)