### PR TITLE
Allow notification icon rendering without a title

### DIFF
--- a/Sources/Shared/Notifications/NotificationSender/NotificationCommunicationDecorator.swift
+++ b/Sources/Shared/Notifications/NotificationSender/NotificationCommunicationDecorator.swift
@@ -33,10 +33,7 @@ public final class NotificationCommunicationDecoratorImpl: NotificationCommunica
         sender: NotificationSenderInfo,
         api: HomeAssistantAPI?
     ) async -> UNNotificationContent {
-        let title = content.title
-        guard !title.isEmpty else { return content }
-
-        let intent = await buildIntent(sender: sender, title: title, body: content.body, api: api)
+        let intent = await buildIntent(sender: sender, title: sender.senderName, body: content.body, api: api)
         do {
             return try content.updating(from: intent)
         } catch {

--- a/Sources/Shared/Notifications/NotificationSender/NotificationSenderParser.swift
+++ b/Sources/Shared/Notifications/NotificationSender/NotificationSenderParser.swift
@@ -6,7 +6,10 @@ import UserNotifications
 public enum NotificationSenderParser {
     public static func parse(from content: UNNotificationContent) -> NotificationSenderInfo? {
         // Communication notifications display the sender name in place of the title,
-        // so fall back to the app name for notifications sent without one.
+        // so fall back to the app name for notifications sent without one. Hardcoded
+        // rather than read from CFBundleDisplayName because this runs inside the
+        // notification extensions, where Bundle.main reports the extension's own
+        // display name (e.g. "APNSAttachmentService"), not the app's.
         let senderName = content.title.isEmpty ? "Home Assistant" : content.title
 
         let userInfo = content.userInfo

--- a/Sources/Shared/Notifications/NotificationSender/NotificationSenderParser.swift
+++ b/Sources/Shared/Notifications/NotificationSender/NotificationSenderParser.swift
@@ -5,8 +5,9 @@ import UserNotifications
 
 public enum NotificationSenderParser {
     public static func parse(from content: UNNotificationContent) -> NotificationSenderInfo? {
-        let senderName = content.title
-        guard !senderName.isEmpty else { return nil }
+        // Communication notifications display the sender name in place of the title,
+        // so fall back to the app name for notifications sent without one.
+        let senderName = content.title.isEmpty ? "Home Assistant" : content.title
 
         let userInfo = content.userInfo
         let nestedData = userInfo["data"] as? [String: Any]

--- a/Tests/Shared/NotificationSender/NotificationCommunicationDecoratorTests.swift
+++ b/Tests/Shared/NotificationSender/NotificationCommunicationDecoratorTests.swift
@@ -98,8 +98,7 @@ final class NotificationCommunicationDecoratorTests: XCTestCase {
         XCTAssertNotEqual(ia.conversationIdentifier, ib.conversationIdentifier)
     }
 
-    func testDecorate_emptyTitle_returnsOriginalContentUnchanged() async {
-        let original = content(title: "", body: "x")
+    func testBuildIntent_usesSenderNameAsDisplayName() async {
         let info = NotificationSenderInfo(
             source: .mdi(
                 name: "mdi:door",
@@ -108,10 +107,15 @@ final class NotificationCommunicationDecoratorTests: XCTestCase {
                 colorString: "#FF0000",
                 iconColorString: "#FFFFFF"
             ),
-            senderName: "X"
+            senderName: "Home Assistant"
         )
-        let result = await decorator.decorate(content: original, sender: info, api: api)
-        XCTAssertEqual(result, original)
+        let intent = await decorator.buildIntent(
+            sender: info,
+            title: info.senderName,
+            body: "x",
+            api: api
+        )
+        XCTAssertEqual(intent.sender?.displayName, "Home Assistant")
     }
 
     func testBuildIntent_iconURL_cacheHit_skipsDownload() async throws {

--- a/Tests/Shared/NotificationSender/NotificationCommunicationDecoratorTests.swift
+++ b/Tests/Shared/NotificationSender/NotificationCommunicationDecoratorTests.swift
@@ -98,7 +98,8 @@ final class NotificationCommunicationDecoratorTests: XCTestCase {
         XCTAssertNotEqual(ia.conversationIdentifier, ib.conversationIdentifier)
     }
 
-    func testBuildIntent_usesSenderNameAsDisplayName() async {
+    func testDecorate_emptyTitle_stillDecorates() async {
+        let original = content(title: "", body: "x")
         let info = NotificationSenderInfo(
             source: .mdi(
                 name: "mdi:door",
@@ -109,13 +110,11 @@ final class NotificationCommunicationDecoratorTests: XCTestCase {
             ),
             senderName: "Home Assistant"
         )
-        let intent = await decorator.buildIntent(
-            sender: info,
-            title: info.senderName,
-            body: "x",
-            api: api
+        let result = await decorator.decorate(content: original, sender: info, api: api)
+        XCTAssertFalse(
+            result === original,
+            "a notification without a title must still be decorated with the sender intent"
         )
-        XCTAssertEqual(intent.sender?.displayName, "Home Assistant")
     }
 
     func testBuildIntent_iconURL_cacheHit_skipsDownload() async throws {

--- a/Tests/Shared/NotificationSender/NotificationSenderParserTests.swift
+++ b/Tests/Shared/NotificationSender/NotificationSenderParserTests.swift
@@ -30,9 +30,10 @@ final class NotificationSenderParserTests: XCTestCase {
         XCTAssertNil(NotificationSenderParser.parse(from: content(userInfo: [:])))
     }
 
-    func testEmptyTitle_returnsNil_evenWithIcon() {
+    func testEmptyTitle_fallsBackToAppNameAsSenderName() {
         let c = content(title: "", userInfo: ["notification_icon": "mdi:door"])
-        XCTAssertNil(NotificationSenderParser.parse(from: c))
+        let parsed = NotificationSenderParser.parse(from: c)
+        XCTAssertEqual(parsed?.senderName, "Home Assistant")
     }
 
     func testMdiOnly_defaults() {


### PR DESCRIPTION
NotificationSenderParser required a non-empty title to build sender info, so notifications sent with only a message and a notification_icon / icon_url silently skipped the communication notification decoration. Fall back to the app name as the sender name instead, and let the decorator use the parsed sender name so it no longer depends on the content title.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
