### PR TITLE
Prevent duplicate server names

### DIFF
--- a/Sources/HANetworking/Sources/ServerManager.swift
+++ b/Sources/HANetworking/Sources/ServerManager.swift
@@ -231,9 +231,22 @@ public final class ServerManagerImpl: ServerManager {
 
     @discardableResult
     public func add(identifier: Identifier<Server>, serverInfo: ServerInfo) -> Server {
+        let existingServers = all
         let setValue = with(serverInfo) {
             if $0.sortOrder == ServerInfo.defaultSortOrder {
-                $0.sortOrder = all.map(\.info.sortOrder).max().map { $0 + 1000 } ?? 0
+                $0.sortOrder = existingServers.map(\.info.sortOrder).max().map { $0 + 1000 } ?? 0
+            }
+
+            let takenNames = Set(
+                existingServers
+                    .filter { $0.identifier != identifier }
+                    .map(\.info.name)
+            )
+            let uniqueName = Self.uniqueName(for: $0.name, takenNames: takenNames)
+            if uniqueName != $0.name {
+                // Stored in the local-name override so a later remote-name sync (e.g. get_config
+                // returning the server's location_name) can't reintroduce the duplicate.
+                $0.setSetting(value: uniqueName, for: .localName)
             }
         }
 
@@ -295,6 +308,18 @@ public final class ServerManagerImpl: ServerManager {
         restoredMirroredServers = []
 
         notify()
+    }
+
+    /// Returns `name` unchanged when no other server already uses it, otherwise the first
+    /// numbered variant ("\(name) 2", "\(name) 3", …) that isn't taken.
+    private static func uniqueName(for name: String, takenNames: Set<String>) -> String {
+        guard takenNames.contains(name) else { return name }
+
+        var suffix = 2
+        while takenNames.contains("\(name) \(suffix)") {
+            suffix += 1
+        }
+        return "\(name) \(suffix)"
     }
 
     // MARK: Cache and Observation

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -107,6 +107,8 @@ class ServerManagerTests: XCTestCase {
         XCTAssertTrue(servers.server(for: FakeServerIdentifierProviding(serverIdentifier: "fake2")) === server2)
         XCTAssertEqual(server2.info, with(info2) {
             $0.sortOrder = 1000
+            // both fakes share a name, so adding the second one dedupes it locally
+            $0.setSetting(value: "Fake Server 2", for: .localName)
         })
 
         XCTAssertEqual(servers.all, [server1, server2])
@@ -180,6 +182,7 @@ class ServerManagerTests: XCTestCase {
         XCTAssertNil(servers.server(for: "fake1"))
         XCTAssertEqual(servers.server(for: "fake2")?.info, with(info2) {
             $0.sortOrder = 1000
+            $0.setSetting(value: "Fake Server 2", for: .localName)
         })
         XCTAssertEqual(servers.server(for: "fake3")?.info, with(info3) {
             $0.sortOrder = 2000
@@ -221,6 +224,7 @@ class ServerManagerTests: XCTestCase {
         })
         XCTAssertEqual(servers.server(for: "fake2")?.info, with(info2) {
             $0.sortOrder = 1000
+            $0.setSetting(value: "Fake Server 2", for: .localName)
         })
         XCTAssertNil(servers.server(for: "fake3"))
 
@@ -337,6 +341,74 @@ class ServerManagerTests: XCTestCase {
 
         servers.server(for: "fake3")?.info.sortOrder = 0
         XCTAssertEqual(servers.all.map(\.identifier), ["fake3", "fake1", "fake2"])
+    }
+
+    func testAddingServersWithDuplicateNamesAppendsNumberSuffix() throws {
+        try setupRegular()
+
+        let server1 = servers.add(identifier: "fake1", serverInfo: .fake())
+        let server2 = servers.add(identifier: "fake2", serverInfo: .fake())
+        let server3 = servers.add(identifier: "fake3", serverInfo: .fake())
+
+        XCTAssertEqual(server1.info.name, "Fake Server")
+        XCTAssertEqual(server2.info.name, "Fake Server 2")
+        XCTAssertEqual(server3.info.name, "Fake Server 3")
+
+        // the remote name stays untouched; the deduplicated name lives in the local override
+        XCTAssertEqual(server2.info.remoteName, "Fake Server")
+        XCTAssertEqual(server2.info.setting(for: .localName), "Fake Server 2")
+        XCTAssertEqual(server3.info.remoteName, "Fake Server")
+        XCTAssertEqual(server3.info.setting(for: .localName), "Fake Server 3")
+    }
+
+    func testAddingDuplicateNameSkipsAlreadyTakenNumberSuffix() throws {
+        try setupRegular()
+
+        servers.add(identifier: "fake1", serverInfo: .fake())
+        servers.add(identifier: "fake2", serverInfo: with(.fake()) {
+            $0.remoteName = "Fake Server 2"
+        })
+
+        let added = servers.add(identifier: "fake3", serverInfo: .fake())
+        XCTAssertEqual(added.info.name, "Fake Server 3")
+    }
+
+    func testAddingDuplicateOfLocallyRenamedServerDedupesAgainstEffectiveName() throws {
+        try setupRegular()
+
+        servers.add(identifier: "fake1", serverInfo: with(.fake()) {
+            $0.remoteName = "Original"
+            $0.setSetting(value: "Home", for: .localName)
+        })
+
+        let added = servers.add(identifier: "fake2", serverInfo: with(.fake()) {
+            $0.remoteName = "Home"
+        })
+        XCTAssertEqual(added.info.name, "Home 2")
+    }
+
+    func testReAddingSameServerDoesNotRenameAgainstItself() throws {
+        try setupRegular()
+
+        let first = servers.add(identifier: "fake1", serverInfo: .fake())
+        XCTAssertEqual(first.info.name, "Fake Server")
+        XCTAssertNil(first.info.setting(for: .localName))
+
+        let readded = servers.add(identifier: "fake1", serverInfo: .fake())
+        XCTAssertEqual(readded.info.name, "Fake Server")
+        XCTAssertNil(readded.info.setting(for: .localName))
+    }
+
+    func testAddingServerWithUniqueNameIsNotRenamed() throws {
+        try setupRegular()
+
+        servers.add(identifier: "fake1", serverInfo: .fake())
+
+        let other = servers.add(identifier: "fake2", serverInfo: with(.fake()) {
+            $0.remoteName = "Other"
+        })
+        XCTAssertEqual(other.info.name, "Other")
+        XCTAssertNil(other.info.setting(for: .localName))
     }
 
     private func notificationContent(webhookID: String?) -> UNNotificationContent {


### PR DESCRIPTION
When adding a server whose name matches an existing one, the new server is automatically renamed by appending a numeric suffix ("Home" becomes "Home 2", then "Home 3", and so on) until the name is unique.

The deduplicated name is stored in the local name override, so a later remote name sync from the server can't reintroduce the duplicate. Re-adding the same server keeps its name unchanged.

Includes unit tests.