### PR TITLE
Add kiosk screensaver mode and brightness push commands

### DIFF
--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -10,6 +10,7 @@ enum KioskPushCommand: String, CaseIterable {
     case hideCamera = "kiosk_hide_camera"
     case setBrightness = "kiosk_set_brightness"
     case setVolume = "kiosk_set_volume"
+    case setScreensaverMode = "kiosk_set_screensaver_mode"
     case reload = "kiosk_reload"
     case defaultDashboard = "kiosk_default"
 
@@ -34,7 +35,18 @@ enum KioskPushCommand: String, CaseIterable {
             return "level"
         case .setVolume:
             return "volume"
-        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .reload, .defaultDashboard:
+        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .setScreensaverMode, .reload,
+             .defaultDashboard:
+            return nil
+        }
+    }
+
+    var modeKey: String? {
+        switch self {
+        case .setScreensaverMode:
+            return "mode"
+        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .setBrightness, .setVolume, .reload,
+             .defaultDashboard:
             return nil
         }
     }
@@ -76,6 +88,30 @@ enum KioskPushCommand: String, CaseIterable {
         }
     }
 
+    func screensaverMode(from userInfo: [AnyHashable: Any]?) -> KioskScreensaverMode? {
+        guard let modeKey, let userInfo,
+              let raw = Self.stringValue(forKey: modeKey, in: userInfo) else {
+            return nil
+        }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return KioskScreensaverMode(rawValue: normalized)
+    }
+
+    private static func stringValue(forKey key: String, in userInfo: [AnyHashable: Any]) -> String? {
+        if let value = userInfo[key] as? String {
+            return value
+        }
+        if let homeassistant = userInfo["homeassistant"] as? [String: Any],
+           let value = homeassistant[key] as? String {
+            return value
+        }
+        if let homeassistant = userInfo["homeassistant"] as? [AnyHashable: Any],
+           let value = homeassistant[key] as? String {
+            return value
+        }
+        return nil
+    }
+
     var localizedString: String {
         switch self {
         case .showScreensaver:
@@ -90,6 +126,8 @@ enum KioskPushCommand: String, CaseIterable {
             return L10n.Kiosk.PushCommand.setBrightness
         case .setVolume:
             return L10n.Kiosk.PushCommand.setVolume
+        case .setScreensaverMode:
+            return L10n.Kiosk.PushCommand.setScreensaverMode
         case .reload:
             return L10n.Kiosk.PushCommand.reload
         case .defaultDashboard:
@@ -115,6 +153,8 @@ enum KioskPushCommand: String, CaseIterable {
             return .sunMax
         case .setVolume:
             return .speakerWave3Fill
+        case .setScreensaverMode:
+            return .moonStars
         case .reload:
             return .arrowClockwise
         case .defaultDashboard:
@@ -136,6 +176,8 @@ enum KioskPushCommand: String, CaseIterable {
             return (.white, .yellow)
         case .setVolume:
             return (.white, .teal)
+        case .setScreensaverMode:
+            return (.white, .purple)
         case .reload:
             return (.white, .green)
         case .defaultDashboard:

--- a/Sources/App/Notifications/KioskPushCommand.swift
+++ b/Sources/App/Notifications/KioskPushCommand.swift
@@ -11,6 +11,7 @@ enum KioskPushCommand: String, CaseIterable {
     case setBrightness = "kiosk_set_brightness"
     case setVolume = "kiosk_set_volume"
     case setScreensaverMode = "kiosk_set_screensaver_mode"
+    case setScreensaverBrightness = "kiosk_set_screensaver_brightness"
     case reload = "kiosk_reload"
     case defaultDashboard = "kiosk_default"
 
@@ -31,7 +32,7 @@ enum KioskPushCommand: String, CaseIterable {
     /// The payload key holding this command's numeric level, for commands that take one.
     var levelKey: String? {
         switch self {
-        case .setBrightness:
+        case .setBrightness, .setScreensaverBrightness:
             return "level"
         case .setVolume:
             return "volume"
@@ -45,8 +46,8 @@ enum KioskPushCommand: String, CaseIterable {
         switch self {
         case .setScreensaverMode:
             return "mode"
-        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .setBrightness, .setVolume, .reload,
-             .defaultDashboard:
+        case .showScreensaver, .hideScreensaver, .showCamera, .hideCamera, .setBrightness, .setVolume,
+             .setScreensaverBrightness, .reload, .defaultDashboard:
             return nil
         }
     }
@@ -128,6 +129,8 @@ enum KioskPushCommand: String, CaseIterable {
             return L10n.Kiosk.PushCommand.setVolume
         case .setScreensaverMode:
             return L10n.Kiosk.PushCommand.setScreensaverMode
+        case .setScreensaverBrightness:
+            return L10n.Kiosk.PushCommand.setScreensaverBrightness
         case .reload:
             return L10n.Kiosk.PushCommand.reload
         case .defaultDashboard:
@@ -155,6 +158,8 @@ enum KioskPushCommand: String, CaseIterable {
             return .speakerWave3Fill
         case .setScreensaverMode:
             return .moonStars
+        case .setScreensaverBrightness:
+            return .sunMinFill
         case .reload:
             return .arrowClockwise
         case .defaultDashboard:
@@ -178,6 +183,8 @@ enum KioskPushCommand: String, CaseIterable {
             return (.white, .teal)
         case .setScreensaverMode:
             return (.white, .purple)
+        case .setScreensaverBrightness:
+            return (.white, .indigo)
         case .reload:
             return (.white, .green)
         case .defaultDashboard:

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -633,6 +633,12 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             } else {
                 Current.Log.error("Ignoring \(command.rawValue): missing or invalid mode in payload")
             }
+        case .setScreensaverBrightness:
+            if let level = command.level(from: userInfo) {
+                Current.kiosk.setScreensaverDimLevel(Double(level))
+            } else {
+                Current.Log.error("Ignoring \(command.rawValue): missing or invalid level in payload")
+            }
         case .reload:
             Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
         case .defaultDashboard:

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -627,6 +627,12 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
             } else {
                 Current.Log.error("Ignoring \(command.rawValue): missing or invalid volume in payload")
             }
+        case .setScreensaverMode:
+            if let mode = command.screensaverMode(from: userInfo) {
+                Current.kiosk.setScreensaverMode(mode)
+            } else {
+                Current.Log.error("Ignoring \(command.rawValue): missing or invalid mode in payload")
+            }
         case .reload:
             Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
         case .defaultDashboard:

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -605,6 +605,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.push_command.hide_screensaver" = "Hiding screensaver";
 "kiosk.push_command.reload" = "Reloading dashboard";
 "kiosk.push_command.set_brightness" = "Setting brightness";
+"kiosk.push_command.set_screensaver_mode" = "Setting screensaver mode";
 "kiosk.push_command.set_volume" = "Setting volume";
 "kiosk.push_command.show_camera" = "Showing camera";
 "kiosk.push_command.show_screensaver" = "Showing screensaver";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -605,6 +605,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "kiosk.push_command.hide_screensaver" = "Hiding screensaver";
 "kiosk.push_command.reload" = "Reloading dashboard";
 "kiosk.push_command.set_brightness" = "Setting brightness";
+"kiosk.push_command.set_screensaver_brightness" = "Setting screensaver brightness";
 "kiosk.push_command.set_screensaver_mode" = "Setting screensaver mode";
 "kiosk.push_command.set_volume" = "Setting volume";
 "kiosk.push_command.show_camera" = "Showing camera";

--- a/Sources/Shared/Environment/KioskModeManager.swift
+++ b/Sources/Shared/Environment/KioskModeManager.swift
@@ -56,6 +56,18 @@ public final class KioskModeManager: ObservableObject {
         }
     }
 
+    public func setScreensaverDimLevel(_ level: Double) {
+        do {
+            try Current.database().write { db in
+                var settings = try KioskSettings.fetchOne(db) ?? KioskSettings()
+                settings.screensaver.dimLevel = min(max(level, 0), 1)
+                try settings.insert(db, onConflict: .replace)
+            }
+        } catch {
+            Current.Log.error("Failed to set kiosk screensaver dim level: \(error)")
+        }
+    }
+
     public func setCameraOverlayVisible(_ visible: Bool) {
         isCameraOverlayVisible = visible
     }

--- a/Sources/Shared/Environment/KioskModeManager.swift
+++ b/Sources/Shared/Environment/KioskModeManager.swift
@@ -44,6 +44,18 @@ public final class KioskModeManager: ObservableObject {
         screensaverCommandSubject.send(command)
     }
 
+    public func setScreensaverMode(_ mode: KioskScreensaverMode) {
+        do {
+            try Current.database().write { db in
+                var settings = try KioskSettings.fetchOne(db) ?? KioskSettings()
+                settings.screensaver.mode = mode
+                try settings.insert(db, onConflict: .replace)
+            }
+        } catch {
+            Current.Log.error("Failed to set kiosk screensaver mode: \(error)")
+        }
+    }
+
     public func setCameraOverlayVisible(_ visible: Bool) {
         isCameraOverlayVisible = visible
     }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2177,6 +2177,8 @@ public enum L10n {
       public static var reload: String { return L10n.tr("Localizable", "kiosk.push_command.reload") }
       /// Setting brightness
       public static var setBrightness: String { return L10n.tr("Localizable", "kiosk.push_command.set_brightness") }
+      /// Setting screensaver mode
+      public static var setScreensaverMode: String { return L10n.tr("Localizable", "kiosk.push_command.set_screensaver_mode") }
       /// Setting volume
       public static var setVolume: String { return L10n.tr("Localizable", "kiosk.push_command.set_volume") }
       /// Showing camera

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2177,6 +2177,8 @@ public enum L10n {
       public static var reload: String { return L10n.tr("Localizable", "kiosk.push_command.reload") }
       /// Setting brightness
       public static var setBrightness: String { return L10n.tr("Localizable", "kiosk.push_command.set_brightness") }
+      /// Setting screensaver brightness
+      public static var setScreensaverBrightness: String { return L10n.tr("Localizable", "kiosk.push_command.set_screensaver_brightness") }
       /// Setting screensaver mode
       public static var setScreensaverMode: String { return L10n.tr("Localizable", "kiosk.push_command.set_screensaver_mode") }
       /// Setting volume

--- a/Tests/App/Notifications/KioskPushCommandTests.swift
+++ b/Tests/App/Notifications/KioskPushCommandTests.swift
@@ -12,6 +12,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand(message: "kiosk_set_brightness"), .setBrightness)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_set_volume"), .setVolume)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_set_screensaver_mode"), .setScreensaverMode)
+        XCTAssertEqual(KioskPushCommand(message: "kiosk_set_screensaver_brightness"), .setScreensaverBrightness)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_reload"), .reload)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_default"), .defaultDashboard)
     }
@@ -42,6 +43,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand.setBrightness.rawValue, "kiosk_set_brightness")
         XCTAssertEqual(KioskPushCommand.setVolume.rawValue, "kiosk_set_volume")
         XCTAssertEqual(KioskPushCommand.setScreensaverMode.rawValue, "kiosk_set_screensaver_mode")
+        XCTAssertEqual(KioskPushCommand.setScreensaverBrightness.rawValue, "kiosk_set_screensaver_brightness")
         XCTAssertEqual(KioskPushCommand.reload.rawValue, "kiosk_reload")
         XCTAssertEqual(KioskPushCommand.defaultDashboard.rawValue, "kiosk_default")
     }
@@ -57,11 +59,31 @@ final class KioskPushCommandTests: XCTestCase {
     func testOnlyLevelCommandsHaveLevelKey() {
         XCTAssertEqual(KioskPushCommand.setBrightness.levelKey, "level")
         XCTAssertEqual(KioskPushCommand.setVolume.levelKey, "volume")
+        XCTAssertEqual(KioskPushCommand.setScreensaverBrightness.levelKey, "level")
         XCTAssertNil(KioskPushCommand.showScreensaver.levelKey)
         XCTAssertNil(KioskPushCommand.hideScreensaver.levelKey)
         XCTAssertNil(KioskPushCommand.showCamera.levelKey)
         XCTAssertNil(KioskPushCommand.hideCamera.levelKey)
         XCTAssertNil(KioskPushCommand.setScreensaverMode.levelKey)
+    }
+
+    func testScreensaverBrightnessParsesLevel() {
+        XCTAssertEqual(
+            KioskPushCommand.setScreensaverBrightness.level(from: ["level": 20]) ?? .nan,
+            0.2,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            KioskPushCommand.setScreensaverBrightness.level(from: ["level": 0.35]) ?? .nan,
+            0.35,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            KioskPushCommand.setScreensaverBrightness.level(from: ["homeassistant": ["level": "80"]]) ?? .nan,
+            0.8,
+            accuracy: 0.0001
+        )
+        XCTAssertNil(KioskPushCommand.setScreensaverBrightness.level(from: [:]))
     }
 
     func testLevelParsesFraction() {
@@ -109,6 +131,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand.setScreensaverMode.modeKey, "mode")
         XCTAssertNil(KioskPushCommand.showScreensaver.modeKey)
         XCTAssertNil(KioskPushCommand.setBrightness.modeKey)
+        XCTAssertNil(KioskPushCommand.setScreensaverBrightness.modeKey)
     }
 
     func testModeParsesKnownModes() {

--- a/Tests/App/Notifications/KioskPushCommandTests.swift
+++ b/Tests/App/Notifications/KioskPushCommandTests.swift
@@ -1,5 +1,6 @@
 @testable import HomeAssistant
 import SFSafeSymbols
+import Shared
 import XCTest
 
 final class KioskPushCommandTests: XCTestCase {
@@ -10,6 +11,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand(message: "kiosk_hide_camera"), .hideCamera)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_set_brightness"), .setBrightness)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_set_volume"), .setVolume)
+        XCTAssertEqual(KioskPushCommand(message: "kiosk_set_screensaver_mode"), .setScreensaverMode)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_reload"), .reload)
         XCTAssertEqual(KioskPushCommand(message: "kiosk_default"), .defaultDashboard)
     }
@@ -39,6 +41,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertEqual(KioskPushCommand.hideCamera.rawValue, "kiosk_hide_camera")
         XCTAssertEqual(KioskPushCommand.setBrightness.rawValue, "kiosk_set_brightness")
         XCTAssertEqual(KioskPushCommand.setVolume.rawValue, "kiosk_set_volume")
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.rawValue, "kiosk_set_screensaver_mode")
         XCTAssertEqual(KioskPushCommand.reload.rawValue, "kiosk_reload")
         XCTAssertEqual(KioskPushCommand.defaultDashboard.rawValue, "kiosk_default")
     }
