### PR TITLE
Fix automatic sensor updates only reaching one server in multi-server setups

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/BarometerSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BarometerSensor.swift
@@ -53,6 +53,73 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
         latestPressureKpa = nil
         isObserving = false
     }
+
+    private let oneShotLock = NSLock()
+    private var pendingOneShot: Promise<CMAltitudeData>?
+
+    /// Performs a single relative-altitude read, coalescing concurrent callers onto one
+    /// `CMAltimeter` session.
+    ///
+    /// `CMAltimeter.startRelativeAltitudeUpdates(to:withHandler:)` keeps only a single handler on
+    /// the shared altimeter (`Current.barometer`), so a second concurrent `start` orphans the first
+    /// caller's handler — which then never fires. Because sensor generation waits for *every*
+    /// provider (`when(resolved:)`), that orphaned read leaves the whole payload promise unresolved
+    /// and no `update_sensor_states` webhook is ever sent for that server. In a multi-server setup
+    /// the servers' sweeps are dispatched in list order, so the first (default) server was
+    /// deterministically starved while the last one worked. See issue #5100.
+    ///
+    /// Sharing one in-flight read fixes that, and a timeout guarantees the promise always settles
+    /// even if the hardware never reports (which would otherwise hang the sweep forever).
+    func oneShotReading() -> Promise<CMAltitudeData> {
+        let lock = oneShotLock
+        lock.lock()
+        if let pendingOneShot {
+            lock.unlock()
+            return pendingOneShot
+        }
+
+        let (promise, seal) = Promise<CMAltitudeData>.pending()
+        pendingOneShot = promise
+        lock.unlock()
+
+        let queue = OperationQueue()
+        queue.name = "barometer-sensor"
+        queue.maxConcurrentOperationCount = 1
+
+        var timeoutWork: DispatchWorkItem?
+        var resolved = false
+        // Called from the altimeter handler and from the timeout; the lock serializes them so the
+        // promise resolves exactly once and the shared slot is cleared for the next read.
+        let finish: (CMAltitudeData?, Error?) -> Void = { [weak self] data, error in
+            lock.lock()
+            let alreadyResolved = resolved
+            resolved = true
+            if self?.pendingOneShot === promise {
+                self?.pendingOneShot = nil
+            }
+            lock.unlock()
+
+            guard !alreadyResolved else { return }
+            timeoutWork?.cancel()
+            Current.barometer.stopUpdates()
+
+            if let data {
+                seal.fulfill(data)
+            } else {
+                seal.reject(error ?? BarometerSensor.BarometerError.noData)
+            }
+        }
+
+        let work = DispatchWorkItem { finish(nil, BarometerSensor.BarometerError.noData) }
+        timeoutWork = work
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 5, execute: work)
+
+        Current.barometer.startUpdatesOnQueueHandler(queue) { data, error in
+            finish(data, error)
+        }
+
+        return promise
+    }
 }
 
 public class BarometerSensor: SensorProvider {
@@ -79,9 +146,18 @@ public class BarometerSensor: SensorProvider {
             return .init(error: BarometerError.noData)
         }
 
-        return firstly {
-            latestBarometerData()
-        }.map { data in
+        guard Current.barometer.isAuthorized() else {
+            return .init(error: BarometerError.unauthorized)
+        }
+
+        guard Current.barometer.isAvailable() else {
+            Current.Log.warning("Barometer is not available")
+            return .init(error: BarometerError.unavailable)
+        }
+
+        // Route through the signaler so concurrent per-server sweeps share a single altimeter
+        // read instead of orphaning each other's handler (see `oneShotReading`, issue #5100).
+        return signaler.oneShotReading().map { data in
             [Self.pressureSensor(fromKpa: data.pressure.doubleValue)]
         }
     }
@@ -97,41 +173,5 @@ public class BarometerSensor: SensorProvider {
             state: round(pressureHpa * 100) / 100,
             unit: "hPa"
         )
-    }
-
-    private func latestBarometerData() -> Promise<CMAltitudeData> {
-        guard Current.barometer.isAuthorized() else {
-            return .init(error: BarometerError.unauthorized)
-        }
-
-        guard Current.barometer.isAvailable() else {
-            Current.Log.warning("Barometer is not available")
-            return .init(error: BarometerError.unavailable)
-        }
-
-        let (promise, seal) = Promise<CMAltitudeData>.pending()
-        let queue = OperationQueue()
-        queue.name = "barometer-sensor"
-        queue.maxConcurrentOperationCount = 1
-
-        // startRelativeAltitudeUpdates is a streaming API, so an in-flight callback
-        // could arrive after stopUpdates(). Guard against double-resolving the promise,
-        // and ensure late callbacks become no-ops before stopping updates.
-        var resolved = false
-        Current.barometer.startUpdatesOnQueueHandler(queue) { data, error in
-            guard !resolved else { return }
-            resolved = true
-            Current.barometer.stopUpdates()
-
-            if let data {
-                seal.fulfill(data)
-            } else if let error {
-                seal.reject(error)
-            } else {
-                seal.reject(BarometerError.noData)
-            }
-        }
-
-        return promise
     }
 }

