### PR TITLE
Make shake gesture do nothing by default

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -472,6 +472,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func migrateIfNeeded() {
         resetLocalPush()
+        resetShakeGesture()
+    }
+
+    /// Shake gesture no longer opens debug by default, users that had it set to debug are reset once to none
+    private func resetShakeGesture() {
+        if !Current.settingsStore.migratedShakeGestureToNone {
+            if Current.settingsStore.gestures[.shake] == .openDebug {
+                Current.settingsStore.gestures[.shake] = HAGestureAction.none
+                Current.Log.info("Reset shake gesture from open debug to none due to migration")
+            }
+            Current.settingsStore.migratedShakeGestureToNone = true
+        }
     }
 
     /// Local push becomes opt-in on 2025.6, users will have local push reset and need to re-enable it

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -475,11 +475,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         resetShakeGesture()
     }
 
-    /// Shake gesture no longer opens debug by default, users that had it set to debug are reset once to none
+    /// Shake gesture no longer opens debug by default; users who had it set to debug are reset once to none.
     private func resetShakeGesture() {
         if !Current.settingsStore.migratedShakeGestureToNone {
-            if Current.settingsStore.gestures[.shake] == .openDebug {
-                Current.settingsStore.gestures[.shake] = HAGestureAction.none
+            var gestures = Current.settingsStore.gestures
+            if gestures[.shake] == .openDebug {
+                gestures[.shake] = HAGestureAction.none
+                Current.settingsStore.gestures = gestures
                 Current.Log.info("Reset shake gesture from open debug to none due to migration")
             }
             Current.settingsStore.migratedShakeGestureToNone = true

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
@@ -321,7 +321,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
-            let action = Current.settingsStore.gestures[.shake] ?? .openDebug
+            let action = Current.settingsStore.gestures[.shake] ?? .none
             webViewGestureHandler.handleGestureAction(action)
         }
     }

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -205,7 +205,7 @@ public extension [AppGesture: HAGestureAction] {
             ._3FingersSwipeUp: .showServersList,
             ._3FingersSwipeRight: .nextServer,
             ._3FingersSwipeLeft: .previousServer,
-            .shake: .openDebug,
+            .shake: .none,
         ]
     }
 

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -307,6 +307,16 @@ public class SettingsStore {
         }
     }
 
+    /// Shake gesture no longer opens debug by default, users that had it set to debug are reset once to none
+    public var migratedShakeGestureToNone: Bool {
+        get {
+            prefs.bool(forKey: "migratedShakeGestureToNone")
+        }
+        set {
+            prefs.set(newValue, forKey: "migratedShakeGestureToNone")
+        }
+    }
+
     public var periodicUpdateInterval: TimeInterval? {
         get {
             if prefs.object(forKey: "periodicUpdateInterval") == nil {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -307,7 +307,7 @@ public class SettingsStore {
         }
     }
 
-    /// Shake gesture no longer opens debug by default, users that had it set to debug are reset once to none
+    /// Shake gesture no longer opens debug by default; users who had it set to debug are reset once to none.
     public var migratedShakeGestureToNone: Bool {
         get {
             prefs.bool(forKey: "migratedShakeGestureToNone")


### PR DESCRIPTION
Shake was defaulting to opening the debug screen. The default is now
none, both in defaultGestures and in the motionEnded fallback. Existing
users who have shake mapped to open debug are reset once to none via a
one-time migration at launch, following the existing resetLocalPush
pattern; afterwards they can still opt back in from gesture settings or
the debug screen toggle.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016jfbp9eDW3QLFXrm4VEp74