### PR TITLE
Add Communication Notifications entitlement to iOS app

### DIFF
--- a/Configuration/Entitlements/App-ios.entitlements
+++ b/Configuration/Entitlements/App-ios.entitlements
@@ -18,6 +18,8 @@
 	</array>
 	<key>com.apple.developer.siri</key>
 	<true/>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(BUNDLE_ID_PREFIX).homeassistant$(BUNDLE_ID_SUFFIX)</string>


### PR DESCRIPTION
## Summary

Adds `com.apple.developer.usernotifications.communication` to `App-ios.entitlements`.

The notification service extension already decorates notifications that carry `notification_icon` / `color` / `notification_icon_color` (and `icon_url`) into communication notifications via `INSendMessageIntent` + `updating(from:)`. The intent donation and content update succeed, but without the Communication Notifications capability on the app target the system silently ignores the styling and renders a plain notification with the default app icon — no error is surfaced anywhere.

Apple's [Implementing communication notifications](https://developer.apple.com/documentation/usernotifications/implementing-communication-notifications) requires enabling the capability on the app target; `NSUserActivityTypes` with `INSendMessageIntent` is already present in the app and NotificationService Info.plists.

## Notes

- The App ID needs the Communication Notifications capability enabled in the developer portal and release provisioning profiles regenerated before this can ship (no special Apple approval needed, unlike critical alerts).
- Catalyst (`App-catalyst.entitlements`) is intentionally left out for now to avoid breaking Mac signing until the Catalyst App ID capability is enabled.

## Testing

Diagnosed from device logs: a push with `title`, `notification_icon: mdi:washing-machine`, `color`, and `notification_icon_color` reached the NotificationService, parsed and decorated without errors, yet rendered without the avatar — matching the missing-entitlement silent failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)