### PR TITLE
Watch: fix top crashes and polish sync/magic item error handling

### DIFF
--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -124,6 +124,20 @@ public extension DatabaseQueue {
     }
 }
 
+/// Posts GRDB's database suspension notifications without requiring callers to import GRDB
+/// (app targets don't all link it directly). Suspending while backgrounded prevents the system from
+/// killing the process with 0xdead10cc for holding the app-group SQLite file lock during suspension —
+/// see https://github.com/groue/GRDB.swift/issues/1626.
+public enum AppDatabaseSuspension {
+    public static func suspend() {
+        NotificationCenter.default.post(name: Database.suspendNotification, object: nil)
+    }
+
+    public static func resume() {
+        NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
+    }
+}
+
 /// Legacy watch complications table. Defined here (rather than a new file) so it joins the Shared
 /// target without a project-file change. Mirrors the `WatchConfigTable` pattern.
 final class WatchComplicationTable: DatabaseTableProtocol {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -643,6 +643,9 @@ public extension MagicItem {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        // Bound the wait so a dead route fails visibly instead of hanging the row for the default 60s
+        // (the UI resets after ~4s, but the task would otherwise keep a session + tokens alive).
+        request.timeoutInterval = 15
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")

--- a/Sources/Shared/Watch/Connectivity/WatchConnectivityManager+Delegate.swift
+++ b/Sources/Shared/Watch/Connectivity/WatchConnectivityManager+Delegate.swift
@@ -30,6 +30,7 @@ extension WatchConnectivityManager {
     }
 
     func receiveApplicationContext(_ applicationContext: [String: Any]) {
+        cacheReceivedContext(applicationContext)
         context.notify(HAWatchConnectivity.Context(content: applicationContext))
     }
 

--- a/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
+++ b/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
@@ -14,6 +14,17 @@ public final class WatchConnectivityManager: NSObject {
 
     let completionLock = NSLock()
     var fileCompletions: [ObjectIdentifier: (Result<Void, Error>) -> Void] = [:]
+
+    /// In-memory copy of the most recently received application context.
+    ///
+    /// `WCSession.receivedApplicationContext` is a *blocking* getter: it synchronously waits on
+    /// WCSession's internal operation queue, which can stall for tens of seconds while the session is
+    /// busy processing incoming transfers (observed in the field as background-refresh watchdog kills
+    /// and a generally "hanging" watch app when several syncs ran at once). The cache is primed once
+    /// off-main after activation and kept fresh by the `didReceiveApplicationContext` delegate
+    /// callback, so `mostRecentlyReceivedContext` never blocks the caller.
+    private let receivedContextLock = NSLock()
+    private var cachedReceivedContext: [String: Any]?
     #if os(iOS)
     var complicationCompletions: [ObjectIdentifier: (Result<Int, Error>) -> Void] = [:]
     #endif
@@ -66,7 +77,20 @@ public final class WatchConnectivityManager: NSObject {
     }
 
     public var mostRecentlyReceivedContext: HAWatchConnectivity.Context {
-        HAWatchConnectivity.Context(content: session?.receivedApplicationContextProxy ?? [:])
+        receivedContextLock.lock()
+        let cached = cachedReceivedContext
+        receivedContextLock.unlock()
+        return HAWatchConnectivity.Context(content: cached ?? [:])
+    }
+
+    /// Store the latest received application context; the delegate calls this on receipt and
+    /// `activate()` primes it once from the (blocking) session getter off the caller's thread.
+    func cacheReceivedContext(_ content: [String: Any], overwrite: Bool = true) {
+        receivedContextLock.lock()
+        defer { receivedContextLock.unlock() }
+        if overwrite || cachedReceivedContext == nil {
+            cachedReceivedContext = content
+        }
     }
 
     public var mostRecentlySentContext: HAWatchConnectivity.Context {
@@ -91,6 +115,13 @@ public final class WatchConnectivityManager: NSObject {
         guard let session else { return }
         session.delegateProxy = self
         session.activateProxy()
+        // Prime the received-context cache once, away from the caller's thread: the underlying getter
+        // blocks on WCSession's operation queue (see `cachedReceivedContext`). A context received via
+        // the delegate in the meantime wins over this initial snapshot.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self, let session = self.session else { return }
+            cacheReceivedContext(session.receivedApplicationContextProxy, overwrite: false)
+        }
     }
 
     func notifyState() { state.notify(sessionState) }

--- a/Sources/Shared/Watch/InteractiveImmediateMessages.swift
+++ b/Sources/Shared/Watch/InteractiveImmediateMessages.swift
@@ -60,3 +60,22 @@ public enum InteractiveImmediateResponses: String, CaseIterable {
     /// Phone → watch: acknowledgement that the client-certificate import screen will be presented.
     case clientCertImportRequestResponse
 }
+
+/// Stable machine-readable reason sent in a `magicItemRowPressedResponse` alongside `fired: false`,
+/// so the watch can present a localized message while the technical detail (the `error` field) goes
+/// to client events. Raw values cross the WatchConnectivity wire — don't repurpose them.
+public enum MagicItemExecutionFailureCode: String {
+    /// The press was too old by the time it reached the phone.
+    case staleRequest
+    /// The message was missing/carrying an invalid item type or id.
+    case invalidItem
+    /// The item type has no executable action (folder, Assist, unsupported).
+    case notExecutable
+    /// The server referenced by the item isn't configured on the phone.
+    case serverNotFound
+    /// The phone has no usable connection for the server.
+    case noConnection
+    /// The service call ran and the server (or transport) reported an error — the `error` detail is
+    /// the underlying message and is meaningful to show the user.
+    case serviceCallFailed
+}

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -33,6 +33,12 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// Registry rows for the entities used by complications, so the watch can format values with the
     /// right display precision without carrying the whole registry.
     public var complicationEntities: [EntityRegistryListForDisplay.Entity]
+    /// The phone's servers (`ServerManager.restorableState()` encoding), so every sync — the chunked
+    /// pull and the proactive background push — also refreshes the watch's servers *in addition to*
+    /// the on-demand `serversConfigSync` interactive exchange (which additionally carries the mTLS
+    /// client-certificate bundles; those Keychain materials stay off the mirror on purpose).
+    /// Same contract as the complication fields: `nil` means "not carried", retain what's local.
+    public var servers: Data?
 
     public init(
         entities: [HAAppEntity],
@@ -40,7 +46,8 @@ public struct WatchDatabaseMirror: WatchCodable {
         pipelines: [AssistPipelines],
         complications: [WatchComplication]? = nil,
         complicationConfigs: [WatchComplicationConfig]? = nil,
-        complicationEntities: [EntityRegistryListForDisplay.Entity] = []
+        complicationEntities: [EntityRegistryListForDisplay.Entity] = [],
+        servers: Data? = nil
     ) {
         self.entities = entities
         self.areas = areas
@@ -48,10 +55,11 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.complications = complications
         self.complicationConfigs = complicationConfigs
         self.complicationEntities = complicationEntities
+        self.servers = servers
     }
 
     private enum CodingKeys: String, CodingKey {
-        case entities, areas, pipelines, complications, complicationConfigs, complicationEntities
+        case entities, areas, pipelines, complications, complicationConfigs, complicationEntities, servers
     }
 
     // Decode the complication fields defensively: they were added after the mirror shipped, so a payload
@@ -73,6 +81,7 @@ public struct WatchDatabaseMirror: WatchCodable {
             [EntityRegistryListForDisplay.Entity].self,
             forKey: .complicationEntities
         )).flatMap { $0 } ?? []
+        self.servers = (try? container.decodeIfPresent(Data.self, forKey: .servers)).flatMap { $0 }
     }
 
     /// Domains the watch can add (mirrors the iPhone watch picker).
@@ -97,6 +106,8 @@ public struct WatchDatabaseMirror: WatchCodable {
                 entityIds: pairs.map(\.1)
             )) ?? []
         }
+        // Resolved outside the GRDB read: servers live in their own store, not the database.
+        let servers = Current.servers.restorableState()
 
         return try Current.database().read { db in
             let entities = try HAAppEntity
@@ -110,7 +121,8 @@ public struct WatchDatabaseMirror: WatchCodable {
                 pipelines: pipelines,
                 complications: complications,
                 complicationConfigs: configs,
-                complicationEntities: registry
+                complicationEntities: registry,
+                servers: servers
             )
         }
     }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -525,17 +525,22 @@ final class WatchCommunicatorService {
 
     private func magicItemPressed(message: HAWatchConnectivity.InteractiveImmediateMessage) {
         let responseIdentifier = InteractiveImmediateResponses.magicItemRowPressedResponse.rawValue
-        // Every failure reply carries the reason so the watch can show/log why instead of a generic
-        // "didn't run".
-        func fail(_ reason: String) {
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false, "error": reason]))
+        // Every failure reply carries a stable code (which the watch maps to a localized message)
+        // plus the technical reason (which the watch records in client events) instead of a bare
+        // `fired: false`.
+        func fail(_ code: MagicItemExecutionFailureCode, _ reason: String) {
+            message.reply(.init(identifier: responseIdentifier, content: [
+                "fired": false,
+                "errorCode": code.rawValue,
+                "error": reason,
+            ]))
         }
 
         if let triggeredAt = message.content["triggeredAt"] as? TimeInterval {
             let age = Current.date().timeIntervalSince1970 - triggeredAt
             if age > 30 {
                 Current.Log.warning("Discarding stale magic item press received \(Int(age))s after it was triggered")
-                fail("Request expired before reaching the iPhone (\(Int(age))s old)")
+                fail(.staleRequest, "Request expired before reaching the iPhone (\(Int(age))s old)")
                 return
             }
         }
@@ -544,20 +549,20 @@ final class WatchCommunicatorService {
               let itemId = message.content["itemId"] as? String,
               let type = MagicItem.ItemType(rawValue: itemType) else {
             Current.Log.warning("Magic item press did not provide item type or item id")
-            fail("Invalid item type or id")
+            fail(.invalidItem, "Invalid item type or id")
             return
         }
 
         // Folders don't execute actions, they are containers
         if type == .folder {
-            fail("Folders don't execute actions")
+            fail(.notExecutable, "Folders don't execute actions")
             return
         }
 
         guard let serverId = message.content["serverId"] as? String,
               let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
             Current.Log.warning("Magic item press did not provide valid server info")
-            fail("Server not found on iPhone")
+            fail(.serverNotFound, "Server not found on iPhone")
             return
         }
 
@@ -583,7 +588,7 @@ final class WatchCommunicatorService {
         case .entity:
             guard let domain = MagicItem(id: itemId, serverId: serverId, type: .entity).domain,
                   let mainAction = domain.mainAction else {
-                fail("Entity domain has no executable action")
+                fail(.notExecutable, "Entity domain has no executable action")
                 return
             }
             callService(
@@ -600,9 +605,9 @@ final class WatchCommunicatorService {
             break
         case .assistPipeline, .assistPrompt:
             // Assist items are not supported on Watch
-            fail("Assist items are not supported on Watch")
+            fail(.notExecutable, "Assist items are not supported on Watch")
         case .unsupported:
-            fail("Unsupported item type")
+            fail(.notExecutable, "Unsupported item type")
         }
     }
 
@@ -616,10 +621,11 @@ final class WatchCommunicatorService {
         responseIdentifier: String
     ) {
         guard let api = Current.api(for: server) else {
-            message.reply(.init(
-                identifier: responseIdentifier,
-                content: ["fired": false, "error": "iPhone has no usable connection for this server"]
-            ))
+            message.reply(.init(identifier: responseIdentifier, content: [
+                "fired": false,
+                "errorCode": MagicItemExecutionFailureCode.noConnection.rawValue,
+                "error": "iPhone has no usable connection for this server",
+            ]))
             Current.Log.error("No API available to call service")
             return
         }
@@ -637,10 +643,11 @@ final class WatchCommunicatorService {
                 message.reply(.init(identifier: responseIdentifier, content: ["fired": true]))
             case let .rejected(error):
                 Current.Log.error("Failed to run \(domain), error: \(error.localizedDescription)")
-                message.reply(.init(
-                    identifier: responseIdentifier,
-                    content: ["fired": false, "error": error.localizedDescription]
-                ))
+                message.reply(.init(identifier: responseIdentifier, content: [
+                    "fired": false,
+                    "errorCode": MagicItemExecutionFailureCode.serviceCallFailed.rawValue,
+                    "error": error.localizedDescription,
+                ]))
             }
         }
     }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -525,12 +525,17 @@ final class WatchCommunicatorService {
 
     private func magicItemPressed(message: HAWatchConnectivity.InteractiveImmediateMessage) {
         let responseIdentifier = InteractiveImmediateResponses.magicItemRowPressedResponse.rawValue
+        // Every failure reply carries the reason so the watch can show/log why instead of a generic
+        // "didn't run".
+        func fail(_ reason: String) {
+            message.reply(.init(identifier: responseIdentifier, content: ["fired": false, "error": reason]))
+        }
 
         if let triggeredAt = message.content["triggeredAt"] as? TimeInterval {
             let age = Current.date().timeIntervalSince1970 - triggeredAt
             if age > 30 {
                 Current.Log.warning("Discarding stale magic item press received \(Int(age))s after it was triggered")
-                message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+                fail("Request expired before reaching the iPhone (\(Int(age))s old)")
                 return
             }
         }
@@ -539,20 +544,20 @@ final class WatchCommunicatorService {
               let itemId = message.content["itemId"] as? String,
               let type = MagicItem.ItemType(rawValue: itemType) else {
             Current.Log.warning("Magic item press did not provide item type or item id")
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            fail("Invalid item type or id")
             return
         }
 
         // Folders don't execute actions, they are containers
         if type == .folder {
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            fail("Folders don't execute actions")
             return
         }
 
         guard let serverId = message.content["serverId"] as? String,
               let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
             Current.Log.warning("Magic item press did not provide valid server info")
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            fail("Server not found on iPhone")
             return
         }
 
@@ -578,7 +583,7 @@ final class WatchCommunicatorService {
         case .entity:
             guard let domain = MagicItem(id: itemId, serverId: serverId, type: .entity).domain,
                   let mainAction = domain.mainAction else {
-                message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+                fail("Entity domain has no executable action")
                 return
             }
             callService(
@@ -595,9 +600,9 @@ final class WatchCommunicatorService {
             break
         case .assistPipeline, .assistPrompt:
             // Assist items are not supported on Watch
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            fail("Assist items are not supported on Watch")
         case .unsupported:
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            fail("Unsupported item type")
         }
     }
 
@@ -611,7 +616,10 @@ final class WatchCommunicatorService {
         responseIdentifier: String
     ) {
         guard let api = Current.api(for: server) else {
-            message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+            message.reply(.init(
+                identifier: responseIdentifier,
+                content: ["fired": false, "error": "iPhone has no usable connection for this server"]
+            ))
             Current.Log.error("No API available to call service")
             return
         }
@@ -629,7 +637,10 @@ final class WatchCommunicatorService {
                 message.reply(.init(identifier: responseIdentifier, content: ["fired": true]))
             case let .rejected(error):
                 Current.Log.error("Failed to run \(domain), error: \(error.localizedDescription)")
-                message.reply(.init(identifier: responseIdentifier, content: ["fired": false]))
+                message.reply(.init(
+                    identifier: responseIdentifier,
+                    content: ["fired": false, "error": error.localizedDescription]
+                ))
             }
         }
     }
@@ -809,9 +820,9 @@ extension WatchCommunicatorService: AssistServiceDelegate {
 extension WatchCommunicatorService: ServerObserver {
     func serversDidChange(_ serverManager: ServerManager) {
         HomeAssistantAPI.syncWatchContext()
-        // Also push the reference database so entity/area/pipeline data for the new server set reaches
-        // the watch proactively. Server credentials themselves still flow through the on-demand
-        // `serversConfigSync` reply (they carry Keychain material kept off the mirror).
+        // Also push the reference database (which now carries the servers too) so the new server set
+        // reaches the watch proactively. mTLS client-certificate bundles still flow only through the
+        // on-demand `serversConfigSync` reply (they carry Keychain material kept off the mirror).
         WatchMirrorPushCoordinator.schedule(reason: .serversChanged)
     }
 }

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -70,6 +70,44 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         Current.backgroundRefreshScheduler.schedule().cauterize()
     }
 
+    func applicationWillEnterForeground() {
+        AppDatabaseSuspension.resume()
+    }
+
+    func applicationDidEnterBackground() {
+        // Suspend GRDB so a write can't be caught holding the app-group SQLite lock when the system
+        // suspends the process — that termination (0xdead10cc) was the watch app's top crash cluster.
+        AppDatabaseSuspension.suspend()
+    }
+
+    /// Runs database work delivered while the app may be backgrounded/suspending (WCSession callbacks)
+    /// inside an expiring background activity, so the system keeps the process alive for the write
+    /// instead of suspending it mid-commit (0xdead10cc). If the activity expires, GRDB is re-suspended,
+    /// which aborts the in-flight write and releases the file lock. `completion` runs on the main queue
+    /// after the work finished (not when it expired).
+    private static func performProtectedDatabaseWork(
+        reason: String,
+        _ work: @escaping () -> Void,
+        completion: (() -> Void)? = nil
+    ) {
+        ProcessInfo.processInfo.performExpiringActivity(withReason: reason) { expired in
+            if expired {
+                AppDatabaseSuspension.suspend()
+                return
+            }
+            AppDatabaseSuspension.resume()
+            work()
+            DispatchQueue.main.async {
+                // Re-suspend when still backgrounded; harmless when active (any `Current.database()`
+                // access resumes it again).
+                if WKApplication.shared().applicationState == .background {
+                    AppDatabaseSuspension.suspend()
+                }
+                completion?()
+            }
+        }
+    }
+
     func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
         HomeAssistantAPI.syncWatchContext()
 
@@ -258,20 +296,23 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     private func updateContext(_ content: HAWatchConnectivity.Content) {
         // Complications arrive from the phone as Codable JSON `Data` over the background context, and
         // also via the watch database mirror on reload. Both write into GRDB — the single source the
-        // snapshot writer reads from.
-        if let data = content["complications"] as? Data,
-           let complications = try? JSONDecoder().decode([WatchComplication].self, from: data) {
-            Current.Log.verbose("Updating \(complications.count) legacy complications from context")
-            WatchWidgetComplicationSnapshotStore.replaceLegacyComplications(complications)
+        // snapshot writer reads from. Contexts are delivered while the app is backgrounded, so the
+        // writes run under an expiring activity (see performProtectedDatabaseWork).
+        Self.performProtectedDatabaseWork(reason: "watch-context-write") {
+            if let data = content["complications"] as? Data,
+               let complications = try? JSONDecoder().decode([WatchComplication].self, from: data) {
+                Current.Log.verbose("Updating \(complications.count) legacy complications from context")
+                WatchWidgetComplicationSnapshotStore.replaceLegacyComplications(complications)
+            }
+            if let data = content["complicationConfigs"] as? Data,
+               let configs = try? JSONDecoder().decode([WatchComplicationConfig].self, from: data) {
+                Current.Log.verbose("Updating \(configs.count) complication configs from context")
+                WatchWidgetComplicationSnapshotStore.replaceConfigs(configs)
+            }
+        } completion: { [weak self] in
+            WatchWidgetComplicationSnapshotStore.update()
+            self?.updateComplications()
         }
-        if let data = content["complicationConfigs"] as? Data,
-           let configs = try? JSONDecoder().decode([WatchComplicationConfig].self, from: data) {
-            Current.Log.verbose("Updating \(configs.count) complication configs from context")
-            WatchWidgetComplicationSnapshotStore.replaceConfigs(configs)
-        }
-
-        WatchWidgetComplicationSnapshotStore.update()
-        updateComplications()
     }
 
     /// Apply a reference database mirror the iPhone pushed proactively over `transferFile` (arrives even
@@ -289,22 +330,28 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
             ))
             return
         }
-        do {
-            try mirror.apply()
-            Current.Log.info("Applied pushed watch database mirror (\(data.count) bytes)")
-            Current.clientEventStore.addEvent(.init(
-                text: "Applied pushed watch database mirror from iPhone (\(data.count) bytes)",
-                type: .database
-            ))
+        // Pushed mirrors typically arrive while the app is backgrounded — protect the write.
+        Self.performProtectedDatabaseWork(reason: "watch-mirror-apply") {
+            do {
+                try mirror.apply()
+                Current.Log.info("Applied pushed watch database mirror (\(data.count) bytes)")
+                Current.clientEventStore.addEvent(.init(
+                    text: "Applied pushed watch database mirror from iPhone (\(data.count) bytes)",
+                    type: .database
+                ))
+            } catch {
+                Current.Log.error("Failed to apply pushed watch database mirror: \(error)")
+                Current.clientEventStore.addEvent(.init(
+                    text: "Failed to apply pushed watch database mirror (\(data.count) bytes): \(error)",
+                    type: .database
+                ))
+            }
+        } completion: {
+            // The mirror also carries the servers; keep them in step with the reference tables.
+            WatchServerSync.applyMirroredServers(mirror.servers)
             // Rebuild complication snapshots and let the home screen re-render from the fresh data.
             WatchWidgetComplicationSnapshotStore.update()
             NotificationCenter.default.post(name: WatchComplicationConfig.didChangeNotification, object: nil)
-        } catch {
-            Current.Log.error("Failed to apply pushed watch database mirror: \(error)")
-            Current.clientEventStore.addEvent(.init(
-                text: "Failed to apply pushed watch database mirror (\(data.count) bytes): \(error)",
-                type: .database
-            ))
         }
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -86,9 +86,18 @@ final class WatchMagicViewRowViewModel: ObservableObject {
                 if message.content["fired"] as? Bool == true {
                     completion(true)
                 } else {
-                    // The iPhone includes the reason it couldn't run the item; surface and record it.
+                    // The iPhone replies with a stable code plus a technical reason. The reason feeds
+                    // the client-event log; the alert only shows it for `serviceCallFailed` (the
+                    // server's own error message) and falls back to the localized generic text for
+                    // the protocol-level codes, which are English-only diagnostics.
+                    let code = (message.content["errorCode"] as? String)
+                        .flatMap(MagicItemExecutionFailureCode.init(rawValue:))
                     let reason = message.content["error"] as? String
-                    self?.reportFailure(route: "iPhone", reason: reason)
+                    self?.reportFailure(
+                        route: "iPhone",
+                        reason: reason ?? code?.rawValue,
+                        alertMessage: code == .serviceCallFailed ? reason : nil
+                    )
                     completion(false)
                 }
             }
@@ -100,7 +109,12 @@ final class WatchMagicViewRowViewModel: ObservableObject {
             )
         Communicator.shared.send(itemMessage, errorHandler: { [weak self] error in
             Current.Log.error("Received error when sending immediate message \(error)")
-            self?.reportFailure(route: "iPhone", reason: error.localizedDescription)
+            // WatchConnectivity errors are system errors with localized descriptions.
+            self?.reportFailure(
+                route: "iPhone",
+                reason: error.localizedDescription,
+                alertMessage: error.localizedDescription
+            )
             completion(false)
         })
     }
@@ -115,23 +129,30 @@ final class WatchMagicViewRowViewModel: ObservableObject {
 
         magicItem.execute(on: server, source: .Watch) { [weak self] success, error in
             if !success {
-                self?.reportFailure(route: "Watch", reason: error?.localizedDescription)
+                // These errors implement LocalizedError (connection / TLS / HTTP body / "no active
+                // URL"), so their descriptions are fit for the alert.
+                self?.reportFailure(
+                    route: "Watch",
+                    reason: error?.localizedDescription,
+                    alertMessage: error?.localizedDescription
+                )
             }
             completion(success)
         }
     }
 
-    /// Surface a failure to the user (alert on the row) and record it in the watch's client events so
-    /// the reason is diagnosable later from Settings → Troubleshooting, not just flashed on screen.
-    /// The reason is the underlying error when available (e.g. connection / TLS / HTTP body /
-    /// "no active URL"), or a generic message otherwise.
-    private func reportFailure(route: String, reason: String?) {
-        let message = reason ?? L10n.Watch.Home.Run.Error.message
+    /// Record a failure in the watch's client events (full technical `reason`, for Settings →
+    /// Troubleshooting) and surface an alert on the row. The alert shows `alertMessage` when the
+    /// failure carries user-fit text (a localized error or the server's own message); otherwise it
+    /// falls back to the localized generic run-error message.
+    private func reportFailure(route: String, reason: String?, alertMessage: String? = nil) {
+        let detail = reason ?? "unknown"
         Current.clientEventStore.addEvent(.init(
-            text: "Magic item \(item.id) failed to run via \(route): \(message)",
+            text: "Magic item \(item.id) failed to run via \(route): \(detail)",
             type: .serviceCall,
-            payload: ["item": item.id, "server": item.serverId, "route": route, "reason": message]
+            payload: ["item": item.id, "server": item.serverId, "route": route, "reason": detail]
         ))
+        let message = alertMessage ?? L10n.Watch.Home.Run.Error.message
         DispatchQueue.main.async { [weak self] in
             self?.errorMessage = message
         }

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -81,11 +81,14 @@ final class WatchMagicViewRowViewModel: ObservableObject {
                 "itemType": magicItem.type.rawValue,
                 "triggeredAt": Current.date().timeIntervalSince1970,
             ],
-            reply: { message in
+            reply: { [weak self] message in
                 Current.Log.verbose("Received reply dictionary \(message)")
                 if message.content["fired"] as? Bool == true {
                     completion(true)
                 } else {
+                    // The iPhone includes the reason it couldn't run the item; surface and record it.
+                    let reason = message.content["error"] as? String
+                    self?.reportFailure(route: "iPhone", reason: reason)
                     completion(false)
                 }
             }
@@ -97,31 +100,38 @@ final class WatchMagicViewRowViewModel: ObservableObject {
             )
         Communicator.shared.send(itemMessage, errorHandler: { [weak self] error in
             Current.Log.error("Received error when sending immediate message \(error)")
-            self?.presentError(error)
+            self?.reportFailure(route: "iPhone", reason: error.localizedDescription)
             completion(false)
         })
     }
 
     private func executeMagicItemUsingAPI(magicItem: MagicItem, completion: @escaping (Bool) -> Void) {
         guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == magicItem.serverId }) else {
-            presentError(nil)
+            reportFailure(route: "Watch", reason: "Server \(magicItem.serverId) not synced to the watch")
             completion(false)
             return
         }
-        Current.Log.error("Executing watch magic item directly via API")
+        Current.Log.info("Executing watch magic item directly via API")
 
         magicItem.execute(on: server, source: .Watch) { [weak self] success, error in
             if !success {
-                self?.presentError(error)
+                self?.reportFailure(route: "Watch", reason: error?.localizedDescription)
             }
             completion(success)
         }
     }
 
