### PR TITLE
Default to edge to edge display starting on Home Assistant 2026.8.0

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
@@ -52,8 +52,8 @@ extension WebViewController {
 
         if reason == .settingChange {
             setNeedsUpdateOfHomeIndicatorAutoHidden()
-            // The web view is always edge-to-edge (see `setupWebViewConstraints`); only the SwiftUI themed
-            // status-bar bar reacts to setting changes.
+            // The web view is always edge-to-edge (see `setupWebViewConstraints`); only the SwiftUI-themed
+            // status-bar strip reacts to setting changes.
             updateThemedStatusBar()
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
@@ -52,18 +52,14 @@ extension WebViewController {
 
         if reason == .settingChange {
             setNeedsUpdateOfHomeIndicatorAutoHidden()
-            updateEdgeToEdgeLayout()
+            // The web view is always edge-to-edge (see `setupWebViewConstraints`); only the SwiftUI themed
+            // status-bar bar reacts to setting changes.
+            updateThemedStatusBar()
         }
     }
 
     @objc func updateWebViewSettingsForNotification() {
         updateWebViewSettings(reason: .settingChange)
-    }
-
-    func updateEdgeToEdgeLayout() {
-        // The web view is always edge-to-edge now (see `setupWebViewConstraints`); only the SwiftUI themed
-        // status-bar bar reacts to the edge-to-edge / full-screen setting.
-        updateThemedStatusBar()
     }
 
     /// The themed colour for the top status-bar area (web app theme, or header background on older cores).
@@ -74,10 +70,15 @@ extension WebViewController {
             : cachedColors[.appThemeColor]
     }
 
-    /// Publishes the themed status-bar bar to SwiftUI. Shown only on iOS when the user hasn't enabled
-    /// edge-to-edge / full-screen; otherwise the web view runs truly edge-to-edge (no bar).
+    /// Publishes the themed status-bar bar to SwiftUI. On iPhone the web view runs truly edge-to-edge
+    /// (no bar) by default when the server core supports it (2026.8+) or full-screen is enabled; the
+    /// bar is drawn for older cores, on iPad, or when the developer "always below status bar" override
+    /// is on.
     func updateThemedStatusBar() {
-        let edgeToEdge = Current.settingsStore.edgeToEdge || Current.settingsStore.fullScreen
+        let isPhone = UIDevice.current.userInterfaceIdiom == .phone
+        let coreSupportsEdgeToEdge = server.info.version >= .canDisplayEdgeToEdge
+        let edgeToEdge = (isPhone && coreSupportsEdgeToEdge && !Current.settingsStore.webViewAlwaysBelowStatusBar)
+            || Current.settingsStore.fullScreen
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             overlayState?.statusBarColor = (edgeToEdge || Current.isCatalyst) ? nil : themedStatusBarColor()

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
@@ -70,10 +70,10 @@ extension WebViewController {
             : cachedColors[.appThemeColor]
     }
 
-    /// Publishes the themed status-bar bar to SwiftUI. On iPhone the web view runs truly edge-to-edge
-    /// (no bar) by default when the server core supports it (2026.8+) or full-screen is enabled; the
-    /// bar is drawn for older cores, on iPad, or when the developer "always below status bar" override
-    /// is on.
+    /// Publishes the themed status-bar strip to SwiftUI. On iPhone the web view runs truly edge-to-edge
+    /// (no strip) by default when the server core supports it (2026.8+) or full-screen is enabled.
+    /// The strip is drawn for older cores, on iPad (unless full-screen is enabled), or when the
+    /// developer "always below status bar" override is on.
     func updateThemedStatusBar() {
         let isPhone = UIDevice.current.userInterfaceIdiom == .phone
         let coreSupportsEdgeToEdge = server.info.version >= .canDisplayEdgeToEdge

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -43,6 +43,9 @@ extension WebViewController {
         guard let changedServer = notification.object as? Server,
               changedServer.identifier == server.identifier else { return }
 
+        // Edge-to-edge is assumed until the version proves otherwise; re-evaluate now that it changed.
+        updateThemedStatusBar()
+
         Current.Log.info("Resetting frontend cache for \(server.identifier) after server version change")
         Current.websiteDataStoreHandler
             .cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) { [weak self] in

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1285,6 +1285,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.developer.mock_thread_credentials_sharing.title" = "Simulator Thread Credentials Sharing";
 "settings.developer.show_log_files.title" = "Show log files in Finder";
 "settings.developer.sync_watch_context.title" = "Sync Watch Context";
+"settings.developer.web_view_below_status_bar.title" = "Always draw web view below status bar";
 "settings.event_log.title" = "Event Log";
 "settings.location_history.detail.explanation" = "The purple circle is your location and its accuracy. Blue circles are your zones. You are inside a zone if the purple circle overlaps a blue circle. Orange circles are additional regions used for sub-100 m zones.";
 "settings.location_history.empty" = "No Location History";
@@ -1400,9 +1401,6 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
-"settings_details.general.edge_to_edge.enabled.title" = "Enable";
-"settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";
-"settings_details.general.edge_to_edge.title" = "Edge to edge display";
 "settings_details.general.full_screen.title" = "Full Screen";
 "settings_details.general.launch_on_login.title" = "Launch App on Login";
 "settings_details.general.links.title" = "Links";

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -472,6 +472,16 @@ struct DebugView: View {
                 Text(L10n.Settings.Debugging.ReceiveDebugNotifications.title)
             }
 
+            if !Current.isCatalyst {
+                Toggle(isOn: .init(get: {
+                    Current.settingsStore.webViewAlwaysBelowStatusBar
+                }, set: { newValue in
+                    Current.settingsStore.webViewAlwaysBelowStatusBar = newValue
+                })) {
+                    Text(L10n.Settings.Developer.WebViewBelowStatusBar.title)
+                }
+            }
+
             Picker(selection: Binding(
                 get: { Current.settingsStore.webViewEmptyStateTimeout },
                 set: { Current.settingsStore.webViewEmptyStateTimeout = $0 }

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -470,7 +470,7 @@ struct DebugView: View {
                 Text(L10n.Settings.Debugging.ReceiveDebugNotifications.title)
             }
 
-            if !Current.isCatalyst {
+            if !Current.isCatalyst, UIDevice.current.userInterfaceIdiom == .phone {
                 Toggle(isOn: .init(get: {
                     Current.settingsStore.webViewAlwaysBelowStatusBar
                 }, set: { newValue in

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -48,7 +48,6 @@ struct GeneralSettingsView: View {
                 fullScreen
                 refreshAfterInactive
             }
-            edgeToEdge
         }
         .id(redrawHelper)
     }
@@ -172,29 +171,6 @@ struct GeneralSettingsView: View {
                 redrawView()
             })) {
                 Text(L10n.SettingsDetails.General.FullScreen.title)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var edgeToEdge: some View {
-        if !Current.isCatalyst {
-            Section {
-                Toggle(isOn: .init(get: {
-                    Current.settingsStore.edgeToEdge
-                }, set: { newValue in
-                    Current.settingsStore.edgeToEdge = newValue
-                    redrawView()
-                })) {
-                    Text(L10n.SettingsDetails.General.EdgeToEdge.Enabled.title)
-                }
-            } header: {
-                HStack(spacing: DesignSystem.Spaces.one) {
-                    Text(L10n.SettingsDetails.General.EdgeToEdge.title)
-                    LabsLabel()
-                }
-            } footer: {
-                Text(L10n.SettingsDetails.General.EdgeToEdge.footer)
             }
         }
     }

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -411,6 +411,8 @@ public extension Version {
     static let inZonesOnLocationUpdate: Version = .init(major: 2026, minor: 6, patch: 0, prerelease: "any0")
     /// Frontend sends `frontend/loaded` when its launch screen is removed from 2026.8.0.
     static let frontendLoadedExternalBus: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
+    /// Frontend handles safe-area insets itself from 2026.8.0, so the app can display edge-to-edge by default.
+    static let canDisplayEdgeToEdge: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
 
     var coreRequiredString: String {
         L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4329,6 +4329,10 @@ public enum L10n {
         /// Sync Watch Context
         public static var title: String { return L10n.tr("Localizable", "settings.developer.sync_watch_context.title") }
       }
+      public enum WebViewBelowStatusBar {
+        /// Always draw web view below status bar
+        public static var title: String { return L10n.tr("Localizable", "settings.developer.web_view_below_status_bar.title") }
+      }
     }
     public enum EventLog {
       /// Event Log
@@ -4699,16 +4703,6 @@ public enum L10n {
       public enum DeviceName {
         /// Device Name
         public static var title: String { return L10n.tr("Localizable", "settings_details.general.device_name.title") }
-      }
-      public enum EdgeToEdge {
-        /// Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.
-        public static var footer: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.footer") }
-        /// Edge to edge display
-        public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.title") }
-        public enum Enabled {
-          /// Enable
-          public static var title: String { return L10n.tr("Localizable", "settings_details.general.edge_to_edge.enabled.title") }
-        }
       }
       public enum FullScreen {
         /// Full Screen

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -234,12 +234,14 @@ public class SettingsStore {
         }
     }
 
-    public var edgeToEdge: Bool {
+    /// Debug override: always draw the web view below the iPhone status bar, even on cores that
+    /// support edge-to-edge display (2026.8+).
+    public var webViewAlwaysBelowStatusBar: Bool {
         get {
-            prefs.bool(forKey: "edgeToEdge_experimental")
+            prefs.bool(forKey: "webViewAlwaysBelowStatusBar")
         }
         set {
-            prefs.set(newValue, forKey: "edgeToEdge_experimental")
+            prefs.set(newValue, forKey: "webViewAlwaysBelowStatusBar")
             NotificationCenter.default.post(name: Self.webViewRelatedSettingDidChange, object: nil)
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
- Starting on Home Assistant 2026.8.0, the frontend UI is considered ready to be displayed edge to edge, so this PR removes the experimental toggle and display by default based on Home Assistant version.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