@@ -58,6 +61,7 @@ final class KioskPushCommandTests: XCTestCase {
         XCTAssertNil(KioskPushCommand.hideScreensaver.levelKey)
         XCTAssertNil(KioskPushCommand.showCamera.levelKey)
         XCTAssertNil(KioskPushCommand.hideCamera.levelKey)
+        XCTAssertNil(KioskPushCommand.setScreensaverMode.levelKey)
     }
 
     func testLevelParsesFraction() {
@@ -97,5 +101,42 @@ final class KioskPushCommandTests: XCTestCase {
     func testLevelReturnsNilForValuelessCommands() {
         XCTAssertNil(KioskPushCommand.showScreensaver.level(from: ["level": 0.5]))
         XCTAssertNil(KioskPushCommand.hideCamera.level(from: ["volume": 0.5]))
+    }
+
+    // MARK: - Payload screensaver mode parsing
+
+    func testOnlyModeCommandHasModeKey() {
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.modeKey, "mode")
+        XCTAssertNil(KioskPushCommand.showScreensaver.modeKey)
+        XCTAssertNil(KioskPushCommand.setBrightness.modeKey)
+    }
+
+    func testModeParsesKnownModes() {
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "clock"]), .clock)
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "dim"]), .dim)
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "blank"]), .blank)
+    }
+
+    func testModeTrimsWhitespaceAndIgnoresCase() {
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "  Clock \n"]), .clock)
+        XCTAssertEqual(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "DIM"]), .dim)
+    }
+
+    func testModeReadsNestedHomeassistantPayload() {
+        XCTAssertEqual(
+            KioskPushCommand.setScreensaverMode.screensaverMode(from: ["homeassistant": ["mode": "blank"]]),
+            .blank
+        )
+    }
+
+    func testModeReturnsNilWhenMissingOrInvalid() {
+        XCTAssertNil(KioskPushCommand.setScreensaverMode.screensaverMode(from: [:]))
+        XCTAssertNil(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": "off"]))
+        XCTAssertNil(KioskPushCommand.setScreensaverMode.screensaverMode(from: ["mode": 3]))
+    }
+
+    func testModeReturnsNilForNonModeCommands() {
+        XCTAssertNil(KioskPushCommand.showScreensaver.screensaverMode(from: ["mode": "clock"]))
+        XCTAssertNil(KioskPushCommand.setBrightness.screensaverMode(from: ["mode": "clock"]))
     }
 }


