### PR TITLE
Fetch WebRTC client config from server to fix remote camera streaming

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCClient.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCClient.swift
@@ -285,29 +285,35 @@ final class WebRTCClient: NSObject {
 
     weak var delegate: WebRTCClientDelegate?
     private let peerConnection: RTCPeerConnection
-    private let mediaConstrains = [
-        kRTCMediaConstraintsOfferToReceiveAudio: kRTCMediaConstraintsValueTrue,
-        kRTCMediaConstraintsOfferToReceiveVideo: kRTCMediaConstraintsValueTrue,
-    ]
     private var remoteVideoTrack: RTCVideoTrack?
     private var remoteAudioTrack: RTCAudioTrack?
+    private var localDataChannel: RTCDataChannel?
     private var remoteDataChannel: RTCDataChannel?
+    /// Set while an offer waits for ICE gathering to finish (candidates-upfront mode); invoked
+    /// from the gathering-state delegate callback once the local description is complete.
+    private var iceGatheringCompletionHandler: (() -> Void)?
 
     @available(*, unavailable)
     override init() {
         fatalError("WebRTCClient:init is unavailable")
     }
 
-    required init(iceServers: [String]) {
+    init(configuration: WebRTCClientConfiguration) {
         let config = RTCConfiguration()
-        config.iceServers = [RTCIceServer(urlStrings: iceServers)]
+        config.iceServers = configuration.iceServers
 
         // Unified plan is more superior than planB
         config.sdpSemantics = .unifiedPlan
 
-        // gatherContinually will let WebRTC to listen to any network changes and send any new candidates to the other
-        // client
-        config.continualGatheringPolicy = .gatherContinually
+        if configuration.getCandidatesUpfront {
+            // The backend needs every candidate inside the offer, so gather once and wait for the
+            // gathering state to reach `.complete` (which `.gatherContinually` never does).
+            config.continualGatheringPolicy = .gatherOnce
+        } else {
+            // gatherContinually will let WebRTC to listen to any network changes and send any new
+            // candidates to the other client
+            config.continualGatheringPolicy = .gatherContinually
+        }
 
         // Define media constraints. DtlsSrtpKeyAgreement is required to be true to be able to connect with web
         // browsers.
@@ -327,6 +333,9 @@ final class WebRTCClient: NSObject {
         self.peerConnection = peerConnection
         super.init()
         createMediaTracks()
+        if let dataChannelLabel = configuration.dataChannelLabel {
+            createDataChannel(label: dataChannelLabel)
+        }
 
         self.peerConnection.delegate = self
     }
@@ -337,34 +346,34 @@ final class WebRTCClient: NSObject {
 
     // MARK: Signaling
 
-    func offer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void) {
+    /// Creates an offer and returns its SDP. With `waitForCandidates` (candidates-upfront
+    /// backends), the completion fires only after ICE gathering completes, with a local
+    /// description that already contains every gathered candidate.
+    func offer(waitForCandidates: Bool, completion: @escaping (_ sdp: String) -> Void) {
         let constrains = RTCMediaConstraints(
-            mandatoryConstraints: mediaConstrains,
+            mandatoryConstraints: nil,
             optionalConstraints: nil
         )
-        peerConnection.offer(for: constrains) { sdp, _ in
-            guard let sdp else {
+        peerConnection.offer(for: constrains) { [weak self] sdp, error in
+            guard let self, let sdp else {
+                Current.Log.error("Failed to create WebRTC offer: \(error?.localizedDescription ?? "unknown error")")
                 return
             }
 
-            self.peerConnection.setLocalDescription(sdp, completionHandler: { _ in
-                completion(sdp)
-            })
-        }
-    }
-
-    func answer(completion: @escaping (_ sdp: RTCSessionDescription) -> Void) {
-        let constrains = RTCMediaConstraints(
-            mandatoryConstraints: mediaConstrains,
-            optionalConstraints: nil
-        )
-        peerConnection.answer(for: constrains) { sdp, _ in
-            guard let sdp else {
-                return
-            }
-
-            self.peerConnection.setLocalDescription(sdp, completionHandler: { _ in
-                completion(sdp)
+            peerConnection.setLocalDescription(sdp, completionHandler: { [weak self] _ in
+                guard let self else { return }
+                if waitForCandidates {
+                    iceGatheringCompletionHandler = { [weak self] in
+                        guard let self else { return }
+                        completion(peerConnection.localDescription?.sdp ?? sdp.sdp)
+                    }
+                    // Gathering may already have finished before the handler was set.
+                    if peerConnection.iceGatheringState == .complete {
+                        flushIceGatheringCompletionHandler()
+                    }
+                } else {
+                    completion(sdp.sdp)
+                }
             })
         }
     }
@@ -402,20 +411,32 @@ final class WebRTCClient: NSObject {
     }
 
     private func createMediaTracks() {
-        let streamId = "stream"
-        let videoTrack = createVideoTrack()
-        peerConnection.add(videoTrack, streamIds: [streamId])
-        remoteVideoTrack = peerConnection.transceivers.first { $0.mediaType == .video }?.receiver
-            .track as? RTCVideoTrack
+        // Receive-only transceivers, matching the frontend player: we never send media, so no
+        // local track or capturer is needed (RTCCameraVideoCapturer is unavailable in app
+        // extensions anyway), and the offer negotiates recvonly m-lines.
+        let audioTransceiverInit = RTCRtpTransceiverInit()
+        audioTransceiverInit.direction = .recvOnly
+        peerConnection.addTransceiver(of: .audio, init: audioTransceiverInit)
+
+        let videoTransceiverInit = RTCRtpTransceiverInit()
+        videoTransceiverInit.direction = .recvOnly
+        let videoTransceiver = peerConnection.addTransceiver(of: .video, init: videoTransceiverInit)
+        remoteVideoTrack = videoTransceiver?.receiver.track as? RTCVideoTrack
     }
 
-    private func createVideoTrack() -> RTCVideoTrack {
-        // The local track only exists to establish the transceiver we read the remote track from;
-        // we never send video, so there's no capturer. RTCCameraVideoCapturer is also unavailable in
-        // app extensions, which is why a capturer here broke the device build of the notification ext.
-        let videoSource = WebRTCClient.factory.videoSource()
-        let videoTrack = WebRTCClient.factory.videoTrack(with: videoSource, trackId: "video0")
-        return videoTrack
+    private func createDataChannel(label: String) {
+        let configuration = RTCDataChannelConfiguration()
+        guard let dataChannel = peerConnection.dataChannel(forLabel: label, configuration: configuration) else {
+            Current.Log.warning("Could not create WebRTC data channel \(label)")
+            return
+        }
+        dataChannel.delegate = self
+        localDataChannel = dataChannel
+    }
+
+    private func flushIceGatheringCompletionHandler() {
+        iceGatheringCompletionHandler?()
+        iceGatheringCompletionHandler = nil
     }
 
     private func setRemoteAudioTrack() {
@@ -460,6 +481,9 @@ extension WebRTCClient: RTCPeerConnectionDelegate {
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {
         Current.Log.info("peerConnection new gathering state: \(newState)")
+        if newState == .complete {
+            flushIceGatheringCompletionHandler()
+        }
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
@@ -473,15 +497,8 @@ extension WebRTCClient: RTCPeerConnectionDelegate {
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {
         Current.Log.info("peerConnection did open data channel")
+        dataChannel.delegate = self
         remoteDataChannel = dataChannel
-    }
-}
-
-extension WebRTCClient {
-    private func setTrackEnabled<T: RTCMediaStreamTrack>(_ type: T.Type, isEnabled: Bool) {
-        peerConnection.transceivers
-            .compactMap { $0.sender.track as? T }
-            .forEach { $0.isEnabled = isEnabled }
     }
 }
 

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCClientConfiguration.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCClientConfiguration.swift
@@ -1,0 +1,55 @@
+import Foundation
+import HAKit
+import Shared
+import WebRTC
+
+/// WebRTC client configuration provided by the server, mirroring what the frontend fetches via
+/// `camera/webrtc/get_client_config` before opening a peer connection. This is how user-configured
+/// STUN/TURN servers (e.g. from go2rtc) reach the client — required for remote connections that
+/// can't be established with a direct or STUN-derived path.
+struct WebRTCClientConfiguration {
+    let iceServers: [RTCIceServer]
+    /// Label of a data channel the backend expects the client to open, if any.
+    let dataChannelLabel: String?
+    /// When true the backend doesn't support trickle ICE, so the offer must already contain all
+    /// ICE candidates and gathering has to finish before sending it.
+    let getCandidatesUpfront: Bool
+
+    /// Used when `get_client_config` fails; matches the frontend's default STUN servers.
+    static let fallback = WebRTCClientConfiguration(
+        iceServers: [RTCIceServer(urlStrings: AppConstants.WebRTC.iceServers)],
+        dataChannelLabel: nil,
+        getCandidatesUpfront: false
+    )
+
+    init(iceServers: [RTCIceServer], dataChannelLabel: String?, getCandidatesUpfront: Bool) {
+        self.iceServers = iceServers
+        self.dataChannelLabel = dataChannelLabel
+        self.getCandidatesUpfront = getCandidatesUpfront
+    }
+
+    init(data: HAData) {
+        var servers: [RTCIceServer] = []
+        if let configuration: [String: Any] = try? data.decode("configuration"),
+           let iceServers = configuration["iceServers"] as? [[String: Any]] {
+            for server in iceServers {
+                let urls: [String]
+                if let url = server["urls"] as? String {
+                    urls = [url]
+                } else if let urlList = server["urls"] as? [String] {
+                    urls = urlList
+                } else {
+                    continue
+                }
+                servers.append(RTCIceServer(
+                    urlStrings: urls,
+                    username: server["username"] as? String,
+                    credential: server["credential"] as? String
+                ))
+            }
+        }
+        self.iceServers = servers.isEmpty ? Self.fallback.iceServers : servers
+        self.dataChannelLabel = try? data.decode("dataChannel")
+        self.getCandidatesUpfront = (try? data.decode("getCandidatesUpfront")) ?? false
+    }
+}

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
@@ -95,7 +95,8 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
             .onChange(of: viewModel.didFail) { didFail in
                 // Any WebRTC failure (ICE failure, signaling error, timeout) cascades to the next
                 // streaming method — HLS works remotely where a TURN-less WebRTC path can't.
-                if didFail {
+                // Unsupported-camera failures already cascade via `isWebRTCUnsupported` above.
+                if didFail, !viewModel.isWebRTCUnsupported {
                     onWebRTCUnsupported?()
                 }
             }

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerView.swift
@@ -92,6 +92,13 @@ struct WebRTCVideoPlayerView: View, AppCameraView {
                     onWebRTCUnsupported?()
                 }
             }
+            .onChange(of: viewModel.didFail) { didFail in
+                // Any WebRTC failure (ICE failure, signaling error, timeout) cascades to the next
+                // streaming method — HLS works remotely where a TURN-less WebRTC path can't.
+                if didFail {
+                    onWebRTCUnsupported?()
+                }
+            }
             .onChange(of: viewModel.showLoader) { showLoader in
                 self.showLoader.wrappedValue = showLoader
             }

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewController.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCVideoPlayerViewController.swift
@@ -23,15 +23,15 @@ class WebRTCVideoPlayerViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupVideoView()
+        // The peer connection is created after the client config is fetched, so the renderer is
+        // registered up front and attached by the view model once the connection exists.
+        viewModel.attach(renderer: remoteVideoView)
         viewModel.start()
-        if let client = viewModel.webRTCClient {
-            client.renderRemoteVideo(to: remoteVideoView)
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        viewModel.webRTCClient?.closeConnection()
+        viewModel.stop()
     }
 
     private func setupVideoView() {
@@ -54,7 +54,7 @@ extension WebRTCVideoPlayerViewController: RTCVideoViewDelegate {
     func videoView(_ videoView: RTCVideoRenderer, didChangeVideoSize size: CGSize) {
         // Hide loader when the first frame is rendered
         DispatchQueue.main.async { [weak self] in
-            self?.viewModel.showLoader = false
+            self?.viewModel.handleVideoRendered()
             self?.onVideoStarted?()
             self?.onVideoSizeChanged?(size)
         }

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
@@ -146,7 +146,7 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
         client.offer(waitForCandidates: configuration.getCandidatesUpfront) { [weak self] sdp in
             DispatchQueue.main.async {
                 guard let self, token == self.connectionToken else { return }
-                sendOffer(sdp, api: api)
+                self.sendOffer(sdp, api: api)
             }
         }
     }

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
@@ -105,6 +105,9 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
 
         guard let api = Current.api(for: server) else {
             assertionFailure("API for server is nil")
+            // Fail instead of returning silently so the player falls back rather than
+            // leaving the loader spinning with no connection attempt.
+            handleFailure(reason: nil)
             return
         }
 

--- a/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
+++ b/Sources/App/Cameras/CameraPlayer/WebRTC/WebRTCViewPlayerViewModel.swift
@@ -9,6 +9,7 @@ enum WebRTCSignalType: String {
     case session
     case answer
     case candidate
+    case error
     case unknown
 
     init(_ raw: String) {
@@ -18,13 +19,24 @@ enum WebRTCSignalType: String {
 
 final class WebRTCViewPlayerViewModel: ObservableObject {
     enum Constants: String {
+        case clientConfig = "camera/webrtc/get_client_config"
         case offer = "camera/webrtc/offer"
-        case cadidate = "camera/webrtc/candidate"
+        case candidate = "camera/webrtc/candidate"
     }
+
+    /// How long to wait for the first rendered frame before giving up so callers can fall back
+    /// to HLS instead of showing a spinner forever (e.g. remote connections that need TURN).
+    private static let connectionTimeout: TimeInterval = 15
 
     var webRTCClient: WebRTCClient?
     private var sessionId: String?
     private var pendingCandidates: [RTCIceCandidate] = []
+    private var offerSubscription: HACancellable?
+    private var timeoutWorkItem: DispatchWorkItem?
+    /// Regenerated on every start/teardown so async setup steps (config fetch, offer creation)
+    /// from a previous attempt are ignored instead of resurrecting a torn-down connection.
+    private var connectionToken = UUID()
+    private weak var renderer: RTCVideoRenderer?
     private let server: Server
     private let cameraEntityId: String
     private let supportsTalkback: Bool
@@ -35,15 +47,25 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
     @Published var isWebRTCUnsupported: Bool = false
     @Published var isTalkbackSupported: Bool = false
     @Published var isTalking: Bool = false
+    /// Set when the stream can't be established (offer rejected, signaling error, ICE failure or
+    /// timeout), so the in-app player can cascade to the next streaming method.
+    @Published var didFail: Bool = false
 
-    /// Invoked on offer rejection or ICE failure. Used by the notification extension to fall back;
-    /// the SwiftUI player leaves it `nil` and observes the published properties instead.
+    /// Invoked on offer rejection, signaling error, ICE failure or timeout. Used by the
+    /// notification extension to fall back; the SwiftUI player leaves it `nil` and observes the
+    /// published properties instead.
     var onFailure: (() -> Void)?
 
     init(server: Server, cameraEntityId: String, supportsTalkback: Bool = false) {
         self.server = server
         self.cameraEntityId = cameraEntityId
         self.supportsTalkback = supportsTalkback
+    }
+
+    deinit {
+        offerSubscription?.cancel()
+        timeoutWorkItem?.cancel()
+        webRTCClient?.closeConnection()
     }
 
     func toggleTalkback() {}
@@ -59,63 +81,147 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
         isMuted = webRTCClient.isAudioMuted()
     }
 
+    /// Registers the view that remote video frames should be rendered into. The peer connection is
+    /// created asynchronously (after the client config is fetched), so the renderer is stored and
+    /// attached once the connection exists.
+    func attach(renderer: RTCVideoRenderer) {
+        self.renderer = renderer
+        webRTCClient?.renderRemoteVideo(to: renderer)
+    }
+
+    /// Called when the first frame is rendered.
+    func handleVideoRendered() {
+        cancelTimeout()
+        showLoader = false
+    }
+
     // MARK: - WebRTC
 
     func start() {
-        webRTCClient = nil
-        webRTCClient = WebRTCClient(iceServers: AppConstants.WebRTC.iceServers)
-        guard let webRTCClient else {
-            assertionFailure("WebRTCClient initialization failed")
+        tearDownConnection()
+        showLoader = true
+        failureReason = nil
+        didFail = false
+
+        guard let api = Current.api(for: server) else {
+            assertionFailure("API for server is nil")
             return
         }
-        webRTCClient.delegate = self
-        webRTCClient.offer { [weak self] sdp in
-            guard let self else {
-                assertionFailure("Self is nil in WebRTCViewPlayerViewModel.start")
-                return
-            }
-            guard let api = Current.api(for: server) else {
-                assertionFailure("API for server is nil")
-                return
-            }
 
-            api.connection.subscribe(to: .init(type: .webSocket(Constants.offer.rawValue), data: [
-                "entity_id": cameraEntityId,
-                "offer": sdp.sdp,
-            ])) { [weak self] result in
-                switch result {
-                case let .success(data):
-                    Current.Log.verbose("WebRTC offer sent successfully: \(data)")
-                case let .failure(error):
-                    Current.Log.error("Failed to send WebRTC offer: \(error.localizedDescription)")
-                    self?.showLoader = false
-                    self?.failureReason = error.localizedDescription
-                    // Check if the error indicates WebRTC is not supported
-                    if error.localizedDescription.contains("does not support WebRTC") ||
-                        error.localizedDescription.contains("frontend_stream_types") {
-                        self?.isWebRTCUnsupported = true
-                    }
-                    self?.onFailure?()
-                }
-            } handler: { [weak self] _, data in
-                guard let self else { return }
-                guard let typeString: String = try? data.decode("type") else {
-                    assertionFailure("Failed to decode type from data")
-                    return
-                }
-                let type = WebRTCSignalType(typeString)
-                switch type {
-                case .session:
-                    handleSession(data)
-                case .answer:
-                    handleAnswer(data)
-                case .candidate:
-                    handleCandidate(data)
-                case .unknown:
-                    debugPrint("Unknown type: \(typeString)")
-                }
+        scheduleTimeout()
+        let token = connectionToken
+
+        // Same flow as the frontend player: ask the server for the client configuration (ICE
+        // servers, including any user-configured TURN, and trickle-ICE support) before creating
+        // the peer connection.
+        api.connection.send(.init(type: .webSocket(Constants.clientConfig.rawValue), data: [
+            "entity_id": cameraEntityId,
+        ])).promise.pipe { [weak self] result in
+            switch result {
+            case let .fulfilled(data):
+                self?.startConnection(configuration: .init(data: data), api: api, token: token)
+            case let .rejected(error):
+                Current.Log.error("WebRTC client config fetch failed, using fallback: \(error.localizedDescription)")
+                self?.startConnection(configuration: .fallback, api: api, token: token)
             }
         }
+    }
+
+    func stop() {
+        cancelTimeout()
+        tearDownConnection()
+    }
+
+    private func startConnection(configuration: WebRTCClientConfiguration, api: HomeAssistantAPI, token: UUID) {
+        guard token == connectionToken else { return }
+        let client = WebRTCClient(configuration: configuration)
+        webRTCClient = client
+        client.delegate = self
+        if let renderer {
+            client.renderRemoteVideo(to: renderer)
+        }
+        client.offer(waitForCandidates: configuration.getCandidatesUpfront) { [weak self] sdp in
+            DispatchQueue.main.async {
+                guard let self, token == self.connectionToken else { return }
+                sendOffer(sdp, api: api)
+            }
+        }
+    }
+
+    private func sendOffer(_ sdp: String, api: HomeAssistantAPI) {
+        offerSubscription = api.connection.subscribe(to: .init(type: .webSocket(Constants.offer.rawValue), data: [
+            "entity_id": cameraEntityId,
+            "offer": sdp,
+        ]), initiated: { [weak self] result in
+            switch result {
+            case let .success(data):
+                Current.Log.verbose("WebRTC offer sent successfully: \(data)")
+            case let .failure(error):
+                Current.Log.error("Failed to send WebRTC offer: \(error.localizedDescription)")
+                // Check if the error indicates WebRTC is not supported
+                if error.localizedDescription.contains("does not support WebRTC") ||
+                    error.localizedDescription.contains("frontend_stream_types") {
+                    self?.isWebRTCUnsupported = true
+                }
+                self?.handleFailure(reason: error.localizedDescription)
+            }
+        }, handler: { [weak self] _, data in
+            guard let self else { return }
+            guard let typeString: String = try? data.decode("type") else {
+                assertionFailure("Failed to decode type from data")
+                return
+            }
+            let type = WebRTCSignalType(typeString)
+            switch type {
+            case .session:
+                handleSession(data)
+            case .answer:
+                handleAnswer(data)
+            case .candidate:
+                handleCandidate(data)
+            case .error:
+                handleErrorEvent(data)
+            case .unknown:
+                Current.Log.warning("Unknown WebRTC signal type: \(typeString)")
+            }
+        })
+    }
+
+    private func tearDownConnection() {
+        connectionToken = UUID()
+        offerSubscription?.cancel()
+        offerSubscription = nil
+        webRTCClient?.closeConnection()
+        webRTCClient = nil
+        sessionId = nil
+        pendingCandidates.removeAll()
+    }
+
+    private func scheduleTimeout() {
+        timeoutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard showLoader, failureReason == nil else { return }
+            Current.Log.error("WebRTC stream for \(cameraEntityId) timed out before first frame")
+            handleFailure(reason: nil)
+        }
+        timeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.connectionTimeout, execute: workItem)
+    }
+
+    private func cancelTimeout() {
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+    }
+
+    private func handleFailure(reason: String?) {
+        cancelTimeout()
+        showLoader = false
+        if let reason {
+            failureReason = reason
+        }
+        didFail = true
+        onFailure?()
     }
 
     private func handleSession(_ data: HAData) {
@@ -144,12 +250,10 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
     }
 
     private func handleCandidate(_ data: HAData) {
-        guard let candidateDict: [String: Any] = try? data.decode("candidate") else {
-            assertionFailure("Failed to decode candidate from data")
-            return
-        }
-        guard let candidateStr = candidateDict["candidate"] as? String else {
-            assertionFailure("Missing candidate string in candidateDict")
+        guard let candidateDict: [String: Any] = try? data.decode("candidate"),
+              let candidateStr = candidateDict["candidate"] as? String,
+              !candidateStr.isEmpty else {
+            // An empty/null candidate signals end-of-candidates; nothing to add.
             return
         }
         let sdpMLineIndex = candidateDict["sdpMLineIndex"] as? Int32 ?? 0
@@ -161,9 +265,16 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
         )
         webRTCClient?.set(remoteCandidate: candidate) { error in
             if let error {
-                print("Failed to add remote candidate: \(error)")
+                Current.Log.error("Failed to add remote candidate: \(error.localizedDescription)")
             }
         }
+    }
+
+    private func handleErrorEvent(_ data: HAData) {
+        let code: String? = try? data.decode("code")
+        let message: String? = try? data.decode("message")
+        Current.Log.error("WebRTC signaling error (\(code ?? "unknown")): \(message ?? "no message")")
+        handleFailure(reason: message ?? code)
     }
 
     private func sendCandidate(_ candidate: RTCIceCandidate) {
@@ -177,7 +288,7 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
             return
         }
         // Send candidate to backend
-        api.connection.send(.init(type: .webSocket(Constants.cadidate.rawValue), data: [
+        api.connection.send(.init(type: .webSocket(Constants.candidate.rawValue), data: [
             "entity_id": cameraEntityId,
             "session_id": sessionId,
             "candidate": [
@@ -198,14 +309,21 @@ final class WebRTCViewPlayerViewModel: ObservableObject {
 
 extension WebRTCViewPlayerViewModel: WebRTCClientDelegate {
     func webRTCClient(_ client: WebRTCClient, didDiscoverLocalCandidate candidate: RTCIceCandidate) {
-        sendCandidate(candidate)
+        // WebRTC delegate callbacks arrive on its signaling thread; all view model state is
+        // main-thread confined.
+        DispatchQueue.main.async { [weak self] in
+            self?.sendCandidate(candidate)
+        }
     }
 
     func webRTCClient(_ client: WebRTCClient, didChangeConnectionState state: RTCIceConnectionState) {
-        debugPrint(state)
         Current.Log.info("WebRTC connection state changed to: \(state)")
-        if state == .failed {
-            onFailure?()
+        guard state == .failed else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            // Ignore state changes from a connection that was already torn down/replaced.
+            guard client === webRTCClient else { return }
+            handleFailure(reason: nil)
         }
     }
 

--- a/Sources/Extensions/NotificationContent/CameraStreamWebRTCViewController.swift
+++ b/Sources/Extensions/NotificationContent/CameraStreamWebRTCViewController.swift
@@ -69,7 +69,7 @@ final class CameraStreamWebRTCViewController: UIViewController, CameraStreamHand
 
     deinit {
         timeoutWorkItem?.cancel()
-        viewModel.webRTCClient?.closeConnection()
+        viewModel.stop()
     }
 
     override func viewDidLoad() {
@@ -129,7 +129,7 @@ final class CameraStreamWebRTCViewController: UIViewController, CameraStreamHand
     private func detachPlayer() {
         timeoutWorkItem?.cancel()
         timeoutWorkItem = nil
-        viewModel.webRTCClient?.closeConnection()
+        viewModel.stop()
         playerViewController?.willMove(toParent: nil)
         playerViewController?.view.removeFromSuperview()
         playerViewController?.removeFromParent()
@@ -163,7 +163,7 @@ final class CameraStreamWebRTCViewController: UIViewController, CameraStreamHand
         hasResolved = true
         // Tear down the peer connection now rather than waiting for deinit, so we don't keep a
         // failed/timed-out connection alive while the cascade falls back to HLS/MJPEG.
-        viewModel.webRTCClient?.closeConnection()
+        viewModel.stop()
         seal.reject(WebRTCError.unavailable)
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
WebRTC cameras often failed to play when connecting remotely: the app hardcoded two STUN servers and never fetched the server's WebRTC client configuration, so user-configured TURN servers (needed when UDP hole punching fails, e.g. on cellular/CGNAT) were ignored — and on ICE failure the player showed an infinite spinner.

This mirrors the web frontend's player flow:
- Fetch `camera/webrtc/get_client_config` before creating the peer connection and use the server-provided ICE servers (including TURN credentials), falling back to the bundled STUN list.
- Honor `getCandidatesUpfront` for backends without trickle ICE, open the backend-requested data channel, handle `error` signaling events, and use receive-only transceivers instead of a dummy local send track.
- Surface ICE failure, signaling errors and a 15s first-frame timeout so the in-app player falls back to HLS instead of spinning forever; retain and cancel the offer subscription on teardown so it no longer leaks on the shared WebSocket connection.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