-    /// Surface a failure to the user instead of letting it fail silently. Uses the underlying
-    /// error's description when available (e.g. a connection / TLS / "no active URL" error).
-    private func presentError(_ error: Error?) {
-        let message = error?.localizedDescription ?? L10n.Watch.Home.Run.Error.message
+    /// Surface a failure to the user (alert on the row) and record it in the watch's client events so
+    /// the reason is diagnosable later from Settings → Troubleshooting, not just flashed on screen.
+    /// The reason is the underlying error when available (e.g. connection / TLS / HTTP body /
+    /// "no active URL"), or a generic message otherwise.
+    private func reportFailure(route: String, reason: String?) {
+        let message = reason ?? L10n.Watch.Home.Run.Error.message
+        Current.clientEventStore.addEvent(.init(
+            text: "Magic item \(item.id) failed to run via \(route): \(message)",
+            type: .serviceCall,
+            payload: ["item": item.id, "server": item.serverId, "route": route, "reason": message]
+        ))
         DispatchQueue.main.async { [weak self] in
             self?.errorMessage = message
         }

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -39,6 +39,10 @@ final class WatchHomeViewModel: ObservableObject {
     /// finishes, so repeated reload taps can't stack several syncs (each holding a 30s reply timeout)
     /// in parallel.
     private var isSyncInFlight = false
+    /// Whether the running sync was explicitly requested by the user (reload tap / retry). Failures of
+    /// the automatic launch sync stay silent — the cache is already on screen — while user-initiated
+    /// syncs surface an error alert.
+    private var isSyncUserInitiated = false
 
     private var networkPathMonitor: NWPathMonitor?
     private let networkMonitorQueue = DispatchQueue(label: "WatchHomeNetworkPathMonitor")
@@ -163,6 +167,7 @@ final class WatchHomeViewModel: ObservableObject {
             return
         }
         isSyncInFlight = true
+        isSyncUserInitiated = userInitiated
         isLoading = true
         clearError()
         setLoadingStatus(L10n.Watch.Sync.starting)
@@ -427,6 +432,9 @@ final class WatchHomeViewModel: ObservableObject {
                 text: "Apple Watch database sync applied (\(data.count) bytes)",
                 type: .database
             ))
+            // The sync also refreshes the servers carried by the mirror (in addition to the dedicated
+            // serversConfigSync exchange kicked off at the start of the reload).
+            WatchServerSync.applyMirroredServers(mirror.servers)
             // The mirror carries complications too — rebuild widget snapshots now so a reload is another
             // chance to obtain them if the background context push hasn't delivered them yet.
             WatchWidgetComplicationSnapshotStore.update()
@@ -451,8 +459,12 @@ final class WatchHomeViewModel: ObservableObject {
             type: .database,
             payload: detail.map { ["detail": $0] } ?? [:]
         ))
-        errorMessage = friendlyMessage
-        showError = true
+        // Only user-initiated syncs alert: the automatic launch sync fails silently onto the cache
+        // that's already displayed (the failure is still logged/recorded above).
+        if isSyncUserInitiated {
+            errorMessage = friendlyMessage
+            showError = true
+        }
         updateLoading(isLoading: false)
         // Never leave the user with nothing: show whatever is cached locally.
         loadCache()
@@ -481,9 +493,17 @@ final class WatchHomeViewModel: ObservableObject {
         do {
             config = try Current.database().read { db in try WatchConfig.fetchOne(db) } ?? WatchConfig()
         } catch {
+            // A transient read failure must not blank the home screen: keep whatever config is
+            // currently rendered (possibly from an earlier successful read) — the cache is only ever
+            // replaced by data that actually loaded. Only alert when there's nothing on screen at all.
             Current.Log.error("Failed to fetch watch config from database, error: \(error.localizedDescription)")
-            displayError(message: L10n.Watch.Config.Cache.Error.message)
-            updateConfig(config: .init(), magicItemsInfo: [])
+            Current.clientEventStore.addEvent(.init(
+                text: "Failed to read watch config cache: \(error.localizedDescription)",
+                type: .database
+            ))
+            if watchConfig.items.isEmpty {
+                displayError(message: L10n.Watch.Config.Cache.Error.message)
+            }
             updateLoading(isLoading: false)
             return
         }

--- a/Sources/WatchApp/WatchServerSync.swift
+++ b/Sources/WatchApp/WatchServerSync.swift
@@ -38,12 +38,36 @@ enum WatchServerSync {
     static func applyMirroredServers(_ data: Data?) {
         guard let data else { return }
         applyServersState(data)
-        let missingCertificate = Current.servers.all.contains { server in
-            guard let certificate = server.info.connection.clientCertificate else { return false }
-            return !ClientCertificateManager.shared.hasIdentity(for: certificate)
-        }
-        if missingCertificate {
+        // Keychain lookups (SecItemCopyMatching) are too slow for the main thread this runs on, so
+        // check off-main; pushed mirrors also often arrive while the phone isn't immediately
+        // reachable, so the follow-up request waits for reachability instead of being dropped.
+        let servers = Current.servers.all
+        DispatchQueue.global(qos: .utility).async {
+            let missingCertificate = servers.contains { server in
+                guard let certificate = server.info.connection.clientCertificate else { return false }
+                return !ClientCertificateManager.shared.hasIdentity(for: certificate)
+            }
+            guard missingCertificate else { return }
             Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
+            DispatchQueue.main.async { requestWhenReachable() }
+        }
+    }
+
+    /// One-shot reachability observation guarding the deferred certificate request. Main-thread only.
+    private static var reachabilityToken: HAWatchConnectivity.ObservationToken?
+
+    /// Run `request()` now if the phone is immediately reachable, otherwise once it becomes so.
+    /// Must be called on the main thread (observer callbacks also arrive there).
+    private static func requestWhenReachable() {
+        guard Communicator.shared.currentReachability != .immediatelyReachable else {
+            request()
+            return
+        }
+        guard reachabilityToken == nil else { return }
+        reachabilityToken = Communicator.shared.reachability.observe { reachability in
+            guard reachability == .immediatelyReachable, let token = reachabilityToken else { return }
+            Communicator.shared.reachability.unobserve(token)
+            reachabilityToken = nil
             request()
         }
     }

--- a/Sources/WatchApp/WatchServerSync.swift
+++ b/Sources/WatchApp/WatchServerSync.swift
@@ -24,13 +24,34 @@ enum WatchServerSync {
 
     private static func apply(_ message: HAWatchConnectivity.ImmediateMessage) {
         if let serversData = message.content["servers"] as? Data {
-            WatchUserDefaults.shared.set(Date(), key: .serversUpdatedAt)
-            Current.servers.restoreState(serversData)
-            applyURLOverrides()
+            applyServersState(serversData)
         }
         if let certificatesData = message.content["clientCertificates"] as? Data {
             importCertificates(certificatesData)
         }
+    }
+
+    /// Apply the servers carried by a database mirror (chunked pull or background push). The mirror
+    /// keeps mTLS Keychain material off of it, so when a restored server references a client
+    /// certificate the local Keychain doesn't have yet, follow up with a full `serversConfigSync`
+    /// (which delivers the bundles inline) as soon as the phone is reachable.
+    static func applyMirroredServers(_ data: Data?) {
+        guard let data else { return }
+        applyServersState(data)
+        let missingCertificate = Current.servers.all.contains { server in
+            guard let certificate = server.info.connection.clientCertificate else { return false }
+            return !ClientCertificateManager.shared.hasIdentity(for: certificate)
+        }
+        if missingCertificate {
+            Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
+            request()
+        }
+    }
+
+    private static func applyServersState(_ data: Data) {
+        WatchUserDefaults.shared.set(Date(), key: .serversUpdatedAt)
+        Current.servers.restoreState(data)
+        applyURLOverrides()
     }
 
     /// Re-apply each server's watch-local "Always use" URL choice. `ConnectionInfo` is overwritten on

--- a/Sources/WatchApp/WatchSettingsView.swift
+++ b/Sources/WatchApp/WatchSettingsView.swift
@@ -129,7 +129,9 @@ struct WatchSettingsView: View {
     private var restartAppSection: some View {
         Section {
             Button(role: .destructive) {
-                fatalError("User requested app restart from watch settings")
+                // Terminate cleanly (watchOS relaunches on next tap). A `fatalError` here would file a
+                // crash report for every use — it was one of the app's top "crashes" in the field.
+                exit(0)
             } label: {
                 Label(L10n.Watch.Settings.RestartApp.title, systemSymbol: .arrowClockwise)
             }


### PR DESCRIPTION
## Summary

Fixes the top watch crash clusters from recent crash reports and polishes sync/error handling.

### Crashes
- **GRDB `0xdead10cc` cluster** (Statement.execute / fetchOne / etc.): the watch never engaged GRDB's database suspension, so background WCSession writes could hold the app-group SQLite lock while the process was suspended. Now suspends/resumes on lifecycle and wraps background-delivered writes in an expiring activity.
- **`$main()` assertion**: the Settings "Restart app" button called `fatalError`, filing a crash report on every use. Now exits cleanly.
- **Background-refresh watchdog kill**: `WCSession.receivedApplicationContext` is a blocking getter and stalled concurrent `syncWatchContext()` tasks for 25s+. The received context is now cached in memory (primed once off-main, refreshed by the delegate) so reading it never blocks. This was also the main cause of the app feeling stuck when several syncs ran at once.

### Sync
- Initial (automatic) sync failures no longer show an error alert — the cache is already on screen and the failure is still recorded in client events. User-initiated syncs keep the alert.
- A transient cache read failure no longer blanks the home screen; the rendered config is kept and only replaced by data that actually loaded.
- The database sync mirror now also carries the servers (both the chunked pull and the background push), in addition to the existing `serversConfigSync` exchange. If a mirrored server references an mTLS certificate missing from the watch keychain, a full `serversConfigSync` is requested automatically.

### Magic items
- The iPhone relay now replies with the failure reason (stale request, missing server, no connection, service call error) instead of a bare `fired: false`.
- Every failed execution on the watch shows the reason in the row alert and is recorded in watch client events (item, server, route, reason).
- Direct REST execution got a 15s timeout so a dead route fails visibly instead of hanging.