### PR TITLE
Clean stale frontend cache periodically

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -73,6 +73,17 @@ extension WebViewController {
             return
         }
 
+        Current.websiteDataStoreHandler.cleanFrontendAssetCacheIfNeeded { [weak self] _ in
+            self?.continueLoadingActiveURLIfNeeded()
+        }
+    }
+
+    private func continueLoadingActiveURLIfNeeded() {
+        guard !isAppInBackground() else {
+            Current.Log.info("not loading, in background")
+            return
+        }
+
         var previousAttemptHung = false
         if let inFlightTask = loadActiveURLTask {
             let startDate = loadActiveURLTaskStartDate ?? .distantPast

--- a/Sources/Shared/WebsiteDataStoreHandler.swift
+++ b/Sources/Shared/WebsiteDataStoreHandler.swift
@@ -3,6 +3,7 @@ import WebKit
 
 public protocol WebsiteDataStoreHandlerProtocol {
     func cleanCache(dataTypes: Set<String>, completion: (() -> Void)?)
+    func cleanFrontendAssetCacheIfNeeded(completion: ((Bool) -> Void)?)
 }
 
 public extension WebsiteDataStoreHandlerProtocol {
@@ -12,16 +13,47 @@ public extension WebsiteDataStoreHandlerProtocol {
 }
 
 final class WebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
+    private enum Constants {
+        static let lastFrontendAssetCacheCleanDateKey = "lastFrontendAssetCacheCleanDate"
+    }
+
+    private var lastFrontendAssetCacheCleanDate: Date? {
+        get {
+            Current.settingsStore.prefs.object(forKey: Constants.lastFrontendAssetCacheCleanDateKey) as? Date
+        }
+        set {
+            Current.settingsStore.prefs.set(newValue, forKey: Constants.lastFrontendAssetCacheCleanDateKey)
+        }
+    }
+
     func cleanCache(dataTypes: Set<String>, completion: (() -> Void)? = nil) {
         Self.onMainThread {
             WKWebsiteDataStore.default().removeData(
                 ofTypes: dataTypes,
                 modifiedSince: Date(timeIntervalSince1970: 0),
                 completionHandler: {
+                    if dataTypes.isSuperset(of: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) {
+                        self.lastFrontendAssetCacheCleanDate = Current.date()
+                    }
                     Current.Log.verbose("Cleaned browser cache for data types: \(dataTypes)")
                     Self.onMainThread(completion)
                 }
             )
+        }
+    }
+
+    func cleanFrontendAssetCacheIfNeeded(completion: ((Bool) -> Void)? = nil) {
+        guard WebsiteDataStoreHandlerImpl.shouldCleanFrontendAssetCache(
+            lastCleanDate: lastFrontendAssetCacheCleanDate,
+            now: Current.date()
+        ) else {
+            Self.onMainThread { completion?(false) }
+            return
+        }
+
+        Current.Log.info("Resetting frontend cache because it has not been cleaned in more than 3 days")
+        cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) {
+            completion?(true)
         }
     }
 
@@ -38,6 +70,13 @@ final class WebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
 public enum WebsiteDataStoreHandlerImpl {
     static func build() -> WebsiteDataStoreHandlerProtocol {
         WebsiteDataStoreHandler()
+    }
+
+    static let frontendAssetCacheCleanInterval: TimeInterval = 3 * 24 * 60 * 60
+
+    static func shouldCleanFrontendAssetCache(lastCleanDate: Date?, now: Date) -> Bool {
+        guard let lastCleanDate else { return true }
+        return now.timeIntervalSince(lastCleanDate) > frontendAssetCacheCleanInterval
     }
 
     public static let frontendAssetDataTypes: Set<String> = [

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -166,6 +166,31 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(handler.cleanCacheCallCount, 0)
     }
 
+    func testFrontendAssetCacheCleanDecisionCleansWhenNeverCleaned() {
+        XCTAssertTrue(WebsiteDataStoreHandlerImpl.shouldCleanFrontendAssetCache(
+            lastCleanDate: nil,
+            now: Date(timeIntervalSince1970: 100)
+        ))
+    }
+
+    func testFrontendAssetCacheCleanDecisionSkipsWhenRecentlyCleaned() {
+        let now = Date(timeIntervalSince1970: 1000)
+
+        XCTAssertFalse(WebsiteDataStoreHandlerImpl.shouldCleanFrontendAssetCache(
+            lastCleanDate: now.addingTimeInterval(-WebsiteDataStoreHandlerImpl.frontendAssetCacheCleanInterval),
+            now: now
+        ))
+    }
+
+    func testFrontendAssetCacheCleanDecisionCleansWhenOlderThanThreeDays() {
+        let now = Date(timeIntervalSince1970: 1000)
+
+        XCTAssertTrue(WebsiteDataStoreHandlerImpl.shouldCleanFrontendAssetCache(
+            lastCleanDate: now.addingTimeInterval(-WebsiteDataStoreHandlerImpl.frontendAssetCacheCleanInterval - 1),
+            now: now
+        ))
+    }
+
     func testServerErrorResponseDecisionShowsEmptyStateForProxyServerErrors() {
         for statusCode in [500, 502, 503, 521, 522, 523, 524] {
             let decision = WebViewController.decisionForMainFrameErrorResponse(
@@ -264,8 +289,12 @@ final class WebViewControllerTests: XCTestCase {
 
 private final class FakeWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
     private(set) var cleanCacheCallCount = 0
+    private(set) var cleanFrontendAssetCacheIfNeededCallCount = 0
     private(set) var lastDataTypes: Set<String>?
+    var completesFrontendAssetCacheCleanImmediately = true
+    var frontendAssetCacheCleanResult = false
     private var pendingCompletion: (() -> Void)?
+    private var pendingFrontendAssetCacheCompletion: ((Bool) -> Void)?
 
     func cleanCache(dataTypes: Set<String>, completion: (() -> Void)?) {
         cleanCacheCallCount += 1
@@ -273,25 +302,46 @@ private final class FakeWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol
         pendingCompletion = completion
     }
 
+    func cleanFrontendAssetCacheIfNeeded(completion: ((Bool) -> Void)?) {
+        cleanFrontendAssetCacheIfNeededCallCount += 1
+        pendingFrontendAssetCacheCompletion = completion
+        if completesFrontendAssetCacheCleanImmediately {
+            invokePendingFrontendAssetCacheCompletion(didClean: frontendAssetCacheCleanResult)
+        }
+    }
+
     func invokePendingCompletion() {
         let completion = pendingCompletion
         pendingCompletion = nil
         completion?()
+    }
+
+    func invokePendingFrontendAssetCacheCompletion(didClean: Bool) {
+        let completion = pendingFrontendAssetCacheCompletion
+        pendingFrontendAssetCacheCompletion = nil
+        completion?(didClean)
     }
 }
 
 @MainActor
 final class WebViewControllerURLLoadingTests: XCTestCase {
     private var previousRefreshNetworkInformation: (() async -> Void)!
+    private var previousWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol!
+    private var websiteDataStoreHandler: FakeWebsiteDataStoreHandler!
 
     override func setUp() {
         super.setUp()
         previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
+        previousWebsiteDataStoreHandler = Current.websiteDataStoreHandler
+        websiteDataStoreHandler = FakeWebsiteDataStoreHandler()
         Current.connectivity.refreshNetworkInformation = {}
+        Current.websiteDataStoreHandler = websiteDataStoreHandler
     }
 
     override func tearDown() {
         Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
+        Current.websiteDataStoreHandler = previousWebsiteDataStoreHandler
+        websiteDataStoreHandler = nil
         super.tearDown()
     }
 
@@ -330,6 +380,36 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
         sut.isAppInBackground = { true }
 
         sut.loadActiveURLIfNeeded()
+
+        XCTAssertEqual(websiteDataStoreHandler.cleanFrontendAssetCacheIfNeededCallCount, 0)
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
+    func testLoadActiveURLWaitsForFrontendAssetCacheCleanCheckBeforeLoading() async {
+        let sut = makeSUT()
+        websiteDataStoreHandler.completesFrontendAssetCacheCleanImmediately = false
+
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertEqual(websiteDataStoreHandler.cleanFrontendAssetCacheIfNeededCallCount, 1)
+        XCTAssertNil(sut.loadActiveURLTask)
+
+        websiteDataStoreHandler.invokePendingFrontendAssetCacheCompletion(didClean: true)
+
+        XCTAssertNotNil(sut.loadActiveURLTask)
+        await sut.loadActiveURLTask?.value
+    }
+
+    func testLoadActiveURLRechecksBackgroundStateAfterFrontendAssetCacheCleanCheck() {
+        var isAppInBackground = false
+        let sut = makeSUT()
+        sut.isAppInBackground = { isAppInBackground }
+        websiteDataStoreHandler.completesFrontendAssetCacheCleanImmediately = false
+
+        sut.loadActiveURLIfNeeded()
+        isAppInBackground = true
+        websiteDataStoreHandler.invokePendingFrontendAssetCacheCompletion(didClean: false)
 
         XCTAssertNil(sut.loadActiveURLTask)
         XCTAssertNil(sut.loadActiveURLTaskStartDate)


### PR DESCRIPTION
## Summary
- Clear stale frontend asset cache when it has not been cleaned for more than 3 days.
- Keep existing server-version cache reset behavior.