### PR TITLE
Restore model manager subscription so zones sync again

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -425,6 +425,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Import any legacy Realm data into GRDB before anything reads it
         RealmToGRDBMigration.migrateIfNeeded()
         NotificationCategory.setupObserver()
+        // Start the server-state subscriptions that keep GRDB models in sync
+        // (zones via the states cache); without this, appZone is never populated
+        // and region monitoring has nothing to track.
+        Current.modelManager.cleanup().cauterize()
+        Current.modelManager.subscribe(isAppInForeground: {
+            UIApplication.shared.applicationState == .active
+        })
     }
 
     private func setupMenus() {


### PR DESCRIPTION
## Summary

Zone enter/exit tracking is currently dead: the `appZone` GRDB table is never populated from the server, so `ZoneManager` has nothing to monitor and the Location settings screen shows no zones.

The states-cache subscription that keeps `AppZone` in sync (`LegacyModelManager.SubscribeDefinition.defaults` → `.states(domain: "zone", type: AppZone.self)`) is only started by `modelManager.subscribe(isAppInForeground:)`. That call lived in `WebViewSceneDelegate` and was dropped in the UIKit→SwiftUI app migration (#4748) without a replacement — since then, nothing in the app starts it.

The regression went unnoticed because stale `RLMZone` rows written before #4748 persisted on disk, so region monitoring kept working off old data. It became visible once the Realm→GRDB migration (#4954, fixed in #5116) switched reads to the fresh `appZone` table.

## Changes

- Call `Current.modelManager.cleanup()` and `Current.modelManager.subscribe(isAppInForeground:)` from `AppDelegate.setupModels()`, after the Realm→GRDB import and before `ZoneManager` is created. `LegacyModelManager` re-subscribes itself on server changes, so the single call at launch is sufficient.

## Testing

Verified in the simulator with two connected servers: on launch the logs show `store(AppZone)` creating all 22 zones (`from(0) eligible(21) new(21)` + `zone.home` on the second server) and `ZoneManager sync > available 22, monitoring 20, started 19`, where before it was `available 0, monitoring 0`. The `appZone` table (previously confirmed empty via sqlite) is now populated and zone data live-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)