### PR TITLE
Protect reminders sync from 0xdead10cc suspension kills

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -1,5 +1,6 @@
 import EventKit
 import Foundation
+import PromiseKit
 import Shared
 import UIKit
 
@@ -54,11 +55,40 @@ final class RemindersSyncManager: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.scheduleSync(after: 1)
+                self?.restartPeriodicRefresh()
+            }
+        })
+
+        notificationObservers.append(NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.appDidEnterBackground()
             }
         })
 
         scheduleSync(after: 5)
         restartPeriodicRefresh()
+    }
+
+    /// Backgrounding: stop the debounce and periodic-refresh timers so a sync can't start during
+    /// the background-execution grace window without protection; both are re-armed on the next
+    /// foreground. A sync that is already running is left alone — it holds a background task for
+    /// its whole duration — but `LifecycleManager` has just suspended GRDB underneath it, so
+    /// resume the database for the remainder of the protected sync (this runs after
+    /// LifecycleManager's handler because it hops onto the main actor in a fresh task); `syncAll`
+    /// re-suspends when it finishes.
+    private func appDidEnterBackground() {
+        if isSyncing {
+            AppDatabaseSuspension.resume()
+        } else {
+            pendingSyncTask?.cancel()
+            pendingSyncTask = nil
+            periodicRefreshTask?.cancel()
+            periodicRefreshTask = nil
+        }
     }
 
     /// Called when the user changes the sync settings: restarts the foreground refresh timer and
@@ -142,13 +172,54 @@ final class RemindersSyncManager: ObservableObject {
     }
 
     func syncAll() async {
-        guard !isSyncing else { return }
-        let configs = RemindersSyncConfig.all()
-        guard !configs.isEmpty, authorizationState == .authorized else { return }
+        guard !isSyncing, authorizationState == .authorized else { return }
+
+        // GRDB is suspended whenever the app is backgrounded (LifecycleManager); resume it so the
+        // config read and the sync's writes also work from a background refresh. Every exit path
+        // below re-suspends while still backgrounded.
+        AppDatabaseSuspension.resume()
+        let configs = await Self.databaseAccess { RemindersSyncConfig.all() }
+        guard !configs.isEmpty else {
+            suspendDatabaseIfBackgrounded()
+            return
+        }
 
         isSyncing = true
         suppressStoreChangeSync = true
+
+        // Hold a background task for the duration of the sync: getting suspended while a sync
+        // write was mid-commit held the app-group SQLite file lock and killed the app with
+        // 0xdead10cc (see the suspension notes in GRDB+Initialization.swift).
+        let (untilSyncEnds, syncEndSeal) = Promise<Void>.pending()
+        let syncTask = Task { [weak self] in
+            await self?.sync(configs: configs)
+        }
+        Current.backgroundTask(withName: BackgroundTask.remindersSync.rawValue) { _ in untilSyncEnds }
+            .catch { _ in
+                // Out of background time: stop syncing and suspend GRDB right away, aborting any
+                // in-flight write so the file lock is released before the process is frozen.
+                syncTask.cancel()
+                AppDatabaseSuspension.suspend()
+            }
+        // Backgrounding between the resume above and this point suspends GRDB again
+        // (LifecycleManager); undo that now that the background task is held.
+        AppDatabaseSuspension.resume()
+        await syncTask.value
+        syncEndSeal.fulfill(())
+        suspendDatabaseIfBackgrounded()
+
+        isSyncing = false
+        // EKEventStoreChanged notifications for our own writes can arrive slightly after commit.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            self?.suppressStoreChangeSync = false
+        }
+    }
+
+    private func sync(configs: [RemindersSyncConfig]) async {
         for config in configs {
+            // Cancelled when the background task expires; whatever didn't finish syncs next time.
+            guard !Task.isCancelled else { return }
             do {
                 try await sync(config)
             } catch {
@@ -157,11 +228,24 @@ final class RemindersSyncManager: ObservableObject {
                 )
             }
         }
-        isSyncing = false
-        // EKEventStoreChanged notifications for our own writes can arrive slightly after commit.
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 3_000_000_000)
-            self?.suppressStoreChangeSync = false
+    }
+
+    /// Runs synchronous GRDB access on a background thread instead of the main actor. The
+    /// 0xdead10cc termination this sync used to hit showed the main thread blocked in a commit's
+    /// `fsync`: it couldn't service the `didEnterBackground` notification that suspends GRDB and
+    /// was still holding the app-group SQLite lock when the process was frozen.
+    private nonisolated static func databaseAccess<T: Sendable>(
+        _ access: @escaping @Sendable () -> T
+    ) async -> T {
+        await Task.detached { access() }.value
+    }
+
+    /// Counterpart to `LifecycleManager`'s suspend-on-background: after the sync touches the
+    /// database while backgrounded, GRDB goes back to the suspended state so nothing can hold the
+    /// app-group SQLite lock when the process is frozen.
+    private func suspendDatabaseIfBackgrounded() {
+        if UIApplication.shared.applicationState == .background {
+            AppDatabaseSuspension.suspend()
         }
     }
 
