### PR TITLE
Add AI policy section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,12 @@
 <!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
 Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).
 
+Select exactly one option that describes AI usage in this contribution:
+
 - [ ] AI assistance was used for this contribution
 - [ ] AI took full control of the code generation for this contribution
 - [ ] I have not used AI for this contribution
+
 - [ ] I have read the AI policy
 
 ## Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,14 @@
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
 
+## AI Policy
+<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
+Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).
+
+- [ ] AI assistance was used for this contribution
+- [ ] AI took full control of the code generation for this contribution
+- [ ] I have not used AI for this contribution
+- [ ] I have read the AI policy
+
 ## Summary
 <!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 


### PR DESCRIPTION
Adds an AI policy section at the top of the pull request template, linking to the AI policy and adding checkboxes for how AI was used.