### PR TITLE
CI: eliminate duplicate build pass in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,6 @@ jobs:
             ```
 
   test:
-    needs: lint
     runs-on: macos-26
     timeout-minutes: 60
     steps:

--- a/fastlane/lanes/testing.rb
+++ b/fastlane/lanes/testing.rb
@@ -41,6 +41,9 @@ lane :test do
     result_bundle: true,
     skip_package_dependencies_resolution: true,
     skip_detect_devices: true,
+    # Run only the `test` action: `build test` compiles every SPM target twice
+    # because the plain `build` action disables testability for packages.
+    skip_build: true,
     code_coverage: code_coverage,
     xcargs: 'COMPILER_INDEX_STORE_ENABLE=NO',
     destination: 'platform=iOS Simulator,name=iPhone 17,OS=latest'


### PR DESCRIPTION
## Summary

CI test runs take 39–60 minutes, yet actual test execution is **under 2 minutes** — the rest is build, and most of it is duplicated.

Analysis of recent run logs shows `fastlane test` (scan) invokes `xcodebuild build test`, and **every one of the 192 targets compiles twice with identical file counts** in the two passes (GRDB 501/501 files, RealmCore 396/396, App 420/419, Shared-watchOS 590/590…). The plain `build` action compiles SPM packages without testability, then the `test` action rebuilds them all with `ENABLE_TESTABILITY=YES`, which cascades into rebuilding every downstream project target too.

| Phase | Slow run (43 min) | Warm-cache run (24 min) |
|-------|-------------------|-------------------------|
| Build pass 1 (`build` action) | ~20 min | ~4.5 min |
| Build pass 2 (`test` action) | ~14 min | ~13.5 min |
| Running the tests | ~3 min | ~2 min |

## Changes

- **`skip_build: true`** in the `test` lane, so scan runs only `xcodebuild test` — one build pass, with test flags. As a bonus, the DerivedData cache warmed on `main` (saved after the test-action build) now contains flag-compatible products for PR runs, so the cache finally pays off.
- **Removed `needs: lint`** from the `test` job so it starts immediately instead of waiting ~1 minute for lint. Runners are free on public repos, so serializing saved nothing.

## Expected impact

- Cache-miss runs: ~40–60 min → roughly ~20–25 min
- Warm-cache PR runs: ~22–24 min → ~10–15 min

## Possible follow-ups (not in this PR)

- Slim the test host: the `Tests-Unit` scheme builds the full App including the watch app and every extension (Shared-watchOS alone is 590 files per rebuild).
- Normalize source mtimes after checkout so project targets stay incremental on cache hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)