### PR TITLE
Fix watch complication/widget expired-token auth failures

### DIFF
--- a/Sources/HAModels/Sources/WatchWidgetServerCredential.swift
+++ b/Sources/HAModels/Sources/WatchWidgetServerCredential.swift
@@ -9,8 +9,10 @@ import Foundation
 /// self-signed) request is captured as plain, `Codable` data so the widget can apply it with a small
 /// `URLSession` delegate rather than reusing the server/connection objects.
 ///
-/// The token is a snapshot: a widget cannot refresh an expired token, so a stale token simply makes the
-/// fetch fail and the widget keeps its last-known snapshot until the WatchApp writes a fresh credential.
+/// The access token is a snapshot, but the credential also carries the long-lived `refreshToken` and the
+/// access token's `expiration`, so the widget can refresh the access token itself (a plain form-encoded
+/// `POST /auth/token`) when it's near expiry — keeping complications fresh on the widget's own budget and,
+/// crucially, never sending an expired token (which the server logs as invalid auth and eventually bans).
 public struct WatchWidgetServerCredential: Codable, Equatable {
     /// Matches `WatchComplicationConfig.serverId`.
     public let serverId: String
@@ -18,6 +20,13 @@ public struct WatchWidgetServerCredential: Codable, Equatable {
     public let baseURL: URL
     /// Bearer token snapshot at write time.
     public let token: String
+    /// Absolute expiration of `token`. The widget refreshes before this (and skips the request entirely
+    /// if it can't get a valid token) rather than sending an expired token.
+    public let expiration: Date
+    /// Long-lived refresh token, used by the widget to mint a fresh access token via `POST /auth/token`.
+    public let refreshToken: String
+    /// OAuth `client_id` the refresh request must present (differs between debug and release builds).
+    public let clientID: String
     /// Keychain label of the mTLS client identity, or nil when the server doesn't use a client cert.
     public let clientCertLabel: String?
     /// Raw `SecTrustCopyExceptions` blobs for self-signed / pinned server trust (empty when none).
@@ -27,14 +36,26 @@ public struct WatchWidgetServerCredential: Codable, Equatable {
         serverId: String,
         baseURL: URL,
         token: String,
+        expiration: Date,
+        refreshToken: String,
+        clientID: String,
         clientCertLabel: String?,
         trustExceptions: [Data]
     ) {
         self.serverId = serverId
         self.baseURL = baseURL
         self.token = token
+        self.expiration = expiration
+        self.refreshToken = refreshToken
+        self.clientID = clientID
         self.clientCertLabel = clientCertLabel
         self.trustExceptions = trustExceptions
+    }
+
+    /// The OAuth `client_id` to present when refreshing a token, matching the value used during
+    /// onboarding (`OnboardingAuthDetails`) and by `AuthenticationRoutes`.
+    public static func clientID(isDebug: Bool) -> String {
+        isDebug ? "https://home-assistant.io/iOS/dev-auth" : "https://home-assistant.io/iOS"
     }
 
     /// App-group `UserDefaults` key the blob array is stored under.

--- a/Sources/HANetworking/Sources/ServerManager.swift
+++ b/Sources/HANetworking/Sources/ServerManager.swift
@@ -589,7 +589,15 @@ public final class ServerManagerImpl: ServerManager {
             for (key, serverInfo) in state {
                 let identifier = Identifier<Server>(rawValue: key)
                 if let existing = cache.read({ $0.server[identifier] }) {
-                    existing.info = serverInfo
+                    var incoming = serverInfo
+                    // Don't let a restored snapshot downgrade a token this instance already refreshed to a
+                    // later expiry — e.g. the watch refreshing independently of the phone that produced this
+                    // snapshot. Keeping the fresher token avoids sending a stale one the server rejects.
+                    let current = existing.info.token
+                    if current.expiration > incoming.token.expiration {
+                        incoming.token = current
+                    }
+                    existing.info = incoming
                 } else {
                     add(identifier: identifier, serverInfo: serverInfo)
                 }

--- a/Sources/HANetworking/Sources/TokenManager.swift
+++ b/Sources/HANetworking/Sources/TokenManager.swift
@@ -111,9 +111,10 @@ public final class TokenManager: @unchecked Sendable {
         Promise<(String, Date)> { seal in
             let tokenInfo = server.info.token
 
-            // Add a margin to -10 seconds so that we never get into a state where we return a token
-            // that immediately fails.
-            if tokenInfo.expiration.addingTimeInterval(-10) > HANetworkingEnvironment.current.date() {
+            // Refresh a full minute early (matching `TokenInfo.needsRefresh`) so we never hand back a
+            // token that lapses in flight — especially on slow watch/cloud paths where the round trip
+            // can outlast a token with only seconds left, which the server then logs as invalid auth.
+            if tokenInfo.expiration.addingTimeInterval(-60) > HANetworkingEnvironment.current.date() {
                 seal.fulfill((tokenInfo.accessToken, tokenInfo.expiration))
             } else {
                 if let expirationAmount = Calendar.current.dateComponents(

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -735,13 +735,20 @@ private enum ComplicationStateFetcher {
     /// own WidgetKit budget (it can't link the networking stack to derive these itself). Mirrors the
     /// inputs `fetchState` uses: the resolved base URL, a bearer token, and the mTLS/self-signed material.
     static func credential(for server: Server) async -> WatchWidgetServerCredential? {
-        guard let baseURL = await server.activeURL(), let token = await bearerToken(for: server) else {
+        // Resolve the URL and ensure a currently-valid access token (refreshing if needed). Reading
+        // `server.info.token` afterwards gives us the matching expiration + long-lived refresh token, so
+        // the widget can mint its own fresh access tokens on its budget instead of relying on this snapshot.
+        guard let baseURL = await server.activeURL(), await bearerToken(for: server) != nil else {
             return nil
         }
+        let tokenInfo = server.info.token
         return WatchWidgetServerCredential(
             serverId: server.identifier.rawValue,
             baseURL: baseURL,
-            token: token,
+            token: tokenInfo.accessToken,
+            expiration: tokenInfo.expiration,
+            refreshToken: tokenInfo.refreshToken,
+            clientID: WatchWidgetServerCredential.clientID(isDebug: Current.appConfiguration == .debug),
             clientCertLabel: server.info.connection.clientCertificate?.keychainIdentifier,
             trustExceptions: server.info.connection.securityExceptions.rawExceptionData
         )

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -22,18 +22,26 @@ enum WatchWidgetLiveFetch {
         guard !configs.isEmpty else { return }
 
         let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID)
-        let credentialsByServer = Dictionary(
+        let stored = Dictionary(
             WatchWidgetServerCredential.read(from: defaults).map { ($0.serverId, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        guard !credentialsByServer.isEmpty else { return }
+        guard !stored.isEmpty else { return }
+
+        // Ensure each server's access token is valid before touching `/api/states`. If it's at/near
+        // expiry we refresh it ourselves (a plain `POST /auth/token`); if we can't get a valid token we
+        // drop that server so we skip the request entirely rather than send an expired token — the latter
+        // is what the server logs as invalid auth and eventually IP-bans.
+        let (usable, persist) = await validated(stored)
+        if let persist { WatchWidgetServerCredential.write(persist, to: defaults) }
+        guard !usable.isEmpty else { return }
 
         let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
         var updates: [String: String] = [:] // config.id -> fresh value text
 
         for config in targets where config.kind == .entity {
             guard let entityId = config.entityId,
-                  let credential = credentialsByServer[config.serverId],
+                  let credential = usable[config.serverId],
                   let value = await fetchValue(config: config, entityId: entityId, credential: credential) else {
                 continue
             }
@@ -42,6 +50,80 @@ enum WatchWidgetLiveFetch {
 
         guard !updates.isEmpty else { return }
         applyUpdates(updates)
+    }
+
+    // MARK: - Token validity / refresh
+
+    /// Returns the credentials that currently hold a valid access token (refreshing the ones near expiry),
+    /// plus the full set to persist back to the app group when a refresh changed anything (nil = no write
+    /// needed). Servers whose token can't be validated are omitted from the usable set but kept in the
+    /// persisted set, so their refresh token survives for the next attempt.
+    private static func validated(
+        _ stored: [String: WatchWidgetServerCredential]
+    ) async -> (usable: [String: WatchWidgetServerCredential], persist: [WatchWidgetServerCredential]?) {
+        var usable: [String: WatchWidgetServerCredential] = [:]
+        var persist = stored
+        var changed = false
+        for (serverId, credential) in stored {
+            // Refresh a little before the real expiry so the token doesn't lapse in flight.
+            if credential.expiration.addingTimeInterval(-60) > Date() {
+                usable[serverId] = credential
+            } else if let refreshed = await refreshedCredential(credential) {
+                usable[serverId] = refreshed
+                persist[serverId] = refreshed
+                changed = true
+            }
+        }
+        return (usable, changed ? Array(persist.values) : nil)
+    }
+
+    /// Mints a fresh access token via `POST /auth/token` (`grant_type=refresh_token`), returning the
+    /// credential updated with the new token + expiration, or nil if the refresh fails.
+    private static func refreshedCredential(
+        _ credential: WatchWidgetServerCredential
+    ) async -> WatchWidgetServerCredential? {
+        var request = URLRequest(url: credential.baseURL.appendingPathComponent("auth/token"))
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = formEncode([
+            "grant_type": "refresh_token",
+            "refresh_token": credential.refreshToken,
+            "client_id": credential.clientID,
+        ]).data(using: .utf8)
+
+        let delegate = WatchWidgetTLSDelegate(credential: credential)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String else {
+            return nil
+        }
+        let ttl = (json["expires_in"] as? Double) ?? (json["expires_in"] as? Int).map(Double.init) ?? 1800
+        return WatchWidgetServerCredential(
+            serverId: credential.serverId,
+            baseURL: credential.baseURL,
+            token: accessToken,
+            expiration: Date(timeIntervalSinceNow: ttl),
+            refreshToken: credential.refreshToken,
+            clientID: credential.clientID,
+            clientCertLabel: credential.clientCertLabel,
+            trustExceptions: credential.trustExceptions
+        )
+    }
+
+    /// `application/x-www-form-urlencoded` body: percent-encode everything but the RFC 3986 unreserved set
+    /// so values like the `client_id` URL survive intact.
+    private static func formEncode(_ params: [String: String]) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return params.map { key, value in
+            let k = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+            let v = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+            return "\(k)=\(v)"
+        }.joined(separator: "&")
     }
 
     // MARK: - Fetch

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -230,6 +230,61 @@ class ServerManagerTests: XCTestCase {
         XCTAssertTrue(keychain.data.isEmpty)
     }
 
+    func testRestoreStateKeepsFresherExistingTokenButUpdatesOtherFields() throws {
+        // Existing server holds a freshly-refreshed token (later expiration).
+        let existing = with(ServerInfo.fake()) {
+            $0.connection.webhookID = "webhook1"
+            $0.token = .init(
+                accessToken: "fresh",
+                refreshToken: "refresh",
+                expiration: Current.date().addingTimeInterval(3600)
+            )
+        }
+        try setupRegular(["fake1": existing])
+
+        // Incoming snapshot carries an older token (earlier expiration) but a changed non-token field.
+        let older = with(existing) {
+            $0.connection.webhookID = "webhook1-updated"
+            $0.token = .init(
+                accessToken: "stale",
+                refreshToken: "refresh",
+                expiration: Current.date().addingTimeInterval(60)
+            )
+        }
+        servers.restoreState(try encoder.encode(["fake1": older]))
+
+        let server = try XCTUnwrap(servers.server(for: "fake1"))
+        // Token is not downgraded (compared by value since TokenInfo.== ignores expiration)...
+        XCTAssertEqual(server.info.token.accessToken, "fresh")
+        XCTAssertEqual(server.info.token.expiration, existing.token.expiration)
+        // ...but the rest of the snapshot still applies.
+        XCTAssertEqual(server.info.connection.webhookID, "webhook1-updated")
+    }
+
+    func testRestoreStateAcceptsNewerIncomingToken() throws {
+        let existing = with(ServerInfo.fake()) {
+            $0.token = .init(
+                accessToken: "old",
+                refreshToken: "refresh",
+                expiration: Current.date().addingTimeInterval(60)
+            )
+        }
+        try setupRegular(["fake1": existing])
+
+        let newer = with(existing) {
+            $0.token = .init(
+                accessToken: "new",
+                refreshToken: "refresh",
+                expiration: Current.date().addingTimeInterval(3600)
+            )
+        }
+        servers.restoreState(try encoder.encode(["fake1": newer]))
+
+        let server = try XCTUnwrap(servers.server(for: "fake1"))
+        XCTAssertEqual(server.info.token.accessToken, "new")
+        XCTAssertEqual(server.info.token.expiration, newer.token.expiration)
+    }
+
     func testWithInitialServers() throws {
         let info1 = with(ServerInfo.fake()) {
             $0.connection.webhookID = "webhook1"

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -251,7 +251,7 @@ class ServerManagerTests: XCTestCase {
                 expiration: Current.date().addingTimeInterval(60)
             )
         }
-        servers.restoreState(try encoder.encode(["fake1": older]))
+        try servers.restoreState(encoder.encode(["fake1": older]))
 
         let server = try XCTUnwrap(servers.server(for: "fake1"))
         // Token is not downgraded (compared by value since TokenInfo.== ignores expiration)...
@@ -278,7 +278,7 @@ class ServerManagerTests: XCTestCase {
                 expiration: Current.date().addingTimeInterval(3600)
             )
         }
-        servers.restoreState(try encoder.encode(["fake1": newer]))
+        try servers.restoreState(encoder.encode(["fake1": newer]))
 
         let server = try XCTUnwrap(servers.server(for: "fake1"))
         XCTAssertEqual(server.info.token.accessToken, "new")


### PR DESCRIPTION
## Summary

Watch complications and the `WatchWidgets` extension were repeatedly hitting `/api/states/<entity>` with **expired access tokens**, which Home Assistant logs as invalid authentication and eventually IP-bans:

```
Login attempt or request with invalid authentication from localhost (127.0.0.1).
Requested URL: '/api/states/weather.home_weather'. (Extensions-WatchWidgets/… CFNetwork/… Darwin/…)
Login attempt or request with invalid authentication from localhost (127.0.0.1).
Requested URL: '/api/states/sensor.…_battery_level'. (Home Assistant/… watchOS …)
```

**Root cause:** HA OAuth access tokens live ~30 minutes, but:
- The `WatchWidgets` extension only held a **static token snapshot** written by the watch app and had no way to refresh it. When the snapshot aged past ~30 min, every timeline fetch on the widget's own WidgetKit budget went out with an expired token.
- The watch-app complication path refreshed only when within 10s of expiry, so a token could lapse **in flight** over a slow watch/cloud round trip.
- Phone→watch server-state sync (`restoreState`) overwrote a token the watch had refreshed independently with the phone's staler one.

## Changes

- **`WatchWidgetServerCredential`** now carries the access-token `expiration`, the long-lived `refreshToken`, and the OAuth `clientID`.
- **`WatchWidgetLiveFetch`** validates each server's token before touching `/api/states`. Near-expiry tokens are refreshed in-extension via a plain form-encoded `POST /auth/token` (reusing the existing mTLS/self-signed `URLSession` delegate); refreshed tokens are persisted back to the app group. **If a valid token can't be obtained, the request is skipped entirely** — the extension never sends an expired token again.
- **`ComplicationStateFetcher.credential(for:)`** writes the full `TokenInfo` (expiration + refresh token) and the resolved `client_id` so the widget can self-refresh.
- **`TokenManager.currentToken`** now refreshes 60s early (matching `TokenInfo.needsRefresh`) instead of 10s, preventing in-flight expiry.
- **`ServerManager.restoreState`** keeps the existing token when it has a later expiration than an incoming snapshot, so the watch's freshly-refreshed token isn't clobbered by the phone's staler one.

## Rollout note

The credential's new fields are non-optional, so a blob written by the previous build won't decode — the widget shows its last snapshot until the updated watch app writes a fresh credential on next launch/refresh. Both ship in the same watch app bundle, so the window is brief and self-healing; no migration needed.

## Testing

- `WatchApp` scheme builds cleanly (compiles `HAModels`, `HANetworking`, the watch app, and the `WatchWidgets` extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)