### PR TITLE
Empty TestFlight communication catalog

### DIFF
--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationCatalog.swift
@@ -33,19 +33,5 @@ import Shared
 /// )
 /// ```
 enum TestFlightCommunicationCatalog {
-    static let message: TestFlightMessage? = TestFlightMessage(
-        id: .includeEmailWhenReporting,
-        title: "Reporting an issue?",
-        items: [
-            WhatsNewItem(
-                id: "testflight-include-email",
-                title: "Optional, but it helps a lot",
-                body: "When you report a problem through TestFlight, it's optional but really valuable to " +
-                    "include your email address or Discord handle. With it we can reach out to share " +
-                    "setup instructions or ask follow-up questions — without it we have no way to get " +
-                    "back to you.",
-                icon: .sfSymbol(.envelope)
-            ),
-        ]
-    )
+    static let message: TestFlightMessage? = nil
 }

--- a/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
+++ b/Sources/App/TestFlightCommunication/TestFlightCommunicationModels.swift
@@ -15,10 +15,6 @@ struct TestFlightMessageId: RawRepresentable, Hashable {
     init(rawValue: String) { self.rawValue = rawValue }
 }
 
-extension TestFlightMessageId {
-    static let includeEmailWhenReporting = TestFlightMessageId("include-email-when-reporting-2026-06")
-}
-
 struct TestFlightMessage: Identifiable, Equatable {
     struct CallToAction: Equatable {
         let title: String


### PR DESCRIPTION
Clears the TestFlight tester message so nothing is shown until the next one is added.