### PR DESCRIPTION
## Summary

Adds two new kiosk remote commands that let a push notification configure the kiosk screensaver.

| `message` | Payload | Action |
| --- | --- | --- |
| `kiosk_set_screensaver_mode` | `mode`: `clock`, `dim` or `blank` | Sets the screensaver mode. |
| `kiosk_set_screensaver_brightness` | `level`: `0`–`100` (or `0`–`1` fraction) | Sets the screensaver dim/brightness level. |

Both commands:
- Read their value from the payload top-level or nested under `homeassistant` (same lookup as `kiosk_set_brightness`/`kiosk_set_volume`). `mode` is case-insensitive and whitespace-trimmed; missing/invalid values are ignored and logged.
- Persist into the kiosk screensaver settings (`KioskSettings.screensaver`) via new `Current.kiosk.setScreensaverMode(_:)` / `setScreensaverDimLevel(_:)`. The change flows through the existing settings `ValueObservation`, so a visible screensaver updates live and future ones use the new value.
- Add a localized toast title plus a distinct SF Symbol/accent color.

### Example payloads

```json
{ "message": "kiosk_set_screensaver_mode", "mode": "dim" }
{ "message": "kiosk_set_screensaver_brightness", "level": 20 }
```

## Testing

- Extended `KioskPushCommandTests` with parsing, `levelKey`/`modeKey`, and value-extraction coverage (known modes, nested `homeassistant` payload, case-insensitivity, fractions/percentages, invalid/missing values, and non-matching commands returning `nil`).
- `Tools/build_tool swiftformat --lint` and `swiftlint` pass on the changed files; pre-commit autocorrect (swiftformat + rubocop) clean.

## Related

- Docs: companion.home-assistant PR (documents both new commands)
- Relay: mobile-apps-fcm-push draft PR (forwards `mode`; `level` already forwarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)