### PR TITLE
Fix top iOS crashes: off-main oneShotLocation trap and Realm fallback fatalError

### DIFF
--- a/Sources/Shared/Common/Extensions/Realm+Initialization.swift
+++ b/Sources/Shared/Common/Extensions/Realm+Initialization.swift
@@ -209,8 +209,14 @@ public extension Realm {
             )
 
             do {
-                // temporarily provide an in-memory instance so we don't crash
-                return try Realm(configuration: .init(inMemoryIdentifier: "Fallback"))
+                // Temporarily provide an in-memory instance so we don't crash. The identifier must be
+                // unique per call: in-memory Realms share schema by identifier, so reusing one across
+                // calls with different `objectTypes` throws a schema mismatch — which used to hit the
+                // fatalError below and take the whole app down at launch.
+                return try Realm(configuration: .init(
+                    inMemoryIdentifier: "Fallback-\(UUID().uuidString)",
+                    objectTypes: objectTypes
+                ))
             } catch {
                 fatalError(String(describing: error))
             }
@@ -294,7 +300,10 @@ public extension Realm {
             timer.fire()
         }
         #else
-        fatalError("\(message) \(error.localizedDescription)")
+        // Don't crash here: on watchOS this ran before `getRealm`'s in-memory fallback could engage,
+        // so any Realm open error (e.g. file locked during a background wake) killed the app instead
+        // of degrading to the fallback store.
+        Current.Log.error("Realm error (continuing with fallback): \(message) \(error.localizedDescription)")
         #endif
     }
 

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -4,10 +4,20 @@ import PromiseKit
 
 public extension CLLocationManager {
     static func oneShotLocation(timeout: TimeInterval) -> Promise<CLLocation> {
-        OneShotLocationProxy(
-            locationManager: CLLocationManager(),
-            timeout: after(seconds: timeout)
-        ).promise
+        // The proxy asserts main-thread invariants (CLLocationManager delegate callbacks need the main
+        // run loop), but callers reach this from promise chains and Swift concurrency tasks on
+        // arbitrary queues — which crashed in the field. Hop to main instead of trapping; stay
+        // synchronous when already there.
+        let makeProxy = {
+            OneShotLocationProxy(
+                locationManager: CLLocationManager(),
+                timeout: after(seconds: timeout)
+            ).promise
+        }
+        if Thread.isMainThread {
+            return makeProxy()
+        }
+        return DispatchQueue.main.async(.promise, execute: makeProxy).then { $0 }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the two actionable crash clusters from the 2026.8.0 iOS crash reports.

### `OneShotLocationProxy.init` precondition failure (2 of the top signatures)
`OneShotLocationProxy.init` asserts `Thread.isMainThread`, but `CLLocationManager.oneShotLocation(timeout:)` is reached from promise chains and Swift concurrency tasks on arbitrary queues — the field crashes came from an async task. The wrapper now hops to the main queue when needed (staying synchronous when already on main) instead of trapping. Existing tests construct the proxy directly on main and are unaffected.

### `Realm.getRealm` launch crash (`AppDelegate.setupModels`)
When the file-based Realm fails to open, the in-memory fallback reused the fixed identifier `"Fallback"` with the full default schema. In-memory Realms share schema by identifier, so a later `getRealm(objectTypes:)` call with a different type set throws a schema mismatch and hit the `fatalError` — killing the app at launch. The fallback now uses a unique identifier per call and passes `objectTypes` through.

Also, `Realm.handleError` called `fatalError` on non-iOS platforms *before* the in-memory fallback could engage, so on watchOS any Realm open error (e.g. file locked during a background wake) crashed outright. It now logs and lets the fallback take over.

### Not addressed (verified non-actionable)
`DYLD Library not loaded: RealmSwift` — one device; other crash logs from the same build show RealmSwift loaded from the app bundle, so packaging is correct and that install was corrupt. `CFNetwork`, `JavaScriptCore timed_wait`, `Realm ExternalCommitHelper::listen()` and `NO_CRASH_STACK` are system/Realm-internal signatures with one device each; tracking device counts across builds.