### PR TITLE
Hide native loader based on frontend loaded event

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
@@ -10,6 +10,7 @@ enum WebViewExternalBusMessage: String, CaseIterable {
     case configScreenShow = "config_screen/show"
     case haptic
     case connectionStatus = "connection-status"
+    case frontendLoaded = "frontend/loaded"
     case tagRead = "tag/read"
     case tagWrite = "tag/write"
     case themeUpdate = "theme-update"

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -82,6 +82,8 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
                     return
                 }
                 webViewController.updateFrontendConnectionState(state: connEvt)
+            case .frontendLoaded:
+                webViewController.updateFrontendConnectionState(state: FrontEndConnectionState.loaded.rawValue)
             case .tagRead:
                 response = Current.tags.readNFC().map { tag in
                     WebSocketMessage(id: incomingMessage.ID!, type: "result", result: ["success": true, "tag": tag])

--- a/Sources/App/Frontend/WebView/FrontEndConnectionState.swift
+++ b/Sources/App/Frontend/WebView/FrontEndConnectionState.swift
@@ -2,7 +2,19 @@ import Foundation
 
 enum FrontEndConnectionState: String {
     case connected
+    case loaded
     case disconnected
     case authInvalid = "auth-invalid"
     case unknown
+}
+
+extension FrontEndConnectionState {
+    var isReadyForDisplay: Bool {
+        switch self {
+        case .connected, .loaded:
+            true
+        case .disconnected, .authInvalid, .unknown:
+            false
+        }
+    }
 }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -95,6 +95,14 @@ final class HomeAssistantViewModel: ObservableObject {
         overlayState.emptyState == nil && !isFullScreenLoaderVisible ? 0 : 1
     }
 
+    private func didReachLoaderReadyState(_ connectionState: FrontEndConnectionState) -> Bool {
+        if server.info.version >= .frontendLoadedExternalBus {
+            connectionState == .loaded
+        } else {
+            connectionState.isReadyForDisplay
+        }
+    }
+
     func updateReduceMotion(_ reduceMotion: Bool) {
         self.reduceMotion = reduceMotion
     }
@@ -173,11 +181,15 @@ final class HomeAssistantViewModel: ObservableObject {
             .store(in: &cancellables)
 
         overlayState.$connectionState
-            .sink { [weak self] _ in self?.updateFullScreenLoaderVisibility() }
+            .sink { [weak self] connectionState in
+                self?.updateFullScreenLoaderVisibility(connectionState: connectionState)
+            }
             .store(in: &cancellables)
 
         overlayState.$emptyState
-            .sink { [weak self] _ in self?.updateFullScreenLoaderVisibility() }
+            .sink { [weak self] emptyState in
+                self?.updateFullScreenLoaderVisibility(hasEmptyState: emptyState != nil)
+            }
             .store(in: &cancellables)
     }
 
@@ -203,17 +215,21 @@ final class HomeAssistantViewModel: ObservableObject {
         }
     }
 
