### PR TITLE
Protect background database access from 0xdead10cc suspension kills

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GRDB
 import PromiseKit
 import Shared
 import UIKit
@@ -81,7 +80,7 @@ class LifecycleManager {
 
     @objc private func willEnterForeground() {
         isActive = true
-        NotificationCenter.default.post(name: Database.resumeNotification, object: self)
+        AppDatabaseSuspension.resume()
         refreshNetworkInformation()
         syncLiveActivities()
     }
@@ -98,7 +97,7 @@ class LifecycleManager {
 
     @objc private func didEnterBackground() {
         isActive = false
-        NotificationCenter.default.post(name: Database.suspendNotification, object: self)
+        AppDatabaseSuspension.suspend()
         Current.backgroundTask(withName: BackgroundTask.lifecycleManagerDidEnterBackground.rawValue) { _ in
             when(fulfilled: Current.apis.map { api in
                 api.CreateEvent(

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -131,17 +131,102 @@ public extension DatabaseQueue {
     }
 }
 
-/// Posts GRDB's database suspension notifications without requiring callers to import GRDB
+/// Coordinates GRDB's database suspension notifications without requiring callers to import GRDB
 /// (app targets don't all link it directly). Suspending while backgrounded prevents the system from
 /// killing the process with 0xdead10cc for holding the app-group SQLite file lock during suspension —
 /// see https://github.com/groue/GRDB.swift/issues/1626.
-public enum AppDatabaseSuspension {
+public final class AppDatabaseSuspension {
+    public static let shared = AppDatabaseSuspension()
+
+    private let lock = NSLock()
+    /// Whether the lifecycle currently wants the database suspended (set on background, cleared on
+    /// foreground). Accesses that arrive while this is set resume GRDB only under an expiring
+    /// activity that re-suspends it before the process is frozen (see `resumeForAccess`).
+    private var wantsSuspension = false
+    /// Parks the thread of the currently-armed expiring activity; nil when none is armed.
+    private var activitySemaphore: DispatchSemaphore?
+
+    private let performExpiringActivity: (String, @escaping (Bool) -> Void) -> Void
+    private let postNotification: (Notification.Name) -> Void
+
+    /// The defaults are the real system behaviors; tests inject recorders into a dedicated instance
+    /// so parallel suites can't interfere through shared state.
+    init(
+        performExpiringActivity: @escaping (String, @escaping (Bool) -> Void) -> Void = { reason, block in
+            ProcessInfo.processInfo.performExpiringActivity(withReason: reason, using: block)
+        },
+        postNotification: @escaping (Notification.Name) -> Void = { name in
+            NotificationCenter.default.post(name: name, object: nil)
+        }
+    ) {
+        self.performExpiringActivity = performExpiringActivity
+        self.postNotification = postNotification
+    }
+
     public static func suspend() {
-        NotificationCenter.default.post(name: Database.suspendNotification, object: nil)
+        shared.suspend()
     }
 
     public static func resume() {
-        NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
+        shared.resume()
+    }
+
+    public func suspend() {
+        lock.lock()
+        wantsSuspension = true
+        lock.unlock()
+        postNotification(Database.suspendNotification)
+    }
+
+    public func resume() {
+        lock.lock()
+        wantsSuspension = false
+        let parked = activitySemaphore
+        activitySemaphore = nil
+        lock.unlock()
+        postNotification(Database.resumeNotification)
+        // The app is interactive again; release the protection activity, if one was armed.
+        parked?.signal()
+    }
+
+    /// Resumes the database for an access that may happen while the app is backgrounded (App Intents,
+    /// background refresh, pushes, …). A plain resume there would defeat the suspension entirely and
+    /// leave the access exposed to 0xdead10cc, so when the lifecycle has asked for suspension the
+    /// resume is paired with a system expiring activity: the process is kept alive while the access
+    /// runs, and when the activity expires — right before the process would be frozen — GRDB is
+    /// re-suspended so no statement is caught holding the app-group SQLite file lock.
+    func resumeForAccess() {
+        lock.lock()
+        let needsProtection = wantsSuspension && activitySemaphore == nil
+        var parked: DispatchSemaphore?
+        if needsProtection {
+            parked = DispatchSemaphore(value: 0)
+            activitySemaphore = parked
+        }
+        lock.unlock()
+
+        // Resume synchronously so the caller's access can proceed immediately (keeping
+        // background-woken accesses like App Intents from aborting mid-shortcut).
+        postNotification(Database.resumeNotification)
+
+        guard let parked else { return }
+        performExpiringActivity("database-background-access") { [self] expired in
+            if expired {
+                lock.lock()
+                let isCurrent = activitySemaphore === parked
+                if isCurrent { activitySemaphore = nil }
+                lock.unlock()
+                // A stale expiration (the app foregrounded, or a newer activity took over) must not
+                // re-suspend the now-active database.
+                guard isCurrent else { return }
+                postNotification(Database.suspendNotification)
+                parked.signal()
+            } else {
+                // Hold the activity (keeping the process alive and the database usable) until the
+                // app foregrounds or the system expires it.
+                parked.wait()
+            }
+        }
     }
 }
 

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -136,7 +136,7 @@ public extension DatabaseQueue {
 /// killing the process with 0xdead10cc for holding the app-group SQLite file lock during suspension —
 /// see https://github.com/groue/GRDB.swift/issues/1626.
 public final class AppDatabaseSuspension {
-    public static let shared = AppDatabaseSuspension()
+    static let shared = AppDatabaseSuspension()
 
     private let lock = NSLock()
     /// Whether the lifecycle currently wants the database suspended (set on background, cleared on
@@ -171,14 +171,14 @@ public final class AppDatabaseSuspension {
         shared.resume()
     }
 
-    public func suspend() {
+    func suspend() {
         lock.lock()
         wantsSuspension = true
         lock.unlock()
         postNotification(Database.suspendNotification)
     }
 
-    public func resume() {
+    func resume() {
         lock.lock()
         wantsSuspension = false
         let parked = activitySemaphore

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -199,8 +199,11 @@ public class AppEnvironment {
 
     public var database: () -> DatabaseQueue = {
         // App Intents can run in a background-woken process without a foreground transition,
-        // leaving the DB suspended; resume it here so accesses don't abort mid-shortcut.
-        NotificationCenter.default.post(name: Database.resumeNotification, object: nil)
+        // leaving the DB suspended; resume it here so accesses don't abort mid-shortcut. While
+        // backgrounded the resume is protected by an expiring activity that re-suspends GRDB
+        // before the process freezes, so no access is caught holding the app-group SQLite file
+        // lock (0xdead10cc).
+        AppDatabaseSuspension.shared.resumeForAccess()
         return .appDatabase
     }
 

--- a/Tests/Shared/Database/AppDatabaseSuspension.test.swift
+++ b/Tests/Shared/Database/AppDatabaseSuspension.test.swift
@@ -1,0 +1,122 @@
+import Foundation
+import GRDB
+@testable import Shared
+import Testing
+
+@Suite("AppDatabaseSuspension")
+struct AppDatabaseSuspensionTests {
+    /// Records the notifications posted and expiring-activity blocks armed by an instance under test.
+    private final class Recorder {
+        private let lock = NSLock()
+        private var postedNames: [Notification.Name] = []
+        private var activityBlocks: [(Bool) -> Void] = []
+
+        var posted: [Notification.Name] {
+            lock.lock()
+            defer { lock.unlock() }
+            return postedNames
+        }
+
+        var armedActivities: [(Bool) -> Void] {
+            lock.lock()
+            defer { lock.unlock() }
+            return activityBlocks
+        }
+
+        func recordPost(_ name: Notification.Name) {
+            lock.lock()
+            postedNames.append(name)
+            lock.unlock()
+        }
+
+        func recordActivity(_ block: @escaping (Bool) -> Void) {
+            lock.lock()
+            activityBlocks.append(block)
+            lock.unlock()
+        }
+    }
+
+    private func makeSuspension() -> (AppDatabaseSuspension, Recorder) {
+        let recorder = Recorder()
+        let suspension = AppDatabaseSuspension(
+            performExpiringActivity: { _, block in recorder.recordActivity(block) },
+            postNotification: { recorder.recordPost($0) }
+        )
+        return (suspension, recorder)
+    }
+
+    @Test("Foreground access resumes without arming an expiring activity")
+    func foregroundAccessDoesNotArmActivity() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.resumeForAccess()
+
+        #expect(recorder.posted == [Database.resumeNotification])
+        #expect(recorder.armedActivities.isEmpty)
+    }
+
+    @Test("Background access resumes under an expiring activity that re-suspends on expiry")
+    func backgroundAccessArmsActivityAndExpiryResuspends() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.suspend()
+        #expect(recorder.posted == [Database.suspendNotification])
+
+        suspension.resumeForAccess()
+        #expect(recorder.posted == [Database.suspendNotification, Database.resumeNotification])
+        #expect(recorder.armedActivities.count == 1)
+
+        // Expiry re-suspends so nothing is caught holding the SQLite file lock (0xdead10cc).
+        recorder.armedActivities[0](true)
+        #expect(recorder.posted.last == Database.suspendNotification)
+
+        // A later access re-arms a fresh activity.
+        suspension.resumeForAccess()
+        #expect(recorder.armedActivities.count == 2)
+    }
+
+    @Test("Repeated background accesses share a single expiring activity")
+    func onlyOneActivityArmedAtATime() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.suspend()
+        suspension.resumeForAccess()
+        suspension.resumeForAccess()
+
+        #expect(recorder.armedActivities.count == 1)
+    }
+
+    @Test("Foreground resume releases the parked expiring activity")
+    func resumeReleasesParkedActivity() throws {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.suspend()
+        suspension.resumeForAccess()
+        let block = try #require(recorder.armedActivities.first)
+
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            // The non-expired invocation parks until foreground resume (or expiry).
+            block(false)
+            finished.signal()
+        }
+
+        suspension.resume()
+        #expect(finished.wait(timeout: .now() + 5) == .success)
+    }
+
+    @Test("A stale expiration after foreground resume does not re-suspend")
+    func staleExpirationDoesNotSuspend() throws {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.suspend()
+        suspension.resumeForAccess()
+        let block = try #require(recorder.armedActivities.first)
+
+        suspension.resume()
+        let postedBeforeExpiry = recorder.posted
+
+        block(true)
+        #expect(recorder.posted == postedBeforeExpiry)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a TestFlight crash (2026.8.0/2026.2428): `RUNNINGBOARD 0xdead10cc` — the OS killed the app for holding the app-group SQLite file lock while being suspended, with a GRDB read mid-flight on a background queue.

The existing mitigation (suspend GRDB on `didEnterBackground`, `observesSuspensionNotifications`) was being defeated: every `Current.database()` access unconditionally posted `Database.resumeNotification` (added so background-woken App Intents don't abort). Since `didEnterBackground` itself immediately triggers database work (widget updates, lifecycle events), the suspension was undone within milliseconds every time, and nothing re-suspended the database before the process froze — so any background wakeup touching the database was exposed to the kill.

Changes:
- `AppDatabaseSuspension` now tracks whether the lifecycle wants suspension. Database accesses while backgrounded still resume GRDB (keeping App Intents and background refresh working), but under a `ProcessInfo` expiring activity that keeps the process alive while the access runs and re-suspends GRDB when it expires — right before the freeze — so no statement is caught holding the file lock. This mirrors the watch app's proven fix for the same crash cluster (`ExtensionDelegate.performProtectedDatabaseWork`).
- Only one activity is armed at a time; foreground resume releases it, and a stale expiration after foregrounding cannot wrongly re-suspend.
- `LifecycleManager` routes through `AppDatabaseSuspension` instead of posting GRDB notifications directly, so the state tracking stays accurate.
- Worst case, when the system grants no background time, a database access aborts with GRDB's suspension error (the designed failure mode) instead of the process being killed.
- Adds unit tests for the suspension state machine via injected dependencies.

Related: #(claude/crash-analysis-dq8xvq branch) protects the Reminders sync's multi-write runs with a scoped background task for another `0xdead10cc` report. The two compose: that fix's explicit `resume()`/`suspend()` calls hand off cleanly with the access-level protection added here.

## Screenshots
Not applicable — no user-facing changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The crash report shows the process backgrounded for ~5.5 hours, then woken for background work and frozen mid-GRDB-read (thread 10: `queue.sync` into GRDB's `SerializedDatabase` decoding records; thread 11 mid-HTTP-request). `0xdead10cc` is a system termination for holding a file lock in a shared container during suspension, not a code crash — see https://github.com/groue/GRDB.swift/issues/1626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187EWGEn9gXHKkhi6H4UNwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0187EWGEn9gXHKkhi6H4UNwv)_