### PR TITLE
Migrate onboarding to NavigationStack

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1143,6 +1143,7 @@
 				Steps/DeviceName/DeviceNameView.swift,
 				Steps/Permissions/OnboardingPermissionsNavigationView.swift,
 				Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift,
+				Steps/Permissions/OnboardingPermissionsStepView.swift,
 				Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/LocalAccessPermissionView.swift,
 				Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/LocalAccessPermissionViewModel.swift,
 				"Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/SelectionOptionView-Usage.md",

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1139,6 +1139,7 @@
 				API/Steps/OnboardingAuthStepSensors.swift,
 				Container/OnboardingNavigationView.swift,
 				Container/OnboardingNavigationViewModel.swift,
+				Container/OnboardingRoute.swift,
 				Steps/DeviceName/DeviceNameView.swift,
 				Steps/Permissions/OnboardingPermissionsNavigationView.swift,
 				Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift,

--- a/Sources/App/Container/AppContainerCoordinator.swift
+++ b/Sources/App/Container/AppContainerCoordinator.swift
@@ -108,13 +108,13 @@ final class AppContainerCoordinator: AppCoordinator {
             Current.appSessionValues.inviteURL = inviteURL
             return
         }
-        let navigationView = NavigationView {
+        let navigationView = NavigationStack {
             OnboardingServersListView(
                 prefillURL: inviteURL,
                 shouldDismissOnSuccess: true,
                 onboardingStyle: .secondary
             )
-        }.navigationViewStyle(.stack)
+        }
         frontend.presentOverlayController(
             controller: navigationView.embeddedInHostingController(),
             animated: true

--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -92,19 +92,12 @@ struct ContainerView: View {
         .fullScreenCover(item: $viewModel.fullScreenCover, onDismiss: { refreshWebView() }) { cover in
             switch cover {
             case let .onboardingPermissions(server, steps):
-                NavigationView {
-                    OnboardingPermissionsNavigationView(
-                        onboardingServer: server,
-                        steps: steps,
-                        onDismiss: { viewModel.fullScreenCover = nil }
-                    )
-                    .toolbar {
-                        ToolbarItem(placement: .topBarLeading) {
-                            CloseButton { viewModel.fullScreenCover = nil }
-                        }
-                    }
-                }
-                .navigationViewStyle(.stack)
+                OnboardingPermissionsNavigationView(
+                    onboardingServer: server,
+                    steps: steps,
+                    onDismiss: { viewModel.fullScreenCover = nil },
+                    showsCloseButton: true
+                )
                 .injectingViewControllerProvider()
             }
         }

--- a/Sources/App/Container/ContainerViewModel.swift
+++ b/Sources/App/Container/ContainerViewModel.swift
@@ -57,7 +57,13 @@ final class ContainerViewModel: ObservableObject {
             queue.append(.testFlight(message))
         }
         pendingLaunchMessages = queue
-        showNextLaunchMessage()
+        // This is evaluated from the onboarding → web view screen swap. Presenting the sheet in the same
+        // transaction as the swap (which itself rides the tail of the permissions cover dismissal) corrupts
+        // UIKit's presentation state: the old onboarding view stays installed and the web view never attaches.
+        // Delay the first message until the new hierarchy has settled.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.showNextLaunchMessage()
+        }
     }
 
     /// Presents the next queued launch message, if any. Called on first evaluation and on each sheet dismiss so

--- a/Sources/App/Frontend/WebView/ConnectionSecurityLevelBlock/ConnectionSecurityLevelBlockView.swift
+++ b/Sources/App/Frontend/WebView/ConnectionSecurityLevelBlock/ConnectionSecurityLevelBlockView.swift
@@ -213,21 +213,12 @@ struct ConnectionSecurityLevelBlockView: View {
     }
 
     private var connectionPreferencesView: some View {
-        NavigationView {
-            OnboardingPermissionsNavigationView(
-                onboardingServer: server,
-                steps: [.localAccess, .updatePreferencesSuccess],
-                onDismiss: { showConnectionSecurityPreferences = false }
-            )
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    CloseButton {
-                        showConnectionSecurityPreferences = false
-                    }
-                }
-            }
-            .navigationViewStyle(.stack)
-        }
+        OnboardingPermissionsNavigationView(
+            onboardingServer: server,
+            steps: [.localAccess, .updatePreferencesSuccess],
+            onDismiss: { showConnectionSecurityPreferences = false },
+            showsCloseButton: true
+        )
         .onDisappear {
             reload()
         }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import PromiseKit
 import Shared
 import SwiftUI
