### PR TITLE
Add server selection sheet to standby view

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -6,6 +6,8 @@ struct HomeAssistantView: View, WebFrontendView {
     @StateObject private var viewModel: HomeAssistantViewModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var showServerSelection = false
+    @Namespace private var serverSelectionNamespace
 
     init(server: Server, onWebViewController: @escaping (WebViewController) -> Void) {
         self.init(server: server, initialPath: nil, onWebViewController: onWebViewController)
@@ -49,6 +51,21 @@ struct HomeAssistantView: View, WebFrontendView {
             }
             noActiveURLState
             standByView
+        }
+        .sheet(isPresented: $showServerSelection) {
+            ServerSelectView(prompt: nil, includeSettings: false, selectAction: viewModel.selectServer)
+                .presentationDetents([.medium, .large])
+                .presentationBackground(Color(uiColor: .systemBackground))
+                .modify { view in
+                    if #available(iOS 18.0, *) {
+                        view.navigationTransition(.zoom(
+                            sourceID: HomeAssistantStandByView.serverSelectionTransitionID,
+                            in: serverSelectionNamespace
+                        ))
+                    } else {
+                        view
+                    }
+                }
         }
         .animation(DesignSystem.Animation.easeInOutFaster, value: viewModel.overlayState.emptyState != nil)
         .animation(DesignSystem.Animation.easeInOutFaster, value: viewModel.overlayState.showsNoActiveURL)
@@ -120,6 +137,8 @@ struct HomeAssistantView: View, WebFrontendView {
                 server: viewModel.server,
                 emptyState: viewModel.displayedEmptyState,
                 isLoading: viewModel.overlayState.isLoading,
+                serverSelectionNamespace: serverSelectionNamespace,
+                onSelectServerTapped: { showServerSelection = true },
                 onGestureAction: { action in
                     viewModel.webViewController?.webViewGestureHandler.handleGestureAction(action)
                 },

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -274,4 +274,10 @@ final class HomeAssistantViewModel: ObservableObject {
         }
         isFullScreenLoaderMounted = false
     }
