### PR TITLE
Fix snooze notification actions on Apple Watch

### DIFF
--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -423,7 +423,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
         if let minutes = NotificationSnoozeAction.minutes(fromActionIdentifier: response.actionIdentifier) {
             Current.notificationDispatcher.reschedule(
                 response.notification.request.content,
-                after: TimeInterval(minutes * 60)
+                after: TimeInterval(minutes) * 60
             )
             completionHandler()
             return

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -420,11 +420,7 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
 
         // Snooze is an on-device-only convenience: reschedule a local re-delivery of the same
         // notification (so it keeps its snooze actions) and skip forwarding to Home Assistant.
-        if response.actionIdentifier.hasPrefix(NotificationSnoozeAction.actionIdentifierPrefix),
-           let minutes = Int(
-               response.actionIdentifier
-                   .dropFirst(NotificationSnoozeAction.actionIdentifierPrefix.count)
-           ) {
+        if let minutes = NotificationSnoozeAction.minutes(fromActionIdentifier: response.actionIdentifier) {
             Current.notificationDispatcher.reschedule(
                 response.notification.request.content,
                 after: TimeInterval(minutes * 60)

--- a/Sources/HAModels/Sources/NotificationSnoozeAction.swift
+++ b/Sources/HAModels/Sources/NotificationSnoozeAction.swift
@@ -26,9 +26,13 @@ public struct NotificationSnoozeAction: Codable, FetchableRecord, PersistableRec
     }
 
     /// Parses the snooze duration out of a notification action identifier, or nil when the
-    /// identifier is not a snooze action (e.g. `HA_SNOOZE_15` → 15).
+    /// identifier is not a snooze action (e.g. `HA_SNOOZE_15` → 15). Non-positive durations are
+    /// rejected so the result is always a valid reschedule delay: action identifiers can come from
+    /// notification payloads, and a zero or negative interval would be invalid to schedule.
     public static func minutes(fromActionIdentifier identifier: String) -> Int? {
-        guard identifier.hasPrefix(actionIdentifierPrefix) else { return nil }
-        return Int(identifier.dropFirst(actionIdentifierPrefix.count))
+        guard identifier.hasPrefix(actionIdentifierPrefix),
+              let minutes = Int(identifier.dropFirst(actionIdentifierPrefix.count)),
+              minutes > 0 else { return nil }
+        return minutes
     }
 }

--- a/Sources/HAModels/Sources/NotificationSnoozeAction.swift
+++ b/Sources/HAModels/Sources/NotificationSnoozeAction.swift
@@ -24,4 +24,11 @@ public struct NotificationSnoozeAction: Codable, FetchableRecord, PersistableRec
     public var actionIdentifier: String {
         Self.actionIdentifierPrefix + String(minutes)
     }
+
+    /// Parses the snooze duration out of a notification action identifier, or nil when the
+    /// identifier is not a snooze action (e.g. `HA_SNOOZE_15` → 15).
+    public static func minutes(fromActionIdentifier identifier: String) -> Int? {
+        guard identifier.hasPrefix(actionIdentifierPrefix) else { return nil }
+        return Int(identifier.dropFirst(actionIdentifierPrefix.count))
+    }
 }

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -414,7 +414,7 @@ extension ExtensionDelegate: UNUserNotificationCenterDelegate {
         if let minutes = NotificationSnoozeAction.minutes(fromActionIdentifier: response.actionIdentifier) {
             Current.notificationDispatcher.reschedule(
                 response.notification.request.content,
-                after: TimeInterval(minutes * 60)
+                after: TimeInterval(minutes) * 60
             )
             completionHandler()
             return

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -400,6 +400,26 @@ extension ExtensionDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
+        #if DEBUG
+        if response.actionIdentifier == NotificationSnoozeAction.debugTenSecondsActionIdentifier {
+            Current.notificationDispatcher.reschedule(response.notification.request.content, after: 10)
+            completionHandler()
+            return
+        }
+        #endif
+
+        // Snooze is an on-device-only convenience, mirroring NotificationManager on iOS: reschedule
+        // a local re-delivery of the same notification on the watch (so it keeps its snooze actions)
+        // instead of forwarding a notification action event to Home Assistant.
+        if let minutes = NotificationSnoozeAction.minutes(fromActionIdentifier: response.actionIdentifier) {
+            Current.notificationDispatcher.reschedule(
+                response.notification.request.content,
+                after: TimeInterval(minutes * 60)
+            )
+            completionHandler()
+            return
+        }
+
         guard let info = HomeAssistantAPI.PushActionInfo(response: response),
               let server = Current.servers.server(for: response.notification.request.content) else {
             completionHandler()

--- a/Tests/Shared/Models/NotificationSnoozeAction.test.swift
+++ b/Tests/Shared/Models/NotificationSnoozeAction.test.swift
@@ -19,4 +19,9 @@ final class NotificationSnoozeActionTests: XCTestCase {
         XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_abc"))
         XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: UNNotificationDefaultActionIdentifier))
     }
+
+    func testMinutesNilForNonPositiveDurations() {
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_0"))
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_-5"))
+    }
 }

--- a/Tests/Shared/Models/NotificationSnoozeAction.test.swift
+++ b/Tests/Shared/Models/NotificationSnoozeAction.test.swift
@@ -1,0 +1,22 @@
+@testable import Shared
+import UserNotifications
+import XCTest
+
+final class NotificationSnoozeActionTests: XCTestCase {
+    func testMinutesParsedFromActionIdentifier() {
+        XCTAssertEqual(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_5"), 5)
+        XCTAssertEqual(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_90"), 90)
+    }
+
+    func testMinutesRoundTripsThroughActionIdentifier() {
+        let action = NotificationSnoozeAction(minutes: 15, sortOrder: 0)
+        XCTAssertEqual(NotificationSnoozeAction.minutes(fromActionIdentifier: action.actionIdentifier), 15)
+    }
+
+    func testMinutesNilForNonSnoozeIdentifiers() {
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "SNOOZE_5"))
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_"))
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: "HA_SNOOZE_abc"))
+        XCTAssertNil(NotificationSnoozeAction.minutes(fromActionIdentifier: UNNotificationDefaultActionIdentifier))
+    }
+}


### PR DESCRIPTION
## AI Policy
Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] AI assistance was used for this contribution
- [x] AI took full control of the code generation for this contribution
- [ ] I have not used AI for this contribution

- [x] I have read the AI policy

## Summary
Snooze actions tapped on a notification shown on Apple Watch did not snooze: the watch forwarded them to Home Assistant as notification action events and nothing was rescheduled. The watch notification response handler now intercepts snooze identifiers and reschedules a local re-delivery of the notification, matching the existing iOS behavior. The snooze identifier parsing was moved into a shared helper used by both platforms, with unit tests.

## Screenshots
N/A (no UI changes)

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYn7DiVSw5eSUUWGfy1PhJ)_