### PR TITLE
Reset frontend cache before reload on pull-to-refresh

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController+Settings.swift
+++ b/Sources/App/Frontend/WebView/WebViewController+Settings.swift
@@ -91,29 +91,11 @@ extension WebViewController {
     }
 
     @objc func pullToRefresh(_ sender: UIRefreshControl) {
-        let now = Current.date()
-
-        // Check if this is a consecutive pull-to-refresh within 10 seconds
-        if let lastTimestamp = lastPullToRefreshTimestamp,
-           now.timeIntervalSince(lastTimestamp) < 10 {
-            // Second pull-to-refresh within 10 seconds - reset frontend cache
-            Current.Log.info("Consecutive pull-to-refresh detected within 10 seconds, resetting frontend cache")
-            Current.impactFeedback.impactOccurred(style: .medium)
-
-            // Reset the cache
-            Current.websiteDataStoreHandler.cleanCache { [weak self] in
-                Current.Log.info("Frontend cache reset after consecutive pull-to-refresh")
+        Current.Log.info("Pull-to-refresh: resetting frontend cache before reload")
+        Current.websiteDataStoreHandler
+            .cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) { [weak self] in
                 self?.pullToRefreshActions()
             }
-
-            // Set the timestamp to now after cache reset to ensure proper timing for next pull
-            // This prevents immediate re-triggering while still tracking for future pulls
-            lastPullToRefreshTimestamp = now
-        } else {
-            // First pull-to-refresh or outside the 10-second window
-            lastPullToRefreshTimestamp = now
-            pullToRefreshActions()
-        }
     }
 
     func pullToRefreshActions() {

--- a/Sources/App/Frontend/WebView/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController.swift
@@ -61,9 +61,6 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
     /// Wrapper around the application state; replaceable in tests.
     var isAppInBackground: @MainActor () -> Bool = { UIApplication.shared.applicationState == .background }
 
-    /// Track the timestamp of the last pull-to-refresh action
-    var lastPullToRefreshTimestamp: Date?
-
     /// Handler for messages sent from the webview to the app
     var webViewExternalMessageHandler: WebViewExternalMessageHandlerProtocol = WebViewExternalMessageHandler(
         improvManager: ImprovManager.shared


### PR DESCRIPTION
## Summary

Pull-to-refresh now **always clears the cached frontend assets before reloading** the web view, so a stale or corrupted cached frontend can't survive a manual refresh.

`pullToRefresh(_:)` clears `WebsiteDataStoreHandlerImpl.frontendAssetDataTypes` (disk / memory / fetch caches + service worker registrations) and then runs the existing `pullToRefreshActions()` (`refresh()` + sensor update) in the completion. This reuses the same clear-then-reload pattern already used on server version change and by the empty-state retry button (#5050).

The targeted data-type set forces fresh frontend assets **without touching cookies**, so the user stays logged in.

## What changed

- `pullToRefresh(_:)` is now a single, unconditional clear-then-refresh.
- Removed the "second pull within 10 seconds" escalation and its full `cleanCache()` (which cleared *all* website data, including cookies).
- Removed the now-unused `lastPullToRefreshTimestamp` property and the escalation-only medium haptic.

## Notes

Pull-to-refresh is now a true hard-refresh every time (re-fetches frontend assets on each pull), matching a browser hard reload. The refresh spinner still ends via the existing `WKNavigationDelegate` callbacks once the reload navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)