### PR TITLE
Fix crash when selecting a server during initial onboarding

### DIFF
--- a/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
+++ b/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
@@ -64,7 +64,7 @@ struct OnboardingWelcomeView: View {
 
     private var continueButtonBlock: some View {
         VStack {
-            NavigationLink(destination: OnboardingServersListView(onboardingStyle: .initial)) {
+            NavigationLink(destination: serversListDestination) {
                 Text(verbatim: L10n.Onboarding.Welcome.primaryButton)
             }
             .buttonStyle(.primaryButton)
@@ -76,6 +76,14 @@ struct OnboardingWelcomeView: View {
         }
         .padding([.horizontal, .top], DesignSystem.Spaces.two)
         .background(Color(uiColor: .systemBackground))
+    }
+
+    /// Pushed pages get their own hosting controller, so the `ViewControllerProvider` injected at the
+    /// onboarding root (`embeddedInHostingController()`) does not reach them — re-inject it here or the
+    /// servers list crashes on first access.
+    private var serversListDestination: some View {
+        OnboardingServersListView(onboardingStyle: .initial)
+            .injectingViewControllerProvider()
     }
 }
 


### PR DESCRIPTION
## Summary

Tapping a discovered server row (or entering a URL manually) on the servers list during **initial onboarding** crashes the app with:

```
SwiftUICore/EnvironmentObject.swift:93: Fatal error: No ObservableObject of type ViewControllerProvider found.
A View.environmentObject(_:) for ViewControllerProvider may be missing as an ancestor of this view.
```

## Root cause

Since the SwiftUI app migration (#4748), initial onboarding is hosted through `OnboardingHostingView` → `embeddedInHostingController()`, which applies `.environmentObject(provider)` to the hosting controller's **root view**. `OnboardingServersListView` is a `NavigationLink` **pushed destination** inside the legacy `NavigationView`, and pushed pages get their own hosting controller that does not receive that root-level environment object.

The crash only fires on row tap because rendering never reads `hostingProvider` — the first access is in `presentingViewController` inside the button action.

Reproduced on both iOS 26.5 and iOS 27.0 simulators, so this is an app bug rather than an OS regression. The secondary flow (Settings → Add Server) is unaffected because there the servers list is the navigation root, not a pushed page.

## Fix

Re-inject the provider directly on the pushed destination with the existing `injectingViewControllerProvider()` helper — the same pattern `ContainerView` already uses for its onboarding-permissions cover.

## Testing

- Reproduced the crash on fresh installs (iPhone 17 sim / iOS 26.5 and iPhone 17 Pro sim / iOS 27.0): Welcome → Connect to my Home Assistant → tap discovered server → crash.
- With the fix, the same flow presents the OAuth login as expected on both OS versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)