### PR TITLE
Run watch magic item execution off the Swift-concurrency pool

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -193,24 +193,36 @@ public class HomeAssistantAPI {
         return URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
     }
 
-    public static func apiAvailabilityCheck(for server: Server, timeout: TimeInterval = 5) async -> Bool {
-        var connectionInfo = server.info.connection
-        guard let baseURL = await connectionInfo.activeURL() else {
-            return false
+    /// Callback-based on purpose (its only caller is the watch's magic item execution): watchOS
+    /// gives the Swift-concurrency cooperative pool a single thread, and a starved pool would keep
+    /// an async check from ever running. The URL is evaluated from the last-known network state,
+    /// which is always current on watchOS.
+    public static func apiAvailabilityCheck(
+        for server: Server,
+        timeout: TimeInterval = 5,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard let baseURL = server.activeURLUsingLastKnownNetworkState() else {
+            completion(false)
+            return
         }
 
         var request = URLRequest(url: baseURL.appendingPathComponent("api"))
         request.timeoutInterval = timeout
 
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
-        defer { session.finishTasksAndInvalidate() }
-        do {
-            let (_, response) = try await session.data(for: request)
-            return response is HTTPURLResponse
-        } catch {
-            Current.Log.info("API availability check failed for \(server.info.name): \(error.localizedDescription)")
-            return false
+        let task = session.dataTask(with: request) { [session] _, response, error in
+            // The session strongly retains its delegate until invalidated; do it once the task ends.
+            defer { session.finishTasksAndInvalidate() }
+            if let error {
+                Current.Log
+                    .info("API availability check failed for \(server.info.name): \(error.localizedDescription)")
+                completion(false)
+                return
+            }
+            completion(response is HTTPURLResponse)
         }
+        task.resume()
     }
 
     convenience init?() {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -560,26 +560,27 @@ public extension MagicItem {
             return
         }
 
-        Task {
-            guard let baseURL = await server.activeURL() else {
-                Current.Log.error("No active URL while executing magic item \(id) on watch")
-                completion(false, ServerConnectionError.noActiveURL(server.info.name))
-                return
-            }
+        // No Swift concurrency on this path: watchOS gives the cooperative pool a single thread,
+        // and a starved pool left taps hanging before the request ever started. The synchronous
+        // URL evaluation is equivalent — on watchOS the last-known network state is always current.
+        guard let baseURL = server.activeURLUsingLastKnownNetworkState() else {
+            Current.Log.error("No active URL while executing magic item \(id) on watch")
+            completion(false, ServerConnectionError.noActiveURL(server.info.name))
+            return
+        }
 
-            let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
-            tokenManager.bearerToken.done { token, _ in
-                self.sendRESTServiceCall(
-                    baseURL: baseURL,
-                    server: server,
-                    token: token,
-                    serviceCall: serviceCall,
-                    completion: completion
-                )
-            }.catch { error in
-                Current.Log.error("Token unavailable executing magic item \(self.id): \(error.localizedDescription)")
-                completion(false, error)
-            }
+        let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+        tokenManager.bearerToken.done { token, _ in
+            self.sendRESTServiceCall(
+                baseURL: baseURL,
+                server: server,
+                token: token,
+                serviceCall: serviceCall,
+                completion: completion
+            )
+        }.catch { error in
+            Current.Log.error("Token unavailable executing magic item \(self.id): \(error.localizedDescription)")
+            completion(false, error)
         }
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -183,11 +183,26 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         let magicItem = item
         Current.Log.verbose("Selected magic item id: \(magicItem.id)")
         startTimeoutTimerWhichResetsState(completion: completion)
-        Task { [weak self] in
-            // First evidence the task got scheduled at all — the watch's cooperative thread pool is
-            // tiny, and a starved pool means this line never appears in the trace.
-            self?.trace?.log(.info, "Execution task started")
-            await self?.routeExecution(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+        // The execution runs on GCD, not Swift concurrency: watchOS gives the cooperative pool a
+        // single thread, and a starved pool (seen on hardware) meant the old `Task`-based execution
+        // never even started. Every step of this path is synchronous or callback-based.
+        startConcurrencyPoolCanary()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.trace?.log(.info, "Execution started")
+            self?.routeExecution(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+        }
+    }
+
+    /// Verbose-trace diagnostic for the failure mode that used to swallow executions: schedules a
+    /// no-op `Task` and records how long the cooperative pool took to run it. The execution itself
+    /// no longer depends on the pool, so a starved pool shows up here as a late (or missing)
+    /// canary entry instead of a hang.
+    private func startConcurrencyPoolCanary() {
+        guard let trace else { return }
+        let scheduled = Current.date()
+        Task {
+            let elapsed = String(format: "%.2fs", Current.date().timeIntervalSince(scheduled))
+            trace.log(.info, "Swift-concurrency pool canary ran after \(elapsed)", isProgress: false)
         }
     }
 
@@ -199,38 +214,46 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         magicItem: MagicItem,
         timeTriggered: Date,
         completion: @escaping (MagicItemResponse) -> Void
-    ) async {
+    ) {
         let target = WatchUserDefaults.shared.effectivePerformActionTarget
-        await logExecutionContext(magicItem: magicItem, target: target)
+        logExecutionContext(magicItem: magicItem, target: target)
         switch target {
         case .iPhone:
             executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         case .appleWatch:
-            await Current.connectivity.refreshNetworkInformation()
             executeViaWatch(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
         case .auto:
+            guard let server = Current.servers.all
+                .first(where: { $0.identifier.rawValue == magicItem.serverId }) else {
+                Current.Log.info("Auto: server not synced to the watch, relaying via iPhone")
+                trace?.log(.error, "Server \(magicItem.serverId) not synced to the watch — relaying via iPhone")
+                executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+                return
+            }
             trace?.log(.info, "Pinging Home Assistant directly from the watch…")
             let pingStarted = Current.date()
-            if let server = Current.servers.all.first(where: { $0.identifier.rawValue == magicItem.serverId }),
-               await HomeAssistantAPI.apiAvailabilityCheck(for: server) {
-                Current.Log.info("Auto: Watch can reach Home Assistant directly, executing on watch")
-                trace?.log(.success, "Reached Home Assistant in \(elapsedText(since: pingStarted))")
-                executeViaWatch(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
-            } else {
-                Current.Log.info("Auto: Watch cannot reach Home Assistant directly, relaying via iPhone")
-                trace?.log(
-                    .error,
-                    "No direct answer after \(elapsedText(since: pingStarted)) — relaying via iPhone"
-                )
-                executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+            HomeAssistantAPI.apiAvailabilityCheck(for: server) { [weak self] available in
+                guard let self else { return }
+                if available {
+                    Current.Log.info("Auto: Watch can reach Home Assistant directly, executing on watch")
+                    trace?.log(.success, "Reached Home Assistant in \(elapsedText(since: pingStarted))")
+                    executeViaWatch(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+                } else {
+                    Current.Log.info("Auto: Watch cannot reach Home Assistant directly, relaying via iPhone")
+                    trace?.log(
+                        .error,
+                        "No direct answer after \(elapsedText(since: pingStarted)) — relaying via iPhone"
+                    )
+                    executeViaiPhone(magicItem: magicItem, timeTriggered: timeTriggered, completion: completion)
+                }
             }
         }
     }
 
     /// Snapshot of everything relevant to routing, recorded at the start of a verbose trace.
-    /// Each potentially blocking call (server list, Wi-Fi lookup) is announced before it runs, so a
+    /// Each potentially blocking call (server list resolution) is announced before it runs, so a
     /// hang pinpoints itself: the last entry in the trace names the step that never returned.
-    private func logExecutionContext(magicItem: MagicItem, target: WatchActionTarget) async {
+    private func logExecutionContext(magicItem: MagicItem, target: WatchActionTarget) {
         guard let trace else { return }
         trace.log(.info, "Running \(magicItem.id) (\(magicItem.type.rawValue)) on server id \(magicItem.serverId)")
         if WatchUserDefaults.shared.allowChoosingMagicItemRoute {
@@ -246,8 +269,9 @@ final class WatchMagicViewRowViewModel: ObservableObject {
             .first(where: { $0.identifier.rawValue == magicItem.serverId })?.info.name
             ?? "unknown (id \(magicItem.serverId))"
         trace.log(.info, "Server: \"\(serverName)\"")
-        trace.log(.info, "Checking watch Wi-Fi…")
-        if let ssid = await Current.connectivity.currentWiFiSSID() {
+        // The last-known state is read synchronously — the watch has no network info of its own,
+        // so this is always current (and the SSID always empty) on watchOS.
+        if let ssid = Current.connectivity.lastKnownNetworkState().ssid {
             trace.log(.info, "Watch Wi-Fi: \(ssid)")
         } else {
             trace.log(.info, "No Wi-Fi on watch (traffic may proxy via iPhone or LTE)")
@@ -310,7 +334,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
 
         timeoutWorkItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            let lastStep = trace?.lastProgressMessage ?? "execution task never started"
+            let lastStep = trace?.lastProgressMessage ?? "execution never started"
             trace?.log(
                 .info,
                 "Still waiting after 4s — row resets while execution continues (last step: \(lastStep))",
@@ -323,7 +347,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         // most likely stuck (not just slow), so leave a trace of the step it never came back from.
         watchdogWorkItem = DispatchWorkItem { [weak self] in
             guard let self, let trace else { return }
-            let lastStep = trace.lastProgressMessage ?? "execution task never started"
+            let lastStep = trace.lastProgressMessage ?? "execution never started"
             trace.log(
                 .error,
                 "Still no result after 15s — execution appears stuck (last step: \(lastStep))",


### PR DESCRIPTION
Watch magic item taps hung with "execution task never started" because watchOS's single-threaded cooperative pool was starved, so the execution `Task` never ran.
The execution path now runs on GCD with callbacks (routing, availability ping, REST call), and the verbose trace schedules a canary `Task` that measures pool health instead of depending on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011KUm5qT7byewHZrV7vE9GG)_