### PR TITLE
Enlarge value-only circular complication and tighten center layout

### DIFF
--- a/Sources/WatchWidgets/Complications/CircularComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CircularComplicationView.swift
@@ -55,26 +55,34 @@ struct CircularComplicationView: View {
     /// alone for legacy/built-ins. `padded` insets it off the surrounding open-gauge ring.
     @ViewBuilder
     private func center(_ complication: WatchWidgetComplicationSnapshot?, padded: Bool) -> some View {
+        let valueOnly = isValueOnly(complication)
         Group {
             if let complication, complication.perFamily != nil {
-                VStack(spacing: 0) {
+                VStack(spacing: WatchWidgetConstants.Layout.circularCenterSpacing) {
                     if complication.showsIcon(for: family), let iconImage = complication.iconImage {
                         iconImage
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 18, height: 18)
+                            .frame(
+                                width: WatchWidgetConstants.Layout.circularIconSize,
+                                height: WatchWidgetConstants.Layout.circularIconSize
+                            )
                             .widgetAccentable()
                     }
                     if complication.showsValue(for: family), !complication.title.isEmpty {
                         Text(complication.title)
-                            .minimumScaleFactor(0.2)
+                            .font(valueOnly ? .system(
+                                size: WatchWidgetConstants.Font.circularValueOnlySize,
+                                weight: .semibold
+                            ) : nil)
                             .lineLimit(1)
+                            .minimumScaleFactor(WatchWidgetConstants.Font.circularValueMinScale)
                             .foregroundStyle(complication.textColor(for: family) ?? .primary)
                     }
                     if complication.showsName(for: family), !complication.subtitle.isEmpty {
                         Text(complication.subtitle)
-                            .font(.system(size: 9))
-                            .minimumScaleFactor(0.4)
+                            .font(.system(size: WatchWidgetConstants.Font.circularNameSize))
+                            .minimumScaleFactor(WatchWidgetConstants.Font.circularNameMinScale)
                             .lineLimit(1)
                             .foregroundStyle(complication.textColor(for: family) ?? .primary)
                     }
@@ -83,7 +91,18 @@ struct CircularComplicationView: View {
                 ComplicationIconView(complication: complication)
             }
         }
-        .padding(padded ? WatchWidgetConstants.Layout.circularIconGaugePadding : 0)
+        // The value-only layout needs the full inner circle, so skip the ring inset that would
+        // otherwise shrink the enlarged value text.
+        .padding(padded && !valueOnly ? WatchWidgetConstants.Layout.circularIconGaugePadding : 0)
+    }
+
+    /// Whether the center renders only the state value (no icon and no name), so it can use the full
+    /// inner circle and a larger font.
+    private func isValueOnly(_ complication: WatchWidgetComplicationSnapshot?) -> Bool {
+        guard let complication, complication.perFamily != nil else { return false }
+        let showsIcon = complication.showsIcon(for: family) && complication.iconImage != nil
+        let showsName = complication.showsName(for: family) && !complication.subtitle.isEmpty
+        return !showsIcon && !showsName
     }
 }
 
@@ -93,6 +112,13 @@ struct CircularComplicationView: View {
     WatchWidgets()
 } timeline: {
     WatchWidgetEntry(date: .now, family: .accessoryCircular, complication: .previewSample(gaugeStyle: "open"))
+}
+
+@available(watchOS 10.0, *)
+#Preview("Open - value only", as: .accessoryCircular) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(date: .now, family: .accessoryCircular, complication: .previewSampleValueOnly(gaugeStyle: "open"))
 }
 
 @available(watchOS 10.0, *)

--- a/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
@@ -226,5 +226,37 @@ extension WatchWidgetComplicationSnapshot {
             menuName: "Battery"
         )
     }
+
+    static func previewSampleValueOnly(
+        title: String = "100%",
+        fraction: Double? = 0.68,
+        gaugeStyle: String = "open"
+    ) -> Self {
+        let options = PerFamily(
+            fraction: fraction,
+            tint: "#34C759FF",
+            showValue: true,
+            showName: false,
+            showIcon: false,
+            showMin: true,
+            showMax: true,
+            gaugeStyle: gaugeStyle,
+            minLabel: "0",
+            maxLabel: "100",
+            textColor: nil
+        )
+        return .init(
+            id: "preview",
+            family: "",
+            title: title,
+            subtitle: "Battery",
+            inlineText: "Battery \(title)",
+            fraction: fraction,
+            tint: "#34C759FF",
+            iconData: nil,
+            perFamily: ["circular": options, "rectangular": options, "inline": options, "corner": options],
+            menuName: "Battery"
+        )
+    }
 }
 #endif

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -66,10 +66,27 @@ enum WatchWidgetConstants {
         static let logoPadding: CGFloat = 5
         static let gaugeLogoPadding: CGFloat = 6
         /// Inset for an icon shown inside a circular gauge, so it doesn't touch the ring.
-        static let circularIconGaugePadding: CGFloat = 8
+        static let circularIconGaugePadding: CGFloat = 2
         static let assistIconPadding: CGFloat = 8
         static let rectangularLogoSize: CGFloat = 18
         static let rectangularSpacing: CGFloat = 6
         static let rectangularTextSpacing: CGFloat = 1
+        /// Size of the icon shown inside a circular complication's center stack.
+        static let circularIconSize: CGFloat = 18
+        /// Vertical spacing between the circular complication's value and name. Negative to counteract
+        /// the value font's tall line box, which otherwise leaves too large a gap above the name.
+        static let circularCenterSpacing: CGFloat = -4
+    }
+
+    /// Font sizes and scaling for the circular complication's center content.
+    enum Font {
+        /// Enlarged value font used when the value is the only thing shown in a circular complication.
+        static let circularValueOnlySize: CGFloat = 22
+        /// Minimum scale the value shrinks to before it's clipped, so long values still fit.
+        static let circularValueMinScale: CGFloat = 0.2
+        /// Font size for the complication name shown beneath the value.
+        static let circularNameSize: CGFloat = 9
+        /// Minimum scale the name shrinks to before it's clipped.
+        static let circularNameMinScale: CGFloat = 0.4
     }
 }


### PR DESCRIPTION
## Summary
- Show the state value in a larger, semibold font when it's the **only** element rendered in a circular complication (no icon, no name).
- Skip the ring inset in the value-only case so the value fills the full inner circle, scaling down (`minimumScaleFactor`) to fit long values.
- Tighten the vertical spacing between the value and the name to counteract the value font's tall line box, which was leaving too large a gap.
- Move the center layout's hardcoded sizes/scales into `WatchWidgetConstants` (`Layout.circularIconSize`, `Layout.circularCenterSpacing`, and a new `Font` group).
- Add an "Open - value only" `#Preview` and its `previewSampleValueOnly` sample.

<img width="576" height="656" alt="CleanShot 2026-07-13 at 17 45 24@2x" src="https://github.com/user-attachments/assets/93e41272-9185-4ef8-a6a5-0fbc011377a3" />