### PR TITLE
Align corner complication in-app preview with widget layout

### DIFF
--- a/Sources/App/Settings/AppleWatch/Complications/Preview/CornerComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/CornerComplicationPreview.swift
@@ -1,57 +1,134 @@
 import Shared
 import SwiftUI
 
-/// iPhone preview of the corner complication: content tucked into the watch face corner with a shallow
-/// arc gauge following the simulated watch's top-trailing curve.
+/// iPhone preview of the corner complication, stacked from the watch face corner inward: icon, name,
+/// value (more prominent than the name), then the gauge arcing below them all.
 struct CornerComplicationPreview: View {
     let context: ComplicationPreviewContext
 
+    // The layout is designed vertically — content stacked on the vertical axis, gauge arc symmetric
+    // around 12 o'clock below it — and the whole composition is rotated 45° into the top-trailing
+    // corner. That keeps everything centered on the curve by construction.
+    private let arcCenter = CGPoint(x: 50, y: 120)
+    /// The content stack hugs the corner and grows inward, whatever subset is visible.
+    private let stackTop: CGFloat = 10
+    private let stackHeight: CGFloat = 52
+    private let stackSpacing: CGFloat = 2
+
+    /// Estimated height of the visible icon/name/value stack, so the gauge can hang just below it.
+    private var stackContentHeight: CGFloat {
+        var heights: [CGFloat] = []
+        if context.iconImage != nil { heights.append(20) }
+        if context.showsName, !context.name.isEmpty { heights.append(11) }
+        if context.showsValue, !context.value.isEmpty { heights.append(17) }
+        guard !heights.isEmpty else { return 0 }
+        return heights.reduce(0, +) + CGFloat(heights.count - 1) * stackSpacing
+    }
+
+    /// The gauge is the innermost element, riding just below whatever the stack shows.
+    private var gaugeRadius: CGFloat { arcCenter.y - (stackTop + stackContentHeight + 9) }
+    /// Half the sweep (degrees), sized for a roughly constant ~55pt arc whatever the radius.
+    private var halfSpan: Double { min(32, 27.5 / gaugeRadius * 180 / .pi) }
+    private var startAngle: Double { -90 - halfSpan }
+    private var endAngle: Double { -90 + halfSpan }
+
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack {
             if context.showsGauge, let fraction = context.fraction {
-                Group {
-                    Path { path in
-                        path.addArc(
-                            center: CGPoint(x: 8, y: 92),
-                            radius: 86,
-                            startAngle: .degrees(-48),
-                            endAngle: .degrees(-18),
-                            clockwise: false
-                        )
-                    }
-                    .stroke(context.tint.opacity(0.28), style: StrokeStyle(lineWidth: 6, lineCap: .round))
-
-                    Path { path in
-                        path.addArc(
-                            center: CGPoint(x: 8, y: 92),
-                            radius: 86,
-                            startAngle: .degrees(-48),
-                            endAngle: .degrees(-48 + (30 * fraction)),
-                            clockwise: false
-                        )
-                    }
-                    .stroke(context.tint, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                Path { path in
+                    path.addArc(
+                        center: arcCenter,
+                        radius: gaugeRadius,
+                        startAngle: .degrees(startAngle),
+                        endAngle: .degrees(endAngle),
+                        clockwise: false
+                    )
                 }
-                .offset(x: -12, y: -16)
+                .stroke(context.tint.opacity(0.28), style: StrokeStyle(lineWidth: 6, lineCap: .round))
+
+                Path { path in
+                    path.addArc(
+                        center: arcCenter,
+                        radius: gaugeRadius,
+                        startAngle: .degrees(startAngle),
+                        endAngle: .degrees(startAngle + (endAngle - startAngle) * fraction),
+                        clockwise: false
+                    )
+                }
+                .stroke(context.tint, style: StrokeStyle(lineWidth: 6, lineCap: .round))
             }
 
-            if context.showsValue, !context.value.isEmpty {
-                Text(context.value)
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundStyle(context.textColor)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
-                    .padding(6)
-                    .rotationEffect(.degrees(45))
+            // Corner inward: icon, name, value. The icon is already gated by the "show icon" toggle.
+            VStack(spacing: stackSpacing) {
+                if let iconImage = context.iconImage {
+                    iconImage
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 20, height: 20)
+                        // Counter the composition's rotation: the icon stays upright, like the
+                        // widget's un-curved icon.
+                        .rotationEffect(.degrees(-45))
+                }
+                if context.showsName, !context.name.isEmpty {
+                    Text(context.name)
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(context.textColor.opacity(0.7))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                        // Bound the width so long text scales down instead of clipping off the edge.
+                        .frame(maxWidth: 56)
+                }
+                if context.showsValue, !context.value.isEmpty {
+                    Text(context.value)
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
+                        .foregroundStyle(context.textColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                        .frame(maxWidth: 56)
+                }
             }
+            .frame(height: stackHeight, alignment: .top)
+            .position(x: arcCenter.x, y: stackTop + stackHeight / 2)
         }
-        .offset(x: -12, y: 12)
         .frame(width: 100, height: 100)
+        // Designed upright, then swung into the top-trailing corner as one piece.
+        .rotationEffect(.degrees(45))
         .environment(\.colorScheme, .dark)
     }
 }
 
 #if DEBUG
+/// Renders every corner permutation side by side so the layout can be checked at a glance.
+private struct CornerVariantsPreview: View {
+    let variants: [(String, ComplicationPreviewContext)] = [
+        ("Icon + name + value + gauge", .previewCorner()),
+        ("Value + name + gauge", .previewCorner(showIcon: false)),
+        ("Value + name", .previewCorner(showIcon: false, gauge: false)),
+        ("Value only", .previewCorner(showName: false, showIcon: false, gauge: false)),
+        ("Name only + gauge", .previewCorner(showValue: false, showIcon: false)),
+        ("Icon + gauge", .previewCorner(showValue: false, showName: false)),
+    ]
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: DesignSystem.Spaces.two) {
+                ForEach(variants, id: \.0) { label, context in
+                    VStack(spacing: DesignSystem.Spaces.one) {
+                        CornerComplicationPreview(context: context)
+                            .background(Color.black, in: RoundedRectangle(cornerRadius: 12))
+                        Text(label).font(.caption)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview("Corner variants") {
+    CornerVariantsPreview()
+}
+
 #Preview {
     ScrollView {
         VStack(spacing: DesignSystem.Spaces.three) {

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
@@ -58,6 +58,39 @@ extension ComplicationPreviewContext {
             iconImage: Image(systemSymbol: .battery75)
         )
     }
+
+    /// Corner-specific sample with individually toggleable value / name / icon / gauge, used to preview
+    /// the corner layout's permutations.
+    static func previewCorner(
+        value: String = "68%",
+        name: String = "Battery",
+        showValue: Bool = true,
+        showName: Bool = true,
+        showIcon: Bool = true,
+        gauge: Bool = true
+    ) -> ComplicationPreviewContext {
+        var config = WatchComplicationConfig(serverId: "preview", widgetFamily: .corner, name: name)
+        if gauge {
+            config.gaugeMin = 0
+            config.gaugeMax = 100
+        }
+        config.setOptions(
+            WatchComplicationConfig.FamilyOptions(
+                showName: showName,
+                showValue: showValue,
+                showIcon: showIcon,
+                showGauge: gauge,
+                tint: "#34C759FF"
+            ),
+            for: .corner
+        )
+        return ComplicationPreviewContext(
+            config: config,
+            value: value,
+            fraction: gauge ? 0.68 : nil,
+            iconImage: showIcon ? Image(systemSymbol: .battery75) : nil
+        )
+    }
 }
 #endif
 


### PR DESCRIPTION
## Summary

Follow-up to #5077. The in-app iPhone preview mock of the corner complication didn't reflect the widget's layout. It now renders one hierarchy stacked from the watch face corner inward:

1. Icon
2. Name
3. Value (more prominent than the name)
4. Gauge, arcing below them all

<img width="1016" height="1944" alt="CleanShot 2026-07-13 at 21 01 43@2x" src="https://github.com/user-attachments/assets/2f214fdd-5625-4aef-bb00-ffdd12e1cb33" />
