### PR TITLE
Add external bus command to reload and clear frontend cache

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
@@ -30,6 +30,7 @@ enum WebViewExternalBusMessage: String, CaseIterable {
     case entityAddToGetActions = "entity/add_to/get_actions"
     case entityAddTo = "entity/add_to"
     case cameraPlayerShow = "camera/show"
+    case frontendReloadAndClearCache = "frontend/reload_and_clear_cache"
 
     @MainActor static var configResult: [String: Any] {
         [

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -197,6 +197,8 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
                     return
                 }
                 showCameraPlayer(entityId: entityId, cameraName: incomingMessage.Payload?["camera_name"] as? String)
+            case .frontendReloadAndClearCache:
+                reloadAndClearFrontendCache()
             }
         } else {
             Current.Log.error("unknown: \(incomingMessage.MessageType)")
@@ -611,6 +613,15 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
         } catch {
             Current.Log.error("Failed to decode entity add to action: \(error)")
         }
+    }
+
+    @MainActor
+    private func reloadAndClearFrontendCache() {
+        Current.Log.info("Resetting frontend cache requested via external bus")
+        Current.websiteDataStoreHandler
+            .cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) { [weak self] in
+                self?.webViewController?.refresh()
+            }
     }
 
     private func showCameraPlayer(entityId: String, cameraName: String?) {

--- a/Tests/App/WebView/Mocks/MockWebsiteDataStoreHandler.swift
+++ b/Tests/App/WebView/Mocks/MockWebsiteDataStoreHandler.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Shared
+
+final class MockWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
+    private(set) var cleanCacheCallCount = 0
+    private(set) var cleanFrontendAssetCacheIfNeededCallCount = 0
+    private(set) var lastDataTypes: Set<String>?
+    private var pendingCompletion: (() -> Void)?
+    private var pendingFrontendAssetCacheCompletion: ((Bool) -> Void)?
+
+    func cleanCache(dataTypes: Set<String>, completion: (() -> Void)?) {
+        cleanCacheCallCount += 1
+        lastDataTypes = dataTypes
+        pendingCompletion = completion
+    }
+
+    func cleanFrontendAssetCacheIfNeeded(completion: ((Bool) -> Void)?) {
+        cleanFrontendAssetCacheIfNeededCallCount += 1
+        pendingFrontendAssetCacheCompletion = completion
+    }
+
+    func invokePendingCompletion() {
+        let completion = pendingCompletion
+        pendingCompletion = nil
+        completion?()
+    }
+
+    func invokePendingFrontendAssetCacheCompletion(didClean: Bool) {
+        let completion = pendingFrontendAssetCacheCompletion
+        pendingFrontendAssetCacheCompletion = nil
+        completion?(didClean)
+    }
+}

--- a/Tests/App/WebView/WebViewExternalBusMessageTests.swift
+++ b/Tests/App/WebView/WebViewExternalBusMessageTests.swift
@@ -36,8 +36,12 @@ final class WebViewExternalBusMessageTests: XCTestCase {
         XCTAssertEqual(WebViewExternalBusMessage.entityAddToGetActions.rawValue, "entity/add_to/get_actions")
         XCTAssertEqual(WebViewExternalBusMessage.entityAddTo.rawValue, "entity/add_to")
         XCTAssertEqual(WebViewExternalBusMessage.cameraPlayerShow.rawValue, "camera/show")
+        XCTAssertEqual(
+            WebViewExternalBusMessage.frontendReloadAndClearCache.rawValue,
+            "frontend/reload_and_clear_cache"
+        )
 
-        XCTAssertEqual(WebViewExternalBusMessage.allCases.count, 24)
+        XCTAssertEqual(WebViewExternalBusMessage.allCases.count, 25)
     }
 
     func testExternalBusOutgoingMessageKeys() {

--- a/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewExternalMessageHandlerTests.swift
@@ -273,6 +273,29 @@ final class WebViewExternalMessageHandlerTests: XCTestCase {
         XCTAssertEqual(mockWebViewController.overlayedController?.modalPresentationStyle, .overFullScreen)
     }
 
+    @MainActor func testHandleExternalMessageFrontendReloadAndClearCacheCleansCacheThenRefreshes() {
+        let original = Current.websiteDataStoreHandler
+        defer { Current.websiteDataStoreHandler = original }
+        let handler = MockWebsiteDataStoreHandler()
+        Current.websiteDataStoreHandler = handler
+
+        let dictionary: [String: Any] = [
+            "id": 1,
+            "message": "",
+            "command": "",
+            "type": "frontend/reload_and_clear_cache",
+        ]
+        sut.handleExternalMessage(dictionary)
+
+        XCTAssertEqual(handler.cleanCacheCallCount, 1)
+        XCTAssertEqual(handler.lastDataTypes, WebsiteDataStoreHandlerImpl.frontendAssetDataTypes)
+        XCTAssertFalse(mockWebViewController.refreshCalled, "reload must wait for cache clearing to finish")
+
+        handler.invokePendingCompletion()
+
+        XCTAssertTrue(mockWebViewController.refreshCalled)
+    }
+
     @MainActor func testSendExternalBusCommandWithRetrySendsCommandWithCorrelatableID() throws {
         let firstSend = expectation(description: "command sent")
         mockWebViewController.evaluateJavaScriptExpectation = firstSend


### PR DESCRIPTION
## AI Policy

Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] AI assistance was used for this contribution
- [x] AI took full control of the code generation for this contribution
- [ ] I have not used AI for this contribution

- [x] I have read the AI policy

## Summary

Adds a new external bus command `frontend/reload_and_clear_cache` that clears the frontend asset caches (disk, memory, fetch and service worker registrations) and then reloads the web view. This lets the frontend request a clean reload when needed.

## Screenshots

N/A, no UI changes.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