@@ -6,31 +7,41 @@ import UIKit
 // MARK: - Onboarding & Security Level
 
 extension WebViewController {
+    /// The permission steps to force a decision for, or `nil` when every decision has been made.
+    /// Declining to share location during onboarding never shows the iOS permission dialog, so the
+    /// system status stays `.notDetermined` even though the user already decided — an explicit
+    /// `.never` privacy setting counts as a decision and must not re-trigger the flow.
+    static func localSecurityLevelDecisionSteps(
+        connection: ConnectionInfo,
+        locationPermissionStatus: CLAuthorizationStatus,
+        userDeclinedLocationSharing: Bool
+    ) -> [OnboardingPermissionsNavigationViewModel.StepID]? {
+        if locationPermissionStatus == .notDetermined, !userDeclinedLocationSharing,
+           connection.hasNonHTTPSURLOptions {
+            return OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission
+        } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {
+            return OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        } else {
+            return nil
+        }
+    }
+
     /// If user has not chosen 'Most secure' or 'Less secure' local access yet, this triggers a screen for decision
     func checkForLocalSecurityLevelDecisionNeeded() {
         let connection = server.info.connection
+        let steps = Self.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: Current.location.permissionStatus,
+            userDeclinedLocationSharing: server.info.setting(for: .locationPrivacy) == .never
+        )
 
-        // Declining to share location during onboarding never shows the iOS permission dialog, so the
-        // system status stays `.notDetermined` even though the user already decided — an explicit
-        // `.never` privacy setting counts as a decision and must not re-trigger the flow.
-        let userDeclinedLocationSharing = server.info.setting(for: .locationPrivacy) == .never
-
-        if Current.location.permissionStatus == .notDetermined, !userDeclinedLocationSharing,
-           connection.hasNonHTTPSURLOptions {
-            Current.Log.verbose("User has not decided location permission yet")
-            showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
-        } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {
-            Current.Log.verbose("User has not decided local access security level yet")
-            showOnboardingPermissions(
-                steps: OnboardingPermissionsNavigationViewModel.StepID
-                    .updateLocalAccessSecurityLevelPreference
-            )
-        } else if connection.hasOnlyHTTPSURLOptions {
-            Current.Log.verbose("Skipping local access security level decision because all configured URLs use HTTPS")
+        if let steps {
+            Current.Log.verbose("Local security level decision needed, requesting steps: \(steps.map(\.rawValue))")
+            showOnboardingPermissions(steps: steps)
         } else {
             Current.Log
                 .verbose(
-                    "User decided \(connection.connectionAccessSecurityLevel) for local access security level"
+                    "No local security level decision needed, level: \(connection.connectionAccessSecurityLevel)"
                 )
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -10,7 +10,13 @@ extension WebViewController {
     func checkForLocalSecurityLevelDecisionNeeded() {
         let connection = server.info.connection
 
-        if Current.location.permissionStatus == .notDetermined, connection.hasNonHTTPSURLOptions {
+        // Declining to share location during onboarding never shows the iOS permission dialog, so the
+        // system status stays `.notDetermined` even though the user already decided — an explicit
+        // `.never` privacy setting counts as a decision and must not re-trigger the flow.
+        let userDeclinedLocationSharing = server.info.setting(for: .locationPrivacy) == .never
+
+        if Current.location.permissionStatus == .notDetermined, !userDeclinedLocationSharing,
+           connection.hasNonHTTPSURLOptions {
             Current.Log.verbose("User has not decided location permission yet")
             showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
         } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {

--- a/Sources/App/Onboarding/API/OnboardingAuthStepClientCertificate.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthStepClientCertificate.swift
@@ -126,8 +126,7 @@ final class OnboardingAuthStepClientCertificate: OnboardingAuthPreStep {
                 )
 
                 let hostingController = UIHostingController(
-                    rootView: NavigationView { view }
-                        .navigationViewStyle(.stack)
+                    rootView: NavigationStack { view }
                 )
                 hostingController.modalPresentationStyle = .pageSheet
 

--- a/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
+++ b/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
@@ -34,7 +34,7 @@ struct OnboardingNavigationView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Group {
                 switch onboardingStyle {
                 case .initial:
@@ -46,7 +46,9 @@ struct OnboardingNavigationView: View {
                     OnboardingWelcomeView(shouldDismissOnboarding: $viewModel.shouldDismiss)
                 }
             }
-            .navigationViewStyle(.stack)
+            .navigationDestination(for: OnboardingRoute.self) { route in
+                destination(for: route)
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     if onboardingStyle.insertsCancelButton, !Current.isCatalyst {
@@ -59,11 +61,21 @@ struct OnboardingNavigationView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .onChange(of: viewModel.shouldDismiss) { newValue in
             if newValue {
                 closeOnboarding()
             }
+        }
+    }
+
+    /// Pushed pages keep their own `ViewControllerProvider` injection so presenting UIKit modals
+    /// (e.g. the auth flow) does not depend on environment propagation from the stack root.
+    @ViewBuilder
+    private func destination(for route: OnboardingRoute) -> some View {
+        switch route {
+        case let .serversList(style):
+            OnboardingServersListView(onboardingStyle: style)
+                .injectingViewControllerProvider()
         }
     }
 

--- a/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
+++ b/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
@@ -73,8 +73,8 @@ struct OnboardingNavigationView: View {
     @ViewBuilder
     private func destination(for route: OnboardingRoute) -> some View {
         switch route {
-        case let .serversList(style):
-            OnboardingServersListView(onboardingStyle: style)
+        case .serversList:
+            OnboardingServersListView(onboardingStyle: onboardingStyle)
                 .injectingViewControllerProvider()
         }
     }

--- a/Sources/App/Onboarding/Container/OnboardingRoute.swift
+++ b/Sources/App/Onboarding/Container/OnboardingRoute.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Value-based destinations pushed onto the onboarding `NavigationStack`.
+enum OnboardingRoute: Hashable {
+    case serversList(OnboardingStyle)
+}

--- a/Sources/App/Onboarding/Container/OnboardingRoute.swift
+++ b/Sources/App/Onboarding/Container/OnboardingRoute.swift
@@ -1,6 +1,4 @@
-import Foundation
-
 /// Value-based destinations pushed onto the onboarding `NavigationStack`.
 enum OnboardingRoute: Hashable {
-    case serversList(OnboardingStyle)
+    case serversList
 }

--- a/Sources/App/Onboarding/Steps/DeviceName/DeviceNameView.swift
+++ b/Sources/App/Onboarding/Steps/DeviceName/DeviceNameView.swift
@@ -20,7 +20,7 @@ struct DeviceNameView: View {
     @State private var onDismissAction: ActionType = .none
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             BaseOnboardingView(
                 illustration: {
                     Image(.Onboarding.pencil)
@@ -62,7 +62,6 @@ struct DeviceNameView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
         .interactiveDismissDisabled(true)
         .onDisappear {
             switch onDismissAction {

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationView.swift
@@ -1,22 +1,25 @@
 import Shared
 import SwiftUI
 
-// This view handles navigation between different permission request steps during onboarding.
-// It is not using NavigationView/Stack because for some unknown reason location permission dialog
-// is popping the screen and no solution was found to prevent that until now.
+/// Hosts the permission steps in their own `NavigationStack` for flows presented over the web view
+/// (forced security-level decisions, connection preference updates). Each step pushes the next one
+/// itself (see `OnboardingPermissionsStepView`), so this view only needs to render the first step.
+///
+/// During onboarding the steps are instead pushed onto the onboarding stack directly (no wrapping
+/// `NavigationStack`) — see `OnboardingServersListView`.
 struct OnboardingPermissionsNavigationView: View {
     @StateObject private var viewModel: OnboardingPermissionsNavigationViewModel
 
-    let onboardingServer: Server
-    private let onDismiss: (() -> Void)?
-
-    @Environment(\.layoutDirection) private var layoutDirection
     @Environment(\.dismiss) private var dismiss
+
+    private let onDismiss: (() -> Void)?
+    private let showsCloseButton: Bool
 
     init(
         onboardingServer: Server,
         steps: [OnboardingPermissionsNavigationViewModel.StepID]? = nil,
-        onDismiss: (() -> Void)? = nil
+        onDismiss: (() -> Void)? = nil,
+        showsCloseButton: Bool = false
     ) {
         self
             ._viewModel =
@@ -24,107 +27,33 @@ struct OnboardingPermissionsNavigationView: View {
                 onboardingServer: onboardingServer,
                 steps: steps
             ))
-        self.onboardingServer = onboardingServer
         self.onDismiss = onDismiss
+        self.showsCloseButton = showsCloseButton
     }
 
     var body: some View {
-        ZStack {
-            ForEach(Array(viewModel.steps.enumerated()), id: \.element) { index, stepId in
-                if index == viewModel.currentStepIndex {
-                    stepView(for: stepId)
-                        .transition(pushTransition)
-                        .id(stepId)
-                        .zIndex(Double(index))
-                }
-            }
+        NavigationStack {
+            rootStep
         }
-        .animation(DesignSystem.Animation.default, value: viewModel.currentStepIndex)
+        .onAppear {
+            viewModel.finish = { finishFlow() }
+        }
     }
 
     @ViewBuilder
-    private func stepView(for stepId: OnboardingPermissionsNavigationViewModel.StepID) -> some View {
-        switch stepId {
-        case .disclaimer:
-            disclaimer
-        case .location:
-            location
-        case .localAccess:
-            localAccess
-        case .homeNetwork:
-            homeNetworkInput
-        case .completion:
-            completionView
-        case .updatePreferencesSuccess:
-            checkmarkSuccessView
-        }
-    }
-
-    private var disclaimer: some View {
-        LocalAccessOnlyDisclaimerView {
-            viewModel.nextStep()
-        }
-    }
-
-    private var location: some View {
-        LocationPermissionView {
-            viewModel.requestLocationPermissionToShareWithHomeAssistant()
-        } secondaryAction: {
-            viewModel.disableLocationSensor()
-            viewModel.nextStep()
-        }
-    }
-
-    private var localAccess: some View {
-        LocalAccessPermissionView { connectionAccessSecurityLevel in
-            switch connectionAccessSecurityLevel {
-            case .undefined:
-                assertionFailure("undefined should not be possible here")
-            case .mostSecure:
-                viewModel.requestLocationPermissionForSecureLocalConnection()
-            case .lessSecure:
-                viewModel.requestLocationPermissionForLessSecureLocalConnection()
-            }
-        }
-    }
-
-    private var homeNetworkInput: some View {
-        HomeNetworkInputView(onNext: { context in
-            if context.networkName != nil || context.hardwareAddress != nil {
-                viewModel.saveHomeNetwork(context)
-            }
-        })
-        .onChange(of: viewModel.storedSSIDSuccessfully) { newValue in
-            if newValue {
-                navigateToCompletionScreen()
-            }
-        }
-    }
-
-    private var completionView: some View {
-        // Empty screen that will fade out
-        Color.clear
-            .onAppear {
-                // Start fade out animation after a short delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    finishFlow()
+    private var rootStep: some View {
+        if let firstStep = viewModel.steps.first {
+            OnboardingPermissionsStepView(step: firstStep, viewModel: viewModel)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        if showsCloseButton {
+                            CloseButton {
+                                finishFlow()
+                            }
+                        }
+                    }
                 }
-            }
-    }
-
-    private var checkmarkSuccessView: some View {
-        // View that display success animation and dismisses the flow shortly after
-        CheckmarkDrawOnView()
-            .onAppear {
-                // Dismiss after a short delay to allow the user to see the success state
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    finishFlow()
-                }
-            }
-    }
-
-    private func navigateToCompletionScreen() {
-        viewModel.nextStep()
+        }
     }
 
     private func finishFlow() {
@@ -133,31 +62,6 @@ struct OnboardingPermissionsNavigationView: View {
         } else {
             dismiss()
         }
-    }
-
-    // MARK: - Animation
-
-    // Mimics UINavigationController push/pop animation
-
-    private var pushTransition: AnyTransition {
-        // Special handling for completion screen - always fade out
-        if viewModel.currentStepIndex == viewModel.steps.count - 1, viewModel.currentStep == .completion {
-            return .opacity
-        }
-
-        // Respect layout direction (RTL vs LTR)
-        let leading: Edge = layoutDirection == .leftToRight ? .leading : .trailing
-        let trailing: Edge = layoutDirection == .leftToRight ? .trailing : .leading
-
-        // Forward: insert from trailing, remove to leading (push)
-        // Backward: insert from leading, remove to trailing (pop)
-        let insertionEdge: Edge = viewModel.isAdvancing ? trailing : leading
-        let removalEdge: Edge = viewModel.isAdvancing ? leading : trailing
-
-        return .asymmetric(
-            insertion: .move(edge: insertionEdge).combined(with: .opacity),
-            removal: .move(edge: removalEdge).combined(with: .opacity)
-        )
     }
 }
 

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreLocation
 import Foundation
 import Shared
@@ -63,10 +64,19 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
     /// SSID Stored into server settings
     @Published var storedSSIDSuccessfully: Bool = false
 
-    // MARK: - Private Properties
+    // MARK: - Navigation
 
-    /// Tracks the previous step index for determining animation direction
-    private var lastStepIndex: Int = 0
+    /// Emits `(from, to)` when the flow should push `to` onto the stack. The currently-visible step view
+    /// whose step equals `from` performs the push via its own `navigationDestination`, so navigation is
+    /// always driven by an on-screen view — never by a cross-view path mutation, which iOS 16's
+    /// `NavigationStack` does not reliably observe after the UIKit auth modals dismiss.
+    let advance = PassthroughSubject<(from: StepID, to: StepID), Never>()
+
+    /// Set by the hosting context to end the flow (complete onboarding, or dismiss for the
+    /// mid-session preference flows).
+    var finish: (() -> Void)?
+
+    // MARK: - Private Properties
 
     private let locationManager = CLLocationManager()
     private let onboardingServer: Server
@@ -75,11 +85,6 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
 
     /// Returns all available steps in the onboarding flow
     let steps: [StepID]
-
-    /// Determines if the user is advancing forward through the steps (for animation purposes)
-    var isAdvancing: Bool {
-        currentStepIndex >= lastStepIndex
-    }
 
     /// Returns the current step based on the current step index
     var currentStep: StepID {
@@ -116,7 +121,8 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
 
     /// Navigates to a specific step in the onboarding flow
     /// - Parameter index: The target step index (0-based)
-    /// - Note: Provides haptic feedback for forward navigation and validates bounds
+    /// - Note: Provides haptic feedback for forward navigation and validates bounds. Reaching the
+    ///   `.completion` step ends the flow instead of pushing a screen.
     func navigateToStep(at index: Int) {
         guard index >= 0, index < steps.count else { return }
 
@@ -125,9 +131,20 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
             Current.impactFeedback.impactOccurred()
         }
 
-        // Update the last step after deciding transition direction
-        lastStepIndex = currentStepIndex
+        let from = currentStep
+        let to = steps[index]
         currentStepIndex = index
+
+        if to == .completion {
+            finish?()
+        } else {
+            advance.send((from: from, to: to))
+        }
+    }
+
+    /// Ends the flow, called by steps that conclude it themselves (e.g. the update-success screen).
+    func finishFlow() {
+        finish?()
     }
 
     /// Navigates to a specific step by its identifier

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsStepView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsStepView.swift
@@ -1,0 +1,92 @@
+import Shared
+import SwiftUI
+
+/// Renders a single permissions step and pushes the next one onto the enclosing `NavigationStack`.
+///
+/// Each visible step owns the push to its successor (via `advance` from the shared view model), so
+/// navigation is always driven by an on-screen view. This avoids two iOS 16 `NavigationStack` pitfalls
+/// hit during onboarding: a cross-view path mutation isn't observed after the UIKit auth modals dismiss,
+/// and nesting a second `NavigationStack` resets the outer one.
+struct OnboardingPermissionsStepView: View {
+    let step: OnboardingPermissionsNavigationViewModel.StepID
+    @ObservedObject var viewModel: OnboardingPermissionsNavigationViewModel
+
+    @State private var pushedStep: OnboardingPermissionsNavigationViewModel.StepID?
+
+    var body: some View {
+        content
+            .navigationDestination(isPresented: Binding(
+                get: { pushedStep != nil },
+                set: { if !$0 { pushedStep = nil } }
+            )) {
+                if let pushedStep {
+                    OnboardingPermissionsStepView(step: pushedStep, viewModel: viewModel)
+                        .navigationBarBackButtonHidden()
+                }
+            }
+            .onReceive(viewModel.advance) { transition in
+                guard transition.from == step else { return }
+                pushedStep = transition.to
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch step {
+        case .disclaimer:
+            LocalAccessOnlyDisclaimerView {
+                viewModel.nextStep()
+            }
+        case .location:
+            LocationPermissionView {
+                viewModel.requestLocationPermissionToShareWithHomeAssistant()
+            } secondaryAction: {
+                viewModel.disableLocationSensor()
+                viewModel.nextStep()
+            }
+        case .localAccess:
+            LocalAccessPermissionView { connectionAccessSecurityLevel in
+                switch connectionAccessSecurityLevel {
+                case .undefined:
+                    assertionFailure("undefined should not be possible here")
+                case .mostSecure:
+                    viewModel.requestLocationPermissionForSecureLocalConnection()
+                case .lessSecure:
+                    viewModel.requestLocationPermissionForLessSecureLocalConnection()
+                }
+            }
+        case .homeNetwork:
+            HomeNetworkInputView(onNext: { context in
+                if context.networkName != nil || context.hardwareAddress != nil {
+                    viewModel.saveHomeNetwork(context)
+                }
+            })
+            .onChange(of: viewModel.storedSSIDSuccessfully) { newValue in
+                if newValue {
+                    viewModel.nextStep()
+                }
+            }
+        case .completion:
+            // Reaching `.completion` finishes the flow in the view model instead of pushing a screen.
+            Color.clear
+        case .updatePreferencesSuccess:
+            // View that display success animation and dismisses the flow shortly after
+            CheckmarkDrawOnView()
+                .onAppear {
+                    // Dismiss after a short delay to allow the user to see the success state
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        viewModel.finishFlow()
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OnboardingPermissionsStepView(
+            step: .location,
+            viewModel: OnboardingPermissionsNavigationViewModel(onboardingServer: ServerFixture.standard)
+        )
+    }
+}

--- a/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/LocalAccessPermissionView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/LocalAccess/LocalAccessPermissionView.swift
@@ -6,7 +6,7 @@ enum LocalAccessPermissionOptions: String {
     case lessSecure
 }
 
-struct LocalAccessPermissionViewInNavigationView: View {
+struct LocalAccessPermissionViewInNavigationStack: View {
     @Environment(\.dismiss) private var dismiss
     let initialSelection: ConnectionSecurityLevel?
     let action: (ConnectionSecurityLevel) -> Void
@@ -17,7 +17,7 @@ struct LocalAccessPermissionViewInNavigationView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             LocalAccessPermissionView(initialSelection: initialSelection) { selection in
                 action(selection)
             }
@@ -30,7 +30,6 @@ struct LocalAccessPermissionViewInNavigationView: View {
                 }
             }
         }
-        .navigationViewStyle(.stack)
     }
 }
 

--- a/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/NetworkInput/HomeNetworkInputView.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/Steps/LocalAccessAndNetworkInput/NetworkInput/HomeNetworkInputView.swift
@@ -129,7 +129,7 @@ struct HomeNetworkInputView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         HomeNetworkInputView(
             onNext: { context in
                 print("Next tapped with network: \(context.networkName ?? "nil")")

--- a/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
@@ -26,7 +26,7 @@ struct ManualURLEntryView: View, KeyboardReadable {
     private let minCharsToActivateSection = URLScheme.allCases.map(\.rawValue.count).min() ?? 0
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             BaseOnboardingView(illustration: {
                 Image(.Onboarding.pencil)
             }, title: L10n.Onboarding.ManualUrlEntry.title, primaryDescription: "", content: {
@@ -53,7 +53,6 @@ struct ManualURLEntryView: View, KeyboardReadable {
             }
             .hideOnboardingTitle(isKeyboardVisible)
             .hideOnboardingIcon(isKeyboardVisible)
-            .navigationViewStyle(.stack)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -138,12 +138,11 @@ struct OnboardingServersListView: View {
             OnboardingPermissionsNavigationView(
                 onboardingServer: viewModel.onboardingServer!,
                 onDismiss: {
-                    if onboardingStyle == .secondary {
-                        viewModel.permissionsFlowCompleted = true
-                        viewModel.showPermissionsFlow = false
-                    } else {
-                        Current.onboardingObservation.complete()
-                    }
+                    // Dismiss the cover first and only signal completion from the cover's `onDismiss`
+                    // (above): completing while the cover is still presented makes `ContainerView` swap
+                    // the screen under a presented cover, which can leave it dangling as a blank screen.
+                    viewModel.permissionsFlowCompleted = true
+                    viewModel.showPermissionsFlow = false
                 }
             )
         }

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -56,7 +56,11 @@ struct OnboardingServersListView: View {
         invitationURL != nil && !rejectedInvitation
     }
 
-    init(prefillURL: URL? = nil, shouldDismissOnSuccess: Bool = false, onboardingStyle: OnboardingStyle) {
+    init(
+        prefillURL: URL? = nil,
+        shouldDismissOnSuccess: Bool = false,
+        onboardingStyle: OnboardingStyle
+    ) {
         self.prefillURL = prefillURL
         self
             ._viewModel =
@@ -123,28 +127,19 @@ struct OnboardingServersListView: View {
                 minHeight: Constants.MacSheetSize.manualInputMinHeight
             )
         }
-        .fullScreenCover(isPresented: .init(get: {
-            viewModel.showPermissionsFlow && viewModel.onboardingServer != nil
+        .navigationDestination(isPresented: .init(get: {
+            viewModel.showPermissionsFlow && viewModel.permissionsViewModel != nil
         }, set: { newValue in
             viewModel.showPermissionsFlow = newValue
-        }), onDismiss: {
-            if viewModel.permissionsFlowCompleted {
-                viewModel.permissionsFlowCompleted = false
-                Current.onboardingObservation.complete()
+        })) {
+            // Push the permission steps onto the onboarding `NavigationStack` (not a nested one). Each
+            // step pushes the next itself, and the last completes onboarding via the view model's `finish`.
+            if let permissionsViewModel = viewModel.permissionsViewModel,
+               let firstStep = permissionsViewModel.steps.first {
+                OnboardingPermissionsStepView(step: firstStep, viewModel: permissionsViewModel)
+                    .navigationBarBackButtonHidden()
+                    .toolbar(.hidden, for: .navigationBar)
             }
-        }) {
-            // isPresented guarantees onboardingServer
-            // swiftlint:disable:next force_unwrapping
-            OnboardingPermissionsNavigationView(
-                onboardingServer: viewModel.onboardingServer!,
-                onDismiss: {
-                    // Dismiss the cover first and only signal completion from the cover's `onDismiss`
-                    // (above): completing while the cover is still presented makes `ContainerView` swap
-                    // the screen under a presented cover, which can leave it dangling as a blank screen.
-                    viewModel.permissionsFlowCompleted = true
-                    viewModel.showPermissionsFlow = false
-                }
-            )
         }
     }
 

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -426,7 +426,7 @@ struct OnboardingServersListView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         OnboardingServersListView(prefillURL: nil, onboardingStyle: .secondary)
     }
 }

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
@@ -19,7 +19,9 @@ final class OnboardingServersListViewModel: ObservableObject {
     @Published var showPermissionsFlow = false
     @Published var shouldDismiss = false
     @Published var onboardingServer: Server?
-    var permissionsFlowCompleted = false
+    /// The permission flow's view model, created when authentication succeeds so the servers list can push
+    /// its first step onto the onboarding `NavigationStack`.
+    @Published var permissionsViewModel: OnboardingPermissionsNavigationViewModel?
 
     @Published var manualInputLoading = false
     @Published var invitationLoading = false
@@ -121,6 +123,9 @@ final class OnboardingServersListViewModel: ObservableObject {
         discovery.stop()
         onboardingServer = server
         disableNonEssentialSensors(server)
+        let permissionsViewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+        permissionsViewModel.finish = { Current.onboardingObservation.complete() }
+        self.permissionsViewModel = permissionsViewModel
         showPermissionsFlow = true
     }
 

--- a/Sources/App/Onboarding/Steps/Welcome/InvitationView.swift
+++ b/Sources/App/Onboarding/Steps/Welcome/InvitationView.swift
@@ -130,7 +130,7 @@ struct InvitationView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         InvitationView(
             invitationURL: URL(string: "http://192.168.0.188:8123")!,
             isAccepting: false,
@@ -138,11 +138,10 @@ struct InvitationView: View {
             onReject: {}
         )
     }
-    .navigationViewStyle(.stack)
 }
 
 #Preview("Long URL") {
-    NavigationView {
+    NavigationStack {
         InvitationView(
             invitationURL: URL(
                 string: "http://thisisaverylongurlsowecantesthowtheuibehaveswiththisurlwhichisgoingtobesuperlongandimnotgoingtoabletofititanywhere:8123"
@@ -152,5 +151,4 @@ struct InvitationView: View {
             onReject: {}
         )
     }
-    .navigationViewStyle(.stack)
 }

--- a/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
+++ b/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
@@ -65,7 +65,7 @@ struct OnboardingWelcomeView: View {
 
     private var continueButtonBlock: some View {
         VStack {
-            NavigationLink(destination: serversListDestination) {
+            NavigationLink(value: OnboardingRoute.serversList(.initial)) {
                 Text(verbatim: L10n.Onboarding.Welcome.primaryButton)
             }
             .buttonStyle(.primaryButton)
@@ -79,17 +79,10 @@ struct OnboardingWelcomeView: View {
         .background(Color(uiColor: .systemBackground))
     }
 
-    /// Pushed pages get their own hosting controller, so the `ViewControllerProvider` injected at the
-    /// onboarding root (`embeddedInHostingController()`) does not reach them — re-inject it here or the
-    /// servers list crashes on first access.
-    private var serversListDestination: some View {
-        OnboardingServersListView(onboardingStyle: .initial)
-            .injectingViewControllerProvider()
-    }
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         if #available(iOS 18.0, *) {
             OnboardingWelcomeView(shouldDismissOnboarding: .constant(false))
                 .toolbarVisibility(.hidden, for: .navigationBar)

--- a/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
+++ b/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
@@ -65,7 +65,7 @@ struct OnboardingWelcomeView: View {
 
     private var continueButtonBlock: some View {
         VStack {
-            NavigationLink(value: OnboardingRoute.serversList(.initial)) {
+            NavigationLink(value: OnboardingRoute.serversList) {
                 Text(verbatim: L10n.Onboarding.Welcome.primaryButton)
             }
             .buttonStyle(.primaryButton)

--- a/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
+++ b/Sources/App/Onboarding/Steps/Welcome/OnboardingWelcomeView.swift
@@ -78,7 +78,6 @@ struct OnboardingWelcomeView: View {
         .padding([.horizontal, .top], DesignSystem.Spaces.two)
         .background(Color(uiColor: .systemBackground))
     }
-
 }
 
 #Preview {

--- a/Sources/App/Onboarding/Views/BaseOnboardingView.swift
+++ b/Sources/App/Onboarding/Views/BaseOnboardingView.swift
@@ -186,7 +186,7 @@ public struct BaseOnboardingView<Illustration: View, Content: View>: View, Keybo
 // MARK: - Previews
 
 #Preview("Location permission example (simple)") {
-    NavigationView {
+    NavigationStack {
         BaseOnboardingView(
             illustration: {
                 Image(.Onboarding.world)
@@ -204,7 +204,7 @@ public struct BaseOnboardingView<Illustration: View, Content: View>: View, Keybo
 }
 
 #Preview("With injected content") {
-    NavigationView {
+    NavigationStack {
         BaseOnboardingView(
             illustration: {
                 Image(.Onboarding.world)

--- a/Sources/App/Onboarding/Views/MTLSLabsLabel.swift
+++ b/Sources/App/Onboarding/Views/MTLSLabsLabel.swift
@@ -8,7 +8,7 @@ struct MTLSLabsLabel: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         List {
             MTLSLabsLabel()
         }

--- a/Sources/App/Settings/Connection/ConnectionSettingsView.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsView.swift
@@ -144,7 +144,7 @@ struct ConnectionSettingsView: View {
             }
         }
         .sheet(isPresented: $showSecurityLevelPicker) {
-            LocalAccessPermissionViewInNavigationView(
+            LocalAccessPermissionViewInNavigationStack(
                 initialSelection: viewModel.securityLevel,
                 action: { level in
                     viewModel.updateSecurityLevel(level)

--- a/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
+++ b/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreLocation
 import Foundation
 @testable import HomeAssistant
@@ -114,21 +115,28 @@ struct OnboardingPermissionsNavigationViewModelTests {
         #expect(viewModel.currentStepIndex == originalIndex)
     }
 
-    @Test("Is advancing detection")
-    func isAdvancingDetection() async throws {
+    @Test("Advance emits transitions and finishes on completion")
+    func advanceEmitsTransitionsAndFinishesOnCompletion() async throws {
+        typealias Step = OnboardingPermissionsNavigationViewModel.StepID
         let server = ServerFixture.standard
         let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+        var transitions = [(from: Step, to: Step)]()
+        var finished = false
+        let cancellable = viewModel.advance.sink { transitions.append($0) }
+        viewModel.finish = { finished = true }
+        defer { cancellable.cancel() }
 
-        // Initially advancing (0 >= 0)
-        #expect(viewModel.isAdvancing == true)
+        // disclaimer -> location
+        viewModel.nextStep()
+        #expect(transitions.count == 1)
+        #expect(transitions.first?.from == .disclaimer)
+        #expect(transitions.first?.to == .location)
+        #expect(finished == false)
 
-        // Move forward
-        viewModel.navigateToStep(at: 2)
-        #expect(viewModel.isAdvancing == true)
-
-        // Move backward
-        viewModel.navigateToStep(at: 1)
-        #expect(viewModel.isAdvancing == false)
+        // Jumping to .completion finishes rather than emitting a transition.
+        viewModel.navigateToStep(.completion)
+        #expect(transitions.count == 1)
+        #expect(finished == true)
     }
 
     // MARK: - Navigation Tests

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 @testable import HomeAssistant
 @testable import Shared
 import UIKit
@@ -306,6 +307,85 @@ final class WebViewControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(restored, URL(string: "http://homeassistant.local:8123/"))
+    }
+
+    // MARK: - Local security level decision
+
+    // ServerInfo.fake() has a non-HTTPS external URL and an undefined security level.
+
+    func testLocalSecurityLevelDecisionRequestsLocationFlowWhenPermissionNotDetermined() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertEqual(steps, OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
+    }
+
+    func testLocalSecurityLevelDecisionSkipsLocationFlowWhenUserDeclinedSharing() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: true
+        )
+
+        XCTAssertEqual(
+            steps,
+            OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        )
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenUserDeclinedSharingAndSecurityLevelDecided() {
+        var connection = ServerInfo.fake().connection
+        connection.connectionAccessSecurityLevel = .mostSecure
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: true
+        )
+
+        XCTAssertNil(steps)
+    }
+
+    func testLocalSecurityLevelDecisionRequestsSecurityLevelFlowWhenUndecided() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .authorizedWhenInUse,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertEqual(
+            steps,
+            OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        )
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenAllURLsAreHTTPS() {
+        var connection = ServerInfo.fake().connection
+        connection.set(address: URL(string: "https://example.com:8123"), for: .external)
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertNil(steps)
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenEverythingDecided() {
+        var connection = ServerInfo.fake().connection
+        connection.connectionAccessSecurityLevel = .lessSecure
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .authorizedAlways,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertNil(steps)
     }
 
     private func makeSUT(server: Server = .fake()) -> WebViewController {


### PR DESCRIPTION
Replaces deprecated `NavigationView` with `NavigationStack` across the onboarding flow, using value-based navigation (`OnboardingRoute`) for the welcome → servers list push.

The custom ZStack-based permissions step navigation is intentionally left untouched for a follow-up PR.