### PR TITLE
Fix iOS Release archive failure from ungated watch notification previews

### DIFF
--- a/Sources/WatchApp/Notifications/DynamicNotificationView.swift
+++ b/Sources/WatchApp/Notifications/DynamicNotificationView.swift
@@ -91,6 +91,7 @@ struct DynamicNotificationView: View {
     }
 }
 
+#if DEBUG
 #Preview("Text") {
     DynamicNotificationView(viewModel: .preview(
         title: "Garage door",
@@ -124,3 +125,4 @@ struct DynamicNotificationView: View {
         }())
     ))
 }
+#endif


### PR DESCRIPTION
## Summary

The iOS distribution archive (`App-Release` scheme) was failing to compile the WatchApp target with:

```
Sources/WatchApp/Notifications/DynamicNotificationView.swift:95:41: error: type 'DynamicNotificationViewModel' has no member 'preview'
… (repeated for the other #Preview blocks, plus cascading .map / .image inference errors)
** ARCHIVE FAILED **
```

### Root cause

The `#Preview` blocks in `DynamicNotificationView.swift` call `DynamicNotificationViewModel.preview(...)`, but that factory is defined inside `#if DEBUG` in `DynamicNotificationViewModel.swift`. The previews themselves were **not** `DEBUG`-gated, so:

- **Debug** builds (local dev, CI tests): `DEBUG` is defined → `.preview` exists → compiles fine.
- **Release** archive (distribution): `DEBUG` is not defined, but the `#Preview` macro still expands and compiles its closure body → `.preview` is missing → compile error → archive aborts.

This was introduced in #5070 (SwiftUI watchOS notifications migration) and only surfaces in the Release distribution build, which is why normal CI stayed green.

### Fix

Wrap the three `#Preview` blocks in `#if DEBUG` / `#endif` so they only compile where the `.preview` factory they depend on exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)