+
+    func selectServer(_ server: Server) {
+        Current.sceneManager.appCoordinator.done { coordinator in
+            coordinator.open(server: server)
+        }
+    }
 }

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -13,13 +13,15 @@ struct HomeAssistantStandByView: View {
     private static let serverPillHeight: CGFloat = 44
     private static let delayedSettingsButtonDelay: Duration = .seconds(5)
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
-    private static let serverSelectionTransitionID = "home-assistant-stand-by-server-selection"
+    static let serverSelectionTransitionID = "home-assistant-stand-by-server-selection"
     fileprivate static let launchScreenLogoSize = CGSize(width: 147, height: 174)
     fileprivate static let launchScreenLogoPreviewOpacity = 0.55
 
     let server: Server
     let emptyState: WebFrontendOverlayState.EmptyStateContent?
     let isLoading: Bool
+    let serverSelectionNamespace: Namespace.ID?
+    let onSelectServerTapped: (() -> Void)?
     let onGestureAction: ((HAGestureAction) -> Void)?
     let onLogoDismiss: (() -> Void)?
 
@@ -33,8 +35,6 @@ struct HomeAssistantStandByView: View {
     @State private var showsDelayedSettingsButton = false
     @State private var hasAppeared = false
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
-    @State private var showServerSelection = false
-    @Namespace private var serverSelectionNamespace
 
     private var showsEmptyState: Bool { emptyState != nil }
     private var loadingContentOffset: CGFloat { showsEmptyState ? 0 : -DesignSystem.Spaces.eight }
@@ -61,12 +61,16 @@ struct HomeAssistantStandByView: View {
         server: Server,
         emptyState: WebFrontendOverlayState.EmptyStateContent?,
         isLoading: Bool = false,
+        serverSelectionNamespace: Namespace.ID? = nil,
+        onSelectServerTapped: (() -> Void)? = nil,
         onGestureAction: ((HAGestureAction) -> Void)? = nil,
         onLogoDismiss: (() -> Void)? = nil
     ) {
         self.server = server
         self.emptyState = emptyState
         self.isLoading = isLoading
+        self.serverSelectionNamespace = serverSelectionNamespace
+        self.onSelectServerTapped = onSelectServerTapped
         self.onGestureAction = onGestureAction
         self.onLogoDismiss = onLogoDismiss
         self._selectedReauthURLType = State(initialValue: emptyState?.availableReauthURLTypes.first ?? .external)
@@ -222,31 +226,17 @@ struct HomeAssistantStandByView: View {
     private var serverNamePill: some View {
         if canSelectServer {
             Button {
-                showServerSelection = true
+                onSelectServerTapped?()
             } label: {
                 serverNameLabel
             }
             .buttonStyle(.plain)
             .modify { view in
-                if #available(iOS 18.0, *) {
+                if #available(iOS 18.0, *), let serverSelectionNamespace {
                     view.matchedTransitionSource(id: Self.serverSelectionTransitionID, in: serverSelectionNamespace)
                 } else {
                     view
                 }
-            }
-            .sheet(isPresented: $showServerSelection) {
-                ServerSelectView(prompt: nil, includeSettings: false, selectAction: selectServer)
-                    .presentationDetents([.medium, .large])
-                    .presentationBackground(Color(uiColor: .systemBackground))
-                    .modify { view in
-                        if #available(iOS 18.0, *) {
-                            view.navigationTransition(
-                                .zoom(sourceID: Self.serverSelectionTransitionID, in: serverSelectionNamespace)
-                            )
-                        } else {
-                            view
-                        }
-                    }
             }
         } else {
             serverNameLabel

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -13,6 +13,7 @@ struct HomeAssistantStandByView: View {
     private static let serverPillHeight: CGFloat = 44
     private static let delayedSettingsButtonDelay: Duration = .seconds(5)
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
+    private static let serverSelectionTransitionID = "home-assistant-stand-by-server-selection"
     fileprivate static let launchScreenLogoSize = CGSize(width: 147, height: 174)
     fileprivate static let launchScreenLogoPreviewOpacity = 0.55
 
@@ -32,6 +33,8 @@ struct HomeAssistantStandByView: View {
     @State private var showsDelayedSettingsButton = false
     @State private var hasAppeared = false
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
+    @State private var showServerSelection = false
+    @Namespace private var serverSelectionNamespace
 
     private var showsEmptyState: Bool { emptyState != nil }
     private var loadingContentOffset: CGFloat { showsEmptyState ? 0 : -DesignSystem.Spaces.eight }
@@ -51,6 +54,8 @@ struct HomeAssistantStandByView: View {
     }
 
     private var showsConnectionTypeIndicator: Bool { configuredURLTypes.count > 1 }
+
+    private var canSelectServer: Bool { Current.servers.all.count > 1 }
 
     init(
         server: Server,
@@ -206,27 +211,66 @@ struct HomeAssistantStandByView: View {
 
     private var currentServerPillContent: some View {
         HStack(spacing: DesignSystem.Spaces.one) {
-            Text(server.info.name)
-                .font(.headline)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .padding(.horizontal, DesignSystem.Spaces.two)
-                .frame(height: Self.serverPillHeight)
-                .modify { view in
-                    if #available(iOS 26.0, *) {
-                        view
-                            .glassEffect(.regular.interactive(), in: .capsule)
-                            .contentShape(Capsule())
-                    } else {
-                        view
-                            .background(Color(uiColor: .secondarySystemBackground))
-                            .clipShape(.capsule)
-                    }
-                }
+            serverNamePill
             if showsConnectionTypeIndicator {
                 connectionTypeIndicator
             }
         }
+    }
+
+    @ViewBuilder
+    private var serverNamePill: some View {
+        if canSelectServer {
+            Button {
+                showServerSelection = true
+            } label: {
+                serverNameLabel
+            }
+            .buttonStyle(.plain)
+            .modify { view in
+                if #available(iOS 18.0, *) {
+                    view.matchedTransitionSource(id: Self.serverSelectionTransitionID, in: serverSelectionNamespace)
+                } else {
+                    view
+                }
+            }
+            .sheet(isPresented: $showServerSelection) {
+                ServerSelectView(prompt: nil, includeSettings: false, selectAction: selectServer)
+                    .presentationDetents([.medium, .large])
+                    .presentationBackground(Color(uiColor: .systemBackground))
+                    .modify { view in
+                        if #available(iOS 18.0, *) {
+                            view.navigationTransition(
+                                .zoom(sourceID: Self.serverSelectionTransitionID, in: serverSelectionNamespace)
+                            )
+                        } else {
+                            view
+                        }
+                    }
+            }
+        } else {
+            serverNameLabel
+        }
+    }
+
+    private var serverNameLabel: some View {
+        Text(server.info.name)
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .padding(.horizontal, DesignSystem.Spaces.two)
+            .frame(height: Self.serverPillHeight)
+            .modify { view in
+                if #available(iOS 26.0, *) {
+                    view
+                        .glassEffect(.regular.interactive(), in: .capsule)
+                        .contentShape(Capsule())
+                } else {
+                    view
+                        .background(Color(uiColor: .secondarySystemBackground))
+                        .clipShape(.capsule)
+                }
+            }
     }
 
     private var connectionTypeIndicator: some View {


### PR DESCRIPTION
Tapping the server name on the standby loading screen now opens the server selection sheet (medium/large detents, zoom transition) when more than one server is configured.