### PR TITLE
Show components library outside debug builds

### DIFF
--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -329,7 +329,6 @@ struct DebugView: View {
 
     private var developerSection: some View {
         Section {
-            #if DEBUG
             NavigationLink {
                 ComponentsLibraryView()
             } label: {
@@ -338,7 +337,6 @@ struct DebugView: View {
                     title: L10n.Settings.Debugging.ComponentsLibrary.title
                 )
             }
-            #endif
 
             NavigationLink {
                 MediaTypesRequiringUserActionForPlaybackView()


### PR DESCRIPTION
## Summary

Removes the `#if DEBUG` gate around the components library entry in the debug/developer settings so it is available in release (TestFlight/App Store) builds too.

The entry stays inside the hidden developer section, which is only revealed after tapping the casita logo 10 times, so it remains hidden from regular users while being accessible on non-debug builds for testing the design system components.

## Changes

- `Sources/App/Settings/DebugView.swift`: drop the `#if DEBUG` / `#endif` wrapping the `ComponentsLibraryView()` navigation link.

`ComponentsLibraryView` already compiles in all configurations (only gated by `#if !os(watchOS)`), so no other changes are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)