### PR TITLE
Prefer critical text over progress percentage in Live Activity trailing slot

### DIFF
--- a/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
@@ -136,16 +136,16 @@ struct HAExpandedTrailingView: View {
     let state: HALiveActivityAttributes.ContentState
     private let minimumScaleFactor: CGFloat = 0.7
     var body: some View {
-        if let fraction = state.progressFraction {
-            Text(HAActivityVisualStyle.percentString(for: fraction))
-                .font(.headline.monospacedDigit())
-                .foregroundStyle(.white)
-                .minimumScaleFactor(minimumScaleFactor)
-        } else if let critical = state.criticalText {
+        if let critical = state.criticalText {
             Text(critical)
                 .font(.headline)
                 .foregroundStyle(.white)
                 .lineLimit(1)
+                .minimumScaleFactor(minimumScaleFactor)
+        } else if let fraction = state.progressFraction {
+            Text(HAActivityVisualStyle.percentString(for: fraction))
+                .font(.headline.monospacedDigit())
+                .foregroundStyle(.white)
                 .minimumScaleFactor(minimumScaleFactor)
         }
     }

--- a/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
@@ -99,15 +99,15 @@ struct HALockScreenView: View {
 
     @ViewBuilder
     private var trailingValue: some View {
-        if let fraction = state.progressFraction {
-            Text(HAActivityVisualStyle.percentString(for: fraction))
-                .font(.headline.monospacedDigit())
+        if let critical = state.criticalText {
+            Text(critical)
+                .font(.headline)
                 .foregroundStyle(primaryTextColor)
                 .lineLimit(1)
                 .minimumScaleFactor(Self.trailingValueMinimumScaleFactor)
-        } else if let critical = state.criticalText {
-            Text(critical)
-                .font(.headline)
+        } else if let fraction = state.progressFraction {
+            Text(HAActivityVisualStyle.percentString(for: fraction))
+                .font(.headline.monospacedDigit())
                 .foregroundStyle(primaryTextColor)
                 .lineLimit(1)
                 .minimumScaleFactor(Self.trailingValueMinimumScaleFactor)


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When a Live Activity has both a progress bar (`progress`/`progress_max`) and `critical_text`, the Lock Screen and the expanded Dynamic Island showed the percentage in the trailing slot and ignored `critical_text`. This meant anyone using a computed percentage just to render a stable progress bar (e.g. appliances that only expose an ETA and total cycle time) was stuck showing a meaningless "%" instead of something useful like the current action ("Rinsing") or the completion time.

This swaps the trailing-slot precedence in `HALockScreenView` and the expanded Dynamic Island so `critical_text` wins when present, falling back to the percentage otherwise. It matches the behaviour the compact Dynamic Island already had, so all three trailing slots are now consistent. Activities that only set `progress` still show the percentage, so the change is backward compatible.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
