### PR TITLE
CI: fix DerivedData cache key so it round-trips (restore == save)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
             ${{ format('{0}-deriveddata-{1}-{2}',
             runner.os,
             env.DEVELOPER_DIR,
-            hashFiles('**/Package.resolved')) }}
+            hashFiles('Package.resolved')) }}
           restore-keys: >-
             ${{ format('{0}-deriveddata-{1}-',
             runner.os,
@@ -210,7 +210,7 @@ jobs:
             ${{ format('{0}-deriveddata-{1}-{2}',
             runner.os,
             env.DEVELOPER_DIR,
-            hashFiles('**/Package.resolved')) }}
+            hashFiles('Package.resolved')) }}
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         name: "Upload Code Coverage"


### PR DESCRIPTION
## What

Scope the `test` job's DerivedData cache key from `hashFiles('**/Package.resolved')` to the repo-root `hashFiles('Package.resolved')`.

## The bug (proven from CI logs)

The DerivedData cache **can never get an exact hit**, and its save **always fails** — because the key is computed over a different set of files at restore time vs save time.

`**/Package.resolved` matches transient SPM checkout files under `BuildTools/.build/checkouts/*/Package.resolved`. Those don't exist on a fresh checkout (when the **restore** key is computed) but *do* exist after the build populates them (when the **save** key is computed). From one real `main` run:

| when | files matched | key |
|---|---|---|
| restore (fresh checkout) | 4 tracked | `…-f3144348ce81efda…` |
| save (after build, `.build` present) | 10 | `…-35a7b04e…` |

So the cache is stored under `35a7b04…` but every restore looks for `f3144348…` → permanent exact-miss (falls back to a prefix match, `cache-hit=false`), and because the save step then recomputes `35a7b04…` which already exists, it dies with:

```
Failed to save: Unable to reserve cache with key …-35a7b04…, another job may be creating this cache.
```

Net effect: the cache is frozen and every run recompiles the third-party SPM dependencies (GRDB, Realm, Firebase, Alamofire, …).

## The fix

`hashFiles('Package.resolved')` (non-recursive) matches only the committed repo-root `Package.resolved`, which is present and identical at both restore and save time → the key round-trips → exact hits become possible and the save stops colliding with itself. The root file pins the same SPM dependency set, so it's the right thing to key on.

## Risk / validation

Cache-key-only change; no build, project, or app changes. This repairs proven-broken caching machinery. Whether it actually cuts wall-clock depends on Xcode reusing the restored DerivedData across runs — which we'll confirm by watching the next `main` run for an exact hit (`cache-hit=true`) and the absence of GRDB/Realm "Compiling" lines. If the reuse doesn't materialize, the durable levers are separate (build fewer targets for unit tests; larger runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)