### PR TITLE
Force dark mode in CameraPlayerView

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -57,6 +57,8 @@ struct CameraPlayerView: View {
         }
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)
+        // Camera playback is a full-screen video experience, always presented in dark mode.
+        .preferredColorScheme(.dark)
     }
 
     private var navigationStack: some View {

--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -57,7 +57,6 @@ struct CameraPlayerView: View {
         }
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)
-        // Camera playback is a full-screen video experience, always presented in dark mode.
         .preferredColorScheme(.dark)
     }
 


### PR DESCRIPTION
## Summary
The camera player is a full-screen video experience, but its chrome (navigation bar, close button, camera-picker menu, loader) followed the system appearance, rendering in light mode over dark video content. This change adds `.preferredColorScheme(.dark)` to the root of `CameraPlayerView`'s body so the entire presentation always renders in dark mode, regardless of the device's light/dark setting. Applying it on the view itself covers all three presentation paths (external message bus, `homeassistant://` deep links, and kiosk camera notifications) with a single change.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The player now always renders in dark appearance; light mode no longer applies to this screen.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behavior changes beyond appearance; the WebRTC/HLS/MJPEG fallback logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZK9mDkyqFtCp6AmCZFGEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZK9mDkyqFtCp6AmCZFGEu)_