--- a/Tests/Shared/Sensors/BarometerSensor.test.swift
+++ b/Tests/Shared/Sensors/BarometerSensor.test.swift
@@ -160,6 +160,34 @@ class BarometerSensorTests: XCTestCase {
         XCTAssertEqual(handlers.count, startCountAfterSetup)
     }
 
+    func testConcurrentSensorsShareASingleAltimeterRead() throws {
+        // Two servers' sensor sweeps run concurrently; each instantiates a BarometerSensor that
+        // shares one signaler (via the same dependencies). Without coalescing, the second sweep's
+        // startRelativeAltitudeUpdates orphaned the first sweep's handler, so the first sweep's
+        // promise never resolved and that server never got an update_sensor_states webhook — the
+        // multi-server "only the last server updates" bug (issue #5100).
+        Current.barometer.isAuthorized = { true }
+        Current.barometer.isAvailable = { true }
+
+        var handlers = [CMAltitudeHandler]()
+        Current.barometer.startUpdatesOnQueueHandler = { _, handler in handlers.append(handler) }
+        Current.barometer.stopUpdates = {}
+
+        let promiseA = BarometerSensor(request: request).sensors()
+        let promiseB = BarometerSensor(request: request).sensors()
+
+        // Only one altimeter session is started; the second sweep reuses the first's in-flight read.
+        XCTAssertEqual(handlers.count, 1)
+
+        // Delivering data to the single handler resolves both sweeps with the same reading.
+        handlers.first?(FakeAltitudeData(pressureValue: 101.0), nil)
+
+        let sensorsA = try hang(promiseA)
+        let sensorsB = try hang(promiseB)
+        XCTAssertEqual(sensorsA[0].State as? Double, 1010.0) // 101.0 kPa * 10
+        XCTAssertEqual(sensorsB[0].State as? Double, 1010.0)
+    }
+
     func testSignalerStartsAndStopsUpdates() {
         Current.barometer.isAuthorized = { true }
         Current.barometer.isAvailable = { true }


### PR DESCRIPTION
Automatic/signalled sensor updates (e.g. Focus toggles) were delivered to
only one server when two or more were configured, always the server after
the first in the list. Manual "Update Sensors" worked for all servers.

Root cause: BarometerSensor does a one-shot read via the shared CMAltimeter
(Current.barometer) whenever its signaler isn't already streaming.
CMAltimeter.startRelativeAltitudeUpdates keeps a single handler, so when the
per-server sensor sweeps run concurrently the second start orphans the first
caller's handler, which never fires. Because sensor generation waits for
every provider (when(resolved:)), that orphaned read leaves the whole
payload promise unresolved, so no update_sensor_states webhook is ever sent
for that server. Servers are swept in list order, making the first (default)
server deterministically starved. Manual updates avoid this because
asyncCompactMap runs the servers sequentially.

Coalesce concurrent one-shot reads onto a single in-flight CMAltimeter
session in the shared signaler, with a timeout so a wedged/orphaned session
can never hang a sweep again. Add a regression test covering two concurrent
sweeps sharing one altimeter read.

Fixes #5100

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Uqb13md1Bom8nba4Toj35X