### PR TITLE
Fix MDI update workflow (pod install + API rate limit)

### DIFF
--- a/.github/workflows/update_material_design_icons.yml
+++ b/.github/workflows/update_material_design_icons.yml
@@ -39,7 +39,7 @@ jobs:
           VERSION=$(sed -n 's/^MDI_VERSION=//p' Tools/BuildMaterialDesignIconsFont.sh)
           git add Tools/BuildMaterialDesignIconsFont.sh
           git add Tools/MaterialDesignIcons.ttf Tools/MaterialDesignIcons.json
-          git add Sources/Shared/Iconic/MaterialDesignIcons.swift
+          git add Sources/HAIconic/Sources/MaterialDesignIcons.swift
           if ! git diff --cached --quiet; then
             git commit -m "Bump MaterialDesignIcons to $VERSION"
           fi

--- a/.github/workflows/update_material_design_icons.yml
+++ b/.github/workflows/update_material_design_icons.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install Gems
         run: bundle install --jobs 4 --retry 3
 
-      - name: Install Pods
-        run: ONLY_SUPPORT_MODULES=1 bundle exec pod install --repo-update
-
       - name: Bump Material Design Icons to latest
         run: ./Tools/BuildMaterialDesignIconsFont.sh --bump
 

--- a/.github/workflows/update_material_design_icons.yml
+++ b/.github/workflows/update_material_design_icons.yml
@@ -27,6 +27,8 @@ jobs:
         run: bundle install --jobs 4 --retry 3
 
       - name: Bump Material Design Icons to latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./Tools/BuildMaterialDesignIconsFont.sh --bump
 
       - name: Commit changes

--- a/Tools/BuildMaterialDesignIconsFont.sh
+++ b/Tools/BuildMaterialDesignIconsFont.sh
@@ -26,9 +26,20 @@ if [ "${1:-}" = "--bump" ]; then
 	BUMP=1
 fi
 
+# Query the GitHub API, authenticating with GITHUB_TOKEN when it is available.
+# Unauthenticated requests share a 60/hour per-IP limit that CI runners routinely
+# exhaust, which returns an error body that parses to an empty result.
+gh_api() {
+	if [ -n "${GITHUB_TOKEN:-}" ]; then
+		curl --silent -H "Authorization: Bearer $GITHUB_TOKEN" "$@"
+	else
+		curl --silent "$@"
+	fi
+}
+
 echo "Checking for latest..."
 
-LATEST=$(curl --silent https://api.github.com/repos/Templarian/MaterialDesign-Webfont/tags | sed -n -e 's/.*"name": "v\([^"]*\)".*/\1/p' | head -1)
+LATEST=$(gh_api https://api.github.com/repos/Templarian/MaterialDesign-Webfont/tags | sed -n -e 's/.*"name": "v\([^"]*\)".*/\1/p' | head -1)
 echo "Latest available: $LATEST; currently pinned: $MDI_VERSION"
 
 if [ "$BUMP" -eq 1 ]; then
@@ -42,10 +53,10 @@ if [ "$BUMP" -eq 1 ]; then
 	fi
 
 	echo "Resolving commit for MaterialDesign-Webfont v$LATEST..."
-	MDI_COMMIT=$(curl --silent https://api.github.com/repos/Templarian/MaterialDesign-Webfont/commits/v$LATEST | sed -n -e 's/.*"sha": *"\([^"]*\)".*/\1/p' | head -1)
+	MDI_COMMIT=$(gh_api https://api.github.com/repos/Templarian/MaterialDesign-Webfont/commits/v$LATEST | sed -n -e 's/.*"sha": *"\([^"]*\)".*/\1/p' | head -1)
 
 	echo "Resolving commit for MaterialDesign-SVG v$LATEST..."
-	SVG_COMMIT=$(curl --silent https://api.github.com/repos/Templarian/MaterialDesign-SVG/commits/v$LATEST | sed -n -e 's/.*"sha": *"\([^"]*\)".*/\1/p' | head -1)
+	SVG_COMMIT=$(gh_api https://api.github.com/repos/Templarian/MaterialDesign-SVG/commits/v$LATEST | sed -n -e 's/.*"sha": *"\([^"]*\)".*/\1/p' | head -1)
 
 	if [ -z "$MDI_COMMIT" ] || [ -z "$SVG_COMMIT" ]; then
 		echo "Could not resolve matching commits for v$LATEST in both repositories; aborting."

--- a/Tools/BuildMaterialDesignIconsFont.sh
+++ b/Tools/BuildMaterialDesignIconsFont.sh
@@ -80,7 +80,15 @@ else
 fi
 
 echo "Ensuring fonttools is installed via pip..."
-pip3 install --user fonttools
+# Install into a throwaway virtualenv so this works on PEP 668 "externally
+# managed" Python (Homebrew on CI) without needing --break-system-packages,
+# which older local pip versions do not support.
+FONTTOOLS_VENV="$(mktemp -d)"
+trap 'rm -rf "$FONTTOOLS_VENV"' EXIT
+python3 -m venv "$FONTTOOLS_VENV"
+# shellcheck disable=SC1091
+source "$FONTTOOLS_VENV/bin/activate"
+pip install --quiet fonttools
 
 if [ ! -f fontname-$FONT_RENAME_COMMIT.py ]; then
   echo "Downloading the fontname script..."


### PR DESCRIPTION
## Summary

The weekly [**Update Material Design Icons**](https://github.com/home-assistant/iOS/blob/main/.github/workflows/update_material_design_icons.yml) workflow had never run cleanly end-to-end after the CocoaPods→SPM and HAIconic-package migrations. This fixes the chain of failures, one per step:

| Step | Failure | Fix |
|------|---------|-----|
| `Install Pods` | `pod` gem removed with CocoaPods → SPM migration | removed the obsolete step |
| `Bump` (version lookup) | unauthenticated GitHub API rate-limited on shared runner IP → empty version | `gh_api` helper sends `Authorization` when `GITHUB_TOKEN` is set; token passed from the workflow |
| `Bump` (pip) | Homebrew Python is PEP 668 "externally managed" → `pip install --user` refused | install `fonttools` into a throwaway virtualenv (no `--break-system-packages`, so local dev is unaffected) |
| `Commit changes` | staged `Sources/Shared/Iconic/MaterialDesignIcons.swift`, a path that no longer exists | corrected to `Sources/HAIconic/Sources/MaterialDesignIcons.swift` per `swiftgen.yml` |

A dispatch on this branch confirmed each fix in turn; the final run reached `Commit changes` (i.e. SwiftGen regenerated the file), which the last commit addresses.

## Verifying

The `Create Pull Request` step operates on the checked-out branch, so a fully-green dispatch **on this branch** would open a bump PR mixed with these fix commits. Cleanest: **merge this PR, then dispatch from `main`** — MDI is behind (7.1.96 → 7.4.47), so it opens a proper standalone bump PR and is the real end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)