### PR TITLE
Show update progress toast when manually refreshing server info

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -299,7 +299,7 @@ extension WebViewController {
     /// Called after view appears and on pull to refresh to avoid blocking app launch
     func updateDatabaseAndPanels() {
         // Update runs in background automatically, returns immediately
-        Current.appDatabaseUpdater.update(server: server, forceUpdate: false)
+        Current.appDatabaseUpdater.update(server: server, forceUpdate: false, showProgress: false)
         Current.panelsUpdater.update()
     }
 }

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
@@ -187,7 +187,7 @@ extension OnboardingServersListViewModel: OnboardingStateObserver {
                 shouldDismiss = true
             }
             if let onboardingServer {
-                Current.appDatabaseUpdater.update(server: onboardingServer, forceUpdate: true)
+                Current.appDatabaseUpdater.update(server: onboardingServer, forceUpdate: true, showProgress: false)
             }
         }
     }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1196,6 +1196,10 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.connection_section.servers_header" = "Servers";
 "settings.connection_section.servers_reorder_footer" = "Drag to reorder your servers. The one at the top is used as the default server.";
 "settings.connection_section.ssid_permission_and_accuracy_message" = "Accessing SSIDs in the background requires 'Always' location permission and 'Full' location accuracy. Tap here to change your settings.";
