### PR TITLE
Allow choosing Live Activity progress bar fill direction

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -718,6 +718,9 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.sample.plain.note" = "Minimum viable layout — only the message field is set. Verifies the bare layout renders without icon, progress, or timer.";
 "live_activity.sample.plain.summary" = "A basic message with nothing else.";
 "live_activity.sample.plain.title" = "Plain Message";
+"live_activity.sample.progress_direction.note" = "progress_bar_direction: decreasing flips the bar's fill: it shows what remains (progress_max − progress) and drains as progress rises. Percent text still shows the raw progress value. Also works on timer bars, e.g. increasing makes a countdown fill up instead of drain.";
+"live_activity.sample.progress_direction.summary" = "A progress bar that drains instead of fills.";
+"live_activity.sample.progress_direction.title" = "Battery · Decreasing Bar";
 "live_activity.sample.rate_limit.note" = "Six updates 2 s apart. On iOS 18 the system renders ~one per 15 s — some are silently dropped and the counter skips. On the simulator and iOS 17 all six render.";
 "live_activity.sample.rate_limit.summary" = "Rapid back-to-back updates to test how many show.";
 "live_activity.sample.rate_limit.title" = "Rate Limit · 6 Rapid Updates";

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -826,7 +826,7 @@ private struct LiveActivitySample: Identifiable {
                 lines.append("\(sub)progress_bar_color: \"\(progressBarColor)\"")
             }
             if let progressBarDirection = stage.progressBarDirection {
-                lines.append("\(sub)progress_bar_direction: \(progressBarDirection)")
+                lines.append("\(sub)progress_bar_direction: \"\(progressBarDirection)\"")
             }
             return lines
         }

