### PR TITLE
Fix widgets failing on external URL with mTLS

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -162,10 +162,9 @@ public class HomeAssistantAPI {
         self.connection = RetryAwareHAConnection(underlying: underlyingConnection)
         connection.delegate = self
 
-        // Use custom delegate that supports client certificates (mTLS)
-        let sessionDelegate: SessionDelegate = server.info.connection.clientCertificate != nil
-            ? ClientCertificateSessionDelegate(server: server)
-            : SessionDelegate()
+        // Attached unconditionally (see makeCertificateAwareURLSession): the delegate resolves the
+        // client certificate fresh at challenge time rather than gating on an init-time snapshot.
+        let sessionDelegate: SessionDelegate = ClientCertificateSessionDelegate(server: server)
 
         let manager = HomeAssistantAPI.configureSessionManager(
             urlConfig: urlConfig,
@@ -181,18 +180,18 @@ public class HomeAssistantAPI {
     }
 
     /// Builds a `URLSession` that presents this server's client certificate and honors its security
-    /// exceptions (mTLS), or a plain ephemeral session when neither is configured. Reused by HAKit's
-    /// REST calls and, on watchOS, by direct REST execution (where WebSocket transport is unavailable).
+    /// exceptions (mTLS). Reused by HAKit's REST calls and, on watchOS, by direct REST execution.
+    ///
+    /// The provider is attached unconditionally and resolves the certificate fresh at challenge
+    /// time. The certificate is not always present in the server-config snapshot when the session
+    /// is built (e.g. the config was just restored from a source that did not carry it, or a
+    /// Keychain read fell back to the sanitized GRDB mirror), yet is usable moments later. Gating
+    /// session construction on that snapshot would leave the session permanently without the
+    /// certificate, so every external, mTLS-protected request 403s for the process's lifetime.
     public static func makeCertificateAwareURLSession(server: Server) -> URLSession {
-        if server.info.connection.clientCertificate != nil || server.info.connection.securityExceptions.hasExceptions {
-            Current.Log.info("[mTLS] Using HAKit certificate provider")
-            let certificateProvider = HomeAssistantCertificateProvider(server: server)
-            let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
-            return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
-        } else {
-            Current.Log.info("[mTLS] Using default URLSession for HAKit")
-            return URLSession(configuration: .ephemeral)
-        }
+        let certificateProvider = HomeAssistantCertificateProvider(server: server)
+        let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
+        return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
     }
 
     public static func apiAvailabilityCheck(for server: Server, timeout: TimeInterval = 5) async -> Bool {

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -135,6 +135,32 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(connection.sentRequests.count, 2)
     }
+
+    func testCertificateAwareSessionAttachesDelegateWithoutClientCertificate() {
+        let server = ServerFixture.withRemoteConnection
+        XCTAssertNil(server.info.connection.clientCertificate)
+        XCTAssertFalse(server.info.connection.securityExceptions.hasExceptions)
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        defer { session.finishTasksAndInvalidate() }
+
+        XCTAssertTrue(session.delegate is HAURLSessionDelegate)
+    }
+
+    func testCertificateAwareSessionAttachesDelegateWithClientCertificate() {
+        let server = ServerFixture.withRemoteConnection
+        server.update { info in
+            info.connection.clientCertificate = ClientCertificate(
+                keychainIdentifier: "com.ha-ios.mtls.identity.test",
+                displayName: "Test"
+            )
+        }
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        defer { session.finishTasksAndInvalidate() }
+
+        XCTAssertTrue(session.delegate is HAURLSessionDelegate)
+    }
 }
 
 private final class FakeHAConnection: HAConnection {

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -137,7 +137,7 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
     }
 
     func testCertificateAwareSessionAttachesDelegateWithoutClientCertificate() {
-        let server = ServerFixture.withRemoteConnection
+        let server = makeServer(clientCertificate: nil)
         XCTAssertNil(server.info.connection.clientCertificate)
         XCTAssertFalse(server.info.connection.securityExceptions.hasExceptions)
 
@@ -148,18 +148,41 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
     }
 
     func testCertificateAwareSessionAttachesDelegateWithClientCertificate() {
-        let server = ServerFixture.withRemoteConnection
-        server.update { info in
-            info.connection.clientCertificate = ClientCertificate(
-                keychainIdentifier: "com.ha-ios.mtls.identity.test",
-                displayName: "Test"
-            )
-        }
+        let server = makeServer(clientCertificate: ClientCertificate(
+            keychainIdentifier: "com.ha-ios.mtls.identity.test",
+            displayName: "Test"
+        ))
 
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
         defer { session.finishTasksAndInvalidate() }
 
         XCTAssertTrue(session.delegate is HAURLSessionDelegate)
+    }
+
+    private func makeServer(clientCertificate: ClientCertificate?) -> Server {
+        var info = ServerInfo(
+            name: "Certificate Server",
+            connection: .init(
+                externalURL: URL(string: "https://external.example.com"),
+                internalURL: nil,
+                cloudhookURL: nil,
+                remoteUIURL: nil,
+                webhookID: "webhook-id",
+                webhookSecret: nil,
+                internalSSIDs: nil,
+                internalHardwareAddresses: nil,
+                isLocalPushEnabled: false,
+                securityExceptions: .init(exceptions: []),
+                connectionAccessSecurityLevel: .undefined,
+                clientCertificate: clientCertificate
+            ),
+            token: .init(accessToken: "access-token", refreshToken: "refresh-token", expiration: Date()),
+            version: "2026.4.1"
+        )
+        return Server(identifier: "certificate-test", getter: { info }, setter: { newInfo in
+            info = newInfo
+            return true
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
Widgets could fail to load state and execute actions when the active connection resolved to an external URL protected by mTLS (for example behind Cloudflare), returning a 403.

The HAKit REST `URLSession` and the Alamofire session decided whether to attach the client-certificate delegate only once, at `HomeAssistantAPI` init, based on whether a client certificate was present in the server config at that instant. In app extensions that snapshot can momentarily lack the certificate (e.g. right after a config restore, or when a Keychain read falls back to the sanitized mirror), so the session was built without certificate support and kept that way for the rest of the process's lifetime. Every later request to the mTLS-protected external URL then got a 403, even though the certificate was actually available (the webhook path, which resolves it lazily, kept working in the same process).

This attaches the certificate-aware delegate unconditionally. The delegate already resolves the client certificate lazily, at TLS-challenge time, and falls back to default handling when there is none, so plain-http and non-mTLS servers are unaffected and the certificate is only ever presented during an https handshake.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
