### PR TITLE
Allow translations on sensors using translation_key

### DIFF
--- a/Sources/Shared/API/Models/WebhookSensor.swift
+++ b/Sources/Shared/API/Models/WebhookSensor.swift
@@ -29,6 +29,8 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
     public var UniqueID: String?
     public var UnitOfMeasurement: String?
     public var entityCategory: String?
+    public var translationKey: String?
+    public var options: [String]?
 
     public var Settings: [WebhookSensorSetting] = []
 
@@ -131,9 +133,24 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
             DeviceClass <- map["device_class"]
             entityCategory <- map["entity_category"]
             Name <- map["name"]
+            options <- map["options"]
             StateClass <- map["state_class"]
+            translationKey <- map["translation_key"]
             UnitOfMeasurement <- map["unit_of_measurement"]
         }
+    }
+
+    /// Declares the translation metadata core needs to localize an enum-style sensor's state:
+    /// the raw state values stay English (existing automations keep working) and the frontend
+    /// renders them through core's `entity.<platform>.<translation_key>.state.<state>` pipeline.
+    /// Core requires `options` to come with an `enum` device class, so it is set here too.
+    /// Servers older than `canRegisterSensorTranslationKeys` fail `register_sensor` validation on
+    /// unknown keys and silently drop the whole registration, so this is a no-op for them.
+    public func setEnumTranslation(key: String, options: [String], serverVersion: Version) {
+        guard serverVersion >= .canRegisterSensorTranslationKeys else { return }
+        translationKey = key
+        self.options = options
+        DeviceClass = .enum
     }
 
     public var StateDescription: String? {

--- a/Sources/Shared/API/Webhook/Sensors/ActivitySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/ActivitySensor.swift
@@ -17,7 +17,7 @@ public class ActivitySensor: SensorProvider {
     public func sensors() -> Promise<[WebhookSensor]> {
         firstly {
             Self.latestMotionActivity()
-        }.map { activity in
+        }.map { [request] activity in
             with(WebhookSensor(name: "Activity", uniqueID: WebhookSensorId.activity.rawValue)) {
                 $0.State = activity.activityTypes.first
                 $0.Attributes = [
@@ -25,6 +25,11 @@ public class ActivitySensor: SensorProvider {
                     "Types": activity.activityTypes,
                 ]
                 $0.Icon = activity.icons.first
+                $0.setEnumTranslation(
+                    key: "activity",
+                    options: CMMotionActivity.allActivityTypes,
+                    serverVersion: request.serverVersion
+                )
             }
         }.map {
             [$0]

--- a/Sources/Shared/API/Webhook/Sensors/BatterySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BatterySensor.swift
@@ -26,11 +26,11 @@ public class BatterySensor: SensorProvider {
 
         return .value(
             Current.device.batteries()
-                .flatMap { Self.sensors(battery: $0) }
+                .flatMap { Self.sensors(battery: $0, serverVersion: request.serverVersion) }
         )
     }
 
-    private static func sensors(battery: DeviceBattery) -> [WebhookSensor] {
+    private static func sensors(battery: DeviceBattery, serverVersion: Version) -> [WebhookSensor] {
         let icon: String = BatteryIcon.forBatteryLevel(battery.level, state: battery.state)
         let isLowPowerMode = Current.device.isLowPowerMode()
         let sensorNamePrefix = battery.name ?? "Battery"
@@ -56,6 +56,11 @@ public class BatterySensor: SensorProvider {
             $0.Attributes = [
                 "Low Power Mode": isLowPowerMode,
             ].merging(battery.attributes, uniquingKeysWith: { a, _ in a })
+            $0.setEnumTranslation(
+                key: "battery_state",
+                options: DeviceBattery.State.allCases.map(\.description),
+                serverVersion: serverVersion
+            )
         }
 
         return [levelSensor, stateSensor]

--- a/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/ConnectivitySensor.swift
@@ -176,9 +176,18 @@ public class ConnectivitySensor: SensorProvider {
                 }
 
                 sensor.Attributes = attributes
+                sensor.setEnumTranslation(
+                    key: "connection_type",
+                    options: Self.connectionTypeOptions,
+                    serverVersion: request.serverVersion
+                )
             },
         ])
     }
+
+    /// Every state `simpleNetworkType` can produce across iOS and Catalyst.
+    private static let connectionTypeOptions: [String] =
+        [NetworkType.unknown, .noConnection, .wifi, .cellular, .ethernet].map(\.description)
 
     #if !targetEnvironment(macCatalyst)
     private func cellularProviders() -> Promise<[WebhookSensor]> {

--- a/Sources/Shared/API/Webhook/Sensors/WatchBatterySensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/WatchBatterySensor.swift
@@ -46,12 +46,18 @@ final class WatchBatterySensor: SensorProvider {
             }
 
             if let batteryState {
-                sensors.append(WebhookSensor(
+                sensors.append(with(WebhookSensor(
                     name: "Watch Battery State",
                     uniqueID: WebhookSensorId.watchBatteryState.rawValue,
                     icon: icon,
                     state: batteryState.description
-                ))
+                )) {
+                    $0.setEnumTranslation(
+                        key: "battery_state",
+                        options: DeviceBattery.State.allCases.map(\.description),
+                        serverVersion: request.serverVersion
+                    )
+                })
             }
         case .notPaired:
             break

--- a/Sources/Shared/Common/Extensions/CMMotion+StringExtensions.swift
+++ b/Sources/Shared/Common/Extensions/CMMotion+StringExtensions.swift
@@ -5,6 +5,12 @@ import Foundation
 // automations expecting localized strings.
 
 extension CMMotionActivity {
+    /// Every value `activityTypes` can produce; registered as the Activity sensor's `options`
+    /// so the value set stays in sync with what's sent as state.
+    static var allActivityTypes: [String] {
+        ["Stationary", "Walking", "Running", "Automotive", "Cycling", "Unknown"]
+    }
+
     var activityTypes: [String] {
         var types: [String] = []
 

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -413,6 +413,10 @@ public extension Version {
     static let frontendLoadedExternalBus: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
     /// Frontend handles safe-area insets itself from 2026.8.0, so the app can display edge-to-edge by default.
     static let canDisplayEdgeToEdge: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
+    /// Core `mobile_app` accepts `translation_key` and `options` in `register_sensor` payloads from 2026.8.0.
+    /// Older cores fail schema validation on unknown keys and silently skip the registration, so these fields
+    /// must never be sent to servers below this version.
+    static let canRegisterSensorTranslationKeys: Version = .init(major: 2026, minor: 8, patch: 0, prerelease: "any0")
 
     var coreRequiredString: String {
         L10n.requiresVersion(String(format: "core-%d.%d", major, minor ?? -1))

--- a/Sources/Shared/Environment/DeviceBattery.swift
+++ b/Sources/Shared/Environment/DeviceBattery.swift
@@ -11,7 +11,7 @@ import WatchKit
 #endif
 
 public struct DeviceBattery {
-    public enum State: CustomStringConvertible {
+    public enum State: CustomStringConvertible, CaseIterable {
         case charging
         case unplugged
         case full

--- a/Tests/Shared/Sensors/ActivitySensor.test.swift
+++ b/Tests/Shared/Sensors/ActivitySensor.test.swift
@@ -87,6 +87,32 @@ class ActivitySensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].UniqueID, "activity")
     }
 
+    func testTranslationMetadataDependsOnServerVersion() throws {
+        let anyActivity = with(FakeMotionActivity()) {
+            $0.walking = true
+        }
+
+        Current.motion.isAuthorized = { true }
+        Current.motion.isActivityAvailable = { true }
+        Current.motion.queryStartEndOnQueueHandler = { _, _, _, hand in hand([anyActivity], nil) }
+
+        let modernRequest = SensorProviderRequest(
+            reason: .trigger("unit-test"),
+            dependencies: .init(),
+            location: nil,
+            serverVersion: .canRegisterSensorTranslationKeys
+        )
+        let modern = try hang(ActivitySensor(request: modernRequest).sensors())[0]
+        XCTAssertEqual(modern.translationKey, "activity")
+        XCTAssertEqual(modern.options, CMMotionActivity.allActivityTypes)
+        XCTAssertEqual(modern.DeviceClass, .enum)
+
+        let legacy = try hang(ActivitySensor(request: request).sensors())[0]
+        XCTAssertNil(legacy.translationKey)
+        XCTAssertNil(legacy.options)
+        XCTAssertNil(legacy.DeviceClass)
+    }
+
     func testQueryActivitiesReturnSensors() throws {
         Current.motion.isAuthorized = { true }
         Current.motion.isActivityAvailable = { true }
@@ -101,6 +127,7 @@ class ActivitySensorTests: XCTestCase {
             { $0.running = true; $0.automotive = true },
             { $0.automotive = true; $0.cycling = true },
             { $0.cycling = true; $0.stationary = true },
+            { _ in /* nothing set produces "Unknown" */ },
             { $0.walking = true; $0.confidence = .low },
             { $0.walking = true; $0.confidence = .medium },
             { $0.walking = true; $0.confidence = .high },
@@ -117,6 +144,9 @@ class ActivitySensorTests: XCTestCase {
             XCTAssertEqual(sensors[0].Icon, activity.icons.first)
             XCTAssertEqual(sensors[0].Attributes?["Confidence"] as? String, activity.confidence.description)
             XCTAssertEqual(sensors[0].Attributes?["Types"] as? [String], activity.activityTypes)
+
+            // every possible state must be a declared translation option
+            XCTAssertTrue(CMMotionActivity.allActivityTypes.contains(try XCTUnwrap(sensors[0].State as? String)))
         }
     }
 }

--- a/Tests/Shared/Sensors/ActivitySensor.test.swift
+++ b/Tests/Shared/Sensors/ActivitySensor.test.swift
@@ -146,7 +146,8 @@ class ActivitySensorTests: XCTestCase {
             XCTAssertEqual(sensors[0].Attributes?["Types"] as? [String], activity.activityTypes)
 
             // every possible state must be a declared translation option
-            XCTAssertTrue(CMMotionActivity.allActivityTypes.contains(try XCTUnwrap(sensors[0].State as? String)))
+            let state = try XCTUnwrap(sensors[0].State as? String)
+            XCTAssertTrue(CMMotionActivity.allActivityTypes.contains(state))
         }
     }
 }

--- a/Tests/Shared/Sensors/BatterySensor.test.swift
+++ b/Tests/Shared/Sensors/BatterySensor.test.swift
@@ -31,6 +31,35 @@ class BatterySensorTests: XCTestCase {
         XCTAssertTrue(didSignal)
     }
 
+    func testTranslationMetadataDependsOnServerVersion() throws {
+        Current.device.batteries = { [DeviceBattery(level: 50, state: .charging, attributes: [:])] }
+        Current.device.isLowPowerMode = { false }
+
+        let modernSensors = try hang(BatterySensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: .init(),
+            location: nil,
+            serverVersion: .canRegisterSensorTranslationKeys
+        )).sensors())
+        let modernLevel = modernSensors[0]
+        let modernState = modernSensors[1]
+        XCTAssertEqual(modernState.translationKey, "battery_state")
+        XCTAssertEqual(modernState.options, ["Charging", "Not Charging", "Full"])
+        XCTAssertEqual(modernState.DeviceClass, .enum)
+        XCTAssertNil(modernLevel.translationKey)
+        XCTAssertEqual(modernLevel.DeviceClass, .battery)
+
+        let legacyState = try hang(BatterySensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: .init(),
+            location: nil,
+            serverVersion: Version()
+        )).sensors())[1]
+        XCTAssertNil(legacyState.translationKey)
+        XCTAssertNil(legacyState.options)
+        XCTAssertNil(legacyState.DeviceClass)
+    }
+
     func testAdditionalInfo() throws {
         let (uLevel, uState, cLevel, cState) = try sensors(level: 100, attributes: ["test": true])
         XCTAssertEqual(uLevel.Attributes?["test"] as? Bool, true)

--- a/Tests/Shared/Sensors/ConnectivitySensor.test.swift
+++ b/Tests/Shared/Sensors/ConnectivitySensor.test.swift
@@ -42,6 +42,42 @@ class ConnectivitySensorTests: XCTestCase {
         )
     }
 
+    func testConnectionTypeTranslationMetadataDependsOnServerVersion() throws {
+        Current.connectivity.hasWiFi = { true }
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "wifi_name", bssid: "bssid") }
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.cellularNetworkType = { .wifi }
+        Current.connectivity.telephonyCarriers = { nil }
+        Current.connectivity.telephonyRadioAccessTechnology = { nil }
+        Current.connectivity.networkAttributes = { [:] }
+
+        let modernSensors = try hang(ConnectivitySensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: .init(),
+            location: nil,
+            serverVersion: .canRegisterSensorTranslationKeys
+        )).sensors())
+        let modern = modernSensors.first(where: { $0.UniqueID == "connectivity_connection_type" })
+        XCTAssertEqual(modern?.translationKey, "connection_type")
+        XCTAssertEqual(modern?.options, ["Unknown", "No Connection", "Wi-Fi", "Cellular", "Ethernet"])
+        XCTAssertEqual(modern?.DeviceClass, .enum)
+        // SSID has free-form states, so it must not declare translation metadata
+        let ssid = modernSensors.first(where: { $0.UniqueID == "connectivity_ssid" })
+        XCTAssertNil(ssid?.translationKey)
+        XCTAssertNil(ssid?.options)
+
+        let legacySensors = try hang(ConnectivitySensor(request: .init(
+            reason: .trigger("unit-test"),
+            dependencies: .init(),
+            location: nil,
+            serverVersion: Version()
+        )).sensors())
+        let legacy = legacySensors.first(where: { $0.UniqueID == "connectivity_connection_type" })
+        XCTAssertNil(legacy?.translationKey)
+        XCTAssertNil(legacy?.options)
+        XCTAssertNil(legacy?.DeviceClass)
+    }
+
     func testSignaler() async throws {
         _ = Current.sensors.sensors(reason: .registration, server: ServerFixture.standard)
 

--- a/Tests/Shared/Webhook/WebhookSensorTranslation.test.swift
+++ b/Tests/Shared/Webhook/WebhookSensorTranslation.test.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ObjectMapper
+@testable import Shared
+import XCTest
+
+class WebhookSensorTranslationTests: XCTestCase {
+    func testSetEnumTranslationOnSupportingServer() {
+        let sensor = WebhookSensor(name: "Test", uniqueID: "test")
+        sensor.setEnumTranslation(
+            key: "test_key",
+            options: ["One", "Two"],
+            serverVersion: .canRegisterSensorTranslationKeys
+        )
+        XCTAssertEqual(sensor.translationKey, "test_key")
+        XCTAssertEqual(sensor.options, ["One", "Two"])
+        XCTAssertEqual(sensor.DeviceClass, .enum)
+    }
+
+    func testSetEnumTranslationIgnoredOnOlderServer() {
+        let sensor = WebhookSensor(name: "Test", uniqueID: "test")
+        sensor.setEnumTranslation(
+            key: "test_key",
+            options: ["One", "Two"],
+            serverVersion: Version(major: 2026, minor: 7)
+        )
+        XCTAssertNil(sensor.translationKey)
+        XCTAssertNil(sensor.options)
+        XCTAssertNil(sensor.DeviceClass)
+    }
+
+    func testRegistrationPayloadContainsTranslationFields() {
+        let sensor = WebhookSensor(name: "Test", uniqueID: "test")
+        sensor.setEnumTranslation(
+            key: "test_key",
+            options: ["One", "Two"],
+            serverVersion: .canRegisterSensorTranslationKeys
+        )
+        let json = sensor.toJSON()
+        XCTAssertEqual(json["translation_key"] as? String, "test_key")
+        XCTAssertEqual(json["options"] as? [String], ["One", "Two"])
+        XCTAssertEqual(json["device_class"] as? String, "enum")
+    }
+
+    func testUpdatePayloadOmitsTranslationFields() {
+        let sensor = WebhookSensor(name: "Test", uniqueID: "test")
+        sensor.setEnumTranslation(
+            key: "test_key",
+            options: ["One", "Two"],
+            serverVersion: .canRegisterSensorTranslationKeys
+        )
+        let json = Mapper<WebhookSensor>(
+            context: WebhookSensorContext(update: true),
+            shouldIncludeNilValues: false
+        ).toJSON(sensor)
+        XCTAssertNil(json["translation_key"])
+        XCTAssertNil(json["options"])
+        XCTAssertNil(json["device_class"])
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Register enum-style sensors (Activity, Battery State, Watch Battery State, Connection Type) with `translation_key` and `options` so their states can be localized by the frontend. Raw state values stay English, so existing automations keep working. The fields are only sent to servers on core 2026.8.0+, since older cores reject unknown keys in `register_sensor`.

## Screenshots
N/A (no in-app UI changes)

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Requires the corresponding `mobile_app` change in core to accept `translation_key`/`options` and ship the translations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHgaKhfxSE1X5zw6RjCJG8)_