### PR TITLE
Run SwiftGen localization jobs on macos-26

### DIFF
--- a/.github/workflows/delete_lokalise_keys.yml
+++ b/.github/workflows/delete_lokalise_keys.yml
@@ -61,7 +61,7 @@ jobs:
   open_cleanup_pr:
     needs: delete_keys
     if: ${{ inputs.dry_run == false }}
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/download_localized_strings.yml
+++ b/.github/workflows/download_localized_strings.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update_strings:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/update_material_design_icons.yml
+++ b/.github/workflows/update_material_design_icons.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   update_icons:
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

The `open_cleanup_pr` job in **Lokalise: Delete Keys** fails with exit **137** ([example run](https://github.com/home-assistant/iOS/actions/runs/29169248154/job/86587701296)):

```
Build of product 'swiftgen' complete! (15.93s)
./Tools/build_tool: line 29:  4380 Killed: 9   swift run … swiftgen
Exit status of command 'cd ../ && ./Tools/build_tool swiftgen' was 137 instead of 0.
```

SwiftGen **builds** fine, then the binary is **SIGKILL'd the instant `swift run` execs it**, before it emits any output.

## Root cause

- Not runtime memory: running the full config locally peaks at ~87 MB RSS; the kill is at the build→run boundary, not in generation.
- Not a runner-image change: the failing and last-passing runs used the same image (`20260624.560`).
- **#4991** ("Move support modules to SPM", merged 2026-07-08) replaced the prebuilt CocoaPods SwiftGen with a from-source `swift run` via `Tools/build_tool`. Since then, `download_localized_strings` (same code path, also on `macos-15`) has failed **every scheduled run** with the identical `Killed: 9` signature.

The exact same `env -u SDKROOT Tools/build_tool swiftgen` runs green as an Xcode build phase on **`macos-26`** in the main CI build. `macos-15` kills it on launch.

## Fix

Move the three jobs that build SwiftGen from source off `macos-15` onto `macos-26` (matching the app-build and distribute jobs):

- `delete_lokalise_keys.yml` — the reported failure
- `download_localized_strings.yml` — failing nightly since #4991
- `update_material_design_icons.yml` — also runs `Tools/build_tool swiftgen` via `BuildMaterialDesignIconsFont.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
