### PR TITLE
Disable CarPlay Quick Access Grid layout option below iOS 26

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "carPlay.action.execute.in_progress" = "Executing...";
 "carPlay.action.intro.item.body" = "Tap to continue on your iPhone";
 "carPlay.action.intro.item.title" = "Create your first action";
+"carPlay.config.quick_access.layout.grid_requirement.subtitle" = "Requires iOS 26 or later";
 "carPlay.config.quick_access.show_add_edit_buttons.footer" = "Show buttons to add and edit Quick Access items directly from the car.";
 "carPlay.config.quick_access.show_add_edit_buttons.title" = "Show Add and Edit buttons";
 "carPlay.config.tabs.title" = "Tabs";

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -125,7 +125,11 @@ struct CarPlayConfigurationView: View {
         Section(L10n.CarPlay.Navigation.Tab.quickAccess) {
             Picker(L10n.Carplay.Tab.QuickAccess.layout, selection: Binding(
                 get: { viewModel.quickAccessLayout },
-                set: { viewModel.quickAccessLayout = $0 }
+                set: { newValue in
+                    // selectionDisabled is iOS 17+, so also ignore Grid here for iOS 16
+                    guard newValue != .grid || isGridLayoutSupported else { return }
+                    viewModel.quickAccessLayout = newValue
+                }
             )) {
                 ForEach(CarPlayQuickAccessLayout.allCases, id: \.rawValue) { layout in
                     layoutPickerOption(layout).tag(layout)

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -128,7 +128,7 @@ struct CarPlayConfigurationView: View {
                 set: { viewModel.quickAccessLayout = $0 }
             )) {
                 ForEach(CarPlayQuickAccessLayout.allCases, id: \.rawValue) { layout in
-                    Text(layout.name).tag(layout)
+                    layoutPickerOption(layout).tag(layout)
                 }
             }
             ForEach(viewModel.config.quickAccessItems, id: \.id) { item in
@@ -141,6 +141,32 @@ struct CarPlayConfigurationView: View {
                 viewModel.deleteItem(at: indexSet)
             }
             addItemButton
+        }
+    }
+
+    @ViewBuilder
+    private func layoutPickerOption(_ layout: CarPlayQuickAccessLayout) -> some View {
+        let isUnsupported = layout == .grid && !isGridLayoutSupported
+        let label = VStack(alignment: .leading, spacing: 2) {
+            Text(layout.name)
+            if isUnsupported {
+                Text(L10n.CarPlay.Config.QuickAccess.Layout.GridRequirement.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        if #available(iOS 17.0, *) {
+            label.selectionDisabled(isUnsupported)
+        } else {
+            label
+        }
+    }
+
+    private var isGridLayoutSupported: Bool {
+        if #available(iOS 26.0, *) {
+            return true
+        } else {
+            return false
         }
     }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -847,6 +847,12 @@ public enum L10n {
     }
     public enum Config {
       public enum QuickAccess {
+        public enum Layout {
+          public enum GridRequirement {
+            /// Requires iOS 26 or later
+            public static var subtitle: String { return L10n.tr("Localizable", "carPlay.config.quick_access.layout.grid_requirement.subtitle") }
+          }
+        }
         public enum ShowAddEditButtons {
           /// Show buttons to add and edit Quick Access items directly from the car.
           public static var footer: String { return L10n.tr("Localizable", "carPlay.config.quick_access.show_add_edit_buttons.footer") }


### PR DESCRIPTION
## AI Policy
Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] AI assistance was used for this contribution
- [ ] AI took full control of the code generation for this contribution
- [ ] I have not used AI for this contribution

- [x] I have read the AI policy

## Summary
The CarPlay Quick Access Grid layout only takes effect on iOS 26+, but the settings picker offered it on every iOS version, silently falling back to List. The Grid option now shows a "Requires iOS 26 or later" subtitle and is disabled on older versions.

Fixes #5192

## Screenshots
N/A

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
None

---
_Generated by [Claude Code](https://claude.ai/code/session_0185iN3pzMwPuBfWX1TRi3MG)_