### PR TITLE
Make server rows indexable in settings search

### DIFF
--- a/Sources/App/Settings/Connection/ConnectionSettingsView.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsView.swift
@@ -547,6 +547,29 @@ struct ConnectionSettingsView: View {
     }
 }
 
+extension ConnectionSettingsView: SettingsScreenSearchable {
+    static var settingsSearchEntries: [SettingsSearchEntry] {
+        [
+            SettingsSearchEntry(L10n.Settings.StatusSection.LocationNameRow.title),
+            SettingsSearchEntry(L10n.SettingsDetails.General.DeviceName.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.InternalBaseUrl.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.ExternalBaseUrl.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.ConnectionAccessSecurityLevel.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.refreshServer),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.ClientCertificate.header),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.LocationSendType.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.SensorSendType.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.connectingVia),
+            SettingsSearchEntry(L10n.Settings.StatusSection.VersionRow.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.Websocket.title),
+            SettingsSearchEntry(L10n.SettingsDetails.Notifications.LocalPush.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.Cloudhook.title),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.loggedInAs),
+            SettingsSearchEntry(L10n.Settings.ConnectionSection.DeleteServer.title),
+        ]
+    }
+}
+
 // MARK: - Supporting Views
 
 private struct NavigationRow: View {

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -258,10 +258,10 @@ struct SettingsView: View {
 
     private var serverSearchResults: [Server] {
         guard isSearching else { return [] }
-        let contentMatches = !serverConnectionContentMatches.isEmpty
-        return serversObserver.servers.filter { server in
-            contentMatches || server.info.name.localizedStandardContains(trimmedSearchQuery)
+        if !serverConnectionContentMatches.isEmpty {
+            return serversObserver.servers
         }
+        return serversObserver.servers.filter { $0.info.name.localizedStandardContains(trimmedSearchQuery) }
     }
 
     private var serverContentSubtitle: String? {

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -245,22 +245,64 @@ struct SettingsView: View {
         if SettingsItem.servers.matches(searchQuery: trimmedSearchQuery) {
             return true
         }
+        if !serverSearchResults.isEmpty {
+            return true
+        }
         return SettingsSection.allCases.contains { !$0.items(matching: trimmedSearchQuery).isEmpty }
+    }
+
+    private var serverConnectionContentMatches: [SettingsSearchEntry] {
+        guard isSearching else { return [] }
+        return ConnectionSettingsView.settingsSearchEntries.filter { $0.matches(searchQuery: trimmedSearchQuery) }
+    }
+
+    private var serverSearchResults: [Server] {
+        guard isSearching else { return [] }
+        let contentMatches = !serverConnectionContentMatches.isEmpty
+        return serversObserver.servers.filter { server in
+            contentMatches || server.info.name.localizedStandardContains(trimmedSearchQuery)
+        }
+    }
+
+    private var serverContentSubtitle: String? {
+        let matched = serverConnectionContentMatches
+        guard !matched.isEmpty else { return nil }
+        return matched.prefix(3).map(\.title).joined(separator: ", ")
     }
 
     @ViewBuilder
     private var searchResultsContent: some View {
         if hasSearchResults {
             // Servers live in their own list normally (including the Catalyst sidebar, where the
-            // item is not "visible"), so surface them as a plain row when searching.
-            if SettingsItem.servers.matches(searchQuery: trimmedSearchQuery) {
+            // item is not "visible"), so surface them as plain rows when searching: the servers
+            // screen itself plus every server whose name or connection settings match the query.
+            let serverResults = serverSearchResults
+            if SettingsItem.servers.matches(searchQuery: trimmedSearchQuery) || !serverResults.isEmpty {
                 Section {
-                    settingsItemRow(.servers, searchQuery: trimmedSearchQuery)
+                    if SettingsItem.servers.matches(searchQuery: trimmedSearchQuery) {
+                        settingsItemRow(.servers, searchQuery: trimmedSearchQuery)
+                    }
+                    ForEach(serverResults, id: \.identifier) { server in
+                        NavigationLink(destination: ConnectionSettingsView(server: server)) {
+                            serverSearchRow(server: server)
+                        }
+                    }
                 }
             }
             settingsSections(matching: trimmedSearchQuery)
         } else {
             noSearchResultsSection
+        }
+    }
+
+    private func serverSearchRow(server: Server) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
+            HomeAssistantAccountRowView(server: server)
+            if let serverContentSubtitle {
+                Text(serverContentSubtitle)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 


### PR DESCRIPTION
Searching a connection row term (e.g. "internal url") now surfaces each server as a tappable result that opens its connection settings.