### PR TITLE
Add haptic feedback when a gesture action is triggered

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -8,7 +8,7 @@ final class WebViewGestureHandler {
 
     func handleGestureAction(_ action: HAGestureAction) {
         if action != .none {
-            Current.impactFeedback.impactOccurred(style: .light)
+            Current.impactFeedback.impactOccurred(style: .medium)
         }
         switch action {
         case .assist:

--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -7,6 +7,9 @@ final class WebViewGestureHandler {
     weak var webView: WebViewControllerProtocol?
 
     func handleGestureAction(_ action: HAGestureAction) {
+        if action != .none {
+            Current.impactFeedback.impactOccurred(style: .light)
+        }
         switch action {
         case .assist:
             showAssistThroughKeyEvent()


### PR DESCRIPTION
## Summary
Adds a light haptic tap whenever a user-configured gesture is recognized and triggers its action, so the user gets physical feedback that the gesture registered. The feedback fires from the single point all gesture routes funnel through (multi-touch swipes, screen-edge pans, shake, the SwiftUI stand-by overlay, and the Mac toolbar), and is skipped for gestures with no action assigned.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