-    private func updateFullScreenLoaderVisibility() {
+    private func updateFullScreenLoaderVisibility(
+        connectionState: FrontEndConnectionState? = nil,
+        hasEmptyState: Bool? = nil
+    ) {
         guard isFullScreenLoaderMounted, loaderMinimumDurationElapsed else { return }
 
-        if overlayState.emptyState != nil {
+        if hasEmptyState ?? (overlayState.emptyState != nil) {
             withAnimation(DesignSystem.Animation.default) {
                 isFullScreenLoaderVisible = true
             }
             return
         }
 
-        guard isFullScreenLoaderVisible, overlayState.connectionState == .connected else { return }
+        guard isFullScreenLoaderVisible,
+              didReachLoaderReadyState(connectionState ?? overlayState.connectionState) else { return }
 
         let finishingCycleID = loaderCycleID
         withAnimation(DesignSystem.Animation.default) {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
@@ -9,7 +9,7 @@ extension WebViewController {
         switch connectionState {
         case .authInvalid:
             .unauthenticated
-        case .connected, .disconnected, .unknown:
+        case .connected, .loaded, .disconnected, .unknown:
             .disconnected
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
@@ -61,7 +61,8 @@ extension WebViewController: WebViewControllerProtocol {
         latestLoadError = nil
 
         let requestedState = FrontEndConnectionState(rawValue: state) ?? .unknown
-        let resolvedState: FrontEndConnectionState = if connectionState == .authInvalid, requestedState != .connected {
+        let resolvedState: FrontEndConnectionState = if connectionState == .authInvalid,
+                                                        !requestedState.isReadyForDisplay {
             .authInvalid
         } else {
             requestedState
@@ -69,9 +70,9 @@ extension WebViewController: WebViewControllerProtocol {
         connectionState = resolvedState
         overlayState?.connectionState = resolvedState
 
-        // Possible values: connected, disconnected, auth-invalid
+        // Possible values: connected, loaded, disconnected, auth-invalid
         switch resolvedState {
-        case .connected:
+        case .connected, .loaded:
             hideEmptyState()
             updateFrontendKioskMode()
         case .authInvalid:
@@ -135,7 +136,7 @@ extension WebViewController: WebViewControllerProtocol {
     }
 
     @objc func refreshIfDisconnected() {
-        guard connectionState != .connected else { return }
+        guard !connectionState.isReadyForDisplay else { return }
         refresh()
     }
 }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
@@ -372,7 +372,7 @@ extension WebViewController {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 switch connectionState {
-                case .connected:
+                case .connected, .loaded:
                     reload()
                 case .disconnected, .unknown:
                     if overlayState?.emptyState != nil {

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -409,6 +409,8 @@ public extension Version {
     static let quickSearchKeyboardShortcut: Version = .init(major: 2026, minor: 2, prerelease: "any0")
     /// Core accepts `in_zones` in update_location payloads from 2026.6.0.
     static let inZonesOnLocationUpdate: Version = .init(major: 2026, minor: 6, patch: 0, prerelease: "any0")
+    /// Frontend sends `frontend/loaded` when its launch screen is removed from 2026.8.0.
+    static let frontendLoadedExternalBus: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
 
     var coreRequiredString: String {
         L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -62,4 +62,49 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertEqual(overlayState.connectionState, .unknown)
         XCTAssertFalse(sut.loaderMinimumDurationElapsed)
     }
+
+    func testConnectedHidesStandbyLoaderBeforeFrontendLoadedEventSupport() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: Version(major: 2026, minor: 7, patch: 0)),
+            overlayState: overlayState
+        )
+        sut.loaderMinimumDurationElapsed = true
+
+        overlayState.connectionState = .connected
+
+        XCTAssertFalse(sut.isFullScreenLoaderVisible)
+    }
+
+    func testConnectedDoesNotHideStandbyLoaderWhenFrontendLoadedEventIsSupported() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: .frontendLoadedExternalBus),
+            overlayState: overlayState
+        )
+        sut.loaderMinimumDurationElapsed = true
+
+        overlayState.connectionState = .connected
+
+        XCTAssertTrue(sut.isFullScreenLoaderVisible)
+    }
+
+    func testLoadedHidesStandbyLoaderWhenFrontendLoadedEventIsSupported() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: .frontendLoadedExternalBus),
+            overlayState: overlayState
+        )
+        sut.loaderMinimumDurationElapsed = true
+
+        overlayState.connectionState = .loaded
+
+        XCTAssertFalse(sut.isFullScreenLoaderVisible)
+    }
+
+    private func server(version: Version) -> Server {
+        Server.fake { info in
+            info.version = version
+        }
+    }
 }

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -252,8 +252,8 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(error.failingURL, url)
     }
 
-    func testInterceptedServerErrorMarksDisconnectedFromConnectedOrUnknown() {
-        for current in [FrontEndConnectionState.connected, .disconnected, .unknown] {
+    func testInterceptedServerErrorMarksDisconnectedFromReadyOrUnknownStates() {
+        for current in [FrontEndConnectionState.connected, .loaded, .disconnected, .unknown] {
             let resolved = WebViewController.connectionStateForInterceptedServerError(current: current)
 
             XCTAssertEqual(resolved, .disconnected, "expected disconnected when current is \(current)")

--- a/Tests/App/WebView/WebViewExternalBusMessageTests.swift
+++ b/Tests/App/WebView/WebViewExternalBusMessageTests.swift
@@ -7,6 +7,7 @@ final class WebViewExternalBusMessageTests: XCTestCase {
         XCTAssertEqual(WebViewExternalBusMessage.configScreenShow.rawValue, "config_screen/show")
         XCTAssertEqual(WebViewExternalBusMessage.haptic.rawValue, "haptic")
         XCTAssertEqual(WebViewExternalBusMessage.connectionStatus.rawValue, "connection-status")
+        XCTAssertEqual(WebViewExternalBusMessage.frontendLoaded.rawValue, "frontend/loaded")
         XCTAssertEqual(WebViewExternalBusMessage.tagRead.rawValue, "tag/read")
         XCTAssertEqual(WebViewExternalBusMessage.tagWrite.rawValue, "tag/write")
         XCTAssertEqual(WebViewExternalBusMessage.themeUpdate.rawValue, "theme-update")
@@ -36,7 +37,7 @@ final class WebViewExternalBusMessageTests: XCTestCase {
         XCTAssertEqual(WebViewExternalBusMessage.entityAddTo.rawValue, "entity/add_to")
         XCTAssertEqual(WebViewExternalBusMessage.cameraPlayerShow.rawValue, "camera/show")
 
-        XCTAssertEqual(WebViewExternalBusMessage.allCases.count, 23)
+        XCTAssertEqual(WebViewExternalBusMessage.allCases.count, 24)
     }
 
     func testExternalBusOutgoingMessageKeys() {

--- a/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
@@ -57,6 +57,19 @@ final class WebViewExternalMessageHandlerTests: XCTestCase {
         XCTAssertEqual(mockWebViewController.lastEvaluatedJavaScriptScript, "notifyThemeColors()")
     }
 
+    @MainActor func testHandleExternalMessageFrontendLoadedMarksFrontendLoaded() {
+        let dictionary: [String: Any] = [
+            "id": 1,
+            "message": "",
+            "command": "",
+            "type": "frontend/loaded",
+        ]
+
+        sut.handleExternalMessage(dictionary)
+
+        XCTAssertEqual(mockWebViewController.lastSettingButtonState, FrontEndConnectionState.loaded.rawValue)
+    }
+
     @MainActor func testHandleExternalMessageBarCodeScanPresentsScanner() {
         let dictionary: [String: Any] = [
             "id": 1,


### PR DESCRIPTION
## Summary
Use the new `frontend/loaded` external bus event as the native loader dismissal signal for Core 2026.8.0 and newer. Keep the existing `connected` fallback for older Core versions so the loader still dismisses before that event is available.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