@@ -189,7 +273,8 @@ final class RemindersSyncManager: ObservableObject {
                 uniquingKeysWith: { first, _ in first }
             )
 
-            let links = RemindersSyncItemLink.links(configId: config.id)
+            let configId = config.id
+            let links = await Self.databaseAccess { RemindersSyncItemLink.links(configId: configId) }
                 .map(RemindersSyncPlanner.LinkState.init(link:))
             details = try await applyPlan(
                 config: config,
@@ -200,18 +285,19 @@ final class RemindersSyncManager: ObservableObject {
                 links: links
             )
         } catch {
-            recordHistory(config: config, error: error, details: details)
+            await recordHistory(config: config, error: error, details: details)
             throw error
         }
 
         // Unchanged runs aren't recorded, so history stays a log of actual changes.
         if !details.isEmpty {
-            recordHistory(config: config, error: nil, details: details)
+            await recordHistory(config: config, error: nil, details: details)
         }
 
         var updated = config
         updated.lastSyncDate = Current.date()
-        updated.save()
+        let configToSave = updated
+        await Self.databaseAccess { configToSave.save() }
     }
 
     /// Plans and applies the operations for one config. Returns the history detail lines for the
@@ -240,7 +326,7 @@ final class RemindersSyncManager: ObservableObject {
         for operation in operations {
             switch operation {
             case .createReminder, .updateReminder, .deleteReminder:
-                let didWriteStore = try applyReminderOperation(
+                let didWriteStore = try await applyReminderOperation(
                     operation,
                     config: config,
                     calendar: calendar,
@@ -286,8 +372,8 @@ final class RemindersSyncManager: ObservableObject {
         return details
     }
 
-    private func recordHistory(config: RemindersSyncConfig, error: Error?, details: [String]) {
-        RemindersSyncHistoryEntry(
+    private func recordHistory(config: RemindersSyncConfig, error: Error?, details: [String]) async {
+        let entry = RemindersSyncHistoryEntry(
             id: UUID().uuidString,
             configId: config.id,
             listLabel: "\(config.reminderListName) ↔ \(config.todoEntityName)",
@@ -295,7 +381,8 @@ final class RemindersSyncManager: ObservableObject {
             success: error == nil,
             error: error?.localizedDescription,
             details: details.joined(separator: "\n")
-        ).save()
+        )
+        await Self.databaseAccess { entry.save() }
     }
 
     /// A localized, human-readable line for the history log describing one applied operation.
@@ -342,7 +429,7 @@ final class RemindersSyncManager: ObservableObject {
         calendar: EKCalendar,
         todoSnapshots: [String: RemindersSyncItemSnapshot],
         remindersById: [String: EKReminder]
-    ) throws -> Bool {
+    ) async throws -> Bool {
         switch operation {
         case let .createReminder(todoItemUid):
             guard let snapshot = todoSnapshots[todoItemUid] else { return false }
@@ -350,7 +437,7 @@ final class RemindersSyncManager: ObservableObject {
             reminder.calendar = calendar
             apply(snapshot, to: reminder)
             try eventStore.save(reminder, commit: false)
-            saveLink(
+            await saveLink(
                 config: config,
                 todoItemUid: todoItemUid,
                 reminderId: reminder.calendarItemIdentifier,
@@ -362,10 +449,14 @@ final class RemindersSyncManager: ObservableObject {
                   let reminder = remindersById[reminderId] else { return false }
             apply(snapshot, to: reminder)
             try eventStore.save(reminder, commit: false)
-            saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
+            await saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
             return true
         case let .deleteReminder(todoItemUid, reminderId):
-            defer { RemindersSyncItemLink.delete(configId: config.id, todoItemUid: todoItemUid) }
+            // The link row goes away regardless of whether the reminder still exists or its
+            // removal fails (this used to be a `defer`); deleting it first keeps that behavior
+            // now that the write needs an await.
+            let configId = config.id
+            await Self.databaseAccess { RemindersSyncItemLink.delete(configId: configId, todoItemUid: todoItemUid) }
             guard let reminder = remindersById[reminderId] else { return false }
             try eventStore.remove(reminder, commit: false)
             return true
@@ -406,21 +497,23 @@ final class RemindersSyncManager: ObservableObject {
                 dueDate: snapshot.dueDateArgument,
                 dueDateTime: snapshot.dueDateTimeArgument
             )
-            saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
+            await saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
             return nil
         case let .deleteTodoItem(todoItemUid, _):
             try await api.removeTodoItem(
                 listId: config.todoEntityId,
                 itemId: todoItemUid
             )
-            RemindersSyncItemLink.delete(configId: config.id, todoItemUid: todoItemUid)
+            let configId = config.id
+            await Self.databaseAccess { RemindersSyncItemLink.delete(configId: configId, todoItemUid: todoItemUid) }
             return nil
         case let .adoptLink(todoItemUid, reminderId):
             guard let snapshot = todoSnapshots[todoItemUid] ?? reminderSnapshots[reminderId] else { return nil }
-            saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
+            await saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
             return nil
         case let .deleteLink(todoItemUid):
-            RemindersSyncItemLink.delete(configId: config.id, todoItemUid: todoItemUid)
+            let configId = config.id
+            await Self.databaseAccess { RemindersSyncItemLink.delete(configId: configId, todoItemUid: todoItemUid) }
             return nil
         default:
             return nil
@@ -437,7 +530,9 @@ final class RemindersSyncManager: ObservableObject {
         reminderSnapshots: [String: RemindersSyncItemSnapshot]
     ) async throws {
         let refreshed = try await fetchTodoItems(api: api, listId: config.todoEntityId)
-        let linkedUids = Set(RemindersSyncItemLink.links(configId: config.id).map(\.todoItemUid))
+        let configId = config.id
+        let existingLinks = await Self.databaseAccess { RemindersSyncItemLink.links(configId: configId) }
+        let linkedUids = Set(existingLinks.map(\.todoItemUid))
         var unlinkedItems = refreshed.filter { !linkedUids.contains($0.uid) }
 
         for reminderId in reminderIds {
@@ -445,7 +540,7 @@ final class RemindersSyncManager: ObservableObject {
                   let index = unlinkedItems
                   .firstIndex(where: { RemindersSyncItemSnapshot(todoItem: $0).title == snapshot.title }) else { continue }
             let item = unlinkedItems.remove(at: index)
-            saveLink(config: config, todoItemUid: item.uid, reminderId: reminderId, snapshot: snapshot)
+            await saveLink(config: config, todoItemUid: item.uid, reminderId: reminderId, snapshot: snapshot)
         }
     }
 
@@ -474,8 +569,8 @@ final class RemindersSyncManager: ObservableObject {
         todoItemUid: String,
         reminderId: String,
         snapshot: RemindersSyncItemSnapshot
-    ) {
-        RemindersSyncItemLink(
+    ) async {
+        let link = RemindersSyncItemLink(
             configId: config.id,
             todoItemUid: todoItemUid,
             reminderId: reminderId,
@@ -483,6 +578,7 @@ final class RemindersSyncManager: ObservableObject {
             lastKnownCompleted: snapshot.isCompleted,
             lastKnownNotes: snapshot.notes,
             lastKnownDue: snapshot.due
-        ).save()
+        )
+        await Self.databaseAccess { link.save() }
     }
 }

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -176,10 +176,12 @@ final class RemindersSyncManager: ObservableObject {
 
         // GRDB is suspended whenever the app is backgrounded (LifecycleManager); resume it so the
         // config read and the sync's writes also work from a background refresh. Every exit path
-        // below re-suspends while still backgrounded.
+        // below re-suspends while still backgrounded. The cancellation check matters when
+        // backgrounding cancels a just-started scheduled sync: bail out instead of continuing
+        // into unprotected work.
         AppDatabaseSuspension.resume()
         let configs = await Self.databaseAccess { RemindersSyncConfig.all() }
-        guard !configs.isEmpty else {
+        guard !configs.isEmpty, !Task.isCancelled else {
             suspendDatabaseIfBackgrounded()
             return
         }
@@ -234,6 +236,12 @@ final class RemindersSyncManager: ObservableObject {
     /// 0xdead10cc termination this sync used to hit showed the main thread blocked in a commit's
     /// `fsync`: it couldn't service the `didEnterBackground` notification that suspends GRDB and
     /// was still holding the app-group SQLite lock when the process was frozen.
+    ///
+    /// Deliberately detached without propagating the caller's cancellation: the closure is
+    /// synchronous with no suspension points, so cancelling the detached task could never
+    /// interrupt it. In-flight SQLite work is instead aborted through
+    /// `AppDatabaseSuspension.suspend()` (see the background-task expiration handler in
+    /// `syncAll`), and `sync(configs:)` stops between configs via its own cancellation check.
     private nonisolated static func databaseAccess<T: Sendable>(
         _ access: @escaping @Sendable () -> T
     ) async -> T {

--- a/Sources/HAModels/Sources/RemindersSyncConfig.swift
+++ b/Sources/HAModels/Sources/RemindersSyncConfig.swift
@@ -4,7 +4,7 @@ import GRDB
 /// A user-configured pairing between an Apple Reminders list and a Home Assistant todo list.
 /// Pure, extension-safe model (Foundation + GRDB only); the `Current.database()`-backed queries
 /// live in an extension in the `Shared` module.
-public struct RemindersSyncConfig: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable {
+public struct RemindersSyncConfig: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable, Sendable {
     public static let databaseTableName = GRDBDatabaseTable.remindersSyncConfig.rawValue
 
     public var id: String

--- a/Sources/HAModels/Sources/RemindersSyncDirection.swift
+++ b/Sources/HAModels/Sources/RemindersSyncDirection.swift
@@ -2,7 +2,7 @@ import Foundation
 import GRDB
 
 /// Which way items flow between an Apple Reminders list and a Home Assistant todo list.
-public enum RemindersSyncDirection: String, Codable, CaseIterable, Identifiable, DatabaseValueConvertible {
+public enum RemindersSyncDirection: String, Codable, CaseIterable, Identifiable, DatabaseValueConvertible, Sendable {
     /// Changes on either side are propagated to the other. When the same item changed on both
     /// sides since the last sync, the Home Assistant copy wins (the server is the shared source
     /// of truth for the household and doesn't expose per-item modification times to compare).

--- a/Sources/HAModels/Sources/RemindersSyncHistoryEntry.swift
+++ b/Sources/HAModels/Sources/RemindersSyncHistoryEntry.swift
@@ -4,7 +4,8 @@ import GRDB
 /// One recorded Reminders sync run for a list pairing: when it happened, whether it succeeded
 /// and what it changed. Runs that change nothing aren't recorded. Pure, extension-safe model;
 /// the `Current.database()`-backed queries live in an extension in the `Shared` module.
-public struct RemindersSyncHistoryEntry: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable {
+public struct RemindersSyncHistoryEntry: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable,
+    Sendable {
     public static let databaseTableName = GRDBDatabaseTable.remindersSyncHistoryEntry.rawValue
 
     public var id: String

--- a/Sources/HAModels/Sources/RemindersSyncItemLink.swift
+++ b/Sources/HAModels/Sources/RemindersSyncItemLink.swift
@@ -5,7 +5,7 @@ import GRDB
 /// `RemindersSyncConfig`, remembering the item state at the last successful sync so the next sync
 /// can tell which side changed. Pure, extension-safe model (Foundation + GRDB only); the
 /// `Current.database()`-backed queries live in an extension in the `Shared` module.
-public struct RemindersSyncItemLink: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable {
+public struct RemindersSyncItemLink: Codable, FetchableRecord, PersistableRecord, Equatable, Identifiable, Sendable {
     public static let databaseTableName = GRDBDatabaseTable.remindersSyncItemLink.rawValue
 
     public var id: String

--- a/Sources/Shared/Common/BackgroundTask.swift
+++ b/Sources/Shared/Common/BackgroundTask.swift
@@ -22,6 +22,7 @@ public enum BackgroundTask: String {
     case connectApi = "connect-api"
     case realmWrite = "realm-write"
     case pushLocationRequest = "push-location-request"
+    case remindersSync = "reminders-sync"
 }
 
 public enum BackgroundTaskError: Error {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
A TestFlight crash report (2026.8.0/2026.2421) showed the app killed with `RUNNINGBOARD 0xdead10cc`: the main thread was blocked in `fsync` inside a GRDB commit from `RemindersSyncConfig.save()` (via `RemindersSyncManager.sync`) when the system suspended the process, so it was still holding the app-group SQLite file lock. The existing suspend-on-background mitigation couldn't help because the suspend notification is delivered on the main thread — the very thread stuck in the commit — and an in-flight `fsync` can't be interrupted anyway.

Three fixes, mirroring the watch app's existing `performProtectedDatabaseWork` pattern:

- **Background-task protection**: every sync run now holds a `UIApplication` background task (new `BackgroundTask.remindersSync` case) so the system keeps the process alive until in-flight commits finish. On expiration the sync is cancelled and GRDB is suspended, releasing the file lock before the freeze.
- **Lifecycle handling**: entering the background cancels the debounce and periodic-refresh timers (re-armed on foreground) so a sync can't start unprotected in the grace window. A sync already running keeps going and re-resumes the database that `LifecycleManager` just suspended underneath it, re-suspending when it finishes.
- **Database work off the main actor**: all of the sync's GRDB reads and writes now run on a background thread, so the main thread stays free to service the `didEnterBackground` notification that suspends GRDB instead of being the one stuck in the commit. The reminders sync model types gain `Sendable` to support this.

Side benefit: syncs started from the `BGTaskScheduler` background refresh now actually work — previously every database access in that path silently failed because GRDB was suspended while the app was backgrounded.

## Screenshots
Not applicable — no user-facing UI changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Crash signature this addresses: `EXC_CRASH (SIGKILL)`, `Termination Reason: RUNNINGBOARD 0xdead10cc`, thread 0 in `fsync` ← `sqlite3PagerCommitPhaseOne` ← `RemindersSyncConfig.save()` (RemindersSyncConfig+Database.swift:22) ← `RemindersSyncManager.sync(_:)` (RemindersSyncManager.swift:214). No behavior change to the sync planning/diff logic itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WvqKV5sf9wpX2uxUiut8v

---
_Generated by [Claude Code](https://claude.ai/code/session_014WvqKV5sf9wpX2uxUiut8v)_