### PR TITLE
Fix watch corner complication value to follow arc curvature

### DIFF
--- a/Sources/WatchWidgets/Complications/CornerComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CornerComplicationView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import WidgetKit
 
-/// Corner complication: an icon (when enabled) or the value/name tucked in the corner, with a curved
-/// bezel label carrying the gauge (when a value exists) or the remaining text.
+/// Corner complication: the value (or the icon, when enabled) curved along the outside of the corner
+/// via `widgetCurvesContent`, with the name carried on the inside of the curve by the bezel label —
+/// alongside the gauge when a value exists (matching the system UV Index / Battery complications).
 @available(watchOS 10.0, *)
 struct CornerComplicationView: View {
     let complication: WatchWidgetComplicationSnapshot?
@@ -11,10 +12,16 @@ struct CornerComplicationView: View {
     var body: some View {
         if let complication {
             Group {
-                if complication.showsIcon(for: family), let iconImage = complication.iconImage {
+                if showsIconInCorner(complication), let iconImage = complication.iconImage {
+                    // The icon sits in the corner un-curved; curving a raster image collapses it.
                     iconImage.renderingMode(.template).resizable().scaledToFit().widgetAccentable()
                 } else {
-                    Text(mainText(complication))
+                    // Curve the value/name along the outer edge of the corner; the system lays the
+                    // widget label on the inside of the same curve.
+                    Text(cornerText(complication))
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                        .widgetCurvesContent()
                 }
             }
             .widgetLabel { bezelLabel(complication) }
@@ -23,32 +30,146 @@ struct CornerComplicationView: View {
         }
     }
 
-    private func mainText(_ complication: WatchWidgetComplicationSnapshot) -> String {
+    /// Whether the icon takes the corner, leaving the value/name to ride the arc.
+    private func showsIconInCorner(_ complication: WatchWidgetComplicationSnapshot) -> Bool {
+        complication.showsIcon(for: family) && complication.iconImage != nil
+    }
+
+    /// The flat corner shows the value, falling back to the name (then the app name) when the value
+    /// is hidden or empty.
+    private func cornerText(_ complication: WatchWidgetComplicationSnapshot) -> String {
         if complication.showsValue(for: family), !complication.title.isEmpty {
             return complication.title
         }
-        return complication.showsName(for: family) ? complication.subtitle : WatchWidgetConstants.appName
+        if complication.showsName(for: family), !complication.subtitle.isEmpty {
+            return complication.subtitle
+        }
+        return WatchWidgetConstants.appName
     }
 
+    /// The curved bezel carries the arc text — as the gauge's label when a fraction exists, otherwise
+    /// as curved text.
     @ViewBuilder
     private func bezelLabel(_ complication: WatchWidgetComplicationSnapshot) -> some View {
         if let fraction = complication.fraction(for: family) {
             Gauge(value: fraction) {
-                Text(complication.showsValue(for: family) ? complication.title : complication.subtitle)
+                Text(arcText(complication))
             }
             .tint(complication.tintColor(for: family))
         } else {
-            Text(complication.showsName(for: family) ? complication.subtitle : complication.title)
+            Text(arcText(complication))
         }
+    }
+
+    /// What rides the arc. When the icon fills the corner, the value goes on the arc (falling back to
+    /// the name). Otherwise the value occupies the corner and the name rides the arc — but only then,
+    /// so the arc never duplicates whatever the corner is already showing.
+    private func arcText(_ complication: WatchWidgetComplicationSnapshot) -> String {
+        if showsIconInCorner(complication) {
+            if complication.showsValue(for: family), !complication.title.isEmpty {
+                return complication.title
+            }
+            return complication.showsName(for: family) ? complication.subtitle : ""
+        }
+        guard complication.showsValue(for: family), !complication.title.isEmpty else { return "" }
+        return complication.showsName(for: family) ? complication.subtitle : ""
     }
 }
 
 // A widget extension can only host widget previews, so preview through the corner-family widget.
 #if DEBUG
 @available(watchOS 10.0, *)
-#Preview(as: .accessoryCorner) {
+#Preview("Value + name + gauge", as: .accessoryCorner) {
     WatchWidgets()
 } timeline: {
     WatchWidgetEntry(date: .now, family: .accessoryCorner, complication: .previewSample())
+}
+
+@available(watchOS 10.0, *)
+#Preview("Value + name, no gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(title: "On", subtitle: "Lamp", fraction: nil)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Value only + gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(showName: false)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Value only, no gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(title: "21.5°", subtitle: "Living Room", fraction: nil, showName: false)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Name only + gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(showValue: false)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Icon only", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(fraction: nil, showValue: false, showName: false, includeIcon: true)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Icon + value", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(fraction: nil, showName: false, includeIcon: true)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Icon + value + gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(showName: false, includeIcon: true)
+    )
+}
+
+@available(watchOS 10.0, *)
+#Preview("Icon + gauge", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(showValue: false, showName: false, includeIcon: true)
+    )
 }
 #endif

