### PR TITLE
Fix permissions flow retrigger and blank screen after onboarding

### DIFF
--- a/Sources/App/Container/ContainerViewModel.swift
+++ b/Sources/App/Container/ContainerViewModel.swift
@@ -57,7 +57,13 @@ final class ContainerViewModel: ObservableObject {
             queue.append(.testFlight(message))
         }
         pendingLaunchMessages = queue
-        showNextLaunchMessage()
+        // This is evaluated from the onboarding → web view screen swap. Presenting the sheet in the same
+        // transaction as the swap (which itself rides the tail of the permissions cover dismissal) corrupts
+        // UIKit's presentation state: the old onboarding view stays installed and the web view never attaches.
+        // Delay the first message until the new hierarchy has settled.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.showNextLaunchMessage()
+        }
     }
 
     /// Presents the next queued launch message, if any. Called on first evaluation and on each sheet dismiss so

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import PromiseKit
 import Shared
 import SwiftUI
@@ -6,31 +7,41 @@ import UIKit
 // MARK: - Onboarding & Security Level
 
 extension WebViewController {
+    /// The permission steps to force a decision for, or `nil` when every decision has been made.
+    /// Declining to share location during onboarding never shows the iOS permission dialog, so the
+    /// system status stays `.notDetermined` even though the user already decided — an explicit
+    /// `.never` privacy setting counts as a decision and must not re-trigger the flow.
+    static func localSecurityLevelDecisionSteps(
+        connection: ConnectionInfo,
+        locationPermissionStatus: CLAuthorizationStatus,
+        userDeclinedLocationSharing: Bool
+    ) -> [OnboardingPermissionsNavigationViewModel.StepID]? {
+        if locationPermissionStatus == .notDetermined, !userDeclinedLocationSharing,
+           connection.hasNonHTTPSURLOptions {
+            return OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission
+        } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {
+            return OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        } else {
+            return nil
+        }
+    }
+
     /// If user has not chosen 'Most secure' or 'Less secure' local access yet, this triggers a screen for decision
     func checkForLocalSecurityLevelDecisionNeeded() {
         let connection = server.info.connection
+        let steps = Self.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: Current.location.permissionStatus,
+            userDeclinedLocationSharing: server.info.setting(for: .locationPrivacy) == .never
+        )
 
-        // Declining to share location during onboarding never shows the iOS permission dialog, so the
-        // system status stays `.notDetermined` even though the user already decided — an explicit
-        // `.never` privacy setting counts as a decision and must not re-trigger the flow.
-        let userDeclinedLocationSharing = server.info.setting(for: .locationPrivacy) == .never
-
-        if Current.location.permissionStatus == .notDetermined, !userDeclinedLocationSharing,
-           connection.hasNonHTTPSURLOptions {
-            Current.Log.verbose("User has not decided location permission yet")
-            showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
-        } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {
-            Current.Log.verbose("User has not decided local access security level yet")
-            showOnboardingPermissions(
-                steps: OnboardingPermissionsNavigationViewModel.StepID
-                    .updateLocalAccessSecurityLevelPreference
-            )
-        } else if connection.hasOnlyHTTPSURLOptions {
-            Current.Log.verbose("Skipping local access security level decision because all configured URLs use HTTPS")
+        if let steps {
+            Current.Log.verbose("Local security level decision needed, requesting steps: \(steps.map(\.rawValue))")
+            showOnboardingPermissions(steps: steps)
         } else {
             Current.Log
                 .verbose(
-                    "User decided \(connection.connectionAccessSecurityLevel) for local access security level"
+                    "No local security level decision needed, level: \(connection.connectionAccessSecurityLevel)"
                 )
         }
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -10,7 +10,13 @@ extension WebViewController {
     func checkForLocalSecurityLevelDecisionNeeded() {
         let connection = server.info.connection
 
-        if Current.location.permissionStatus == .notDetermined, connection.hasNonHTTPSURLOptions {
+        // Declining to share location during onboarding never shows the iOS permission dialog, so the
+        // system status stays `.notDetermined` even though the user already decided — an explicit
+        // `.never` privacy setting counts as a decision and must not re-trigger the flow.
+        let userDeclinedLocationSharing = server.info.setting(for: .locationPrivacy) == .never
+
+        if Current.location.permissionStatus == .notDetermined, !userDeclinedLocationSharing,
+           connection.hasNonHTTPSURLOptions {
             Current.Log.verbose("User has not decided location permission yet")
             showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
         } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -138,12 +138,11 @@ struct OnboardingServersListView: View {
             OnboardingPermissionsNavigationView(
                 onboardingServer: viewModel.onboardingServer!,
                 onDismiss: {
-                    if onboardingStyle == .secondary {
-                        viewModel.permissionsFlowCompleted = true
-                        viewModel.showPermissionsFlow = false
-                    } else {
-                        Current.onboardingObservation.complete()
-                    }
+                    // Dismiss the cover first and only signal completion from the cover's `onDismiss`
+                    // (above): completing while the cover is still presented makes `ContainerView` swap
+                    // the screen under a presented cover, which can leave it dangling as a blank screen.
+                    viewModel.permissionsFlowCompleted = true
+                    viewModel.showPermissionsFlow = false
                 }
             )
         }

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 @testable import HomeAssistant
 @testable import Shared
 import UIKit
@@ -306,6 +307,85 @@ final class WebViewControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(restored, URL(string: "http://homeassistant.local:8123/"))
+    }
+
+    // MARK: - Local security level decision
+
+    // ServerInfo.fake() has a non-HTTPS external URL and an undefined security level.
+
+    func testLocalSecurityLevelDecisionRequestsLocationFlowWhenPermissionNotDetermined() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertEqual(steps, OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
+    }
+
+    func testLocalSecurityLevelDecisionSkipsLocationFlowWhenUserDeclinedSharing() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: true
+        )
+
+        XCTAssertEqual(
+            steps,
+            OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        )
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenUserDeclinedSharingAndSecurityLevelDecided() {
+        var connection = ServerInfo.fake().connection
+        connection.connectionAccessSecurityLevel = .mostSecure
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: true
+        )
+
+        XCTAssertNil(steps)
+    }
+
+    func testLocalSecurityLevelDecisionRequestsSecurityLevelFlowWhenUndecided() {
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: ServerInfo.fake().connection,
+            locationPermissionStatus: .authorizedWhenInUse,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertEqual(
+            steps,
+            OnboardingPermissionsNavigationViewModel.StepID.updateLocalAccessSecurityLevelPreference
+        )
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenAllURLsAreHTTPS() {
+        var connection = ServerInfo.fake().connection
+        connection.set(address: URL(string: "https://example.com:8123"), for: .external)
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .notDetermined,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertNil(steps)
+    }
+
+    func testLocalSecurityLevelDecisionRequiresNothingWhenEverythingDecided() {
+        var connection = ServerInfo.fake().connection
+        connection.connectionAccessSecurityLevel = .lessSecure
+
+        let steps = WebViewController.localSecurityLevelDecisionSteps(
+            connection: connection,
+            locationPermissionStatus: .authorizedAlways,
+            userDeclinedLocationSharing: false
+        )
+
+        XCTAssertNil(steps)
     }
 
     private func makeSUT(server: Server = .fake()) -> WebViewController {


### PR DESCRIPTION
Two fixes for the end of the initial onboarding flow:

- The permissions full screen cover was never dismissed for initial onboarding: `complete()` fired while the cover was still presented, so the container swapped to the web view underneath a dangling blank cover, requiring an app restart. Now the cover is dismissed first and completion is signaled from the cover's `onDismiss`, matching what the add-server flow already did.
- Choosing "Do not share my location" never shows the iOS permission dialog, so the system status stays `.notDetermined` and `checkForLocalSecurityLevelDecisionNeeded()` re-presented the whole location flow right after onboarding. An explicit `.never` location privacy setting now counts as a decision.