### PR TITLE
Remove Live Activity Labs label and TestFlight gate

### DIFF
--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -310,7 +310,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
     private static var canShowLiveActivities: Bool {
         #if os(iOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 17.2, *) {
-            return Current.isTestFlight
+            return true
         } else {
             return false
         }

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -366,7 +366,7 @@ struct SettingsView: View {
             VStack(alignment: .leading) {
                 HStack(spacing: DesignSystem.Spaces.one) {
                     Text(item.title)
-                    if item == .liveActivities || item == .complications || item == .remindersSync {
+                    if item == .complications || item == .remindersSync {
                         LabsLabel()
                     }
                 }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -656,7 +656,7 @@ public class HomeAssistantAPI {
                 if #available(iOS 17.2, *) {
                     // Push-to-start token (stored in Keychain at launch, updated via stream).
                     // The relay server uses this token to start a Live Activity entirely via APNs.
-                    if Current.isTestFlight, let pushToStartToken = LiveActivityRegistry.storedPushToStartToken {
+                    if let pushToStartToken = LiveActivityRegistry.storedPushToStartToken {
                         appData[LiveActivityRegistry.pushToStartRegistrationKey] = pushToStartToken
                     }
                 }

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -168,11 +168,6 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             return true
         }
 
-        guard Current.isTestFlight else {
-            Current.Log.info("LiveActivityRegistry: start gated to TestFlight, skipping tag \(tag)")
-            return false
-        }
-
         // START path — guard against duplicates with reservation
         guard reserve(id: tag) else {
             if reserved.contains(tag) {


### PR DESCRIPTION
## Summary
Makes Live Activities generally available: the settings entry now shows on all iOS 17.2+ builds without the Labs badge, activities can start outside TestFlight, and the push-to-start token is always registered with the server.

## Screenshots
N/A — removes a badge and build-type gates, no new UI.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfiD5go1AhXTK4rcLLFMsw)_