### PR TITLE
Add fuzzy search to entity picker

### DIFF
--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -100,12 +100,9 @@ struct EntityPicker: View {
                     .listRowSeparator(.hidden)
             }
             filtersView
-            ForEach(
-                viewModel.filteredEntitiesByGroup.sorted(by: { $0.key < $1.key }),
-                id: \.key
-            ) { group, filteredEntities in
-                Section(group.uppercased()) {
-                    ForEach(filteredEntities, id: \.id) { entity in
+            ForEach(viewModel.filteredGroups) { group in
+                Section(group.title.uppercased()) {
+                    ForEach(group.entities, id: \.id) { entity in
                         Button(action: {
                             selectedEntity = entity
                             viewModel.showList = false

--- a/Sources/App/Settings/EntityPicker/EntityPickerGroup.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerGroup.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Shared
+
+struct EntityPickerGroup: Identifiable {
+    let title: String
+    let entities: [HAAppEntity]
+
+    var id: String { title }
+}

--- a/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
@@ -27,12 +27,13 @@ final class EntityPickerViewModel: ObservableObject {
     @Published var selectedAreaFilter: String? = nil
     @Published var selectedGrouping: EntityGrouping = .area
     @Published var entitiesByDomain: [String: [HAAppEntity]] = [:]
-    @Published var filteredEntitiesByGroup: [String: [HAAppEntity]] = [:]
+    @Published var filteredGroups: [EntityPickerGroup] = []
 
     // Cached lookups to avoid recomputation on every filter
     private var cachedEntityToArea: [String: String] = [:]
     private var cachedAreaIdToEntityIds: [String: Set<String>] = [:]
     private var cachedEntitiesByServer: [String: [HAAppEntity]] = [:]
+    private var fuzzyIndex: EntityFuzzySearchIndex?
 
     let domainFilter: [Domain]?
     private var filterTask: Task<Void, Never>?
@@ -121,10 +122,16 @@ final class EntityPickerViewModel: ObservableObject {
             rebuildAreaCaches()
             // Prime server cache for this server
             cachedEntitiesByServer[serverId] = entities.filter { $0.serverId == serverId }
+            rebuildFuzzyIndex(for: serverId)
             updateFilteredEntities()
         } catch {
             Current.Log.error("Failed to fetch server data for entity picker, error: \(error)")
         }
+    }
+
+    private func rebuildFuzzyIndex(for serverId: String) {
+        let serverEntities = entities.filter { $0.serverId == serverId }
+        fuzzyIndex = EntityFuzzySearchIndex(entities: serverEntities, serverId: serverId)
     }
 
     func fetchEntities() {
@@ -171,7 +178,7 @@ final class EntityPickerViewModel: ObservableObject {
 
     private func performFiltering() async {
         // Snapshot state needed for filtering
-        let searchTerm = searchTerm
+        let searchTerm = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
         let presetDomains = domainFilter.map { Set($0.map(\.rawValue)) }
         let selectedDomainFilter = selectedDomainFilter
         let areaFilter = selectedAreaFilter
@@ -184,55 +191,64 @@ final class EntityPickerViewModel: ObservableObject {
 
         // Get entities already filtered by server
         let serverScopedEntities = entitiesForCurrentServer()
+        let fuzzyIndex = fuzzyIndex
 
-        let filtered = await Task.detached(priority: .userInitiated) { () -> [String: [HAAppEntity]] in
-            // Resolve area entity id set if filtering by area
+        let groups = await Task.detached(priority: .userInitiated) { () -> [EntityPickerGroup] in
             let areaEntityIds: Set<String>? = areaFilter.flatMap { areaIdToEntityIds[$0] }
 
-            // First, filter entities by domain, area, and search
-            let filteredEntities = serverScopedEntities.filter { entity in
-                // Filter by the preset domain(s), if any were provided by the caller
+            func passesStructuredFilters(_ entity: HAAppEntity) -> Bool {
                 if let presetDomains, !presetDomains.contains(entity.domain) { return false }
-
-                // Filter by the user-selected domain (only offered when there's no preset)
                 if let selectedDomainFilter, entity.domain != selectedDomainFilter { return false }
-
-                // Filter by area if set
                 if let areaEntityIds, !areaEntityIds.contains(entity.entityId) { return false }
-
-                // Filter by search term (only when 3+ chars). `entity.name` is the resolved display
-                // name (registry name, falling back to the state name), baked in at write time.
-                if searchTerm.count > 2 {
-                    let lower = searchTerm.lowercased()
-                    if !entity.name.lowercased().contains(lower),
-                       !entity.entityId.lowercased().contains(lower) {
-                        return false
-                    }
-                }
                 return true
             }
 
-            // Group by selected grouping
+            let isSearching = !searchTerm.isEmpty
+            let baseEntities: [HAAppEntity] = isSearching
+                ? (fuzzyIndex?.search(searchTerm) ?? [])
+                : serverScopedEntities
+            let filteredEntities = baseEntities.filter(passesStructuredFilters)
+
             switch grouping {
             case .domain:
-                return Dictionary(grouping: filteredEntities) { $0.domain }
+                return Self.groupPreservingOrder(filteredEntities, sortAlphabetically: !isSearching) { $0.domain }
             case .area:
-                var result: [String: [HAAppEntity]] = [:]
-                for entity in filteredEntities {
-                    let areaName = entityToArea[entity.entityId] ?? noAreaTitle
-                    result[areaName, default: []].append(entity)
-                }
-                // Ensure the "No Area" group appears last by moving it to the end
-                if let noAreaGroup = result.removeValue(forKey: noAreaTitle) {
-                    result[noAreaTitle] = noAreaGroup
-                }
-                return result
+                return Self.groupPreservingOrder(
+                    filteredEntities,
+                    sortAlphabetically: !isSearching,
+                    lastGroupTitle: noAreaTitle
+                ) { entityToArea[$0.entityId] ?? noAreaTitle }
             }
         }.value
 
         await MainActor.run {
-            self.filteredEntitiesByGroup = filtered
+            self.filteredGroups = groups
         }
+    }
+
+    private static func groupPreservingOrder(
+        _ entities: [HAAppEntity],
+        sortAlphabetically: Bool,
+        lastGroupTitle: String? = nil,
+        keyFor: (HAAppEntity) -> String
+    ) -> [EntityPickerGroup] {
+        var order: [String] = []
+        var grouped: [String: [HAAppEntity]] = [:]
+        for entity in entities {
+            let key = keyFor(entity)
+            if grouped[key] == nil { order.append(key) }
+            grouped[key, default: []].append(entity)
+        }
+
+        if sortAlphabetically {
+            order.sort(by: <)
+            if let lastGroupTitle, let index = order.firstIndex(of: lastGroupTitle) {
+                order.remove(at: index)
+                order.append(lastGroupTitle)
+            }
+        }
+
+        return order.map { EntityPickerGroup(title: $0, entities: grouped[$0] ?? []) }
     }
 
     // MARK: - Test helpers (DEBUG only)

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -72,38 +72,9 @@ public final class ControlEntityProvider {
                             .fetchAll(db)
                     }
                 }
-                if let string {
-                    let deviceMap = entities.devicesMap(for: server.identifier.rawValue)
-                    let areasMap = entities.areasMap(for: server.identifier.rawValue)
-                    entities = entities.filter({ entity in
-                        // `entity.name` is the resolved display name (registry name, falling back to the
-                        // state name), baked in at write time by `AppEntitiesModel`.
-                        let matchName = entity.name.range(
-                            of: string,
-                            options: [.caseInsensitive, .diacriticInsensitive]
-                        ) != nil
-                        let matchEntityId = entity.entityId.range(
-                            of: string,
-                            options: [.caseInsensitive, .diacriticInsensitive]
-                        ) != nil
-                        let matchDeviceName = {
-                            if let deviceName = deviceMap[entity.entityId]?.name {
-                                return deviceName
-                                    .range(of: string, options: [.caseInsensitive, .diacriticInsensitive]) != nil
-                            } else {
-                                return false
-                            }
-                        }()
-                        let matchAreaName = {
-                            if let areaName = areasMap[entity.entityId]?.name {
-                                return areaName
-                                    .range(of: string, options: [.caseInsensitive, .diacriticInsensitive]) != nil
-                            } else {
-                                return false
-                            }
-                        }()
-                        return matchName || matchEntityId || matchDeviceName || matchAreaName
-                    })
+                if let string, !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    let index = EntityFuzzySearchIndex(entities: entities, serverId: server.identifier.rawValue)
+                    entities = index.search(string)
                 }
                 entitiesPerServer.append((server, entities))
             } catch {

--- a/Sources/Shared/Environment/EntityFuzzySearch/BitapSearcher.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/BitapSearcher.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+struct BitapSearcher {
+    struct Options: Sendable {
+        var location = 0
+        var threshold = 0.3
+        var distance = 100
+        var findAllMatches = false
+        var minMatchCharLength = 2
+        var ignoreLocation = true
+    }
+
+    struct Result {
+        var isMatch: Bool
+        var score: Double
+    }
+
+    private static let maxBits = 32
+
+    let options: Options
+    private let normalizedPattern: String
+    private let chunks: [(pattern: [UInt16], alphabet: [UInt16: Int])]
+
+    init(pattern: String, options: Options) {
+        self.options = options
+        let normalized = FuzzyTextNormalizer.normalize(pattern)
+        self.normalizedPattern = normalized
+        let units = FuzzyTextNormalizer.units(normalized)
+        var chunks: [(pattern: [UInt16], alphabet: [UInt16: Int])] = []
+        if !units.isEmpty {
+            let len = units.count
+            if len > Self.maxBits {
+                var i = 0
+                let remainder = len % Self.maxBits
+                let end = len - remainder
+                while i < end {
+                    let sub = Array(units[i ..< (i + Self.maxBits)])
+                    chunks.append((sub, Self.createPatternAlphabet(sub)))
+                    i += Self.maxBits
+                }
+                if remainder != 0 {
+                    let startIndex = len - Self.maxBits
+                    let sub = Array(units[startIndex...])
+                    chunks.append((sub, Self.createPatternAlphabet(sub)))
+                }
+            } else {
+                chunks.append((units, Self.createPatternAlphabet(units)))
+            }
+        }
+        self.chunks = chunks
+    }
+
+    func searchIn(_ text: String) -> Result {
+        let normalizedText = FuzzyTextNormalizer.normalize(text)
+        if normalizedPattern == normalizedText {
+            return Result(isMatch: true, score: 0)
+        }
+        if chunks.isEmpty {
+            return Result(isMatch: false, score: 1)
+        }
+        let textUnits = FuzzyTextNormalizer.units(normalizedText)
+        var totalScore = 0.0
+        var hasMatches = false
+        for chunk in chunks {
+            let result = Self.search(
+                text: textUnits,
+                pattern: chunk.pattern,
+                patternAlphabet: chunk.alphabet,
+                options: options
+            )
+            if result.isMatch { hasMatches = true }
+            totalScore += result.score
+        }
+        return Result(isMatch: hasMatches, score: hasMatches ? totalScore / Double(chunks.count) : 1)
+    }
+
+    private static func createPatternAlphabet(_ pattern: [UInt16]) -> [UInt16: Int] {
+        var mask: [UInt16: Int] = [:]
+        let len = pattern.count
+        for i in 0 ..< len {
+            let character = pattern[i]
+            mask[character] = (mask[character] ?? 0) | (1 << (len - i - 1))
+        }
+        return mask
+    }
+
+    private static func indexOf(_ text: [UInt16], _ pattern: [UInt16], from: Int) -> Int {
+        let textCount = text.count
+        let patternCount = pattern.count
+        if patternCount == 0 { return from <= textCount ? from : -1 }
+        if patternCount > textCount { return -1 }
+        var i = max(0, from)
+        while i <= textCount - patternCount {
+            var j = 0
+            while j < patternCount, text[i + j] == pattern[j] {
+                j += 1
+            }
+            if j == patternCount { return i }
+            i += 1
+        }
+        return -1
+    }
+
+    private static func hasMatchRun(_ matchMask: [Int], minMatchCharLength: Int) -> Bool {
+        var start = -1
+        var index = 0
+        let count = matchMask.count
+        while index < count {
+            let match = matchMask[index]
+            if match != 0, start == -1 {
+                start = index
+            } else if match == 0, start != -1 {
+                if index - start >= minMatchCharLength { return true }
+                start = -1
+            }
+            index += 1
+        }
+        if count > 0, matchMask[index - 1] != 0, index - start >= minMatchCharLength {
+            return true
+        }
+        return false
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private static func search(
+        text: [UInt16],
+        pattern: [UInt16],
+        patternAlphabet: [UInt16: Int],
+        options: Options
+    ) -> Result {
+        let patternLen = pattern.count
+        let textLen = text.count
+        let expectedLocation = max(0, min(options.location, textLen))
+        var currentThreshold = options.threshold
+        var bestLocation = expectedLocation
+        let distance = options.distance
+        let ignoreLocation = options.ignoreLocation
+
+        func calcScore(_ errors: Int, _ currentLocation: Int) -> Double {
+            let accuracy = Double(errors) / Double(patternLen)
+            if ignoreLocation { return accuracy }
+            let proximity = abs(expectedLocation - currentLocation)
+            if distance == 0 { return proximity != 0 ? 1.0 : accuracy }
+            return accuracy + Double(proximity) / Double(distance)
+        }
+
+        func safe(_ array: [Int], _ index: Int) -> Int {
+            (index >= 0 && index < array.count) ? array[index] : 0
+        }
+
+        let computeMatches = options.minMatchCharLength > 1
+        var matchMask = [Int](repeating: 0, count: textLen)
+
+        var occurrence = indexOf(text, pattern, from: bestLocation)
+        while occurrence > -1 {
+            let score = calcScore(0, occurrence)
+            currentThreshold = min(score, currentThreshold)
+            bestLocation = occurrence + patternLen
+            if computeMatches {
+                var offset = 0
+                while offset < patternLen {
+                    matchMask[occurrence + offset] = 1; offset += 1
+                }
+            }
+            occurrence = indexOf(text, pattern, from: bestLocation)
+        }
+
+        bestLocation = -1
+        var lastBitArray: [Int] = []
+        var finalScore = 1.0
+        var bestErrors = 0
+        var binMax = patternLen + textLen
+        let mask = 1 << (patternLen - 1)
+
+        for i in 0 ..< patternLen {
+            var binMin = 0
+            var binMid = binMax
+            while binMin < binMid {
+                let score = calcScore(i, expectedLocation + binMid)
+                if score <= currentThreshold {
+                    binMin = binMid
+                } else {
+                    binMax = binMid
+                }
+                binMid = (binMax - binMin) / 2 + binMin
+            }
+            binMax = binMid
+
+            var start = max(1, expectedLocation - binMid + 1)
+            let finish = options.findAllMatches ? textLen : min(expectedLocation + binMid, textLen) + patternLen
+
+            var bitArray = [Int](repeating: 0, count: finish + 2)
+            bitArray[finish + 1] = (1 << i) - 1
+
+            var j = finish
+            while j >= start {
+                let currentLocation = j - 1
+                let charMatch: Int = {
+                    if currentLocation >= 0, currentLocation < textLen {
+                        return patternAlphabet[text[currentLocation]] ?? 0
+                    }
+                    return 0
+                }()
+
+                bitArray[j] = ((safe(bitArray, j + 1) << 1) | 1) & charMatch
+                if i != 0 {
+                    bitArray[j] |= ((safe(lastBitArray, j + 1) | safe(lastBitArray, j)) << 1) | 1 | safe(
+                        lastBitArray,
+                        j + 1
+                    )
+                }
+
+                if bitArray[j] & mask != 0 {
+                    finalScore = calcScore(i, currentLocation)
+                    if finalScore <= currentThreshold {
+                        currentThreshold = finalScore
+                        bestLocation = currentLocation
+                        bestErrors = i
+                        if bestLocation <= expectedLocation { break }
+                        start = max(1, 2 * expectedLocation - bestLocation)
+                    }
+                }
+                j -= 1
+            }
+
+            if calcScore(i + 1, expectedLocation) > currentThreshold { break }
+            lastBitArray = bitArray
+        }
+
+        if computeMatches, bestLocation >= 0 {
+            let matchEnd = min(textLen - 1, bestLocation + patternLen - 1 + bestErrors)
+            var k = bestLocation
+            while k <= matchEnd {
+                if k >= 0, k < textLen, (patternAlphabet[text[k]] ?? 0) != 0 {
+                    matchMask[k] = 1
+                }
+                k += 1
+            }
+        }
+
+        var isMatch = bestLocation >= 0
+        if computeMatches, !hasMatchRun(matchMask, minMatchCharLength: options.minMatchCharLength) {
+            isMatch = false
+        }
+
+        return Result(isMatch: isMatch, score: max(0.001, finalScore))
+    }
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/EntityFuzzySearchIndex.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/EntityFuzzySearchIndex.swift
@@ -1,0 +1,81 @@
+import Foundation
+import GRDB
+
+public struct EntityFuzzySearchIndex {
+    private static let keys: [FuzzyKey] = [
+        FuzzyKey(name: "name", weight: 10),
+        FuzzyKey(name: "deviceName", weight: 7),
+        FuzzyKey(name: "areaName", weight: 6),
+        FuzzyKey(name: "domainName", weight: 6),
+        FuzzyKey(name: "floorName", weight: 5),
+        FuzzyKey(name: "entityId", weight: 3),
+    ]
+
+    private let entities: [HAAppEntity]
+    private let documents: [FuzzyDocument]
+    private let searcher: FuzzySearcher
+
+    public init(entities: [HAAppEntity], serverId: String) {
+        self.entities = entities
+        self.searcher = FuzzySearcher(keys: Self.keys)
+
+        var areaNames: [String: String] = [:]
+        var floorNames: [String: String] = [:]
+        if let areas = try? AppArea.fetchAreas(for: serverId) {
+            for area in areas {
+                for entityId in area.entities {
+                    areaNames[entityId] = area.name
+                    if let floorName = area.floorName, !floorName.isEmpty {
+                        floorNames[entityId] = floorName
+                    }
+                }
+            }
+        }
+
+        let deviceNames = Self.deviceNames(for: serverId)
+
+        self.documents = entities.map { entity in
+            FuzzyDocument(id: entity.id, fieldValues: [
+                entity.name,
+                deviceNames[entity.entityId],
+                areaNames[entity.entityId],
+                Domain(rawValue: entity.domain)?.name ?? entity.domain,
+                floorNames[entity.entityId],
+                entity.entityId,
+            ])
+        }
+    }
+
+    public func search(_ query: String) -> [HAAppEntity] {
+        searcher.search(query, in: documents).map { entities[$0] }
+    }
+
+    private static func deviceNames(for serverId: String) -> [String: String] {
+        do {
+            let registries = try Current.database().read { db in
+                try EntityRegistryListForDisplay.Entity
+                    .filter(Column(DatabaseTables.DisplayEntityRegistry.serverId.rawValue) == serverId)
+                    .fetchAll(db)
+            }
+            let devices = try Current.database().read { db in
+                try AppDeviceRegistry
+                    .filter(Column(DatabaseTables.DeviceRegistry.serverId.rawValue) == serverId)
+                    .fetchAll(db)
+            }
+            let devicesByDeviceId = Dictionary(
+                devices.map { ($0.deviceId, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+
+            var result: [String: String] = [:]
+            for registry in registries {
+                guard let deviceId = registry.deviceId, let device = devicesByDeviceId[deviceId] else { continue }
+                result[registry.entityId] = device.displayName
+            }
+            return result
+        } catch {
+            Current.Log.error("Failed to build device names for entity fuzzy search: \(error)")
+            return [:]
+        }
+    }
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/EntityFuzzySearchIndex.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/EntityFuzzySearchIndex.swift
@@ -21,7 +21,8 @@ public struct EntityFuzzySearchIndex {
 
         var areaNames: [String: String] = [:]
         var floorNames: [String: String] = [:]
-        if let areas = try? AppArea.fetchAreas(for: serverId) {
+        do {
+            let areas = try AppArea.fetchAreas(for: serverId)
             for area in areas {
                 for entityId in area.entities {
                     areaNames[entityId] = area.name
@@ -30,6 +31,8 @@ public struct EntityFuzzySearchIndex {
                     }
                 }
             }
+        } catch {
+            Current.Log.error("Failed to fetch areas for entity fuzzy search: \(error)")
         }
 
         let deviceNames = Self.deviceNames(for: serverId)

--- a/Sources/Shared/Environment/EntityFuzzySearch/FuzzyDocument.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/FuzzyDocument.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct FuzzyDocument: Sendable {
+    let id: String
+    let fieldValues: [String?]
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/FuzzyFieldNorm.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/FuzzyFieldNorm.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum FuzzyFieldNorm {
+    static func value(_ text: String, weight: Double = 1, mantissa: Int = 3) -> Double {
+        var tokenCount = 1
+        var inSpace = false
+        for unit in text.utf16 {
+            if unit == 32 {
+                if !inSpace { tokenCount += 1; inSpace = true }
+            } else {
+                inSpace = false
+            }
+        }
+        let m = pow(10.0, Double(mantissa))
+        return (m / pow(Double(tokenCount), 0.5 * weight)).rounded() / m
+    }
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/FuzzyKey.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/FuzzyKey.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct FuzzyKey: Sendable {
+    let name: String
+    let weight: Double
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/FuzzySearcher.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/FuzzySearcher.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct FuzzySearcher: Sendable {
+    private struct FieldMatch {
+        let weight: Double
+        let norm: Double
+        let score: Double
+    }
+
+    private let normalizedWeights: [Double]
+    private let options: BitapSearcher.Options
+
+    init(keys: [FuzzyKey], options: BitapSearcher.Options = BitapSearcher.Options()) {
+        let total = keys.reduce(0) { $0 + $1.weight }
+        self.normalizedWeights = keys.map { total > 0 ? $0.weight / total : 0 }
+        self.options = options
+    }
+
+    func search(_ query: String, in documents: [FuzzyDocument]) -> [Int] {
+        let substrings: [Substring] = query.lowercased().split(separator: " ")
+        let terms: [String] = substrings.map(String.init).filter { !$0.isEmpty }
+        if terms.isEmpty { return Array(documents.indices) }
+
+        if terms.count == 1 {
+            let results = searchTerm(terms[0], in: documents)
+            let sorted = results.sorted { lhs, rhs in
+                lhs.score == rhs.score ? lhs.index < rhs.index : lhs.score < rhs.score
+            }
+            return sorted.map(\.index)
+        }
+
+        var aggregate: [Int: (hits: Int, score: Double)] = [:]
+        var termHits = 0
+        for term in terms {
+            let results = searchTerm(term, in: documents)
+            if results.isEmpty { continue }
+            termHits += 1
+            for result in results {
+                let contribution = -log(result.score == 0 ? Double.leastNonzeroMagnitude : result.score)
+                if var existing = aggregate[result.index] {
+                    existing.hits += 1
+                    existing.score += contribution
+                    aggregate[result.index] = existing
+                } else {
+                    aggregate[result.index] = (1, contribution)
+                }
+            }
+        }
+        if termHits != terms.count { return [] }
+        let matched = aggregate.filter { $0.value.hits == terms.count }
+        let sorted = matched.sorted { lhs, rhs in
+            lhs.value.score == rhs.value.score ? lhs.key < rhs.key : lhs.value.score > rhs.value.score
+        }
+        return sorted.map(\.key)
+    }
+
+    private func searchTerm(_ term: String, in documents: [FuzzyDocument]) -> [(index: Int, score: Double)] {
+        var options = options
+        let termLength = term.utf16.count
+        if termLength < options.minMatchCharLength { options.minMatchCharLength = termLength }
+        let searcher = BitapSearcher(pattern: term, options: options)
+
+        var results: [(index: Int, score: Double)] = []
+        for (documentIndex, document) in documents.enumerated() {
+            var matches: [FieldMatch] = []
+            for (keyIndex, weight) in normalizedWeights.enumerated() {
+                guard keyIndex < document.fieldValues.count,
+                      let value = document.fieldValues[keyIndex], !value.isEmpty else { continue }
+                let result = searcher.searchIn(value)
+                if result.isMatch {
+                    matches.append(FieldMatch(weight: weight, norm: FuzzyFieldNorm.value(value), score: result.score))
+                }
+            }
+            if !matches.isEmpty {
+                results.append((documentIndex, combinedScore(matches)))
+            }
+        }
+        return results
+    }
+
+    private func combinedScore(_ matches: [FieldMatch]) -> Double {
+        var total = 1.0
+        for match in matches {
+            let base = match.score == 0 ? Double.ulpOfOne : match.score
+            total *= pow(base, match.weight * match.norm)
+        }
+        return total
+    }
+}

--- a/Sources/Shared/Environment/EntityFuzzySearch/FuzzyTextNormalizer.swift
+++ b/Sources/Shared/Environment/EntityFuzzySearch/FuzzyTextNormalizer.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum FuzzyTextNormalizer {
+    private static let combiningMarks: ClosedRange<UInt32> = 0x0300 ... 0x036F
+
+    static func normalize(_ string: String) -> String {
+        let decomposed = string.lowercased().decomposedStringWithCanonicalMapping
+        var scalars = String.UnicodeScalarView()
+        for scalar in decomposed.unicodeScalars where !combiningMarks.contains(scalar.value) {
+            scalars.append(scalar)
+        }
+        return String(scalars)
+    }
+
+    static func units(_ normalized: String) -> [UInt16] {
+        Array(normalized.utf16)
+    }
+}

--- a/Tests/App/EntityPicker/EntityFuzzySearch.test.swift
+++ b/Tests/App/EntityPicker/EntityFuzzySearch.test.swift
@@ -1,0 +1,127 @@
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("EntityFuzzySearch engine")
+struct EntityFuzzySearchEngineTests {
+    private static let keys: [FuzzyKey] = [
+        FuzzyKey(name: "name", weight: 10),
+        FuzzyKey(name: "deviceName", weight: 7),
+        FuzzyKey(name: "areaName", weight: 6),
+        FuzzyKey(name: "domainName", weight: 6),
+        FuzzyKey(name: "floorName", weight: 5),
+        FuzzyKey(name: "entityId", weight: 3),
+    ]
+
+    private static let documents: [FuzzyDocument] = [
+        make("light.kitchen_ceiling", "Ceiling", "Kitchen Ceiling Light", "Kitchen", "Light", "Ground Floor"),
+        make("light.living_room", "Living Room Lamp", "Living Room Lamp", "Living Room", "Light", "Ground Floor"),
+        make("switch.kitchen_coffee", "Coffee Machine", "Coffee Maker", "Kitchen", "Switch", "Ground Floor"),
+        make(
+            "sensor.bedroom_temperature",
+            "Bedroom Temperature",
+            "Bedroom Multisensor",
+            "Bedroom",
+            "Sensor",
+            "First Floor"
+        ),
+        make("climate.bedroom", "Bedroom Thermostat", "Ecobee", "Bedroom", "Climate", "First Floor"),
+        make("cover.garage_door", "Garage Door", "Garage Opener", "Garage", "Cover", "Ground Floor"),
+        make("light.office_desk", "Desk Lamp", "Office Desk Light", "Office", "Light", "First Floor"),
+        make(
+            "media_player.living_room_tv",
+            "Living Room TV",
+            "Samsung TV",
+            "Living Room",
+            "Media player",
+            "Ground Floor"
+        ),
+        make("light.bathroom", "Bathroom", "Bathroom Light", "Bathroom", "Light", "First Floor"),
+        make("fan.bedroom_ceiling", "Ceiling Fan", "Bedroom Fan", "Bedroom", "Fan", "First Floor"),
+        make("sensor.salao_temperature", "Salão Temperature", "Salão Sensor", "Salão", "Sensor", "Rés do Chão"),
+        make("lock.front_door", "Front Door Lock", "August Lock", "Entrance", "Lock", "Ground Floor"),
+        make(
+            "light.kitchen_under_cabinet",
+            "Under Cabinet",
+            "Kitchen Under Cabinet LED",
+            "Kitchen",
+            "Light",
+            "Ground Floor"
+        ),
+        make("scene.movie_night", "Movie Night", nil, nil, "Scene", nil),
+        make("automation.morning_routine", "Morning Routine", nil, nil, "Automation", nil),
+    ]
+
+    private static func make(
+        _ id: String,
+        _ name: String,
+        _ device: String?,
+        _ area: String?,
+        _ domain: String,
+        _ floor: String?
+    ) -> FuzzyDocument {
+        FuzzyDocument(id: id, fieldValues: [name, device, area, domain, floor, id])
+    }
+
+    private func search(_ query: String) -> [String] {
+        let searcher = FuzzySearcher(keys: Self.keys)
+        return searcher.search(query, in: Self.documents).map { Self.documents[$0].id }
+    }
+
+    @Test("Exact single-term matches across fields, ranked by relevance")
+    func exactMatches() {
+        #expect(search("kitchen") == [
+            "light.kitchen_ceiling",
+            "light.kitchen_under_cabinet",
+            "switch.kitchen_coffee",
+        ])
+        #expect(search("ceiling") == ["light.kitchen_ceiling", "fan.bedroom_ceiling"])
+        #expect(search("thermostat") == ["climate.bedroom"])
+    }
+
+    @Test("Typos are tolerated (fuzzy matching)")
+    func typoTolerance() {
+        #expect(search("kithen") == [
+            "light.kitchen_ceiling",
+            "light.kitchen_under_cabinet",
+            "switch.kitchen_coffee",
+        ])
+        #expect(search("coffe") == ["switch.kitchen_coffee"])
+    }
+
+    @Test("Diacritics are ignored in both directions")
+    func diacriticsInsensitive() {
+        #expect(search("salao") == ["sensor.salao_temperature"])
+        #expect(search("salão") == ["sensor.salao_temperature"])
+    }
+
+    @Test("Spaceless queries still match multi-word fields")
+    func spacelessQuery() {
+        #expect(search("livingroom") == ["light.living_room", "media_player.living_room_tv"])
+    }
+
+    @Test("Multi-term queries require every term to match some field")
+    func multiTermAndSemantics() {
+        #expect(search("living room") == ["light.living_room", "media_player.living_room_tv"])
+        #expect(search("garage door") == ["cover.garage_door"])
+        #expect(search("bedroom light").isEmpty)
+    }
+
+    @Test("Device, area, floor and domain names are searchable")
+    func nonNameFields() {
+        #expect(search("samsung") == ["media_player.living_room_tv"])
+        #expect(search("entrance") == ["lock.front_door"])
+        #expect(search("cabinet") == ["light.kitchen_under_cabinet"])
+    }
+
+    @Test("Unmatched queries return nothing")
+    func noMatch() {
+        #expect(search("xyzzy").isEmpty)
+    }
+
+    @Test("Empty query returns every document in original order")
+    func emptyQuery() {
+        #expect(search("") == Self.documents.map(\.id))
+        #expect(search("   ") == Self.documents.map(\.id))
+    }
+}


### PR DESCRIPTION
## Summary

Makes the entity picker search behave like the [home-assistant/frontend](https://github.com/home-assistant/frontend) entity picker: fuzzy, multi-field, relevance-ranked matching instead of plain substring matching.

Searching now matches against **entity name, device name, area name, floor name** (plus **domain name** and **entity id**, which the frontend also searches), with:
- typo tolerance (`kithen` → Kitchen, `coffe` → Coffee)
- diacritic-insensitivity (`salao` matches `Salão`)
- word-boundary matches (`livingroom` matches "Living Room")
- multi-term AND queries (`garage door`)
- relevance ranking with the frontend's field weights (name 10, device 7, area/domain 6, floor 5, id 3)

## How it works

The frontend's search stack (Fuse.js 7.4.2 Bitap matcher + weighted-geometric scoring + field-length norm + its `multiTermSortedSearch` term aggregation) is ported to a native Swift engine under `Sources/Shared/Environment/EntityFuzzySearch/`, exposed via `EntityFuzzySearchIndex`. It's wired into:
- the in-app `EntityPicker` (relevance-ranked, grouped results while searching; unchanged grouped/alphabetical listing when the query is empty)
- `ControlEntityProvider`, used by the widget/Siri/App-Shortcuts entity pickers

Floor name is searchable even though the frontend picker doesn't search it today — its name infrastructure supports floor, and it was explicitly wanted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)