### PR TITLE
Remove pull to refresh matched geometry transition

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshView.swift
@@ -2,21 +2,8 @@ import Shared
 import SwiftUI
 
 struct HomeAssistantPullToRefreshView: View {
-    private static let logoAnimationID = "pull-to-refresh-logo"
-
     let progress: CGFloat
     let isRefreshing: Bool
-    let logoNamespace: Namespace.ID?
-
-    init(
-        progress: CGFloat,
-        isRefreshing: Bool,
-        logoNamespace: Namespace.ID? = nil
-    ) {
-        self.progress = progress
-        self.isRefreshing = isRefreshing
-        self.logoNamespace = logoNamespace
-    }
 
     var body: some View {
         ZStack {
@@ -41,17 +28,7 @@ struct HomeAssistantPullToRefreshView: View {
         }
         .frame(width: 42, height: 42)
         .scaleEffect(isRefreshing ? 1 : 0.8 + (0.2 * progress))
-        .modify { view in
-            if let logoNamespace {
-                view.matchedGeometryEffect(
-                    id: Self.logoAnimationID,
-                    in: logoNamespace,
-                    isSource: true
-                )
-            } else {
-                view
-            }
-        }
+        .opacity(isRefreshing ? 1 : progress)
         .accessibilityHidden(true)
     }
 }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -4,7 +4,6 @@ import UIKit
 
 struct HomeAssistantView: View, WebFrontendView {
     @StateObject private var viewModel: HomeAssistantViewModel
-    @Namespace private var pullToRefreshLogoNamespace
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -36,13 +35,11 @@ struct HomeAssistantView: View, WebFrontendView {
             // reloads.
             ZStack(alignment: .topLeading) {
                 themedStatusBar
-                    .opacity(viewModel.webViewContentOpacity)
                 homeAssistant
-                    .opacity(viewModel.webViewContentOpacity)
                 pullToRefreshIndicator
                 macTitleBar
-                    .opacity(viewModel.webViewContentOpacity)
             }
+            .opacity(viewModel.webViewContentOpacity)
             noActiveURLState
             standByView
         }
@@ -72,11 +69,10 @@ struct HomeAssistantView: View, WebFrontendView {
 
     @ViewBuilder
     private var pullToRefreshIndicator: some View {
-        if viewModel.showsPullToRefresh, !viewModel.isPullToRefreshActive {
+        if viewModel.showsPullToRefresh {
             HomeAssistantPullToRefreshView(
                 progress: viewModel.pullToRefreshProgress,
-                isRefreshing: viewModel.isPullToRefreshActive,
-                logoNamespace: pullToRefreshLogoNamespace
+                isRefreshing: viewModel.isPullToRefreshActive
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding(.top, DesignSystem.Spaces.two)
@@ -115,9 +111,7 @@ struct HomeAssistantView: View, WebFrontendView {
             HomeAssistantStandByView(
                 server: viewModel.server,
                 emptyState: viewModel.displayedEmptyState,
-                isLoading: viewModel.overlayState.isLoading,
-                logoNamespace: pullToRefreshLogoNamespace,
-                logoIsMatchedGeometrySource: !viewModel.isPullToRefreshActive
+                isLoading: viewModel.overlayState.isLoading
             )
             .transition(.opacity)
             .opacity(viewModel.standByOpacity)

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -35,11 +35,13 @@ struct HomeAssistantView: View, WebFrontendView {
             // reloads.
             ZStack(alignment: .topLeading) {
                 themedStatusBar
+                    .opacity(viewModel.webViewContentOpacity)
                 homeAssistant
+                    .opacity(viewModel.webViewContentOpacity)
                 pullToRefreshIndicator
                 macTitleBar
+                    .opacity(viewModel.webViewContentOpacity)
             }
-            .opacity(viewModel.webViewContentOpacity)
             noActiveURLState
             standByView
         }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -69,7 +69,7 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     var shouldShowStandByView: Bool {
-        isFullScreenLoaderMounted || overlayState.emptyState != nil || isPullToRefreshActive
+        isFullScreenLoaderMounted || overlayState.emptyState != nil
     }
 
     var webViewContentOpacity: Double {
@@ -92,10 +92,7 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     var standByOpacity: Double {
-        if isPullToRefreshActive {
-            return 1
-        }
-        return overlayState.emptyState == nil && !isFullScreenLoaderVisible ? 0 : 1
+        overlayState.emptyState == nil && !isFullScreenLoaderVisible ? 0 : 1
     }
 
     private func didReachLoaderReadyState(_ connectionState: FrontEndConnectionState) -> Bool {
@@ -145,17 +142,8 @@ final class HomeAssistantViewModel: ObservableObject {
             webView: controller.webView,
             threshold: Constants.pullToRefreshThreshold,
             onStateChange: { [weak self] progress, isRefreshing in
-                guard let self else { return }
-
-                if isPullToRefreshActive != isRefreshing {
-                    withAnimation(DesignSystem.Animation.default) {
-                        self.pullToRefreshProgress = progress
-                        self.isPullToRefreshActive = isRefreshing
-                    }
-                } else {
-                    pullToRefreshProgress = progress
-                    isPullToRefreshActive = isRefreshing
-                }
+                self?.pullToRefreshProgress = progress
+                self?.isPullToRefreshActive = isRefreshing
             },
             onRefresh: { [weak self, weak controller] in
                 self?.performPullToRefresh(using: controller)

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -9,8 +9,7 @@ struct HomeAssistantStandByView: View {
     private static let loadingLogoSize = CGSize(width: 110, height: 110)
     private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
     private static let reauthenticationIconSize: CGFloat = 56
-    private static let serverPillHeight: CGFloat = 30
-    private static let connectionTypeIndicatorSize: CGFloat = 38
+    private static let serverPillHeight: CGFloat = 38
     private static let delayedSettingsButtonDelay: Duration = .seconds(5)
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
     fileprivate static let launchScreenLogoSize = CGSize(width: 147, height: 174)
@@ -211,7 +210,7 @@ struct HomeAssistantStandByView: View {
             Image(systemSymbol: connectionTypeIndicatorIcon)
                 .font(.headline)
                 .foregroundStyle(Color.haPrimary)
-                .frame(width: Self.connectionTypeIndicatorSize, height: Self.connectionTypeIndicatorSize)
+                .frame(width: Self.serverPillHeight, height: Self.serverPillHeight)
                 .modify { view in
                     if #available(iOS 26.0, *) {
                         view.glassEffect(.regular.interactive(), in: .circle)

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -80,7 +80,7 @@ struct HomeAssistantStandByView: View {
             progressView
         }
         .background(Color(uiColor: .systemBackground))
-        .overlay(alignment: .topTrailing) {
+        .overlay(alignment: .topLeading) {
             delayedSettingsButton
         }
         .safeAreaInset(edge: .top) {

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -10,6 +10,7 @@ struct HomeAssistantStandByView: View {
     private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
     private static let reauthenticationIconSize: CGFloat = 56
     private static let serverPillHeight: CGFloat = 30
+    private static let connectionTypeIndicatorSize: CGFloat = 38
     private static let delayedSettingsButtonDelay: Duration = .seconds(5)
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
     fileprivate static let launchScreenLogoSize = CGSize(width: 147, height: 174)
@@ -210,7 +211,7 @@ struct HomeAssistantStandByView: View {
             Image(systemSymbol: connectionTypeIndicatorIcon)
                 .font(.headline)
                 .foregroundStyle(Color.haPrimary)
-                .frame(width: Self.serverPillHeight, height: Self.serverPillHeight)
+                .frame(width: Self.connectionTypeIndicatorSize, height: Self.connectionTypeIndicatorSize)
                 .modify { view in
                     if #available(iOS 26.0, *) {
                         view.glassEffect(.regular.interactive(), in: .circle)

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct HomeAssistantStandByView: View {
     static let dismissTapThreshold = 5
 
-    private static let logoAnimationID = "pull-to-refresh-logo"
     private static let headerAccessorySize = CGSize(width: 44, height: 44)
     private static let loadingLogoSize = CGSize(width: 110, height: 110)
     private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
@@ -19,8 +18,6 @@ struct HomeAssistantStandByView: View {
     let server: Server
     let emptyState: WebFrontendOverlayState.EmptyStateContent?
     let isLoading: Bool
-    let logoNamespace: Namespace.ID?
-    let logoIsMatchedGeometrySource: Bool
 
     @State private var selectedReauthURLType: ConnectionInfo.URLType
     @State private var showURLPicker = false
@@ -53,15 +50,11 @@ struct HomeAssistantStandByView: View {
     init(
         server: Server,
         emptyState: WebFrontendOverlayState.EmptyStateContent?,
-        isLoading: Bool = false,
-        logoNamespace: Namespace.ID? = nil,
-        logoIsMatchedGeometrySource: Bool = true
+        isLoading: Bool = false
     ) {
         self.server = server
         self.emptyState = emptyState
         self.isLoading = isLoading
-        self.logoNamespace = logoNamespace
-        self.logoIsMatchedGeometrySource = logoIsMatchedGeometrySource
         self._selectedReauthURLType = State(initialValue: emptyState?.availableReauthURLTypes.first ?? .external)
     }
 
@@ -290,17 +283,6 @@ struct HomeAssistantStandByView: View {
             width: showsEmptyState ? Self.emptyStateLogoSize.width : Self.loadingLogoSize.width,
             height: showsEmptyState ? Self.emptyStateLogoSize.height : Self.loadingLogoSize.height
         )
-        .modify { view in
-            if let logoNamespace {
-                view.matchedGeometryEffect(
-                    id: Self.logoAnimationID,
-                    in: logoNamespace,
-                    isSource: logoIsMatchedGeometrySource
-                )
-            } else {
-                view
-            }
-        }
     }
 
     private func header(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {


### PR DESCRIPTION
## Summary
- Reverts the matched geometry transition between the pull to refresh icon and the stand-by view logo introduced in #5131 — it didn't look good in practice
- Restores the icon's original progress-driven opacity and the simple pull to refresh indicator behavior
- Keeps the pan gesture handling fix from #5131 (refresh only triggers on `.ended` past the threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)