--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -278,6 +278,24 @@ struct LiveActivitySettingsView: View {
                 )]
             ),
             LiveActivitySample(
+                id: "progress-direction",
+                name: L10n.LiveActivity.Sample.ProgressDirection.title,
+                summary: L10n.LiveActivity.Sample.ProgressDirection.summary,
+                note: L10n.LiveActivity.Sample.ProgressDirection.note,
+                tag: "debug-progress-direction",
+                title: "Backup Battery",
+                stages: [.init(
+                    message: "On battery · 35% remaining",
+                    criticalText: "35%",
+                    progress: 65,
+                    progressMax: 100,
+                    icon: "mdi:battery-40",
+                    color: "#FF9800",
+                    progressBarColor: "#FF9800",
+                    progressBarDirection: "decreasing"
+                )]
+            ),
+            LiveActivitySample(
                 id: "all-fields",
                 name: L10n.LiveActivity.Sample.AllFields.title,
                 summary: L10n.LiveActivity.Sample.AllFields.summary,
@@ -736,6 +754,7 @@ private struct LiveActivitySample: Identifiable {
         var backgroundColor: String?
         var textColor: String?
         var progressBarColor: String?
+        var progressBarDirection: String?
 
         func contentState() -> HALiveActivityAttributes.ContentState {
             // countdownEnd is relative to now so the local demo matches `when_relative: true`,
@@ -754,7 +773,8 @@ private struct LiveActivitySample: Identifiable {
                 color: color,
                 backgroundColor: backgroundColor,
                 textColor: textColor,
-                progressBarColor: progressBarColor
+                progressBarColor: progressBarColor,
+                progressBarDirection: progressBarDirection
             )
         }
     }
@@ -804,6 +824,9 @@ private struct LiveActivitySample: Identifiable {
             if let textColor = stage.textColor { lines.append("\(sub)text_color: \"\(textColor)\"") }
             if let progressBarColor = stage.progressBarColor {
                 lines.append("\(sub)progress_bar_color: \"\(progressBarColor)\"")
+            }
+            if let progressBarDirection = stage.progressBarDirection {
+                lines.append("\(sub)progress_bar_direction: \(progressBarDirection)")
             }
             return lines
         }

--- a/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
@@ -1,4 +1,5 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
+import Shared
 import SwiftUI
 
 /// Ticking chronometer text for a Live Activity, mirroring Android's chronometer semantics:
@@ -38,6 +39,9 @@ struct HAActivityTimerProgressBar: View {
     let start: Date?
     let end: Date
     let tint: Color
+    /// Explicit `progress_bar_direction` override; nil keeps the per-timer default
+    /// (countdown drains, bounded count-up fills).
+    var direction: HALiveActivityAttributes.ContentState.ProgressBarDirection?
 
     var body: some View {
         if let interval {
@@ -53,16 +57,17 @@ struct HAActivityTimerProgressBar: View {
         }
     }
 
-    /// Bounded count-up fills from `start` to `end` (and stays full once reached); a countdown
-    /// drains and only renders while still running. An unbounded count-up has no interval — no
-    /// bar. `now` is captured once so the range can't invalidate between check and use.
+    /// By default a bounded count-up fills from `start` to `end` (and stays full once reached)
+    /// while a countdown drains; `direction` overrides that fill direction. A countdown only
+    /// renders while still running, and an unbounded count-up has no interval — no bar.
+    /// `now` is captured once so the range can't invalidate between check and use.
     private var interval: (range: ClosedRange<Date>, countsDown: Bool)? {
         if let start, start < end {
-            return (start ... end, false)
+            return (start ... end, direction == .decreasing)
         }
         let now = Date.now
         if end > now {
-            return (now ... end, true)
+            return (now ... end, direction != .increasing)
         }
         return nil
     }

--- a/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HAActivityTimerProgressBar.swift
@@ -41,7 +41,7 @@ struct HAActivityTimerProgressBar: View {
     let tint: Color
     /// Explicit `progress_bar_direction` override; nil keeps the per-timer default
     /// (countdown drains, bounded count-up fills).
-    var direction: HALiveActivityAttributes.ContentState.ProgressBarDirection?
+    let direction: HALiveActivityAttributes.ContentState.ProgressBarDirection?
 
     var body: some View {
         if let interval {

--- a/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HADynamicIslandView.swift
@@ -170,7 +170,7 @@ struct HAExpandedBottomView: View {
                     .lineLimit(2)
             }
 
-            if let fraction = state.progressFraction {
+            if let fraction = state.progressBarFillFraction {
                 HAActivityProgressBar(
                     fraction: fraction,
                     fillColor: barColor,
@@ -178,7 +178,12 @@ struct HAExpandedBottomView: View {
                     height: 8
                 )
             } else if state.chronometer == true, let end = state.countdownEnd {
-                HAActivityTimerProgressBar(start: state.chronometerStart, end: end, tint: barColor)
+                HAActivityTimerProgressBar(
+                    start: state.chronometerStart,
+                    end: end,
+                    tint: barColor,
+                    direction: state.resolvedProgressBarDirection
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
+++ b/Sources/Extensions/Widgets/LiveActivity/HALockScreenView.swift
@@ -48,7 +48,7 @@ struct HALockScreenView: View {
                 trailingValue
             }
 
-            if let fraction = state.progressFraction {
+            if let fraction = state.progressBarFillFraction {
                 HAActivityProgressBar(
                     fraction: fraction,
                     fillColor: barColor,
@@ -56,7 +56,12 @@ struct HALockScreenView: View {
                     height: 10
                 )
             } else if state.chronometer == true, let end = state.countdownEnd {
-                HAActivityTimerProgressBar(start: state.chronometerStart, end: end, tint: barColor)
+                HAActivityTimerProgressBar(
+                    start: state.chronometerStart,
+                    end: end,
+                    tint: barColor,
+                    direction: state.resolvedProgressBarDirection
+                )
             }
         }
         .padding(.horizontal, DesignSystem.Spaces.two)

--- a/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
+++ b/Sources/Shared/LiveActivity/HALiveActivityAttributes.swift
@@ -112,12 +112,40 @@ public struct HALiveActivityAttributes: ActivityAttributes {
         /// `notification_icon_color` when omitted. Maps to `progress_bar_color`.
         public var progressBarColor: String?
 
+        /// Direction the progress bar visually fills: `"increasing"` or `"decreasing"`.
+        /// Stored as the raw wire string so an unrecognised value degrades to the default
+        /// rendering instead of failing the strict OS-side content-state decode (which would
+        /// silently drop the whole update). Maps to `progress_bar_direction`.
+        public var progressBarDirection: String?
+
+        /// Recognised `progress_bar_direction` values.
+        public enum ProgressBarDirection: String {
+            case increasing
+            case decreasing
+        }
+
         // MARK: - Computed helpers (not sent over wire)
 
         /// Progress as a fraction in [0, 1] for use in SwiftUI ProgressView.
         public var progressFraction: Double? {
             guard let p = progress, let m = progressMax, m > 0 else { return nil }
             return Double(p) / Double(m)
+        }
+
+        /// Parsed `progressBarDirection` (case-insensitive). Nil when unset or unrecognised,
+        /// so each bar keeps its own default: a static bar fills as progress increases, a
+        /// countdown timer bar drains, and a bounded count-up timer bar fills.
+        public var resolvedProgressBarDirection: ProgressBarDirection? {
+            progressBarDirection.flatMap { ProgressBarDirection(rawValue: $0.lowercased()) }
+        }
+
+        /// Fraction of the static progress bar to fill, honoring `progress_bar_direction`:
+        /// `decreasing` fills with what remains (`1 - progressFraction`) so the bar drains as
+        /// progress advances. Percent labels intentionally keep showing `progressFraction` —
+        /// the direction only flips the visual fill.
+        public var progressBarFillFraction: Double? {
+            guard let fraction = progressFraction else { return nil }
+            return resolvedProgressBarDirection == .decreasing ? 1 - fraction : fraction
         }
 
         // MARK: - CodingKeys
@@ -138,6 +166,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             case backgroundColor = "background_color"
             case textColor = "text_color"
             case progressBarColor = "progress_bar_color"
+            case progressBarDirection = "progress_bar_direction"
         }
 
         // MARK: - Init
@@ -156,7 +185,8 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             url: String? = nil,
             backgroundColor: String? = nil,
             textColor: String? = nil,
-            progressBarColor: String? = nil
+            progressBarColor: String? = nil,
+            progressBarDirection: String? = nil
         ) {
             self.title = title
             self.message = message
@@ -172,6 +202,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             self.backgroundColor = backgroundColor
             self.textColor = textColor
             self.progressBarColor = progressBarColor
+            self.progressBarDirection = progressBarDirection
         }
 
         // MARK: - Codable
@@ -208,6 +239,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             self.backgroundColor = try container.decodeIfPresent(String.self, forKey: .backgroundColor)
             self.textColor = try container.decodeIfPresent(String.self, forKey: .textColor)
             self.progressBarColor = try container.decodeIfPresent(String.self, forKey: .progressBarColor)
+            self.progressBarDirection = try container.decodeIfPresent(String.self, forKey: .progressBarDirection)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -230,6 +262,7 @@ public struct HALiveActivityAttributes: ActivityAttributes {
             try container.encodeIfPresent(backgroundColor, forKey: .backgroundColor)
             try container.encodeIfPresent(textColor, forKey: .textColor)
             try container.encodeIfPresent(progressBarColor, forKey: .progressBarColor)
+            try container.encodeIfPresent(progressBarDirection, forKey: .progressBarDirection)
         }
 
         // HA may send progress/progress_max as a JSON float (e.g. 20.1234). ActivityKit decodes

--- a/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
+++ b/Sources/Shared/Notifications/NotificationCommands/HandlerLiveActivity.swift
@@ -146,6 +146,7 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
         let backgroundColor = payload["background_color"] as? String
         let textColor = payload["text_color"] as? String
         let progressBarColor = payload["progress_bar_color"] as? String
+        let progressBarDirection = payload["progress_bar_direction"] as? String
 
         // `when` + `when_relative` → absolute timer end date.
         // Parsed as Double to preserve sub-second Unix timestamps sent by HA.
@@ -182,7 +183,8 @@ struct HandlerStartOrUpdateLiveActivity: NotificationCommandHandler {
             url: url,
             backgroundColor: backgroundColor,
             textColor: textColor,
-            progressBarColor: progressBarColor
+            progressBarColor: progressBarColor,
+            progressBarDirection: progressBarDirection
         )
     }
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2476,6 +2476,14 @@ public enum L10n {
         /// Plain Message
         public static var title: String { return L10n.tr("Localizable", "live_activity.sample.plain.title") }
       }
+      public enum ProgressDirection {
+        /// progress_bar_direction: decreasing flips the bar's fill: it shows what remains (progress_max − progress) and drains as progress rises. Percent text still shows the raw progress value. Also works on timer bars, e.g. increasing makes a countdown fill up instead of drain.
+        public static var note: String { return L10n.tr("Localizable", "live_activity.sample.progress_direction.note") }
+        /// A progress bar that drains instead of fills.
+        public static var summary: String { return L10n.tr("Localizable", "live_activity.sample.progress_direction.summary") }
+        /// Battery · Decreasing Bar
+        public static var title: String { return L10n.tr("Localizable", "live_activity.sample.progress_direction.title") }
+      }
       public enum RateLimit {
         /// Six updates 2 s apart. On iOS 18 the system renders ~one per 15 s — some are silently dropped and the counter skips. On the simulator and iOS 17 all six render.
         public static var note: String { return L10n.tr("Localizable", "live_activity.sample.rate_limit.note") }

--- a/Sources/SharedPush/Sources/NotificationParserLegacy.swift
+++ b/Sources/SharedPush/Sources/NotificationParserLegacy.swift
@@ -254,6 +254,7 @@ public struct LegacyNotificationParserImpl: LegacyNotificationParser {
                 NotificationPayloadKey.notificationIcon.rawValue,
                 NotificationPayloadKey.notificationIconColor.rawValue,
                 "background_color", "text_color", "progress_bar_color",
+                "progress_bar_direction",
                 "silent", "url",
             ] {
                 if let value = data[key] {

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -90,6 +90,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertNil(state.backgroundColor)
         XCTAssertNil(state.textColor)
         XCTAssertNil(state.progressBarColor)
+        XCTAssertNil(state.progressBarDirection)
     }
 
     func testContentState_emptyTitle_isNil() {
@@ -110,6 +111,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
             "background_color": "#101820",
             "text_color": "#FFFFFF",
             "progress_bar_color": "#FF9800",
+            "progress_bar_direction": "decreasing",
         ]
         let state = HandlerStartOrUpdateLiveActivity.contentState(from: payload)
         XCTAssertEqual(state.title, "Test title")
@@ -123,6 +125,7 @@ final class HandlerStartOrUpdateLiveActivityTests: XCTestCase {
         XCTAssertEqual(state.backgroundColor, "#101820")
         XCTAssertEqual(state.textColor, "#FFFFFF")
         XCTAssertEqual(state.progressBarColor, "#FF9800")
+        XCTAssertEqual(state.progressBarDirection, "decreasing")
         XCTAssertNil(state.countdownEnd)
     }
 

--- a/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
+++ b/Tests/Shared/LiveActivity/LiveActivityContractTests.swift
@@ -108,7 +108,8 @@ final class LiveActivityContractTests: XCTestCase {
             url: "/lovelace/0",
             backgroundColor: "#000000",
             textColor: "#FFFFFF",
-            progressBarColor: "#FF9800"
+            progressBarColor: "#FF9800",
+            progressBarDirection: "decreasing"
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970
@@ -131,6 +132,7 @@ final class LiveActivityContractTests: XCTestCase {
             "background_color",
             "text_color",
             "progress_bar_color",
+            "progress_bar_direction",
         ]
         XCTAssertEqual(Set(dict.keys), expectedKeys)
     }
@@ -151,7 +153,8 @@ final class LiveActivityContractTests: XCTestCase {
             url: "/lovelace/laundry",
             backgroundColor: "#101820",
             textColor: "#FFFFFF",
-            progressBarColor: "#FF9800"
+            progressBarColor: "#FF9800",
+            progressBarDirection: "decreasing"
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .secondsSince1970
@@ -181,6 +184,63 @@ final class LiveActivityContractTests: XCTestCase {
             from: Data(#"{"message":"m","progress":20.6}"#.utf8)
         )
         XCTAssertEqual(rounding.progress, 21)
+    }
+
+    /// `progress_bar_direction` is stored as the raw wire string; an unrecognised value must
+    /// decode without throwing (a throw would drop the whole OS-side update) and resolve to nil
+    /// so rendering falls back to the default direction.
+    func testContentState_progressBarDirection_decodesLeniently() throws {
+        let decreasing = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress_bar_direction":"decreasing"}"#.utf8)
+        )
+        XCTAssertEqual(decreasing.resolvedProgressBarDirection, .decreasing)
+
+        // Case-insensitive: Android-style automations may send capitalised values.
+        let uppercase = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress_bar_direction":"Increasing"}"#.utf8)
+        )
+        XCTAssertEqual(uppercase.resolvedProgressBarDirection, .increasing)
+
+        let unknown = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m","progress_bar_direction":"sideways"}"#.utf8)
+        )
+        XCTAssertEqual(unknown.progressBarDirection, "sideways")
+        XCTAssertNil(unknown.resolvedProgressBarDirection)
+
+        let missing = try JSONDecoder().decode(
+            HALiveActivityAttributes.ContentState.self,
+            from: Data(#"{"message":"m"}"#.utf8)
+        )
+        XCTAssertNil(missing.progressBarDirection)
+        XCTAssertNil(missing.resolvedProgressBarDirection)
+    }
+
+    /// `decreasing` flips only the visual fill: the bar shows what remains while
+    /// `progressFraction` (used by percent labels) keeps reporting the raw progress.
+    func testContentState_progressBarFillFraction_honorsDirection() {
+        let base = HALiveActivityAttributes.ContentState(
+            message: "m",
+            progress: 30,
+            progressMax: 100
+        )
+        XCTAssertEqual(base.progressBarFillFraction ?? -1, 0.3, accuracy: 0.0001)
+
+        var decreasing = base
+        decreasing.progressBarDirection = "decreasing"
+        XCTAssertEqual(decreasing.progressBarFillFraction ?? -1, 0.7, accuracy: 0.0001)
+        XCTAssertEqual(decreasing.progressFraction ?? -1, 0.3, accuracy: 0.0001)
+
+        var unknown = base
+        unknown.progressBarDirection = "sideways"
+        XCTAssertEqual(unknown.progressBarFillFraction ?? -1, 0.3, accuracy: 0.0001)
+
+        var noProgress = base
+        noProgress.progress = nil
+        noProgress.progressBarDirection = "decreasing"
+        XCTAssertNil(noProgress.progressBarFillFraction)
     }
 
     /// A content-state payload without progress keys still decodes, with nil progress.

--- a/Tests/Shared/LocalPushManager.test.swift
+++ b/Tests/Shared/LocalPushManager.test.swift
@@ -519,6 +519,7 @@ class LocalPushManagerTests: XCTestCase {
                 "background_color": "#101820",
                 "text_color": "#FFFFFF",
                 "progress_bar_color": "#03A9F4",
+                "progress_bar_direction": "decreasing",
             ],
         ]))
 
@@ -527,6 +528,7 @@ class LocalPushManagerTests: XCTestCase {
         XCTAssertEqual(ha["background_color"] as? String, "#101820")
         XCTAssertEqual(ha["text_color"] as? String, "#FFFFFF")
         XCTAssertEqual(ha["progress_bar_color"] as? String, "#03A9F4")
+        XCTAssertEqual(ha["progress_bar_direction"] as? String, "decreasing")
         XCTAssertEqual(ha["notification_icon_color"] as? String, "#FF0000")
     }
 


### PR DESCRIPTION
## Summary
Adds an optional `progress_bar_direction` field (`increasing` / `decreasing`) to Live Activity notifications, alongside the existing `progress_bar_color`.

- Static progress bars: `decreasing` renders the remaining portion (`progress_max − progress`), so the bar drains as progress advances. Percent labels keep showing the raw progress value.
- Timer progress bars: the field overrides the built-in default (countdown drains, bounded count-up fills).
- Unrecognised values decode leniently and fall back to the default direction, so a bad value never drops an update.
- The field is carried on both delivery paths (APNs content state and the local-push parser promotion) and covered by contract, handler, and local-push tests.
- Adds a "Battery · Decreasing Bar" sample with matching YAML output.

## Screenshots
Not available.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Omitting the field keeps existing behavior unchanged.