+"settings.connection_section.update_database.finished" = "Server information updated";
+"settings.connection_section.update_database.progress.areas" = "Updating areas";
+"settings.connection_section.update_database.progress.devices" = "Updating devices";
+"settings.connection_section.update_database.progress.entities" = "Updating entities";
 "settings.connection_section.validate_error.edit_url" = "Edit URL";
 "settings.connection_section.validate_error.title" = "Error Saving URL";
 "settings.connection_section.validate_error.use_anyway" = "Use Anyway";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -77,7 +77,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
     }
 
     func updateAppDatabase() {
-        server.refreshAppDatabase(forceUpdate: true)
+        server.refreshAppDatabase(forceUpdate: true, showProgress: true)
     }
 
     func retryLocalPush() {

--- a/Sources/App/Settings/DebugDatabaseTransfer.swift
+++ b/Sources/App/Settings/DebugDatabaseTransfer.swift
@@ -286,7 +286,7 @@ enum DebugDatabaseTransfer {
         Current.Log.info("Refreshing app database for \(Current.servers.all.count) server(s) after import")
         for server in Current.servers.all {
             Current.Log.info("Requesting forced app database update for server \(server.identifier.rawValue)")
-            Current.appDatabaseUpdater.update(server: server, forceUpdate: true)
+            Current.appDatabaseUpdater.update(server: server, forceUpdate: true, showProgress: false)
         }
     }
 

--- a/Sources/App/Settings/Settings/ServersListView.swift
+++ b/Sources/App/Settings/Settings/ServersListView.swift
@@ -13,7 +13,7 @@ struct ServersListView: View {
             }
             .contextMenu {
                 Button {
-                    server.refreshAppDatabase(forceUpdate: true)
+                    server.refreshAppDatabase(forceUpdate: true, showProgress: true)
                 } label: {
                     Label(L10n.Settings.ConnectionSection.refreshServer, systemSymbol: .arrowClockwise)
                 }

--- a/Sources/HANetworking/Sources/HANetworkingEnvironment.swift
+++ b/Sources/HANetworking/Sources/HANetworkingEnvironment.swift
@@ -30,9 +30,11 @@ public struct HANetworkingEnvironment {
     public var connectivity = Connectivity.noop
 
     /// Triggers a refresh of a server's cached data from Home Assistant (`Server.refreshAppDatabase`).
-    /// HACore wires this to `Current.appDatabaseUpdater.update(server:forceUpdate:)`; no-op by default
-    /// (and on watchOS, where there is no app database updater).
-    public var refreshAppDatabase: (_ server: Server, _ forceUpdate: Bool) -> Void = { _, _ in }
+    /// HACore wires this to `Current.appDatabaseUpdater.update(server:forceUpdate:showProgress:)`; no-op
+    /// by default (and on watchOS, where there is no app database updater). `showProgress` surfaces
+    /// user-friendly progress through the toast manager and is only set for manual refreshes.
+    public var refreshAppDatabase: (_ server: Server, _ forceUpdate: Bool, _ showProgress: Bool) -> Void = { _, _, _ in
+    }
 
     /// User-defaults store `ServerManager` uses for deleted/restored-server bookkeeping. HACore wires
     /// this to `Current.settingsStore.prefs`.

--- a/Sources/HANetworking/Sources/Server.swift
+++ b/Sources/HANetworking/Sources/Server.swift
@@ -378,8 +378,10 @@ public extension Server {
 public extension Server {
     /// Triggers a refresh of this server's data from Home Assistant
     /// - Parameter forceUpdate: Whether to force the update regardless of cache state. Defaults to `false`.
-    func refreshAppDatabase(forceUpdate: Bool = false) {
-        HANetworkingEnvironment.current.refreshAppDatabase(self, forceUpdate)
+    /// - Parameter showProgress: Whether to surface user-friendly progress through the toast manager.
+    ///   Only manual (user-triggered) refreshes should pass `true`. Defaults to `false`.
+    func refreshAppDatabase(forceUpdate: Bool = false, showProgress: Bool = false) {
+        HANetworkingEnvironment.current.refreshAppDatabase(self, forceUpdate, showProgress)
     }
 }
 #endif

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import HADesignSystem
 import HAKit
+import SFSafeSymbols
+import SwiftUI
 import UIKit
 
 // MARK: - AppDatabaseUpdater
@@ -10,7 +13,7 @@ import UIKit
 /// applies per-server throttling with backoff, and performs careful cancellation and batched DB writes.
 public protocol AppDatabaseUpdaterProtocol {
     func stop()
-    func update(server: Server, forceUpdate: Bool)
+    func update(server: Server, forceUpdate: Bool, showProgress: Bool)
 }
 
 public extension Notification.Name {
@@ -20,6 +23,23 @@ public extension Notification.Name {
 final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
     enum UpdateError: Error {
         case noAPI
+    }
+
+    private enum DatabaseUpdatePhase {
+        case entities
+        case devices
+        case areas
+
+        var localizedDescription: String {
+            switch self {
+            case .entities:
+                return L10n.Settings.ConnectionSection.UpdateDatabase.Progress.entities
+            case .devices:
+                return L10n.Settings.ConnectionSection.UpdateDatabase.Progress.devices
+            case .areas:
+                return L10n.Settings.ConnectionSection.UpdateDatabase.Progress.areas
+            }
+        }
     }
 
     // MARK: - Cancellation Helper
@@ -59,6 +79,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         // Mutated only within the actor, so membership always reflects the true queued-or-running set
         // (no gap between dequeue and start that a duplicate could slip through).
         private var pendingForceByServer: [String: Bool] = [:]
+        private var pendingShowProgressByServer: [String: Bool] = [:]
         private var isProcessingQueue = false
 
         func setTask(_ task: Task<Void, Never>, for serverId: String) {
@@ -74,6 +95,11 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
             pendingForceByServer[serverId] ?? false
         }
 
+        /// Whether the server's queued/running work should surface progress (default off).
+        func effectiveShowProgress(for serverId: String) -> Bool {
+            pendingShowProgressByServer[serverId] ?? false
+        }
+
         func cancelAllTasks() {
             for (_, task) in currentUpdateTasks {
                 task.cancel()
@@ -81,13 +107,14 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
             currentUpdateTasks.removeAll()
             updateQueue.removeAll()
             pendingForceByServer.removeAll()
+            pendingShowProgressByServer.removeAll()
             isProcessingQueue = false
         }
 
         /// Enqueues a server update task to be processed sequentially.
         /// Skips servers that already have work queued or in progress, but a forced request upgrades
         /// an existing non-forced one so the eventual run isn't throttled away.
-        func enqueueUpdate(serverId: String, forceUpdate: Bool, task: @escaping () async -> Void) {
+        func enqueueUpdate(serverId: String, forceUpdate: Bool, showProgress: Bool, task: @escaping () async -> Void) {
             if let existingForce = pendingForceByServer[serverId] {
                 if forceUpdate, !existingForce {
                     pendingForceByServer[serverId] = true
@@ -95,9 +122,14 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                 } else {
                     Current.Log.verbose("Update for server \(serverId) already queued or running, skipping duplicate")
                 }
+                if showProgress, pendingShowProgressByServer[serverId] != true {
+                    pendingShowProgressByServer[serverId] = true
+                    Current.Log.verbose("Upgrading queued update for server \(serverId) to show progress")
+                }
                 return
             }
             pendingForceByServer[serverId] = forceUpdate
+            pendingShowProgressByServer[serverId] = showProgress
             updateQueue.append((serverId: serverId, task: task))
 
             // Start processing if not already running
@@ -118,6 +150,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
                 Current.Log.verbose("Processing queued update for server: \(queuedUpdate.serverId)")
                 await queuedUpdate.task()
                 pendingForceByServer.removeValue(forKey: queuedUpdate.serverId)
+                pendingShowProgressByServer.removeValue(forKey: queuedUpdate.serverId)
             }
 
             isProcessingQueue = false
@@ -198,9 +231,11 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
     /// This method returns immediately and does not block the caller.
     /// - Parameter server: The specific server to update.
     /// - Parameter forceUpdate: Forces update regardless of other conditions
+    /// - Parameter showProgress: Surfaces user-friendly progress through the toast manager. Only manual
+    ///   (user-triggered) refreshes pass `true`; automatic background updates stay silent.
     /// - Server updates are queued and processed sequentially, one at a time.
     /// - Applies per-server throttling with exponential backoff on failures.
-    func update(server: Server, forceUpdate: Bool) {
+    func update(server: Server, forceUpdate: Bool, showProgress: Bool) {
         // Explicitly detach from the calling context to ensure we don't block the main thread
         // Returns immediately while work continues in the background
         Task.detached(priority: .userInitiated) { [weak self] in
@@ -209,7 +244,11 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
             let serverId = server.identifier.rawValue
 
             // Enqueue the update to be processed sequentially
-            await taskCoordinator.enqueueUpdate(serverId: serverId, forceUpdate: forceUpdate) { [weak self] in
+            await taskCoordinator.enqueueUpdate(
+                serverId: serverId,
+                forceUpdate: forceUpdate,
+                showProgress: showProgress
+            ) { [weak self] in
                 guard let self else { return }
 
                 Current.Log.verbose("Updating database for server \(server.info.name)")
@@ -266,6 +305,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         // Read the effective force as late as possible — immediately before the throttle decision —
         // so a forced request that upgraded this server's queued entry isn't throttled into a no-op.
         let forceUpdate = await taskCoordinator.effectiveForce(for: server.identifier.rawValue)
+        let showProgress = await taskCoordinator.effectiveShowProgress(for: server.identifier.rawValue)
         guard await shouldUpdateServer(server, forceUpdate: forceUpdate) else {
             Current.Log.verbose("Skipping update for server \(server.info.name) - throttled")
             return
@@ -274,7 +314,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         // `nil` means the update was cancelled (e.g. app backgrounded); skip tracking entirely so
         // cancellation isn't recorded as a failure (which would add a spurious backoff penalty, and
         // could re-add a failure count that `stop()` just cleared).
-        guard let success = await safeUpdateServer(server: server) else { return }
+        guard let success = await safeUpdateServer(server: server, showProgress: showProgress) else { return }
         updateServerTracking(serverId: server.identifier.rawValue, success: success)
     }
 
@@ -294,9 +334,9 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
     /// Returns `nil` if the update was cancelled, otherwise whether it succeeded — letting the
     /// scheduler apply backoff on failures and update last-run times on success without treating
     /// cancellation as either.
-    private func safeUpdateServer(server: Server) async -> Bool? {
+    private func safeUpdateServer(server: Server, showProgress: Bool) async -> Bool? {
         if isUpdateCancelled() { return nil }
-        await updateServer(server: server)
+        await updateServer(server: server, showProgress: showProgress)
         if isUpdateCancelled() { return nil }
         return true
     }
@@ -315,13 +355,21 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
     /// `list_for_display` registry and bakes it into `HAAppEntity.name`, so readers can use `name`
     /// directly without a per-entity registry lookup. The `/states` fetch itself still happens first
     /// (Step 1); only the database write is deferred.
-    private func updateServer(server: Server) async {
+    private func updateServer(server: Server, showProgress: Bool) async {
         guard !isUpdateCancelled() else { return }
+
+        var didFinish = false
+        defer {
+            if !didFinish {
+                hideProgressToast(server: server, showProgress: showProgress)
+            }
+        }
 
         let totalTimer = ProfilingTimer("Starting full update for server: \(server.info.name)")
 
         // Step 1: Fetch entity states (`/states`). Persistence is deferred to Step 3 (after the
         // registry is saved) so display names can be resolved from `list_for_display`.
+        await presentProgressToast(.entities, server: server, showProgress: showProgress)
         let fetchedEntities: [HAEntity]?
         do {
             let timer = ProfilingTimer("Step 1 (Entities fetch)")
@@ -350,6 +398,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         if isUpdateCancelled() { return }
 
         // Step 4: Devices registry
+        await presentProgressToast(.devices, server: server, showProgress: showProgress)
         do {
             let timer = ProfilingTimer("Step 4 (Devices Registry)")
             await updateDevicesRegistry(server: server)
@@ -360,6 +409,7 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         // Step 5: Areas with their entities
         // IMPORTANT: This must be executed after entities and device registry
         // since we rely on that data to map entities to areas
+        await presentProgressToast(.areas, server: server, showProgress: showProgress)
         do {
             let timer = ProfilingTimer("Step 5 (Areas)")
             await updateAreasDatabase(server: server)
@@ -368,7 +418,49 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
         totalTimer.end()
         Current.Log.info("✅ [Profiling] Full update for server \(server.info.name) completed")
+        await presentFinishedToast(server: server, showProgress: showProgress)
+        didFinish = true
         NotificationCenter.default.post(name: .appDatabaseUpdaterDidFinishRoutine, object: server)
+    }
+
+    // MARK: - Progress Toast
+
+    private static func progressToastID(serverId: String) -> String {
+        "app-database-update-\(serverId)"
+    }
+
+    @MainActor
+    private func presentProgressToast(_ phase: DatabaseUpdatePhase, server: Server, showProgress: Bool) {
+        guard showProgress, #available(iOS 18, *) else { return }
+        ToastPresenter.shared.show(
+            id: Self.progressToastID(serverId: server.identifier.rawValue),
+            symbol: .arrowClockwise,
+            symbolForegroundStyle: (.white, .haPrimary),
+            title: server.info.name,
+            message: phase.localizedDescription
+        )
+    }
+
+    @MainActor
+    private func presentFinishedToast(server: Server, showProgress: Bool) {
+        guard showProgress, #available(iOS 18, *) else { return }
+        ToastPresenter.shared.show(
+            id: Self.progressToastID(serverId: server.identifier.rawValue),
+            symbol: .checkmarkSealFill,
+            symbolForegroundStyle: (.white, .green),
+            title: server.info.name,
+            message: L10n.Settings.ConnectionSection.UpdateDatabase.finished,
+            duration: 4
+        )
+    }
+
+    private func hideProgressToast(server: Server, showProgress: Bool) {
+        guard showProgress else { return }
+        let id = Self.progressToastID(serverId: server.identifier.rawValue)
+        Task { @MainActor in
+            guard #available(iOS 18, *) else { return }
+            ToastPresenter.shared.hide(id: id)
+        }
     }
 
     /// Sends a typed request for `server` and returns the decoded payload, or `nil` on cancellation,

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -149,8 +149,8 @@ public class AppEnvironment {
             lastKnownNetworkState: { Current.connectivity.lastKnownNetworkState() }
         )
         #if !os(watchOS)
-        HANetworkingEnvironment.current.refreshAppDatabase = { server, forceUpdate in
-            Current.appDatabaseUpdater.update(server: server, forceUpdate: forceUpdate)
+        HANetworkingEnvironment.current.refreshAppDatabase = { server, forceUpdate, showProgress in
+            Current.appDatabaseUpdater.update(server: server, forceUpdate: forceUpdate, showProgress: showProgress)
         }
         #endif
         HANetworkingEnvironment.current.prefs = Current.settingsStore.prefs

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4016,6 +4016,18 @@ public enum L10n {
           public static var `none`: String { return L10n.tr("Localizable", "settings.connection_section.sensor_send_type.setting.none") }
         }
       }
+      public enum UpdateDatabase {
+        /// Server information updated
+        public static var finished: String { return L10n.tr("Localizable", "settings.connection_section.update_database.finished") }
+        public enum Progress {
+          /// Updating areas
+          public static var areas: String { return L10n.tr("Localizable", "settings.connection_section.update_database.progress.areas") }
+          /// Updating devices
+          public static var devices: String { return L10n.tr("Localizable", "settings.connection_section.update_database.progress.devices") }
+          /// Updating entities
+          public static var entities: String { return L10n.tr("Localizable", "settings.connection_section.update_database.progress.entities") }
+        }
+      }
       public enum ValidateError {
         /// Edit URL
         public static var editUrl: String { return L10n.tr("Localizable", "settings.connection_section.validate_error.edit_url") }

--- a/Tests/App/Onboarding/ServersList/OnboardingServersListViewModelTests.swift
+++ b/Tests/App/Onboarding/ServersList/OnboardingServersListViewModelTests.swift
@@ -108,7 +108,7 @@ private final class RecordingAppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
     func stop() {}
 
-    func update(server: Server, forceUpdate: Bool) {
+    func update(server: Server, forceUpdate: Bool, showProgress _: Bool) {
         updates.append(Update(serverId: server.identifier.rawValue, forceUpdate: forceUpdate))
         onUpdate?(server, forceUpdate)
     }

--- a/Tests/App/Settings/DebugDatabaseTransfer.test.swift
+++ b/Tests/App/Settings/DebugDatabaseTransfer.test.swift
@@ -270,7 +270,7 @@ private final class RecordingAppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         stopCallCount += 1
     }
 
-    func update(server: Server, forceUpdate: Bool) {
+    func update(server: Server, forceUpdate: Bool, showProgress _: Bool) {
         if forceUpdate {
             updatedServerIds.append(server.identifier.rawValue)
         }


### PR DESCRIPTION
Shows a progress toast when a server's info is manually refreshed (long-press a server row → *Update server information*, or the button in connection settings). Progress advances through entities, devices and areas, then confirms completion.

Automatic background updates stay silent.