### PR TITLE
Default new watch complications to a 0-100 gauge with min/max labels off

### DIFF
--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
@@ -329,7 +329,7 @@ struct WatchComplicationBuilderEditView: View {
     init(existing: WatchComplicationConfig?) {
         self.isNew = existing == nil
         let serverId = Current.servers.all.first?.identifier.rawValue ?? ""
-        let initial = existing ?? WatchComplicationConfig(serverId: serverId)
+        let initial = existing ?? WatchComplicationConfig(serverId: serverId, gaugeMin: 0, gaugeMax: 100)
         _config = State(initialValue: initial)
         // Start expanded only when the config already carries per-size customization, so editing a
         // previously-customized complication doesn't hide the user's settings.

--- a/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/ComplicationListView.swift
@@ -329,7 +329,13 @@ struct WatchComplicationBuilderEditView: View {
     init(existing: WatchComplicationConfig?) {
         self.isNew = existing == nil
         let serverId = Current.servers.all.first?.identifier.rawValue ?? ""
-        let initial = existing ?? WatchComplicationConfig(serverId: serverId, gaugeMin: 0, gaugeMax: 100)
+        let initial = existing ?? WatchComplicationConfig(
+            serverId: serverId,
+            gaugeMin: 0,
+            gaugeMax: 100,
+            showMin: false,
+            showMax: false
+        )
         _config = State(initialValue: initial)
         // Start expanded only when the config already carries per-size customization, so editing a
         // previously-customized complication doesn't hide the user's settings.

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -222,6 +222,8 @@ public enum DatabaseTables {
         case showValue
         case showUnit
         case showWhenInactive
+        case showMin
+        case showMax
         case customTextTemplate
         case customGaugeTemplate
         case sortOrder

--- a/Sources/HAModels/Sources/WatchComplicationConfig.swift
+++ b/Sources/HAModels/Sources/WatchComplicationConfig.swift
@@ -68,6 +68,10 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
     /// Whether the complication is shown while the display is dimmed (wrist down / always-on). Nullable
     /// so pre-existing rows (NULL) default to visible; see `showsWhenInactive()`.
     public var showWhenInactive: Bool?
+    /// Whether the minimum / maximum labels are shown alongside a progress bar / open gauge. Base default
+    /// (can be overridden per size); nullable so pre-existing rows (NULL) default to visible.
+    public var showMin: Bool?
+    public var showMax: Bool?
 
     // Custom-template kind
     public var customTextTemplate: String?
@@ -85,8 +89,8 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         public var showValue: Bool?
         public var showIcon: Bool?
         public var showGauge: Bool?
-        /// Whether the minimum / maximum labels are shown alongside a progress bar / open gauge
-        /// (each default false).
+        /// Per-size override for whether the minimum / maximum labels are shown alongside a progress bar /
+        /// open gauge; nil falls back to the base `showMin` / `showMax`.
         public var showMin: Bool?
         public var showMax: Bool?
         public var gaugeMin: Double?
@@ -131,7 +135,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         case id, serverId, widgetFamily, kind, name
         case entityId, entityDisplayName, iconName, iconColor
         case gaugeAttribute, valueAttribute, valuePrecision, unitOverride, gaugeMin, gaugeMax
-        case showValue, showUnit, showWhenInactive
+        case showValue, showUnit, showWhenInactive, showMin, showMax
         case customTextTemplate, customGaugeTemplate, sortOrder, families
     }
 
@@ -154,6 +158,8 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         showValue: Bool = true,
         showUnit: Bool? = nil,
         showWhenInactive: Bool? = nil,
+        showMin: Bool? = nil,
+        showMax: Bool? = nil,
         customTextTemplate: String? = nil,
         customGaugeTemplate: String? = nil,
         sortOrder: Int = 0,
@@ -177,6 +183,8 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         self.showValue = showValue
         self.showUnit = showUnit
         self.showWhenInactive = showWhenInactive
+        self.showMin = showMin
+        self.showMax = showMax
         self.customTextTemplate = customTextTemplate
         self.customGaugeTemplate = customGaugeTemplate
         self.sortOrder = sortOrder
@@ -205,14 +213,16 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         families?[family.rawValue]?.showIcon ?? (family == .rectangular)
     }
 
-    /// Whether the minimum label is shown next to a progress bar / open gauge (default false).
+    /// Whether the minimum label is shown next to a progress bar / open gauge: per-size override, then
+    /// the base value, then visible by default (so pre-existing configs are unchanged).
     public func showsMin(for family: Family) -> Bool {
-        families?[family.rawValue]?.showMin ?? false
+        families?[family.rawValue]?.showMin ?? showMin ?? true
     }
 
-    /// Whether the maximum label is shown next to a progress bar / open gauge (default false).
+    /// Whether the maximum label is shown next to a progress bar / open gauge: per-size override, then
+    /// the base value, then visible by default (so pre-existing configs are unchanged).
     public func showsMax(for family: Family) -> Bool {
-        families?[family.rawValue]?.showMax ?? false
+        families?[family.rawValue]?.showMax ?? showMax ?? true
     }
 
     /// Whether a gauge/ring should be drawn for this family.

--- a/Sources/HAModels/Sources/WatchComplicationConfig.swift
+++ b/Sources/HAModels/Sources/WatchComplicationConfig.swift
@@ -86,7 +86,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         public var showIcon: Bool?
         public var showGauge: Bool?
         /// Whether the minimum / maximum labels are shown alongside a progress bar / open gauge
-        /// (each default true).
+        /// (each default false).
         public var showMin: Bool?
         public var showMax: Bool?
         public var gaugeMin: Double?
@@ -205,14 +205,14 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         families?[family.rawValue]?.showIcon ?? (family == .rectangular)
     }
 
-    /// Whether the minimum label is shown next to a progress bar / open gauge (default true).
+    /// Whether the minimum label is shown next to a progress bar / open gauge (default false).
     public func showsMin(for family: Family) -> Bool {
-        families?[family.rawValue]?.showMin ?? true
+        families?[family.rawValue]?.showMin ?? false
     }
 
-    /// Whether the maximum label is shown next to a progress bar / open gauge (default true).
+    /// Whether the maximum label is shown next to a progress bar / open gauge (default false).
     public func showsMax(for family: Family) -> Bool {
-        families?[family.rawValue]?.showMax ?? true
+        families?[family.rawValue]?.showMax ?? false
     }
 
     /// Whether a gauge/ring should be drawn for this family.

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -185,6 +185,9 @@ final class WatchComplicationConfigTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.WatchComplicationConfig.showUnit.rawValue, .boolean)
                     // Nullable: absent means "show when inactive" (see showsWhenInactive()).
                     t.column(DatabaseTables.WatchComplicationConfig.showWhenInactive.rawValue, .boolean)
+                    // Nullable: absent means the min/max labels are visible (see showsMin()/showsMax()).
+                    t.column(DatabaseTables.WatchComplicationConfig.showMin.rawValue, .boolean)
+                    t.column(DatabaseTables.WatchComplicationConfig.showMax.rawValue, .boolean)
                     t.column(DatabaseTables.WatchComplicationConfig.customTextTemplate.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.customGaugeTemplate.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.sortOrder.rawValue, .integer).notNull()


### PR DESCRIPTION
## Summary

Changes the defaults applied when creating a **new** modern watch complication in `WatchComplicationBuilderEditView`:

- Gauge / progress bar / ring defaults **ON** for every size. New complications start with `gaugeMin: 0`, `gaugeMax: 100`, which makes `showsGauge(for:)` resolve on for circular (gauge/ring) and rectangular/corner (progress bar).
- The gauge range defaults to **min 0 / max 100**.
- The "Show min" / "Show max" end-label toggles default to **off** for new complications.

## Backwards compatibility

The min/max label default is handled with new **base-level** `showMin`/`showMax` fields (mirroring the existing `showValue` / `showUnit` / `showWhenInactive` pattern), rather than flipping the per-family fallback:

- `showsMin(for:)` / `showsMax(for:)` resolve per-family override → base value → `true`. Existing complications (base NULL) keep showing labels exactly as before, so they are genuinely unaffected.
- New complications are seeded with base `showMin: false` / `showMax: false`, so labels default off only for them. `families` stays nil, so the "Customize" progressive-disclosure section still starts collapsed.

The gauge is only drawn when the value is numeric (the preview and watch-side renderers gate on a resolvable percentile), so non-numeric entities gracefully show no gauge even with the toggle on.

## Changes

- `WatchComplicationConfig`: add base-level `showMin` / `showMax`; `showsMin` / `showsMax` fall back through the base value to `true`.
- `DatabaseTables` + `GRDB+Initialization`: add the two nullable columns (auto-migrated for existing DBs).
- `WatchComplicationBuilderEditView`: seed new configs with `gaugeMin: 0`, `gaugeMax: 100`, `showMin: false`, `showMax: false`.

## Test plan

- [ ] New complication: the gauge/progress bar shows with a 0–100 range, and the Show min / Show max toggles are off.
- [ ] Existing complication with a gauge range: min/max labels unchanged (still shown unless previously toggled off).
- [ ] Editing an existing complication is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)