### PR TITLE
Fix Realm to GRDB migration schema version

### DIFF
--- a/Sources/Shared/Common/Extensions/RealmToGRDBMigration.swift
+++ b/Sources/Shared/Common/Extensions/RealmToGRDBMigration.swift
@@ -89,8 +89,8 @@ private final class LegacyRealmWatchComplication: Object {
 /// opened again; a future release can then drop the RealmSwift dependency and
 /// this file, and delete the legacy store directory.
 public enum RealmToGRDBMigration {
-    static let migrationCompletedKey = "hasCompletedRealmToGRDBMigration"
-    static let migrationAttemptsKey = "realmToGRDBMigrationAttempts"
+    static let migrationCompletedKey = "hasCompletedRealmToGRDBMigrationV2"
+    static let migrationAttemptsKey = "realmToGRDBMigrationAttemptsV2"
     static let maxMigrationAttempts = 3
 
     public static func migrateIfNeeded() {
@@ -182,9 +182,10 @@ public enum RealmToGRDBMigration {
         // 20…25 - 2022-08-13 v2022.x undoing realm automatic migration
         // 26 - 2022-08-13 v2022.x bumping mdi version
         // 29 - 2026-05-27 v2026.x Remove legacy iOS action Realm models
+        // 30 - 2026-07-11 v2026.x Migrate watch complications from Realm to GRDB (#5036)
         let config = Realm.Configuration(
             fileURL: storeURL,
-            schemaVersion: 29,
+            schemaVersion: 30,
             migrationBlock: { migration, oldVersion in
                 Current.Log.info("migrating legacy realm from \(oldVersion)")
                 if oldVersion < 9 {


### PR DESCRIPTION
## Summary

The Realm→GRDB importer opened the legacy store at `schemaVersion: 29`, but the store is already at version 30 (#5036 moved watch complications to GRDB and bumped the Realm schema). Realm refuses to open a store at a lower schema version than what is on disk, so the import threw `InvalidSchemaVersion` on every launch and was abandoned after 3 attempts — leaving zones and notification categories unmigrated and region monitoring empty.

## Changes

- Bump the importer to `schemaVersion: 30`.
- Bump the migration prefs keys to `V2` so the import re-runs once for users the previous version already abandoned. Both keys are bumped: the exhausted attempts counter alone would otherwise re-abandon immediately.
