### PR TITLE
Improve watch-iPhone communication reliability

### DIFF
--- a/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
@@ -8,6 +8,10 @@ public enum InteractiveImmediateResponses: String, CaseIterable {
     case pushActionResponse = "PushActionResponse"
     case assistPipelinesFetchResponse
     case assistAudioDataResponse
+    /// Phone → watch: per-chunk acknowledgement of `assistAudioDataChunked`, carrying
+    /// `{acknowledged, chunkIndex, totalChunks}`. The watch sends the next chunk only after
+    /// receiving this, so audio streams with backpressure instead of flooding the session.
+    case assistAudioChunkAck
     case assistSTTResponse
     case assistIntentEndResponse
     case assistTTSResponse

--- a/Sources/HAWatchCommunicationMessages/Sources/WatchMessageSizeLimits.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/WatchMessageSizeLimits.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Payload ceilings WatchConnectivity enforces at runtime (WCErrorCodePayloadTooLarge). Apple
+/// doesn't document the exact numbers; these are the empirically stable values, used to warn (and
+/// where possible fall back) before WCSession rejects a transfer.
+public enum WatchMessageSizeLimits {
+    /// `sendMessage` payload ceiling (~65.5 KB), applying to interactive messages and their replies.
+    public static let interactiveMessage = 65_536
+    /// `updateApplicationContext` / `transferUserInfo` payload ceiling (~262.1 KB).
+    /// `transferFile` has no such cap.
+    public static let applicationContext = 262_144
+}

--- a/Sources/HAWatchCommunicationMessages/Sources/WatchMessageSizeLimits.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/WatchMessageSizeLimits.swift
@@ -5,7 +5,7 @@ import Foundation
 /// where possible fall back) before WCSession rejects a transfer.
 public enum WatchMessageSizeLimits {
     /// `sendMessage` payload ceiling (~65.5 KB), applying to interactive messages and their replies.
-    public static let interactiveMessage = 65_536
+    public static let interactiveMessage = 65536
     /// `updateApplicationContext` / `transferUserInfo` payload ceiling (~262.1 KB).
     /// `transferFile` has no such cap.
     public static let applicationContext = 262_144

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -55,6 +55,28 @@ public extension HomeAssistantAPI {
         return content
     }
 
+    /// Sync the context unless it exceeds `updateApplicationContext`'s payload ceiling. On iOS the
+    /// only keys are the complication tables, which the database mirror also carries — and
+    /// `transferFile` has no size cap — so an oversized context is delivered through a mirror push
+    /// instead of failing.
+    private static func syncRespectingSizeLimit(_ context: HAWatchConnectivity.Context) throws {
+        #if os(iOS)
+        if let size = WatchConnectivityManager.estimatePayloadSize(of: context.content),
+           size > WatchMessageSizeLimits.applicationContext {
+            Current.Log.error(
+                "Watch context is \(size) bytes, above the ~262 KB ceiling; delivering via database mirror push instead"
+            )
+            Current.clientEventStore.addEvent(.init(
+                text: "Watch context too large to sync (\(size) bytes); scheduled database mirror push instead",
+                type: .database
+            ))
+            WatchMirrorPushCoordinator.schedule(reason: .complicationChanged)
+            return
+        }
+        #endif
+        try Communicator.shared.sync(context)
+    }
+
     static func SyncWatchContext() async -> NSError? {
         #if os(iOS)
         guard case .paired(.installed) = Communicator.shared.currentWatchState else {
@@ -66,7 +88,7 @@ public extension HomeAssistantAPI {
         let context = await HAWatchConnectivity.Context(content: HomeAssistantAPI.watchContext())
 
         do {
-            try Communicator.shared.sync(context)
+            try syncRespectingSizeLimit(context)
             Current.Log.info("updated context")
             Current.clientEventStore.addEvent(.init(
                 text: "Synced watch context to Apple Watch (updateApplicationContext)",
@@ -112,7 +134,7 @@ public extension HomeAssistantAPI {
         }
         let context = await HAWatchConnectivity.Context(content: watchContext())
         do {
-            try Communicator.shared.sync(context)
+            try syncRespectingSizeLimit(context)
             Current.Log.info("Watch reload: context synced")
             return .success
         } catch {

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -10,7 +10,11 @@ import WatchKit
 public extension HomeAssistantAPI {
     // Be mindful of 262.1kb maximum size for context - https://stackoverflow.com/a/35076706/486182
     private static func watchContext() async -> HAWatchConnectivity.Content {
-        var content: HAWatchConnectivity.Content = Communicator.shared.mostRecentlyReceivedContext.content
+        // Each side sends only the keys it owns (see WatchContext). The sent and received
+        // application contexts are separate dictionaries in WCSession, so nothing is lost by not
+        // echoing the counterpart's keys back — echoing only bloated every update toward the size
+        // cap and could resurrect stale values (e.g. an old battery level bouncing back).
+        var content: HAWatchConnectivity.Content = [:]
 
         #if os(iOS)
         // Servers are delivered on demand via the `serversConfigSync` interactive message (see

--- a/Sources/Shared/Watch/Connectivity/HAWatchConnectivityMessages.swift
+++ b/Sources/Shared/Watch/Connectivity/HAWatchConnectivityMessages.swift
@@ -99,7 +99,11 @@ final class ReplyBox {
         lock.unlock()
 
         if let handlerToCall {
-            handlerToCall(response.jsonRepresentation())
+            let envelope = response.jsonRepresentation()
+            // Replies share sendMessage's payload ceiling; an oversized one surfaces on the
+            // counterpart only as a reply timeout, so name the culprit here.
+            WatchConnectivityManager.warnIfExceedsMessageLimit(envelope, identifier: response.identifier)
+            handlerToCall(envelope)
         } else {
             Current.Log.error("WatchConnectivity reply invoked more than once for \(response.identifier)")
         }

--- a/Sources/Shared/Watch/Connectivity/WCSessionProtocol.swift
+++ b/Sources/Shared/Watch/Connectivity/WCSessionProtocol.swift
@@ -17,6 +17,8 @@ public protocol WCSessionProtocol: AnyObject {
     var hasContentPendingProxy: Bool { get }
     var applicationContextProxy: [String: Any] { get }
     var receivedApplicationContextProxy: [String: Any] { get }
+    /// Payloads of `transferUserInfo` calls not yet delivered to the counterpart.
+    var outstandingUserInfoTransfersProxy: [[String: Any]] { get }
 
     func activateProxy()
     func sendMessageProxy(
@@ -49,6 +51,9 @@ extension WCSession: WCSessionProtocol {
     public var hasContentPendingProxy: Bool { hasContentPending }
     public var applicationContextProxy: [String: Any] { applicationContext }
     public var receivedApplicationContextProxy: [String: Any] { receivedApplicationContext }
+    public var outstandingUserInfoTransfersProxy: [[String: Any]] {
+        outstandingUserInfoTransfers.map(\.userInfo)
+    }
 
     public func activateProxy() { activate() }
 

--- a/Sources/Shared/Watch/Connectivity/WatchConnectivityManager+Send.swift
+++ b/Sources/Shared/Watch/Connectivity/WatchConnectivityManager+Send.swift
@@ -7,6 +7,28 @@ public extension WatchConnectivityManager {
     /// guarantees a UI that blocks on the reply can never spin forever.
     static let interactiveReplyTimeout: TimeInterval = 30
 
+    /// Estimated on-wire bytes of a payload dictionary (binary property list, which is what
+    /// WCSession serializes to), or `nil` when the payload isn't property-list-serializable.
+    static func estimatePayloadSize(of content: [String: Any]) -> Int? {
+        guard PropertyListSerialization.propertyList(content, isValidFor: .binary) else { return nil }
+        return (try? PropertyListSerialization.data(
+            fromPropertyList: content,
+            format: .binary,
+            options: 0
+        ))?.count
+    }
+
+    /// Log when an envelope exceeds `sendMessage`'s payload ceiling. The transfer will most likely
+    /// fail with an opaque delivery error (or a silent reply timeout on the counterpart), and this
+    /// ties that failure to the offending message and its size.
+    static func warnIfExceedsMessageLimit(_ envelope: [String: Any], identifier: String) {
+        guard let size = estimatePayloadSize(of: envelope),
+              size > WatchMessageSizeLimits.interactiveMessage else { return }
+        Current.Log.error(
+            "WatchConnectivity payload for \(identifier) is \(size) bytes, above the ~65 KB sendMessage ceiling; delivery will likely fail"
+        )
+    }
+
     /// Interactive request/reply. Requires the counterpart immediately reachable. The response envelope
     /// is decoded back into an `ImmediateMessage` and delivered to `message.reply`. `errorHandler` fires
     /// at most once, on delivery failure or after `timeout` seconds with no reply.
@@ -27,6 +49,8 @@ public extension WatchConnectivityManager {
             errorHandler?(HAWatchConnectivity.ConnectivityError.notReachable)
             return
         }
+
+        Self.warnIfExceedsMessageLimit(message.jsonRepresentation(), identifier: message.identifier)
 
         // At most one of {delivery error, timeout} may call errorHandler; a reply cancels the timeout.
         let errorGate = WatchConnectivityOnceFlag()
@@ -67,6 +91,7 @@ public extension WatchConnectivityManager {
             errorHandler?(HAWatchConnectivity.ConnectivityError.notReachable)
             return
         }
+        Self.warnIfExceedsMessageLimit(message.jsonRepresentation(), identifier: message.identifier)
         session.sendMessageProxy(message.jsonRepresentation(), replyHandler: nil, errorHandler: errorHandler)
     }
 

--- a/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
+++ b/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
@@ -76,6 +76,16 @@ public final class WatchConnectivityManager: NSObject {
         session?.hasContentPendingProxy ?? false
     }
 
+    /// Whether a guaranteed message with this identifier is still queued for delivery
+    /// (`transferUserInfo` not yet handed to the counterpart). Lets callers skip enqueueing a
+    /// duplicate — WCSession queues every transfer verbatim and would deliver them all.
+    public func hasOutstandingGuaranteedMessage(identifier: String) -> Bool {
+        guard let session else { return false }
+        return session.outstandingUserInfoTransfersProxy.contains {
+            HAWatchConnectivity.GuaranteedMessage(content: $0)?.identifier == identifier
+        }
+    }
+
     public var mostRecentlyReceivedContext: HAWatchConnectivity.Context {
         receivedContextLock.lock()
         let cached = cachedReceivedContext

--- a/Sources/Shared/Watch/WatchConfig.swift
+++ b/Sources/Shared/Watch/WatchConfig.swift
@@ -69,17 +69,16 @@ public enum WatchLayout: String, Codable, CaseIterable, DatabaseValueConvertible
 }
 
 public protocol WatchCodable: Codable {
-    func encodeForWatch() -> Data
+    func encodeForWatch() throws -> Data
     static func decodeForWatch(_ data: Data) -> Self?
 }
 
 public extension WatchCodable {
-    func encodeForWatch() -> Data {
-        do {
-            return try PropertyListEncoder().encode(self)
-        } catch {
-            fatalError("Faield to encode watch config for watch transfer, error: \(error.localizedDescription)")
-        }
+    /// Encode for a WatchConnectivity transfer. A failure throws so the sender can skip the
+    /// transfer (and log why) instead of crashing — a codec problem in a communication path must
+    /// never take the app down.
+    func encodeForWatch() throws -> Data {
+        try PropertyListEncoder().encode(self)
     }
 
     static func decodeForWatch(_ data: Data) -> Self? {

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -411,16 +411,19 @@ final class WatchCommunicatorService {
     /// we answer the same way so the config survives the phone being backgrounded/locked. No
     /// reachability required on either side.
     private func respondToGuaranteedWatchConfigRequest() {
+        // The types are spelled out: `.init` here is ambiguous between ImmediateMessage (requires
+        // reachability — would defeat this whole flow) and GuaranteedMessage, and used to compile as
+        // the latter only because Swift prefers the overload without defaulted arguments.
         do {
             if let config: WatchConfig = try Current.database().read({ db in try WatchConfig.fetchOne(db) }) {
                 buildWatchConfigResponseContent(watchConfig: config) { content in
-                    Communicator.shared.send(.init(
+                    Communicator.shared.send(HAWatchConnectivity.GuaranteedMessage(
                         identifier: InteractiveImmediateResponses.watchConfigResponse.rawValue,
                         content: content
                     ))
                 }
             } else {
-                Communicator.shared.send(.init(
+                Communicator.shared.send(HAWatchConnectivity.GuaranteedMessage(
                     identifier: InteractiveImmediateResponses.emptyWatchConfigResponse.rawValue
                 ))
             }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -14,9 +14,19 @@ final class WatchCommunicatorService {
     private var assistService: AssistServiceProtocol?
     private var pendingAudioData: Data?
 
-    // [sessionKey: [chunkIndex: Data]]
-    private var audioChunks: [String: [Int: Data]] = [:]
-    private var audioChunkCounts: [String: Int] = [:]
+    /// One in-progress chunked audio upload from the watch.
+    private struct AudioChunkSession {
+        var chunks: [Int: Data] = [:]
+        var totalChunks: Int
+        var lastChunkAt: Date
+    }
+
+    /// In-progress audio uploads keyed by the watch's per-recording id (or `serverId_pipelineId`
+    /// for watch builds that predate the recording id).
+    private var audioChunkSessions: [String: AudioChunkSession] = [:]
+    /// Partial uploads that stop receiving chunks for this long are abandoned (the watch retried or
+    /// gave up) and dropped, so they can't leak memory or corrupt a later recording.
+    private static let audioChunkSessionTimeout: TimeInterval = 60
 
     /// In-progress database syncs, keyed by transferId → the ordered chunks the watch pulls one by one.
     private var databaseSyncChunks: [String: [Data]] = [:]
@@ -290,30 +300,37 @@ final class WatchCommunicatorService {
             Current.Log.error("Invalid chunked message data")
             return
         }
-        let sessionKey = serverId + "_" + pipelineId
-        if audioChunks[sessionKey] == nil {
-            audioChunks[sessionKey] = [:]
-        }
-        audioChunks[sessionKey]?[chunkIndex] = chunkData
-        audioChunkCounts[sessionKey] = totalChunks
+        // Older watch builds don't send a recordingId; fall back to the legacy key so they keep working.
+        let sessionKey = (message.content["recordingId"] as? String) ?? (serverId + "_" + pipelineId)
 
-        // Reply acknowledging receipt of this chunk
-        message.reply(.init(identifier: "assistAudioChunkAck", content: [
+        // Drop partial uploads that went quiet before starting/continuing this one.
+        let now = Current.date()
+        let staleKeys = audioChunkSessions.filter {
+            now.timeIntervalSince($0.value.lastChunkAt) >= Self.audioChunkSessionTimeout
+        }.keys
+        for staleKey in staleKeys {
+            Current.Log.warning("Dropping abandoned assist audio upload \(staleKey)")
+            audioChunkSessions.removeValue(forKey: staleKey)
+        }
+
+        var session = audioChunkSessions[sessionKey]
+            ?? AudioChunkSession(totalChunks: totalChunks, lastChunkAt: now)
+        session.chunks[chunkIndex] = chunkData
+        session.totalChunks = totalChunks
+        session.lastChunkAt = now
+        audioChunkSessions[sessionKey] = session
+
+        // Acknowledge this chunk; the watch sends the next one only after receiving this.
+        message.reply(.init(identifier: InteractiveImmediateResponses.assistAudioChunkAck.rawValue, content: [
             "acknowledged": true,
             "chunkIndex": chunkIndex,
             "totalChunks": totalChunks,
         ]))
 
-        // Check if all chunks are received
-        if let receivedChunks = audioChunks[sessionKey],
-           receivedChunks.count == totalChunks {
-            // Assemble data in order
-            let sortedChunks = receivedChunks.keys.sorted().compactMap { receivedChunks[$0] }
+        if session.chunks.count == totalChunks {
+            let sortedChunks = session.chunks.keys.sorted().compactMap { session.chunks[$0] }
             let combinedData = sortedChunks.reduce(Data(), +)
-            // Clean up
-            audioChunks.removeValue(forKey: sessionKey)
-            audioChunkCounts.removeValue(forKey: sessionKey)
-            // Call assistAudioData
+            audioChunkSessions.removeValue(forKey: sessionKey)
             assistAudioData(message: message.toImmediateMessage(), data: combinedData)
         }
     }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -29,6 +29,8 @@ final class WatchCommunicatorService {
     private static let audioChunkSessionTimeout: TimeInterval = 60
 
     /// In-progress database syncs, keyed by transferId → the ordered chunks the watch pulls one by one.
+    /// Only one sync is ever meaningful at a time (there is one paired watch), so starting a new sync
+    /// frees any previous buffer — a watch that died mid-pull must not leak the encoded mirror.
     private var databaseSyncChunks: [String: [Data]] = [:]
 
     private var didBecomeActiveObserver: NSObjectProtocol?
@@ -491,6 +493,10 @@ final class WatchCommunicatorService {
     /// cap, which is exactly why the payload itself is chunked rather than returned inline.
     private func watchDatabaseMirrorSyncStart(message: HAWatchConnectivity.InteractiveImmediateMessage) {
         let responseId = InteractiveImmediateResponses.watchDatabaseMirrorResponse.rawValue
+        if !databaseSyncChunks.isEmpty {
+            Current.Log.info("Dropping \(databaseSyncChunks.count) abandoned watch DB sync buffer(s)")
+            databaseSyncChunks.removeAll()
+        }
         let data: Data
         do {
             data = try WatchDatabaseMirror.snapshot().encodeForWatch()
@@ -512,6 +518,13 @@ final class WatchCommunicatorService {
 
         let transferId = UUID().uuidString
         databaseSyncChunks[transferId] = chunks
+        // Backstop for a watch that dies mid-pull and never starts another sync: a healthy pull
+        // completes in seconds (each chunk request has a 30s reply ceiling and one timeout fails the
+        // whole sync on the watch), so a buffer still around after this long is abandoned.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 600) { [weak self] in
+            guard let self, databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
+            Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
+        }
         Current.Log.info("Watch DB sync start: \(chunks.count) chunk(s), \(data.count) bytes, id \(transferId)")
         message.reply(.init(identifier: responseId, content: [
             "transferId": transferId,

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -392,10 +392,17 @@ final class WatchCommunicatorService {
                 }
             }
 
-            completion([
-                "config": watchConfig.encodeForWatch(),
-                "magicItemsInfo": magicItemsInfo.map({ $0.encodeForWatch() }),
-            ])
+            var content: [String: Any] = [
+                "magicItemsInfo": magicItemsInfo.compactMap { try? $0.encodeForWatch() },
+            ]
+            do {
+                content["config"] = try watchConfig.encodeForWatch()
+            } catch {
+                // Without the config key the watch treats the reply as a decode failure and keeps
+                // its cached config — never as an authoritative empty one.
+                Current.Log.error("Failed to encode watch config for reply: \(error.localizedDescription)")
+            }
+            completion(content)
         }
     }
 
@@ -451,10 +458,14 @@ final class WatchCommunicatorService {
                     }
                 return .init(serverId: serverId, serverName: server.info.name, candidates: candidates)
             }
-            message.reply(.init(
-                identifier: responseIdentifier,
-                content: ["availableItems": WatchConfigAvailableItems(servers: groups).encodeForWatch()]
-            ))
+            let content: [String: Any]
+            do {
+                content = try ["availableItems": WatchConfigAvailableItems(servers: groups).encodeForWatch()]
+            } catch {
+                Current.Log.error("Failed to encode available items for watch: \(error.localizedDescription)")
+                content = ["error": true]
+            }
+            message.reply(.init(identifier: responseIdentifier, content: content))
         }
     }
 

--- a/Sources/WatchApp/Assist/WatchAssistService.swift
+++ b/Sources/WatchApp/Assist/WatchAssistService.swift
@@ -43,42 +43,92 @@ final class WatchAssistService: ObservableObject {
             return
         }
 
+        let audioData: Data
         do {
-            let audioData = try Data(contentsOf: audioURL)
+            audioData = try Data(contentsOf: audioURL)
             try FileManager.default.removeItem(at: audioURL)
-
-            Current.Log.verbose("Signaling Assist audio data")
-
-            let chunkSize = 32 * 1024 // 32 KB
-            let totalChunks = Int(ceil(Double(audioData.count) / Double(chunkSize)))
-
-            for chunkIndex in 0 ..< totalChunks {
-                let start = chunkIndex * chunkSize
-                let end = min(start + chunkSize, audioData.count)
-                let chunkData = audioData.subdata(in: start ..< end)
-
-                // Ideally data transfers are done using an specific method to transfer data
-                // but in reality this has demonstrated to not work well specially in watchOS 26
-                // this logic uses the normal communication messages in chunks for more reliability
-                Communicator.shared.send(.init(
-                    identifier: InteractiveImmediateMessages.assistAudioDataChunked.rawValue,
-                    content: [
-                        "chunkData": chunkData,
-                        "chunkIndex": chunkIndex,
-                        "totalChunks": totalChunks,
-                        "sampleRate": sampleRate,
-                        "pipelineId": pipelineId,
-                        "serverId": serverId,
-                    ],
-                    reply: { message in
-                        Current.Log.verbose("Received reply for assist audio chunk #\(chunkIndex): \(message)")
-                    }
-                ))
-            }
         } catch {
             Current.Log.error("Watch assist failed: \(error.localizedDescription)")
             completion(error)
+            return
         }
+
+        Current.Log.verbose("Signaling Assist audio data")
+
+        let chunkSize = 32 * 1024 // 32 KB
+        let totalChunks = max(1, Int(ceil(Double(audioData.count) / Double(chunkSize))))
+        sendChunk(
+            index: 0,
+            // Unique per recording so the phone never mixes chunks of an aborted/retried attempt
+            // into a later one.
+            recordingId: UUID().uuidString,
+            audioData: audioData,
+            chunkSize: chunkSize,
+            totalChunks: totalChunks,
+            sampleRate: sampleRate,
+            completion: completion
+        )
+    }
+
+    /// Send one chunk, then the next only after the phone acknowledges it — backpressure instead of
+    /// flooding the session — so a lost chunk surfaces as an error (reply timeout) rather than the
+    /// phone waiting forever on a partial upload. `completion` fires exactly once, on the main queue:
+    /// `nil` after the last ack, or the first delivery error.
+    ///
+    /// Ideally data transfers are done using an specific method to transfer data
+    /// but in reality this has demonstrated to not work well specially in watchOS 26
+    /// this logic uses the normal communication messages in chunks for more reliability.
+    private func sendChunk(
+        index: Int,
+        recordingId: String,
+        audioData: Data,
+        chunkSize: Int,
+        totalChunks: Int,
+        sampleRate: Double,
+        completion: @escaping (Error?) -> Void
+    ) {
+        let start = index * chunkSize
+        let end = min(start + chunkSize, audioData.count)
+        let chunkData = audioData.subdata(in: start ..< end)
+
+        Communicator.shared.send(.init(
+            identifier: InteractiveImmediateMessages.assistAudioDataChunked.rawValue,
+            content: [
+                "chunkData": chunkData,
+                "chunkIndex": index,
+                "totalChunks": totalChunks,
+                "sampleRate": sampleRate,
+                "pipelineId": pipelineId,
+                "serverId": serverId,
+                "recordingId": recordingId,
+            ],
+            reply: { [weak self] _ in
+                DispatchQueue.main.async {
+                    let next = index + 1
+                    guard next < totalChunks else {
+                        Current.Log.verbose("All \(totalChunks) assist audio chunk(s) acknowledged")
+                        completion(nil)
+                        return
+                    }
+                    self?.sendChunk(
+                        index: next,
+                        recordingId: recordingId,
+                        audioData: audioData,
+                        chunkSize: chunkSize,
+                        totalChunks: totalChunks,
+                        sampleRate: sampleRate,
+                        completion: completion
+                    )
+                }
+            }
+        ), errorHandler: { error in
+            Current.Log.error(
+                "Assist audio chunk \(index + 1)/\(totalChunks) failed: \(error.localizedDescription)"
+            )
+            DispatchQueue.main.async {
+                completion(error)
+            }
+        })
     }
 
     private func setupReachability() {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -113,9 +113,14 @@ final class WatchHomeViewModel: ObservableObject {
     /// it wasn't immediately reachable. Used as a fallback when the interactive request can't run or
     /// times out.
     private func enqueueGuaranteedConfigPull() {
-        Communicator.shared.send(HAWatchConnectivity.GuaranteedMessage(
-            identifier: InteractiveImmediateMessages.watchConfig.rawValue
-        ))
+        let identifier = InteractiveImmediateMessages.watchConfig.rawValue
+        // Every reload while unreachable would otherwise queue another transferUserInfo, and the
+        // phone would answer each with a full config payload once it wakes.
+        guard !Communicator.shared.hasOutstandingGuaranteedMessage(identifier: identifier) else {
+            Current.Log.info("Skipping guaranteed config pull: one is already queued")
+            return
+        }
+        Communicator.shared.send(HAWatchConnectivity.GuaranteedMessage(identifier: identifier))
     }
 
     func startNetworkMonitoring() {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -288,9 +288,19 @@ final class WatchHomeViewModel: ObservableObject {
             adopt(phoneConfig: nil, itemsInfo: [])
             return
         }
+        let configData: Data
+        do {
+            configData = try config.encodeForWatch()
+        } catch {
+            // The local copy stays as-is; it'll sync (or conflict-prompt) on the next reload.
+            Current.Log.error("Failed to encode local watch config for push: \(error.localizedDescription)")
+            loadCache()
+            updateLoading(isLoading: false)
+            return
+        }
         Communicator.shared.send(.init(
             identifier: InteractiveImmediateMessages.watchConfigUpdate.rawValue,
-            content: ["config": config.encodeForWatch()],
+            content: ["config": configData],
             reply: { [weak self] message in
                 Task { @MainActor in self?.adoptPushReply(message) }
             }

--- a/Sources/WatchApp/WatchConfigAssistViewModel.swift
+++ b/Sources/WatchApp/WatchConfigAssistViewModel.swift
@@ -137,10 +137,19 @@ final class WatchConfigAssistViewModel: ObservableObject {
             completion(true)
             return
         }
+        let configData: Data
+        do {
+            configData = try config.encodeForWatch()
+        } catch {
+            Current.Log.error("Failed to encode assist config for sync: \(error.localizedDescription)")
+            // The local copy is already saved; it'll sync on the next reload.
+            completion(true)
+            return
+        }
         isSaving = true
         Communicator.shared.send(.init(
             identifier: InteractiveImmediateMessages.watchConfigUpdate.rawValue,
-            content: ["config": config.encodeForWatch()],
+            content: ["config": configData],
             reply: { [weak self] message in
                 Task { @MainActor in
                     self?.handleSaveResponse(message, completion: completion)

--- a/Sources/WatchApp/WatchSettingsViewModel.swift
+++ b/Sources/WatchApp/WatchSettingsViewModel.swift
@@ -59,9 +59,17 @@ final class WatchSettingsViewModel: ObservableObject {
 
     private func syncToPhone(_ config: WatchConfig) {
         guard Communicator.shared.currentReachability == .immediatelyReachable else { return }
+        let configData: Data
+        do {
+            configData = try config.encodeForWatch()
+        } catch {
+            // The local copy is already saved; it'll sync on the next reload.
+            Current.Log.error("Failed to encode watch layout for sync: \(error.localizedDescription)")
+            return
+        }
         Communicator.shared.send(.init(
             identifier: InteractiveImmediateMessages.watchConfigUpdate.rawValue,
-            content: ["config": config.encodeForWatch()],
+            content: ["config": configData],
             reply: { [weak self] message in
                 DispatchQueue.main.async { self?.handleLayoutSyncResponse(message) }
             }

--- a/Tests/App/Watch/WatchConfig.test.swift
+++ b/Tests/App/Watch/WatchConfig.test.swift
@@ -275,7 +275,7 @@ struct WatchConfigAvailableItems_test {
             .init(serverId: "server2", serverName: "Cabin", candidates: []),
         ])
 
-        let data = original.encodeForWatch()
+        let data = try original.encodeForWatch()
         let decoded = try #require(WatchConfigAvailableItems.decodeForWatch(data))
 
         #expect(decoded.servers.count == 2)
@@ -327,7 +327,7 @@ struct WatchDatabaseMirror_test {
         )
         let original = WatchDatabaseMirror(entities: [entity], areas: [area], pipelines: [pipelines])
 
-        let data = original.encodeForWatch()
+        let data = try original.encodeForWatch()
         let decoded = try #require(WatchDatabaseMirror.decodeForWatch(data))
 
         #expect(decoded.entities == [entity])
@@ -356,7 +356,7 @@ struct WatchConfigLayout_test {
 
     @Test func encodeForWatchRoundTripPreservesLayout() throws {
         let original = WatchConfig(items: [], layout: .grid)
-        let data = original.encodeForWatch()
+        let data = try original.encodeForWatch()
         let decoded = try #require(WatchConfig.decodeForWatch(data))
         #expect(decoded.resolvedLayout == .grid)
     }

--- a/Tests/Shared/WatchConnectivity.test.swift
+++ b/Tests/Shared/WatchConnectivity.test.swift
@@ -12,6 +12,7 @@ private final class FakeWCSession: WCSessionProtocol {
     var hasContentPendingProxy = false
     var applicationContextProxy: [String: Any] = [:]
     var receivedApplicationContextProxy: [String: Any] = [:]
+    var outstandingUserInfoTransfersProxy: [[String: Any]] = []
 
     var didActivate = false
     var sentMessages: [(


### PR DESCRIPTION
## Summary
Six reliability fixes for the WatchConnectivity layer, from an audit of the watch↔iPhone communication. One commit per fix:

1. **Assist audio chunk transfer** — chunks now send sequentially with ack-driven backpressure instead of being fired all at once with no error handler. A lost chunk surfaces as an error instead of a silent hang, the completion callback fires on success (it never did), and each recording carries a unique `recordingId` so a retried recording can never mix stale chunks from the previous attempt into corrupt audio. The phone drops partial uploads idle for 60s instead of leaking them.
2. **Database sync buffer leak** — the phone's in-memory chunk buffer was only freed when the watch requested the final chunk; abandoned syncs leaked the whole encoded mirror. A new sync start now frees previous buffers, with a 10-minute expiry backstop.
3. **`encodeForWatch` no longer crashes** — it called `fatalError` on encode failure; it now throws and all senders fall back gracefully (keep local copy / reply treated as decode failure by the watch, never as an authoritative empty config).
4. **Guaranteed-message hygiene** — every reload while unreachable queued another `transferUserInfo` config pull and the phone answered them all; duplicates are now skipped via the session's outstanding transfers. The phone's guaranteed reply also spells out `GuaranteedMessage` explicitly instead of compiling as it by overload-resolution luck.
5. **Application-context echo-back removed** — each side sent the counterpart's keys back (watch battery bounced back to the watch, complication payloads back to the phone), doubling every update toward the 262 KB cap and able to resurrect stale values. Each side now sends only the keys it owns.
6. **Payload-size guards** — the ~65 KB `sendMessage` and ~262 KB application-context ceilings were only a comment. Every outgoing message and reply is now measured, oversized ones are logged with their identifier and byte count, and an oversized context is rerouted through the database-mirror `transferFile` push (no size cap) instead of failing.

## Screenshots
No UI changes; behavior changes are in transport reliability (previously-hanging assist sessions now surface errors).

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Stacked on #5097 (the `HAWatchCommunicationMessages` package extraction) — the first commit here is that PR's commit, and this diff reduces to the six fixes once it merges. All watch-related unit tests pass (43/43 in Tests-Shared + Tests-App). The wire protocol stays compatible with older counterpart builds: the `recordingId` is optional on the phone side, and all identifiers/raw values are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)