### PR TITLE
Cache user profile picture

### DIFF
--- a/Sources/App/Servers/ServerSelectView.swift
+++ b/Sources/App/Servers/ServerSelectView.swift
@@ -142,11 +142,11 @@ struct ServerSelectViewRow: View {
 
         api.currentUser { user in
             userName = user?.name ?? ""
+        }
 
-            guard let user else { return }
-            api.profilePicture(for: user) { image in
-                profilePictureImage = image
-            }
+        // Loaded independently of the user so a cached picture still shows while offline.
+        api.profilePicture { image in
+            profilePictureImage = image
         }
     }
 }

--- a/Sources/App/Servers/ServerSelectView.swift
+++ b/Sources/App/Servers/ServerSelectView.swift
@@ -140,13 +140,20 @@ struct ServerSelectViewRow: View {
     private func loadUserNameAndProfilePicture() {
         guard let api = Current.api(for: server) else { return }
 
-        api.currentUser { user in
-            userName = user?.name ?? ""
+        // Shows something immediately, and still shows a picture when the server is unreachable.
+        api.cachedProfilePicture { image in
+            if profilePictureImage == nil {
+                profilePictureImage = image
+            }
         }
 
-        // Loaded independently of the user so a cached picture still shows while offline.
-        api.profilePicture { image in
-            profilePictureImage = image
+        api.currentUser { user in
+            userName = user?.name ?? ""
+
+            guard let user else { return }
+            api.profilePicture(for: user) { image in
+                profilePictureImage = image
+            }
         }
     }
 }

--- a/Sources/App/Settings/Settings/HomeAssistantAccountRowView.swift
+++ b/Sources/App/Settings/Settings/HomeAssistantAccountRowView.swift
@@ -66,11 +66,11 @@ struct HomeAssistantAccountRowView: View {
 
         api.currentUser { user in
             userName = user?.name ?? ""
+        }
 
-            guard let user else { return }
-            api.profilePicture(for: user) { image in
-                profilePicture = image
-            }
+        // Loaded independently of the user so a cached picture still shows while offline.
+        api.profilePicture { image in
+            profilePicture = image
         }
     }
 }

--- a/Sources/App/Settings/Settings/HomeAssistantAccountRowView.swift
+++ b/Sources/App/Settings/Settings/HomeAssistantAccountRowView.swift
@@ -64,13 +64,20 @@ struct HomeAssistantAccountRowView: View {
     private func loadUserNameAndProfilePicture() {
         guard let api = Current.api(for: server) else { return }
 
-        api.currentUser { user in
-            userName = user?.name ?? ""
+        // Shows something immediately, and still shows a picture when the server is unreachable.
+        api.cachedProfilePicture { image in
+            if profilePicture == nil {
+                profilePicture = image
+            }
         }
 
-        // Loaded independently of the user so a cached picture still shows while offline.
-        api.profilePicture { image in
-            profilePicture = image
+        api.currentUser { user in
+            userName = user?.name ?? ""
+
+            guard let user else { return }
+            api.profilePicture(for: user) { image in
+                profilePicture = image
+            }
         }
     }
 }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1183,23 +1183,45 @@ public class HomeAssistantAPI {
         }
     }
 
+    private enum ProfilePictureURLResult {
+        /// A picture is configured and its URL resolved successfully.
+        case url(URL)
+        /// The server responded and the user has no picture configured.
+        case missing
+        /// The picture's existence could not be determined (e.g. no connectivity).
+        case failure
+    }
+
     @discardableResult
     public func profilePictureURL(
         for user: HAResponseCurrentUser,
         completion: @escaping (URL?) -> Void
+    ) -> HACancellable {
+        resolveProfilePictureURL(for: user) { result in
+            if case let .url(url) = result {
+                completion(url)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+    private func resolveProfilePictureURL(
+        for user: HAResponseCurrentUser,
+        completion: @escaping (ProfilePictureURLResult) -> Void
     ) -> HACancellable {
         connection.send(HATypedRequest<[HAEntity]>.fetchStates()) { [weak self] result in
             switch result {
             case let .success(states):
                 guard let person = states.first(where: { $0.attributes["user_id"] as? String == user.id }) else {
                     Current.Log.error("Profile picture: No person found for user \(user.id)")
-                    completion(nil)
+                    completion(.missing)
                     return
                 }
 
                 guard let path = person.attributes["entity_picture"] as? String else {
                     Current.Log.error("Profile picture: Missing URL for user entity picture, user id \(user.id)")
-                    completion(nil)
+                    completion(.missing)
                     return
                 }
 
@@ -1208,15 +1230,15 @@ public class HomeAssistantAPI {
                 Task { @MainActor in
                     guard let url = await self?.resolvedProfilePictureURL(from: path) else {
                         Current.Log.error("Profile picture: Invalid URL for user entity picture, user id \(user.id)")
-                        completion(nil)
+                        completion(.failure)
                         return
                     }
 
-                    completion(url)
+                    completion(.url(url))
                 }
             case let .failure(error):
                 Current.Log.error("Failed to retrieve states for profile picture: \(error)")
-                completion(nil)
+                completion(.failure)
             }
         }
     }
@@ -1241,6 +1263,9 @@ public class HomeAssistantAPI {
         return cancellable
     }
 
+    /// The completion may be called twice: first with a previously cached picture (if one exists),
+    /// then with the freshly fetched picture. When the fetch fails and a cached picture was already
+    /// delivered, the cached delivery stands and no `nil` follows.
     @discardableResult
     public func profilePicture(
         for user: HAResponseCurrentUser,
@@ -1248,48 +1273,139 @@ public class HomeAssistantAPI {
     ) -> HACancellable {
         let cancellable = ProfilePictureCancellable()
 
-        cancellable.add(profilePictureURL(for: user) { [weak self] url in
+        cachedProfilePicture { [weak self] cached in
             guard !cancellable.isCancelled else { return }
-            guard let self, let url else {
-                completion(nil)
+
+            if let cached {
+                completion(cached)
+            }
+
+            guard let self else {
+                if cached == nil { completion(nil) }
                 return
             }
 
-            let request = manager.download(url).validate()
-            cancellable.setDownloadRequest(request)
-            request.responseData { response in
-                guard !cancellable.isCancelled else { return }
-                switch response.result {
-                case let .success(data):
-                    completion(UIImage(data: data))
-                case let .failure(error):
-                    Current.Log.error("Failed to download profile picture: \(error)")
-                    completion(nil)
-                }
-            }
-        })
+            fetchRemoteProfilePicture(
+                for: user,
+                cancellable: cancellable,
+                hasCachedFallback: cached != nil,
+                completion: completion
+            )
+        }
 
         return cancellable
     }
 
+    /// The completion may be called twice: first with a previously cached picture (if one exists),
+    /// then with the freshly fetched picture. When the fetch fails and a cached picture was already
+    /// delivered, the cached delivery stands and no `nil` follows.
     @discardableResult
     public func profilePicture(completion: @escaping (UIImage?) -> Void) -> HACancellable {
         let cancellable = ProfilePictureCancellable()
 
-        cancellable.add(currentUser { [weak self] user in
+        cachedProfilePicture { [weak self] cached in
             guard !cancellable.isCancelled else { return }
-            guard let self, let user else {
-                completion(nil)
+
+            if let cached {
+                completion(cached)
+            }
+
+            let hasCachedFallback = cached != nil
+
+            guard let self else {
+                if !hasCachedFallback { completion(nil) }
                 return
             }
 
-            cancellable.add(profilePicture(for: user) { image in
+            cancellable.add(currentUser { [weak self] user in
                 guard !cancellable.isCancelled else { return }
-                completion(image)
+                guard let self, let user else {
+                    if !hasCachedFallback { completion(nil) }
+                    return
+                }
+
+                fetchRemoteProfilePicture(
+                    for: user,
+                    cancellable: cancellable,
+                    hasCachedFallback: hasCachedFallback,
+                    completion: completion
+                )
             })
-        })
+        }
 
         return cancellable
+    }
+
+    private func fetchRemoteProfilePicture(
+        for user: HAResponseCurrentUser,
+        cancellable: ProfilePictureCancellable,
+        hasCachedFallback: Bool,
+        completion: @escaping (UIImage?) -> Void
+    ) {
+        cancellable.add(resolveProfilePictureURL(for: user) { [weak self] result in
+            guard !cancellable.isCancelled else { return }
+            guard let self else {
+                if !hasCachedFallback { completion(nil) }
+                return
+            }
+
+            switch result {
+            case let .url(url):
+                let request = manager.download(url).validate()
+                cancellable.setDownloadRequest(request)
+                request.responseData { response in
+                    guard !cancellable.isCancelled else { return }
+                    switch response.result {
+                    case let .success(data):
+                        if let image = UIImage(data: data) {
+                            self.storeProfilePictureInCache(data)
+                            completion(image)
+                        } else if !hasCachedFallback {
+                            completion(nil)
+                        }
+                    case let .failure(error):
+                        Current.Log.error("Failed to download profile picture: \(error)")
+                        if !hasCachedFallback {
+                            completion(nil)
+                        }
+                    }
+                }
+            case .missing:
+                // The server affirmatively has no picture; a stale cached one must not resurface.
+                removeProfilePictureFromCache()
+                completion(nil)
+            case .failure:
+                if !hasCachedFallback {
+                    completion(nil)
+                }
+            }
+        })
+    }
+
+    var profilePictureCacheKey: String {
+        "profile-picture-\(server.identifier.rawValue)"
+    }
+
+    private func cachedProfilePicture(completion: @escaping (UIImage?) -> Void) {
+        Current.diskCache.value(for: profilePictureCacheKey)
+            .done { (data: Data) in
+                completion(UIImage(data: data))
+            }
+            .catch { _ in
+                completion(nil)
+            }
+    }
+
+    private func storeProfilePictureInCache(_ data: Data) {
+        Current.diskCache.set(data, for: profilePictureCacheKey).catch { error in
+            Current.Log.error("Failed to cache profile picture: \(error)")
+        }
+    }
+
+    private func removeProfilePictureFromCache() {
+        Current.diskCache.delete(for: profilePictureCacheKey).catch { error in
+            Current.Log.error("Failed to remove cached profile picture: \(error)")
+        }
     }
 
     private func resolvedProfilePictureURL(from path: String) async -> URL? {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1214,8 +1214,9 @@ public class HomeAssistantAPI {
             switch result {
             case let .success(states):
                 guard let person = states.first(where: { $0.attributes["user_id"] as? String == user.id }) else {
+                    // Not conclusive that no picture is configured, so not `.missing`.
                     Current.Log.error("Profile picture: No person found for user \(user.id)")
-                    completion(.missing)
+                    completion(.failure)
                     return
                 }
 
@@ -1386,7 +1387,9 @@ public class HomeAssistantAPI {
         "profile-picture-\(server.identifier.rawValue)"
     }
 
-    private func cachedProfilePicture(completion: @escaping (UIImage?) -> Void) {
+    /// Completes with the last successfully fetched profile picture, without any network access.
+    /// Useful to show something immediately, or when the server is unreachable.
+    public func cachedProfilePicture(completion: @escaping (UIImage?) -> Void) {
         Current.diskCache.value(for: profilePictureCacheKey)
             .done { (data: Data) in
                 completion(UIImage(data: data))

--- a/Sources/Shared/Common/DiskCache.swift
+++ b/Sources/Shared/Common/DiskCache.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public protocol DiskCache {
     func value<T: Codable>(for key: String) -> Promise<T>
     func set<T: Codable>(_ value: T, for key: String) -> Promise<Void>
+    func delete(for key: String) -> Promise<Void>
 }
 
 private struct DiskCacheKey: EnvironmentKey {
@@ -64,6 +65,32 @@ public final class DiskCacheImpl: DiskCache {
             ) { url in
                 do {
                     try data.write(to: url)
+                    seal.fulfill(())
+                } catch {
+                    seal.reject(error)
+                }
+            }
+            if let error = coordinatorError {
+                seal.reject(error)
+            }
+        }
+        return promise
+    }
+
+    public func delete(for key: String) -> Promise<Void> {
+        let (promise, seal) = Promise<Void>.pending()
+        DispatchQueue.global().async { [coordinator, container] in
+            var coordinatorError: NSError?
+            coordinator.coordinate(
+                writingItemAt: Self.URL(in: container, for: key),
+                options: .forDeleting,
+                error: &coordinatorError
+            ) { url in
+                do {
+                    let fileManager = FileManager.default
+                    if fileManager.fileExists(atPath: url.path) {
+                        try fileManager.removeItem(at: url)
+                    }
                     seal.fulfill(())
                 } catch {
                     seal.reject(error)

--- a/Tests/Shared/DiskCache.test.swift
+++ b/Tests/Shared/DiskCache.test.swift
@@ -104,6 +104,23 @@ class DiskCacheTests: XCTestCase {
         XCTAssertEqual(try hang(read4), obj4)
     }
 
+    func testDeleteRemovesValue() {
+        let obj1 = TestObject1()
+        let cache: DiskCache = cache
+
+        let write = cache.set(obj1, for: "key")
+        let delete = write.then { cache.delete(for: "key") }
+        let read = delete.then { cache.value(for: "key") as Promise<TestObject1> }
+
+        XCTAssertNoThrow(try hang(delete))
+        XCTAssertThrowsError(try hang(read))
+    }
+
+    func testDeleteMissingKey() {
+        let cache: DiskCache = cache
+        XCTAssertNoThrow(try hang(cache.delete(for: "missing_value")))
+    }
+
     func testJsonEncoderFail() {
         let obj1 = DoubleObject1(value: 3)
         let obj2 = DoubleObject1(value: .infinity)

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -389,7 +389,7 @@ private final class FakeHAConnection: HAConnection {
     @discardableResult
     func send<T>(
         _ request: HATypedRequest<T>,
-        completion: @escaping (Result<T, HAError>) -> Void
+        completion: @escaping (Swift.Result<T, HAError>) -> Void
     ) -> HACancellable where T: HADataDecodable {
         sentRequests.append(request.request)
 

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -311,7 +311,7 @@ private final class FakeDiskCache: DiskCache {
         return Promise(error: FakeDiskCacheError.missing)
     }
 
-    func set<T: Codable>(_ value: T, for key: String) -> Promise<Void> {
+    func set(_ value: some Codable, for key: String) -> Promise<Void> {
         storage[key] = value
         return .value(())
     }

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -208,6 +208,42 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
         XCTAssertEqual(fakeDiskCache.deletedKeys, [api.profilePictureCacheKey])
     }
 
+    func testProfilePictureKeepsCacheWhenPersonEntityNotFound() throws {
+        let api = HomeAssistantAPI(server: ServerFixture.withRemoteConnection)
+        let connection = FakeHAConnection()
+        connection.mockResponses["states"] = .array([
+            .dictionary([
+                "entity_id": "person.someone_else",
+                "state": "home",
+                "last_changed": "2026-04-23T10:00:00Z",
+                "last_updated": "2026-04-23T10:00:00Z",
+                "attributes": [
+                    "user_id": "another-user-id",
+                ],
+                "context": [
+                    "id": "context-id",
+                ],
+            ]),
+        ])
+        api.connection = connection
+
+        fakeDiskCache.storage[api.profilePictureCacheKey] = makePNGData()
+
+        let user = try makeUser()
+        let expectation = expectation(description: "profile picture")
+        var images = [UIImage?]()
+
+        api.profilePicture(for: user) { image in
+            images.append(image)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(images.count, 1)
+        XCTAssertNotNil(images[0])
+        XCTAssertTrue(fakeDiskCache.deletedKeys.isEmpty)
+    }
+
     func testProfilePictureWithoutCacheReturnsNilWhenStatesUnavailable() throws {
         let api = HomeAssistantAPI(server: ServerFixture.withRemoteConnection)
         api.connection = FakeHAConnection()
@@ -244,6 +280,33 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
             preconditionFailure("Unable to encode test image")
         }
         return data
+    }
+
+    private final class FakeDiskCache: DiskCache {
+        enum FakeDiskCacheError: Error {
+            case missing
+        }
+
+        var storage = [String: Any]()
+        private(set) var deletedKeys = [String]()
+
+        func value<T: Codable>(for key: String) -> Promise<T> {
+            if let value = storage[key] as? T {
+                return .value(value)
+            }
+            return Promise(error: FakeDiskCacheError.missing)
+        }
+
+        func set(_ value: some Codable, for key: String) -> Promise<Void> {
+            storage[key] = value
+            return .value(())
+        }
+
+        func delete(for key: String) -> Promise<Void> {
+            storage[key] = nil
+            deletedKeys.append(key)
+            return .value(())
+        }
     }
 
     func testCertificateAwareSessionAttachesDelegateWithoutClientCertificate() {
@@ -293,33 +356,6 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
             info = newInfo
             return true
         })
-    }
-}
-
-private final class FakeDiskCache: DiskCache {
-    enum FakeDiskCacheError: Error {
-        case missing
-    }
-
-    var storage = [String: Any]()
-    private(set) var deletedKeys = [String]()
-
-    func value<T: Codable>(for key: String) -> Promise<T> {
-        if let value = storage[key] as? T {
-            return .value(value)
-        }
-        return Promise(error: FakeDiskCacheError.missing)
-    }
-
-    func set(_ value: some Codable, for key: String) -> Promise<Void> {
-        storage[key] = value
-        return .value(())
-    }
-
-    func delete(for key: String) -> Promise<Void> {
-        storage[key] = nil
-        deletedKeys.append(key)
-        return .value(())
     }
 }
 

--- a/Tests/Shared/HomeAssistantAPIIdentity.test.swift
+++ b/Tests/Shared/HomeAssistantAPIIdentity.test.swift
@@ -1,9 +1,22 @@
 import HAKit
+import PromiseKit
 @testable import Shared
+import UIKit
 import XCTest
 
 final class HomeAssistantAPIIdentityTests: XCTestCase {
+    private var originalDiskCache: DiskCache!
+    private var fakeDiskCache: FakeDiskCache!
+
+    override func setUp() {
+        super.setUp()
+        originalDiskCache = Current.diskCache
+        fakeDiskCache = FakeDiskCache()
+        Current.diskCache = fakeDiskCache
+    }
+
     override func tearDown() {
+        Current.diskCache = originalDiskCache
         ServerFixture.reset()
         super.tearDown()
     }
@@ -136,6 +149,103 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
         XCTAssertEqual(connection.sentRequests.count, 2)
     }
 
+    func testProfilePictureFallsBackToCacheWhenStatesUnavailable() throws {
+        let api = HomeAssistantAPI(server: ServerFixture.withRemoteConnection)
+        api.connection = FakeHAConnection()
+
+        fakeDiskCache.storage[api.profilePictureCacheKey] = makePNGData()
+
+        let user = try makeUser()
+        let expectation = expectation(description: "profile picture")
+        var images = [UIImage?]()
+
+        api.profilePicture(for: user) { image in
+            images.append(image)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(images.count, 1)
+        XCTAssertNotNil(images[0])
+        XCTAssertTrue(fakeDiskCache.deletedKeys.isEmpty)
+    }
+
+    func testProfilePictureDeliversCacheThenClearsWhenPictureMissing() throws {
+        let api = HomeAssistantAPI(server: ServerFixture.withRemoteConnection)
+        let connection = FakeHAConnection()
+        connection.mockResponses["states"] = .array([
+            .dictionary([
+                "entity_id": "person.cepresso",
+                "state": "home",
+                "last_changed": "2026-04-23T10:00:00Z",
+                "last_updated": "2026-04-23T10:00:00Z",
+                "attributes": [
+                    "user_id": "user-id",
+                ],
+                "context": [
+                    "id": "context-id",
+                ],
+            ]),
+        ])
+        api.connection = connection
+
+        fakeDiskCache.storage[api.profilePictureCacheKey] = makePNGData()
+
+        let user = try makeUser()
+        let expectation = expectation(description: "profile picture")
+        expectation.expectedFulfillmentCount = 2
+        var images = [UIImage?]()
+
+        api.profilePicture(for: user) { image in
+            images.append(image)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(images.count, 2)
+        XCTAssertNotNil(images[0])
+        XCTAssertNil(images[1])
+        XCTAssertEqual(fakeDiskCache.deletedKeys, [api.profilePictureCacheKey])
+    }
+
+    func testProfilePictureWithoutCacheReturnsNilWhenStatesUnavailable() throws {
+        let api = HomeAssistantAPI(server: ServerFixture.withRemoteConnection)
+        api.connection = FakeHAConnection()
+
+        let user = try makeUser()
+        let expectation = expectation(description: "profile picture")
+
+        api.profilePicture(for: user) { image in
+            XCTAssertNil(image)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    private func makeUser() throws -> HAResponseCurrentUser {
+        try HAResponseCurrentUser(data: .dictionary([
+            "id": "user-id",
+            "name": "cepresso",
+            "is_owner": false,
+            "is_admin": true,
+            "credentials": [],
+            "mfa_modules": [],
+        ]))
+    }
+
+    private func makePNGData() -> Data {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1))
+        let image = renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        guard let data = image.pngData() else {
+            preconditionFailure("Unable to encode test image")
+        }
+        return data
+    }
+
     func testCertificateAwareSessionAttachesDelegateWithoutClientCertificate() {
         let server = makeServer(clientCertificate: nil)
         XCTAssertNil(server.info.connection.clientCertificate)
@@ -183,6 +293,33 @@ final class HomeAssistantAPIIdentityTests: XCTestCase {
             info = newInfo
             return true
         })
+    }
+}
+
+private final class FakeDiskCache: DiskCache {
+    enum FakeDiskCacheError: Error {
+        case missing
+    }
+
+    var storage = [String: Any]()
+    private(set) var deletedKeys = [String]()
+
+    func value<T: Codable>(for key: String) -> Promise<T> {
+        if let value = storage[key] as? T {
+            return .value(value)
+        }
+        return Promise(error: FakeDiskCacheError.missing)
+    }
+
+    func set<T: Codable>(_ value: T, for key: String) -> Promise<Void> {
+        storage[key] = value
+        return .value(())
+    }
+
+    func delete(for key: String) -> Promise<Void> {
+        storage[key] = nil
+        deletedKeys.append(key)
+        return .value(())
     }
 }
 


### PR DESCRIPTION


## AI Policy

Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] AI assistance was used for this contribution
- [x] AI took full control of the code generation for this contribution
- [ ] I have not used AI for this contribution

- [x] I have read the AI policy

## Summary
Cache the user profile picture on disk so it shows immediately on app launch and is still available when the server can't be reached. The cache is updated on every successful fetch and cleared when the server reports no picture.

## Screenshots
No visual changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
