### PR TITLE
Only add default snooze actions when push payload has no actions

### DIFF
--- a/Sources/Shared/Notifications/UNNotificationContent+Additions.swift
+++ b/Sources/Shared/Notifications/UNNotificationContent+Additions.swift
@@ -44,10 +44,10 @@ public extension UNNotificationContent {
             .map(NotificationAction.init(action:))
             .map(\.action)
 
-        let existingIdentifiers = Set(payloadActions.map(\.identifier))
-        let snoozeActions = NotificationSnoozeAction.enabledActions()
-            .filter { !existingIdentifiers.contains($0.identifier) }
+        guard payloadActions.isEmpty else {
+            return Array(payloadActions.prefix(maxActions))
+        }
 
-        return Array((payloadActions + snoozeActions).prefix(maxActions))
+        return Array(NotificationSnoozeAction.enabledActions().prefix(maxActions))
     }
 }

--- a/Tests/Shared/Extensions/UNNotificationContentActions.test.swift
+++ b/Tests/Shared/Extensions/UNNotificationContentActions.test.swift
@@ -1,0 +1,75 @@
+import Foundation
+import GRDB
+@testable import Shared
+import UserNotifications
+import XCTest
+
+final class UNNotificationContentActionsTests: XCTestCase {
+    private var database: DatabaseQueue!
+    private var previousDatabase: (() -> DatabaseQueue)!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        database = try DatabaseQueue()
+        try NotificationSnoozeActionTable().createIfNeeded(database: database)
+        previousDatabase = Current.database
+        Current.database = { self.database }
+    }
+
+    override func tearDown() {
+        Current.database = previousDatabase
+
+        super.tearDown()
+    }
+
+    private func content(actions: [[String: Any]]?) -> UNNotificationContent {
+        let content = UNMutableNotificationContent()
+        if let actions {
+            content.userInfo = ["actions": actions]
+        }
+        return content
+    }
+
+    func testUsesSnoozeActionsWhenPayloadHasNoActions() {
+        let actions = content(actions: nil).userInfoActions
+        let identifiers = actions.map(\.identifier)
+
+        XCTAssertTrue(identifiers.contains(NotificationSnoozeAction.actionIdentifierPrefix + "5"))
+        XCTAssertTrue(identifiers.contains(NotificationSnoozeAction.actionIdentifierPrefix + "15"))
+        XCTAssertTrue(identifiers.contains(NotificationSnoozeAction.actionIdentifierPrefix + "60"))
+        XCTAssertTrue(identifiers.allSatisfy { $0.hasPrefix(NotificationSnoozeAction.actionIdentifierPrefix) })
+    }
+
+    func testIgnoresSnoozeActionsWhenPayloadDefinesActions() {
+        XCTAssertFalse(NotificationSnoozeAction.enabledActions().isEmpty)
+
+        let actions = content(actions: [
+            ["identifier": "CANCEL", "title": "Cancel"],
+        ]).userInfoActions
+
+        XCTAssertEqual(actions.map(\.identifier), ["CANCEL"])
+        XCTAssertFalse(actions.contains { $0.identifier.hasPrefix(NotificationSnoozeAction.actionIdentifierPrefix) })
+    }
+
+    func testKeepsPayloadActionOrderAndDropsSnooze() {
+        let payloadActions = (0 ..< 3).map { index in
+            ["identifier": "ACTION_\(index)", "title": "Action \(index)"]
+        }
+
+        let actions = content(actions: payloadActions).userInfoActions
+
+        XCTAssertEqual(actions.map(\.identifier), ["ACTION_0", "ACTION_1", "ACTION_2"])
+        XCTAssertFalse(actions.contains { $0.identifier.hasPrefix(NotificationSnoozeAction.actionIdentifierPrefix) })
+    }
+
+    func testCapsPayloadActionsAtMaximum() {
+        let payloadActions = (0 ..< 15).map { index in
+            ["identifier": "ACTION_\(index)", "title": "Action \(index)"]
+        }
+
+        let actions = content(actions: payloadActions).userInfoActions
+
+        XCTAssertEqual(actions.count, 10)
+    }
+}


### PR DESCRIPTION
## Summary
Default snooze actions were being appended on top of actions the user already defined in the Home Assistant push payload. This risked mis-taps for users who had muscle memory for the original buttons. Default snooze actions now only show when the payload defines no actions of its own.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
