### PR TITLE
Add kiosk screensaver sensor

### DIFF
--- a/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
@@ -142,7 +142,14 @@ private struct PixelShiftContainer<Content: View>: View {
 /// Drives the screensaver: starts an inactivity timer (per `timeToStart`) and toggles `isActive`. Activity
 /// reported via `recordActivity()` resets the timer; `wake()` dismisses an active screensaver.
 final class KioskScreensaverController: ObservableObject {
-    @Published private(set) var isActive = false
+    @Published private(set) var isActive = false {
+        didSet {
+            guard oldValue != isActive else { return }
+            // Mirror visibility into the shared kiosk manager so the kiosk screensaver sensor can report it.
+            Current.kiosk.setScreensaverVisible(isActive)
+        }
+    }
+
     @Published private(set) var screensaver = KioskScreensaverSettings()
 
     private var isEnabled = false
@@ -192,6 +199,8 @@ final class KioskScreensaverController: ObservableObject {
     deinit {
         idleTimer?.invalidate()
         restoreBrightness()
+        // The screensaver is no longer on screen once this controller goes away (e.g. kiosk mode disabled).
+        Current.kiosk.setScreensaverVisible(false)
     }
 
     func recordActivity() {

--- a/Sources/App/Settings/Kiosk/KioskSensorsViewModel.swift
+++ b/Sources/App/Settings/Kiosk/KioskSensorsViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 /// through `Current.sensors`, so the two screens always mirror each other.
 final class KioskSensorsViewModel: ObservableObject {
     /// Identifiers of the sensors surfaced in the kiosk sensors menu, in display order.
-    static let sensorIds: [WebhookSensorId] = [.kioskMode, .kioskBrightness, .kioskVolume]
+    static let sensorIds: [WebhookSensorId] = [.kioskMode, .kioskBrightness, .kioskVolume, .kioskScreensaver]
     private static let order: [String: Int] = Dictionary(
         uniqueKeysWithValues: sensorIds.enumerated().map { ($0.element.rawValue, $0.offset) }
     )

--- a/Sources/Shared/API/Webhook/Sensors/KioskScreensaverSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/KioskScreensaverSensor.swift
@@ -1,0 +1,64 @@
+import Combine
+import Foundation
+import PromiseKit
+
+final class KioskScreensaverSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
+    private var cancellable: AnyCancellable?
+    private let signal: () -> Void
+
+    init(signal: @escaping () -> Void) {
+        self.signal = signal
+        super.init(relatedSensorsIds: [
+            .kioskScreensaver,
+        ])
+    }
+
+    override func observe() {
+        super.observe()
+        guard !isObserving else { return }
+        cancellable = Current.kiosk.screensaverVisiblePublisher
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.signal()
+            }
+        isObserving = true
+    }
+
+    override func stopObserving() {
+        super.stopObserving()
+        guard isObserving else { return }
+        cancellable?.cancel()
+        cancellable = nil
+        isObserving = false
+    }
+}
+
+/// Reports whether the kiosk screensaver is currently visible: on while the screensaver is on screen,
+/// off otherwise. Enabled only while kiosk mode is enabled, iOS/iPadOS only.
+final class KioskScreensaverSensor: SensorProvider {
+    let request: SensorProviderRequest
+    init(request: SensorProviderRequest) {
+        self.request = request
+    }
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        var sensors: [WebhookSensor] = []
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        let isVisible = Current.kiosk.isScreensaverVisible
+        let sensor = WebhookSensor(
+            name: "Kiosk Screensaver",
+            uniqueID: WebhookSensorId.kioskScreensaver.rawValue,
+            icon: isVisible ? "mdi:sleep" : "mdi:sleep-off",
+            state: isVisible
+        )
+        sensor.Type = "binary_sensor"
+        sensors.append(sensor)
+
+        // Set up our observer for screensaver visibility changes
+        let _: KioskScreensaverSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
+        #endif
+        return .value(sensors)
+    }
+}

--- a/Sources/Shared/API/Webhook/WebhookSensorId.swift
+++ b/Sources/Shared/API/Webhook/WebhookSensorId.swift
@@ -26,4 +26,5 @@ public enum WebhookSensorId: String, CaseIterable {
     case kioskMode
     case kioskBrightness
     case kioskVolume
+    case kioskScreensaver
 }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -384,6 +384,7 @@ public class AppEnvironment {
         $0.register(provider: KioskModeSensor.self)
         $0.register(provider: KioskBrightnessSensor.self)
         $0.register(provider: KioskVolumeSensor.self)
+        $0.register(provider: KioskScreensaverSensor.self)
     }
 
     public var localized = LocalizedManager()

--- a/Sources/Shared/Environment/KioskModeManager.swift
+++ b/Sources/Shared/Environment/KioskModeManager.swift
@@ -15,6 +15,7 @@ public enum KioskScreensaverCommand: Equatable {
 public final class KioskModeManager: ObservableObject {
     @Published public private(set) var settings: KioskSettings
     @Published public private(set) var isCameraOverlayVisible = false
+    @Published public private(set) var isScreensaverVisible = false
 
     public var shouldKeepScreenOn: Bool {
         settings.enabled && settings.keepScreenOn
@@ -33,12 +34,23 @@ public final class KioskModeManager: ObservableObject {
         $isCameraOverlayVisible.eraseToAnyPublisher()
     }
 
+    /// Emits the current screensaver visibility and every subsequent change, so the kiosk screensaver
+    /// sensor can report whether the screensaver is on screen.
+    public var screensaverVisiblePublisher: AnyPublisher<Bool, Never> {
+        $isScreensaverVisible.eraseToAnyPublisher()
+    }
+
     public func requestScreensaver(_ command: KioskScreensaverCommand) {
         screensaverCommandSubject.send(command)
     }
 
     public func setCameraOverlayVisible(_ visible: Bool) {
         isCameraOverlayVisible = visible
+    }
+
+    /// Called by the screensaver controller whenever the screensaver is shown or dismissed.
+    public func setScreensaverVisible(_ visible: Bool) {
+        isScreensaverVisible = visible
     }
 
     private let screensaverCommandSubject = PassthroughSubject<KioskScreensaverCommand, Never>()
@@ -66,11 +78,11 @@ public final class KioskModeManager: ObservableObject {
         )
     }
 
-    /// The kiosk brightness and volume sensors only make sense on a device acting as a kiosk, so we
-    /// keep them enabled only while kiosk mode is enabled. This runs for the observation's initial
-    /// value and every subsequent change, and is idempotent so it won't fire spurious updates.
+    /// The kiosk brightness, volume and screensaver sensors only make sense on a device acting as a
+    /// kiosk, so we keep them enabled only while kiosk mode is enabled. This runs for the observation's
+    /// initial value and every subsequent change, and is idempotent so it won't fire spurious updates.
     private func syncKioskSensorsEnabled(with settings: KioskSettings) {
-        for sensorId in [WebhookSensorId.kioskBrightness, .kioskVolume] {
+        for sensorId in [WebhookSensorId.kioskBrightness, .kioskVolume, .kioskScreensaver] {
             guard Current.sensors.isEnabled(uniqueID: sensorId.rawValue) != settings.enabled else { continue }
             Current.sensors.setEnabled(settings.enabled, forUniqueID: sensorId.rawValue)
         }

--- a/Tests/App/Webhook/WebhookSensorIdTests.swift
+++ b/Tests/App/Webhook/WebhookSensorIdTests.swift
@@ -28,8 +28,9 @@ struct WebhookSensorIdTests {
         assert(WebhookSensorId.kioskMode.rawValue == "kioskMode")
         assert(WebhookSensorId.kioskBrightness.rawValue == "kioskBrightness")
         assert(WebhookSensorId.kioskVolume.rawValue == "kioskVolume")
+        assert(WebhookSensorId.kioskScreensaver.rawValue == "kioskScreensaver")
         assert(
-            WebhookSensorId.allCases.count == 25,
+            WebhookSensorId.allCases.count == 26,
             "WebhookSensorId has different number of cases than defined in test, \(WebhookSensorId.allCases.count)"
         )
     }


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new **Kiosk Screensaver** binary sensor, alongside the existing kiosk sensors (Kiosk Mode, Kiosk Brightness, Kiosk Volume). It reports whether the kiosk screensaver is currently on screen:

- **On** while the screensaver is visible
- **Off** when the screensaver is not on screen

Details:
- `KioskModeManager` now tracks screensaver visibility via `isScreensaverVisible` and a `screensaverVisiblePublisher`, mirroring the existing camera-overlay handling.
- `KioskScreensaverController` forwards its `isActive` state into the shared manager (and resets it on teardown) so the sensor and its update signaler can report and react to changes in real time.
- The sensor follows the established kiosk sensor pattern (`SensorProvider` + `SensorProviderUpdateSignaler`), is a `binary_sensor`, and is iOS/iPadOS only.
- Like the brightness and volume kiosk sensors, it is automatically enabled only while kiosk mode is enabled.
- It is also surfaced in the in-app kiosk **Sensors** settings menu.
- Icon: `mdi:sleep` when on, `mdi:sleep-off` when off.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
_N/A — this adds a webhook sensor; no new user-facing screen. The sensor appears in the existing kiosk Sensors settings list._

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
`WebhookSensorId` gains a `kioskScreensaver` case; the existing `WebhookSensorIdTests` case-count assertion was updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X19UpFyBKpRNaJAgXgqBUX

---
_Generated by [Claude Code](https://claude.ai/code/session_01X19UpFyBKpRNaJAgXgqBUX)_