### PR TITLE
Camera player UI improvements

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -26,6 +26,8 @@ struct CameraPlayerView: View {
     @State private var controlsVisible = true
     @State private var showLoader = true
 
+    private let maxTitleTextWidth: CGFloat = 100
+
     enum PlayerType {
         case webRTC
         case hls
@@ -73,13 +75,13 @@ struct CameraPlayerView: View {
                         }
                     }
 
-                    ToolbarItem(placement: .cancellationAction) {
+                    ToolbarItem(placement: .topBarLeading) {
                         CloseButton {
                             dismiss()
                         }
                     }
 
-                    ToolbarItem(placement: .principal) {
+                    ToolbarItem(placement: .topBarLeading) {
                         nameBadge
                     }
                 }
@@ -121,11 +123,14 @@ struct CameraPlayerView: View {
                         Text(name)
                             .font(DesignSystem.Font.caption.bold())
                             .foregroundStyle(.primary)
+                            .frame(maxWidth: maxTitleTextWidth, alignment: .leading)
                             .truncationMode(.middle)
                         if let subtitle, !subtitle.isEmpty {
                             Text(subtitle)
                                 .font(DesignSystem.Font.caption2)
                                 .foregroundStyle(.secondary)
+                                .frame(maxWidth: maxTitleTextWidth, alignment: .leading)
+                                .truncationMode(.middle)
                         }
                     }
                     if cameras.count > 1 {
@@ -136,21 +141,9 @@ struct CameraPlayerView: View {
                 }
                 .padding(.horizontal, DesignSystem.Spaces.two)
                 .padding(.vertical, DesignSystem.Spaces.one)
-                .modify { view in
-                    if #available(iOS 26.0, *) {
-                        view
-                            .glassEffect(.regular.interactive(), in: .capsule)
-                            .contentShape(Capsule())
-                    } else {
-                        view
-                            .background(.regularMaterial)
-                            .clipShape(.capsule)
-                    }
-                }
             }
             .menuOrder(.fixed)
             .disabled(cameras.count <= 1)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerControlsView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerControlsView.swift
@@ -1,0 +1,147 @@
+import HADesignSystem
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+struct WebRTCVideoPlayerControlsView<Content: View>: View {
+    @Binding private var controlsVisible: Bool
+
+    private let isTalkbackSupported: Bool
+    private let isTalking: Bool
+    private let isMuted: Bool
+    private let onToggleTalkback: () -> Void
+    private let onToggleMute: () -> Void
+    private let content: Content
+
+    init(
+        controlsVisible: Binding<Bool>,
+        isTalkbackSupported: Bool,
+        isTalking: Bool,
+        isMuted: Bool,
+        onToggleTalkback: @escaping () -> Void,
+        onToggleMute: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self._controlsVisible = controlsVisible
+        self.isTalkbackSupported = isTalkbackSupported
+        self.isTalking = isTalking
+        self.isMuted = isMuted
+        self.onToggleTalkback = onToggleTalkback
+        self.onToggleMute = onToggleMute
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .overlay {
+                if controlsVisible, isTalkbackSupported {
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        LinearGradient(
+                            colors: [.clear, .black.opacity(0.6)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 180)
+                    }
+                    .allowsHitTesting(false)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                }
+            }
+            .toolbar {
+                talkbackToolbarItem
+                muteToolbarItem
+            }
+    }
+
+    @ToolbarContentBuilder
+    private var talkbackToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .bottomBar) {
+            if controlsVisible, isTalkbackSupported {
+                Button(action: onToggleTalkback) {
+                    HStack {
+                        if isTalking {
+                            Text(L10n.CameraPlayer.Talkback.stop)
+                                .font(.headline)
+                                .padding(.trailing, DesignSystem.Spaces.one)
+                        }
+                        Image(systemSymbol: isTalking ? .micSlash : .micFill)
+                            .font(DesignSystem.Font.title3)
+                    }
+                    .padding(.vertical, DesignSystem.Spaces.four)
+                    .padding(.horizontal, isTalking ? DesignSystem.Spaces.one : DesignSystem.Spaces.four)
+                    .transition(.move(edge: .trailing).combined(with: .scale))
+                }
+                .modify({ view in
+                    if #available(iOS 26.0, *) {
+                        view
+                            .buttonStyle(.glassProminent)
+                    } else {
+                        view
+                    }
+                })
+                .tint(isTalking ? Color.orange : Color.haPrimary)
+                .contentShape(.capsule)
+                .accessibilityLabel(
+                    isTalking ? L10n.CameraPlayer.Talkback.stop : L10n.CameraPlayer.Talkback.start
+                )
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var muteToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            if controlsVisible {
+                Button(action: onToggleMute) {
+                    Image(systemSymbol: isMuted ? .speakerSlashFill : .speakerWave3)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Mic standby") {
+    NavigationStack {
+        WebRTCVideoPlayerControlsView(
+            controlsVisible: .constant(true),
+            isTalkbackSupported: true,
+            isTalking: false,
+            isMuted: false,
+            onToggleTalkback: {},
+            onToggleMute: {}
+        ) {
+            Rectangle()
+                .fill(.black)
+                .overlay {
+                    Text("Camera preview")
+                        .foregroundStyle(.white)
+                }
+                .ignoresSafeArea()
+        }
+    }
+}
+
+#Preview("Mic on") {
+    NavigationStack {
+        WebRTCVideoPlayerControlsView(
+            controlsVisible: .constant(true),
+            isTalkbackSupported: true,
+            isTalking: true,
+            isMuted: false,
+            onToggleTalkback: {},
+            onToggleMute: {}
+        ) {
+            Rectangle()
+                .fill(.black)
+                .overlay {
+                    Text("Camera preview")
+                        .foregroundStyle(.white)
+                }
+                .ignoresSafeArea()
+        }
+    }
+}
+#endif

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
@@ -1,7 +1,6 @@
 import SFSafeSymbols
 import Shared
 import SwiftUI
-import WebRTC
 
 protocol AppCameraView {
     var controlsVisible: Binding<Bool> { get set }
@@ -52,44 +51,33 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
 
     var body: some View {
         GeometryReader { geometry in
-            ZStack {
-                player
-                errorView
-                CameraZoomGestureOverlay(
-                    onPinchBegan: { _ in
-                        previousFrameScale = lastScale
-                    },
-                    onPinchChanged: { factor, midpoint in
-                        handlePinchChanged(factor: factor, midpoint: midpoint, in: geometry.size)
-                    },
-                    onPinchEnded: {
-                        handlePinchEnded(in: geometry.size)
-                    },
-                    onDoubleTap: { location in
-                        handleDoubleTap(at: location, in: geometry.size)
-                    }
-                )
-            }
-            .background(.black)
-            .overlay {
-                // Fade shade behind the bottom controls so the talkback (mic) button keeps contrast
-                // against a bright camera image. Only shown when the mic button is present. The
-                // container ignores the safe area so the shade extends under the mic button/home
-                // indicator rather than stopping above it.
-                if controlsVisible.wrappedValue, viewModel.isTalkbackSupported {
-                    VStack(spacing: 0) {
-                        Spacer(minLength: 0)
-                        LinearGradient(
-                            colors: [.clear, .black.opacity(0.6)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                        .frame(height: 180)
-                    }
-                    .allowsHitTesting(false)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
+            WebRTCVideoPlayerControlsView(
+                controlsVisible: controlsVisible,
+                isTalkbackSupported: viewModel.isTalkbackSupported,
+                isTalking: viewModel.isTalking,
+                isMuted: viewModel.isMuted,
+                onToggleTalkback: viewModel.toggleTalkback,
+                onToggleMute: viewModel.toggleMute
+            ) {
+                ZStack {
+                    player
+                    errorView
+                    CameraZoomGestureOverlay(
+                        onPinchBegan: { _ in
+                            previousFrameScale = lastScale
+                        },
+                        onPinchChanged: { factor, midpoint in
+                            handlePinchChanged(factor: factor, midpoint: midpoint, in: geometry.size)
+                        },
+                        onPinchEnded: {
+                            handlePinchEnded(in: geometry.size)
+                        },
+                        onDoubleTap: { location in
+                            handleDoubleTap(at: location, in: geometry.size)
+                        }
+                    )
                 }
+                .background(.black)
             }
             .simultaneousGesture(
                 dragGesture(geometry: geometry)
@@ -106,43 +94,6 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
             }
             .onChange(of: viewModel.showLoader) { showLoader in
                 self.showLoader.wrappedValue = showLoader
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .bottomBar) {
-                if controlsVisible.wrappedValue, viewModel.isTalkbackSupported {
-                    Button(action: {
-                        viewModel.toggleTalkback()
-                    }) {
-                        HStack {
-                            if viewModel.isTalking {
-                                Text(L10n.CameraPlayer.Talkback.stop)
-                            }
-                            Image(systemSymbol: viewModel.isTalking ? .micSlash : .micFill)
-                        }
-                        .transition(.opacity.combined(with: .scale))
-                    }
-                    .controlSize({
-                        if #available(iOS 17.0, *) {
-                            return .extraLarge
-                        } else {
-                            return .large
-                        }
-                    }())
-                    .tint(viewModel.isTalking ? Color.orange : Color.haPrimary)
-                    .accessibilityLabel(
-                        viewModel.isTalking ? L10n.CameraPlayer.Talkback.stop : L10n.CameraPlayer.Talkback.start
-                    )
-                }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                if controlsVisible.wrappedValue {
-                    Button(action: {
-                        viewModel.toggleMute()
-                    }) {
-                        Image(systemSymbol: viewModel.isMuted ? .speakerSlashFill : .speakerWave3)
-                    }
-                }
             }
         }
     }
@@ -277,40 +228,16 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
     }
 }
 
-struct WebRTCVideoPlayerViewControllerWrapper: UIViewControllerRepresentable {
-    private let viewModel: WebRTCViewPlayerViewModel
-    @Binding var isVideoPlaying: Bool
-
-    init(viewModel: WebRTCViewPlayerViewModel, isVideoPlaying: Binding<Bool>) {
-        self.viewModel = viewModel
-        self._isVideoPlaying = isVideoPlaying
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(parent: self)
-    }
-
-    func makeUIViewController(context: Context) -> WebRTCVideoPlayerViewController {
-        let vc = WebRTCVideoPlayerViewController(viewModel: viewModel)
-        vc.onVideoStarted = { [weak coordinator = context.coordinator] in
-            coordinator?.videoDidStart()
-        }
-        return vc
-    }
-
-    func updateUIViewController(_ uiViewController: WebRTCVideoPlayerViewController, context: Context) {
-        /* no-op */
-    }
-
-    class Coordinator {
-        var parent: WebRTCVideoPlayerViewControllerWrapper
-
-        init(parent: WebRTCVideoPlayerViewControllerWrapper) {
-            self.parent = parent
-        }
-
-        func videoDidStart() {
-            parent.isVideoPlaying = true
-        }
+#if DEBUG
+#Preview {
+    NavigationStack {
+        WebRTCVideoPlayerView(
+            server: ServerFixture.standard,
+            cameraEntityId: "camera.front_door",
+            cameraName: "Front Door",
+            controlsVisible: .constant(true),
+            showLoader: .constant(false)
+        )
     }
 }
+#endif

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewControllerWrapper.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewControllerWrapper.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import WebRTC
 
 struct WebRTCVideoPlayerViewControllerWrapper: UIViewControllerRepresentable {
     private let viewModel: WebRTCViewPlayerViewModel

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewControllerWrapper.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewControllerWrapper.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import WebRTC
+
+struct WebRTCVideoPlayerViewControllerWrapper: UIViewControllerRepresentable {
+    private let viewModel: WebRTCViewPlayerViewModel
+    @Binding var isVideoPlaying: Bool
+
+    init(viewModel: WebRTCViewPlayerViewModel, isVideoPlaying: Binding<Bool>) {
+        self.viewModel = viewModel
+        self._isVideoPlaying = isVideoPlaying
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> WebRTCVideoPlayerViewController {
+        let vc = WebRTCVideoPlayerViewController(viewModel: viewModel)
+        vc.onVideoStarted = { [weak coordinator = context.coordinator] in
+            coordinator?.videoDidStart()
+        }
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: WebRTCVideoPlayerViewController, context: Context) {
+        /* no-op */
+    }
+
+    class Coordinator {
+        var parent: WebRTCVideoPlayerViewControllerWrapper
+
+        init(parent: WebRTCVideoPlayerViewControllerWrapper) {
+            self.parent = parent
+        }
+
+        func videoDidStart() {
+            parent.isVideoPlaying = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Camera player UI improvements, independent of two-way audio:
- Extracts the WebRTC player controls into a dedicated `WebRTCVideoPlayerControlsView`.
- Adds `WebRTCVideoPlayerViewControllerWrapper` (a `UIViewControllerRepresentable` that drives the player view controller from SwiftUI via an `isVideoPlaying` binding).
- Reworks the `WebRTCVideoPlayerView` and `CameraPlayerView` layout.

The talkback control is present but stays hidden (gated on `isTalkbackSupported`, which is `false` on `main`), so this PR is purely UI and adds no two-way-audio behavior.

Base for the stacked two-way-audio PR #4994.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes