### PR TITLE
Dismiss app settings after activating a server

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsView.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsView.swift
@@ -500,9 +500,15 @@ struct ConnectionSettingsView: View {
     private var activateSection: some View {
         Button {
             viewModel.activateServer()
+            dismissAppSettings()
         } label: {
             Text(L10n.Settings.ConnectionSection.activateServer)
         }
+    }
+
+    private func dismissAppSettings() {
+        AppSettingsPresenter.shared.isSheetPresented = false
+        AppSettingsPresenter.shared.isPushPresented = false
     }
 
     // MARK: - Delete Section


### PR DESCRIPTION
## Summary
Tapping **Activate** on a server's connection settings (Settings → the server row → Activate toolbar button) now dismisses the whole App Settings presentation, so the newly activated server's web view is revealed right away instead of staying hidden behind Settings.

Previously the button only called `viewModel.activateServer()`, which switches the active web view underneath but left Settings on top, so the user had to manually close Settings to see the server they just activated.

- `ConnectionSettingsView.activateSection` now also clears the `AppSettingsPresenter` flags (`isSheetPresented` / `isPushPresented`) after activating, tearing down both the sheet and the pushed presentations. This mirrors the existing `DebugView.dismissSettingsAfterReset()` pattern.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Only affects the iPhone/iPad presentations driven by `AppSettingsPresenter`; Catalyst (Settings in its own scene) is unchanged, consistent with the existing reset-app dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)