### PR TITLE
Fix shortcuts failing with "Database is suspended" after GRDB suspension change

### DIFF
--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -110,7 +110,8 @@ public class AppEnvironment {
     }
 
     public var database: () -> DatabaseQueue = {
-        .appDatabase
+        NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
+        return .appDatabase
     }
 
     public var watchConfig: () throws -> WatchConfig? = {

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -110,6 +110,8 @@ public class AppEnvironment {
     }
 
     public var database: () -> DatabaseQueue = {
+        // App Intents can run in a background-woken process without a foreground transition,
+        // leaving the DB suspended; resume it here so accesses don't abort mid-shortcut.
         NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
         return .appDatabase
     }


### PR DESCRIPTION
## Summary
Shortcuts / App Intents that read or write the local GRDB database started failing with `SQLite error 4: Database is suspended – while executing BEGIN DEFERRED TRANSACTION` after #4999.

#4999 enabled GRDB suspension (`observesSuspensionNotifications`) and posts `Database.suspendNotification` on `didEnterBackground` / `resumeNotification` on `willEnterForeground` to release SQLite locks before iOS suspends the process (fixing `0xdead10cc`). The problem: App Intents run in the **main app process, woken in the background without ever foregrounding**, so `resumeNotification` never fires and the database stays suspended from the last `didEnterBackground`. And because the app uses a `DatabaseQueue` (not WAL mode), GRDB's suspension check aborts **every** transaction while suspended — including the read-only `BEGIN DEFERRED TRANSACTION` — so even read-only shortcuts fail, not just writes.

Every GRDB access funnels through the `Current.database()` accessor (verified: no direct `.appDatabase` usage anywhere else), so this posts `Database.resumeNotification` there before returning the queue. Any background-execution access — both entity-parameter resolution (e.g. `AssistPipelineEntityQuery`) and `perform()` writes (e.g. `AssistService`) — now resumes a suspended database before transacting. This fixes all GRDB-backed shortcuts at a single choke point rather than per-intent.

The `0xdead10cc` protection is preserved: `suspend()` still runs at `didEnterBackground` and calls `interrupt()`, which rolls back any **in-flight** transaction to release its lock; this change only re-enables **new** transactions when the app actually has execution time. This matches GRDB's documented guidance to post `resumeNotification` from background callbacks that use the database.

## Screenshots
N/A — this restores previously-working behavior and has no user-facing UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behavior change beyond re-enabling database access during background execution. The only residual (and pre-existing) risk is a background `asyncWrite` racing OS suspension; the crash #4999 actually fixed was a setup write-lock, which is independently handled by #4999's read-mostly init path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
