### PR TITLE
Fix Release archive hang in watch map notification view

### DIFF
--- a/Sources/WatchApp/Notifications/DynamicNotificationView.swift
+++ b/Sources/WatchApp/Notifications/DynamicNotificationView.swift
@@ -27,17 +27,10 @@ struct DynamicNotificationView: View {
                     .frame(maxWidth: .infinity)
                     .clipShape(RoundedRectangle(cornerRadius: attachmentCornerRadius))
             case let .map(primary, secondary):
-                let pins = [NotificationMapPin(id: "primary", coordinate: primary, tint: .red)] +
-                    (secondary.map { [NotificationMapPin(id: "secondary", coordinate: $0, tint: .green)] } ?? [])
-                let region = secondary.map { MKCoordinateRegion(coordinates: [primary, $0]) }
-                    ?? MKCoordinateRegion(
-                        center: primary,
-                        span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
-                    )
                 Map(
-                    coordinateRegion: .constant(region),
+                    coordinateRegion: .constant(mapRegion(primary: primary, secondary: secondary)),
                     interactionModes: [],
-                    annotationItems: pins
+                    annotationItems: mapPins(primary: primary, secondary: secondary)
                 ) { pin in
                     MapMarker(coordinate: pin.coordinate, tint: pin.tint)
                 }
@@ -69,6 +62,32 @@ struct DynamicNotificationView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, -DesignSystem.Spaces.one) // Hack to remove extra padding in the custom notifications view
+    }
+
+    // Kept out of the ViewBuilder body: building these inline (array `+` concatenation with an
+    // optional-map closure) is expensive for the type checker and can hang the Release compiler.
+    private func mapPins(
+        primary: CLLocationCoordinate2D,
+        secondary: CLLocationCoordinate2D?
+    ) -> [NotificationMapPin] {
+        var pins = [NotificationMapPin(id: "primary", coordinate: primary, tint: .red)]
+        if let secondary {
+            pins.append(NotificationMapPin(id: "secondary", coordinate: secondary, tint: .green))
+        }
+        return pins
+    }
+
+    private func mapRegion(
+        primary: CLLocationCoordinate2D,
+        secondary: CLLocationCoordinate2D?
+    ) -> MKCoordinateRegion {
+        if let secondary {
+            return MKCoordinateRegion(coordinates: [primary, secondary])
+        }
+        return MKCoordinateRegion(
+            center: primary,
+            span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

The `Distribute` workflow's `build (ios)` archive job has been failing on `main` since PR #5070 (watchOS notifications → SwiftUI) was merged ([failing run](https://github.com/home-assistant/iOS/actions/runs/29246142437/job/86809117308)). The archive dies **with no diagnostic** — build output stops mid-compile, a multi-minute gap, then the process is killed and the job exits 1. It is *not* a job timeout (other Distribute runs ran longer and passed), which is the signature of the **Swift type-checker hanging/OOMing under Release whole-module-optimization**.

## Root cause

The `.map` case of `DynamicNotificationView.body` built its pins/region inline inside the `@ViewBuilder`:

```swift
let pins = [NotificationMapPin(...)] + (secondary.map { [NotificationMapPin(...)] } ?? [])
```

Array `+` concatenation combined with an optional `.map { [...] } ?? []` closure inside a ViewBuilder is a known trigger for exponential type-checking. Debug builds compile per-file so it passed locally and in review; only the Release archive (WMO) hit the hang.

## Fix

Move the pin/region computation out of the ViewBuilder into two plain, explicitly-typed helper methods (`mapPins` / `mapRegion`). Behavior is identical — this is purely a type-checker-friendliness refactor.

## Verification

Local diagnostics clean. Definitive confirmation is the `Distribute` archive re-running green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)