--- a/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
@@ -197,15 +197,20 @@ extension WatchWidgetComplicationSnapshot {
     /// Sample used by the SwiftUI previews of the per-family complication views.
     static func previewSample(
         title: String = "100%",
+        subtitle: String = "Battery",
         fraction: Double? = 0.68,
-        gaugeStyle: String = "open"
+        gaugeStyle: String = "open",
+        showValue: Bool = true,
+        showName: Bool = true,
+        showIcon: Bool = true,
+        includeIcon: Bool = false
     ) -> Self {
         let options = PerFamily(
             fraction: fraction,
             tint: "#34C759FF",
-            showValue: true,
-            showName: true,
-            showIcon: true,
+            showValue: showValue,
+            showName: showName,
+            showIcon: showIcon,
             showMin: true,
             showMax: true,
             gaugeStyle: gaugeStyle,
@@ -217,13 +222,13 @@ extension WatchWidgetComplicationSnapshot {
             id: "preview",
             family: "",
             title: title,
-            subtitle: "Battery",
-            inlineText: "Battery \(title)",
+            subtitle: subtitle,
+            inlineText: "\(subtitle) \(title)",
             fraction: fraction,
             tint: "#34C759FF",
-            iconData: nil,
+            iconData: includeIcon ? UIImage(systemName: "lightbulb.fill")?.pngData() : nil,
             perFamily: ["circular": options, "rectangular": options, "inline": options, "corner": options],
-            menuName: "Battery"
+            menuName: subtitle
         )
     }
 }


### PR DESCRIPTION
## Summary

The watchOS **corner** complication wasn't laying its content out like the system corner complications (UV Index, Battery). This makes the value follow the corner's arc and fixes two content bugs found while adding previews.

### Changes
- **Value now follows the arc curvature** via `.widgetCurvesContent()` on the corner content — this was the core request. Per Apple's docs, the system only curves the main corner content when you opt in with this modifier; the `widgetLabel` is placed on the inside of the same curve.
- **Fixed the bezel label repeating the value.** The gauge's curved label previously showed the *value* again instead of the *name*, so the name (e.g. `UVI`, `Battery`) never appeared and the value showed twice. The arc now carries the name.
- **Fixed icon + value dropping the value.** When an icon fills the corner, the value now rides the arc (falling back to the name) instead of being silently dropped. Added a `showsIconInCorner` helper so `body` and `arcText` stay in sync.
- **Added `.minimumScaleFactor(0.5)` + `.lineLimit(1)`** to the curved corner text so it shrinks to fit instead of cropping.
- The icon renders un-curved in the corner (a resizable/scaledToFit image collapses inside the curved layout).

<img width="1528" height="1862" alt="CleanShot 2026-07-13 at 18 26 28@2x" src="https://github.com/user-attachments/assets/80aff3b4-be54-4189-bbad-e2cebbd9037f" />