### PR TITLE
Download files in the background

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -239,6 +239,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if WebhookManager.isManager(forSessionIdentifier: identifier) {
             Current.Log.info("starting webhook handler for \(identifier)")
             Current.webhooks.handleBackground(for: identifier, completionHandler: completionHandler)
+        } else if BackgroundDownloadManager.isManager(forSessionIdentifier: identifier) {
+            Current.Log.info("starting background download handler for \(identifier)")
+            BackgroundDownloadManager.shared.handleBackgroundEvents(completionHandler: completionHandler)
         } else {
             Current.Log.error("couldn't find appropriate session for for \(identifier)")
             completionHandler()

--- a/Sources/App/Frontend/DownloadManager/BackgroundDownloadManager.swift
+++ b/Sources/App/Frontend/DownloadManager/BackgroundDownloadManager.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Shared
+
+/// Runs frontend-initiated file downloads on a background `URLSession` so transfers keep going while the
+/// app is suspended — and finish even if the system relaunches the app for them. See
+/// https://developer.apple.com/documentation/foundation/downloading-files-in-the-background
+///
+/// All calls into this manager and all delegate callbacks happen on the main queue.
+final class BackgroundDownloadManager: NSObject {
+    static let shared = BackgroundDownloadManager()
+
+    static var sessionIdentifier: String { AppConstants.BundleID + ".DownloadManager" }
+
+    static func isManager(forSessionIdentifier identifier: String) -> Bool {
+        identifier == sessionIdentifier
+    }
+
+    /// The presented `DownloadManagerViewModel`, when one is on screen. Downloads finished after a
+    /// background relaunch have no observer; the file is still saved to `AppConstants.DownloadsDirectory`.
+    weak var delegate: BackgroundDownloadManagerDelegate?
+
+    private var backgroundEventsCompletionHandler: (() -> Void)?
+    private var serverIdentifierForTask = [Int: Identifier<Server>]()
+
+    private lazy var session = URLSession(
+        configuration: with(URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)) {
+            $0.sessionSendsLaunchEvents = true
+            $0.isDiscretionary = false
+        },
+        delegate: self,
+        delegateQueue: .main
+    )
+
+    @discardableResult
+    func download(_ request: URLRequest, for server: Server) -> URLSessionDownloadTask {
+        let task = session.downloadTask(with: request)
+        serverIdentifierForTask[task.taskIdentifier] = server.identifier
+        task.resume()
+        return task
+    }
+
+    func cancel(taskIdentifier: Int) {
+        session.getAllTasks { tasks in
+            tasks.first(where: { $0.taskIdentifier == taskIdentifier })?.cancel()
+        }
+    }
+
+    /// Recreates the background session after the system relaunched the app for its events, per
+    /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)`.
+    func handleBackgroundEvents(completionHandler: @escaping () -> Void) {
+        backgroundEventsCompletionHandler = completionHandler
+        // Touching the session reconnects it to the background transfer daemon so queued delegate
+        // events (including `urlSessionDidFinishEvents`) replay.
+        _ = session
+    }
+
+    static func destinationURL(forSuggestedFilename suggestedFilename: String) -> URL? {
+        let name = suggestedFilename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "Unknown"
+        return URL(string: name, relativeTo: AppConstants.DownloadsDirectory)
+    }
+
+    /// Unlike `WKDownload`, a download task happily persists an HTML error page on failure statuses, so the
+    /// response has to be validated before the file is kept.
+    static func validationError(for response: URLResponse?) -> URLError? {
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 else { return nil }
+        return URLError(.badServerResponse, userInfo: [
+            NSLocalizedDescriptionKey: "HTTP \(httpResponse.statusCode)",
+        ])
+    }
+
+    private func server(for task: URLSessionTask, host: String?) -> Server? {
+        if let identifier = serverIdentifierForTask[task.taskIdentifier],
+           let server = Current.servers.server(for: identifier) {
+            return server
+        }
+        // After a background relaunch the task → server map is gone; match by host so security
+        // exceptions and client certificates still apply.
+        return Current.servers.all.first { server in
+            server.activeURLUsingLastKnownNetworkState()?.host == host
+        }
+    }
+}
+
+extension BackgroundDownloadManager: URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        delegate?.backgroundDownload(
+            taskIdentifier: downloadTask.taskIdentifier,
+            didWriteBytes: totalBytesWritten,
+            expectedTotalBytes: totalBytesExpectedToWrite,
+            suggestedFilename: downloadTask.response?.suggestedFilename
+        )
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        serverIdentifierForTask[downloadTask.taskIdentifier] = nil
+
+        if let error = Self.validationError(for: downloadTask.response) {
+            Current.Log.error("Background download failed with \(error) for \(downloadTask)")
+            delegate?.backgroundDownload(taskIdentifier: downloadTask.taskIdentifier, didFailWith: error)
+            return
+        }
+
+        let suggestedFilename = downloadTask.response?.suggestedFilename
+            ?? downloadTask.originalRequest?.url?.lastPathComponent ?? "Unknown"
+        guard let destination = Self.destinationURL(forSuggestedFilename: suggestedFilename) else {
+            delegate?.backgroundDownload(
+                taskIdentifier: downloadTask.taskIdentifier,
+                didFailWith: URLError(.cannotCreateFile)
+            )
+            return
+        }
+
+        // The temporary file only exists until this method returns, so it has to be moved synchronously.
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: location, to: destination)
+            delegate?.backgroundDownload(
+                taskIdentifier: downloadTask.taskIdentifier,
+                didFinishDownloadingTo: destination
+            )
+        } catch {
+            Current.Log.error("Failed to move background download to \(destination), error: \(error)")
+            delegate?.backgroundDownload(taskIdentifier: downloadTask.taskIdentifier, didFailWith: error)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        serverIdentifierForTask[task.taskIdentifier] = nil
+
+        guard let error, (error as? URLError)?.code != .cancelled else { return }
+        Current.Log.error("Background download completed with error: \(error)")
+        delegate?.backgroundDownload(taskIdentifier: task.taskIdentifier, didFailWith: error)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard let server = server(for: task, host: challenge.protectionSpace.host) else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        let (disposition, credential) = server.info.connection.evaluate(challenge)
+        completionHandler(disposition, credential)
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        backgroundEventsCompletionHandler?()
+        backgroundEventsCompletionHandler = nil
+    }
+}

--- a/Sources/App/Frontend/DownloadManager/BackgroundDownloadManager.swift
+++ b/Sources/App/Frontend/DownloadManager/BackgroundDownloadManager.swift
@@ -55,7 +55,13 @@ final class BackgroundDownloadManager: NSObject {
     }
 
     static func destinationURL(forSuggestedFilename suggestedFilename: String) -> URL? {
-        let name = suggestedFilename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "Unknown"
+        // The name can come from a server-provided Content-Disposition header, so strip any path
+        // structure to keep the file inside the downloads directory.
+        let baseName = suggestedFilename
+            .components(separatedBy: "/").last?
+            .components(separatedBy: "\\").last ?? "Unknown"
+        let safeName = [".", ".."].contains(baseName) || baseName.isEmpty ? "Unknown" : baseName
+        let name = safeName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? "Unknown"
         return URL(string: name, relativeTo: AppConstants.DownloadsDirectory)
     }
 
@@ -68,15 +74,18 @@ final class BackgroundDownloadManager: NSObject {
         ])
     }
 
-    private func server(for task: URLSessionTask, host: String?) -> Server? {
+    private func server(for task: URLSessionTask, protectionSpace: URLProtectionSpace) -> Server? {
         if let identifier = serverIdentifierForTask[task.taskIdentifier],
            let server = Current.servers.server(for: identifier) {
             return server
         }
-        // After a background relaunch the task → server map is gone; match by host so security
-        // exceptions and client certificates still apply.
+        // After a background relaunch the task → server map is gone; match by host and port so
+        // security exceptions and client certificates still apply — and to the right server when
+        // several share a host.
         return Current.servers.all.first { server in
-            server.activeURLUsingLastKnownNetworkState()?.host == host
+            guard let url = server.activeURLUsingLastKnownNetworkState(), let host = url.host else { return false }
+            let port = url.port ?? (url.scheme?.lowercased() == "https" ? 443 : 80)
+            return host == protectionSpace.host && port == protectionSpace.port
         }
     }
 }
@@ -150,7 +159,7 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        guard let server = server(for: task, host: challenge.protectionSpace.host) else {
+        guard let server = server(for: task, protectionSpace: challenge.protectionSpace) else {
             completionHandler(.performDefaultHandling, nil)
             return
         }

--- a/Sources/App/Frontend/DownloadManager/BackgroundDownloadManagerDelegate.swift
+++ b/Sources/App/Frontend/DownloadManager/BackgroundDownloadManagerDelegate.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Receives `BackgroundDownloadManager` events, on the main queue. Events carry the download task's
+/// identifier so an observer can ignore tasks it does not own.
+protocol BackgroundDownloadManagerDelegate: AnyObject {
+    func backgroundDownload(
+        taskIdentifier: Int,
+        didWriteBytes totalBytesWritten: Int64,
+        expectedTotalBytes: Int64,
+        suggestedFilename: String?
+    )
+    func backgroundDownload(taskIdentifier: Int, didFinishDownloadingTo url: URL)
+    func backgroundDownload(taskIdentifier: Int, didFailWith error: Error)
+}

--- a/Sources/App/Frontend/DownloadManager/DownloadManagerViewModel.swift
+++ b/Sources/App/Frontend/DownloadManager/DownloadManagerViewModel.swift
@@ -13,6 +13,25 @@ final class DownloadManagerViewModel: NSObject, ObservableObject {
 
     private var progressObservation: NSKeyValueObservation?
     private var lastDownload: WKDownload?
+    private var backgroundTaskIdentifier: Int?
+
+    /// Re-issues a `WKDownload`'s request on `BackgroundDownloadManager`'s background `URLSession` so the
+    /// transfer keeps going while the app is suspended. Cookies live in the web view's store rather than
+    /// the app's shared one, so they are copied onto the request for setups that authenticate with them.
+    func startBackgroundDownload(request: URLRequest, server: Server, cookieStore: WKHTTPCookieStore) {
+        fileName = request.url?.lastPathComponent ?? ""
+        BackgroundDownloadManager.shared.delegate = self
+        cookieStore.getAllCookies { cookies in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let task = BackgroundDownloadManager.shared.download(
+                    Self.request(request, addingCookies: cookies),
+                    for: server
+                )
+                self.backgroundTaskIdentifier = task.taskIdentifier
+            }
+        }
+    }
 
     func deleteFile() {
         if let url = lastURLCreated {
@@ -28,6 +47,34 @@ final class DownloadManagerViewModel: NSObject, ObservableObject {
     func cancelDownload() {
         progressObservation?.invalidate()
         lastDownload?.cancel()
+        if let backgroundTaskIdentifier {
+            BackgroundDownloadManager.shared.cancel(taskIdentifier: backgroundTaskIdentifier)
+        }
+    }
+
+    nonisolated static func request(_ request: URLRequest, addingCookies cookies: [HTTPCookie]) -> URLRequest {
+        guard let url = request.url else { return request }
+        let matching = cookies.filter { cookie($0, matches: url) }
+        guard !matching.isEmpty else { return request }
+        return with(request) { request in
+            for (header, value) in HTTPCookie.requestHeaderFields(with: matching) {
+                request.setValue(value, forHTTPHeaderField: header)
+            }
+        }
+    }
+
+    private nonisolated static func cookie(_ cookie: HTTPCookie, matches url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        let domain = cookie.domain.lowercased()
+        let domainMatches: Bool
+        if domain.hasPrefix(".") {
+            domainMatches = host == String(domain.dropFirst()) || host.hasSuffix(domain)
+        } else {
+            domainMatches = host == domain
+        }
+        guard domainMatches else { return false }
+        if cookie.isSecure, url.scheme?.lowercased() != "https" { return false }
+        return cookie.path == "/" || url.path.hasPrefix(cookie.path)
     }
 
     private func bytesToMBString(_ bytes: Int64) -> String {
@@ -35,6 +82,38 @@ final class DownloadManagerViewModel: NSObject, ObservableObject {
         formatter.allowedUnits = [.useMB]
         formatter.countStyle = .file
         return formatter.string(fromByteCount: bytes)
+    }
+}
+
+extension DownloadManagerViewModel: BackgroundDownloadManagerDelegate {
+    nonisolated func backgroundDownload(
+        taskIdentifier: Int,
+        didWriteBytes totalBytesWritten: Int64,
+        expectedTotalBytes: Int64,
+        suggestedFilename: String?
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self, taskIdentifier == self.backgroundTaskIdentifier else { return }
+            if let suggestedFilename { self.fileName = suggestedFilename }
+            self.progress = bytesToMBString(totalBytesWritten)
+        }
+    }
+
+    nonisolated func backgroundDownload(taskIdentifier: Int, didFinishDownloadingTo url: URL) {
+        Task { @MainActor [weak self] in
+            guard let self, taskIdentifier == self.backgroundTaskIdentifier else { return }
+            self.fileName = url.lastPathComponent
+            self.lastURLCreated = url
+            self.finished = true
+        }
+    }
+
+    nonisolated func backgroundDownload(taskIdentifier: Int, didFailWith error: Error) {
+        Task { @MainActor [weak self] in
+            guard let self, taskIdentifier == self.backgroundTaskIdentifier else { return }
+            self.errorMessage = L10n.DownloadManager.Failed.title(error.localizedDescription)
+            self.failed = true
+        }
     }
 }
 

--- a/Sources/App/Frontend/DownloadManager/DownloadManagerViewModel.swift
+++ b/Sources/App/Frontend/DownloadManager/DownloadManagerViewModel.swift
@@ -74,7 +74,16 @@ final class DownloadManagerViewModel: NSObject, ObservableObject {
         }
         guard domainMatches else { return false }
         if cookie.isSecure, url.scheme?.lowercased() != "https" { return false }
-        return cookie.path == "/" || url.path.hasPrefix(cookie.path)
+        return pathMatches(requestPath: url.path, cookiePath: cookie.path)
+    }
+
+    /// RFC 6265 §5.1.4 path matching: a bare prefix isn't enough — `/admin` must not match `/administrator`.
+    private nonisolated static func pathMatches(requestPath: String, cookiePath: String) -> Bool {
+        let requestPath = requestPath.isEmpty ? "/" : requestPath
+        if cookiePath == requestPath { return true }
+        guard requestPath.hasPrefix(cookiePath) else { return false }
+        if cookiePath.hasSuffix("/") { return true }
+        return requestPath[requestPath.index(requestPath.startIndex, offsetBy: cookiePath.count)] == "/"
     }
 
     private func bytesToMBString(_ bytes: Int64) -> String {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebKitDelegates.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebKitDelegates.swift
@@ -106,7 +106,22 @@ extension WebViewController {
     func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
         if #available(iOS 17.0, *) {
             let viewModel = DownloadManagerViewModel()
-            download.delegate = viewModel
+            if let request = download.originalRequest,
+               let scheme = request.url?.scheme?.lowercased(),
+               ["http", "https"].contains(scheme) {
+                // A `WKDownload` dies with the web content process when the app is suspended, so re-issue
+                // the request on the background `URLSession` instead and let that own the transfer.
+                download.cancel()
+                viewModel.startBackgroundDownload(
+                    request: request,
+                    server: server,
+                    cookieStore: webView.configuration.websiteDataStore.httpCookieStore
+                )
+            } else {
+                // Anything else (e.g. a frontend-generated `blob:` file) only exists inside the web
+                // content process, so it has to stay a `WKDownload`.
+                download.delegate = viewModel
+            }
             // Present via `ContainerView`'s sheet (SwiftUI) instead of a UIKit overlay; the same view model
             // instance must back the sheet and the download delegate.
             Current.sceneManager.appCoordinator.done { $0.showDownloadManager(viewModel) }

--- a/Tests/App/DownloadManager/BackgroundDownloadManagerTests.swift
+++ b/Tests/App/DownloadManager/BackgroundDownloadManagerTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+struct BackgroundDownloadManagerTests {
+    @Test func testSessionIdentifierMatching() {
+        let identifier = BackgroundDownloadManager.sessionIdentifier
+        #expect(BackgroundDownloadManager.isManager(forSessionIdentifier: identifier))
+        #expect(!BackgroundDownloadManager.isManager(forSessionIdentifier: "io.robbie.HomeAssistant.other"))
+    }
+
+    @Test func testDestinationURLLivesInDownloadsDirectory() throws {
+        let url = try #require(BackgroundDownloadManager.destinationURL(forSuggestedFilename: "backup.tar"))
+        #expect(url.lastPathComponent == "backup.tar")
+        #expect(url.absoluteString.hasPrefix(AppConstants.DownloadsDirectory.absoluteString))
+    }
+
+    @Test func testDestinationURLEncodesUnsafeCharacters() throws {
+        let url = try #require(BackgroundDownloadManager.destinationURL(forSuggestedFilename: "my backup.tar"))
+        #expect(url.lastPathComponent == "my backup.tar")
+    }
+
+    @Test func testValidationErrorForSuccessResponse() {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com/file")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        #expect(BackgroundDownloadManager.validationError(for: response) == nil)
+    }
+
+    @Test func testValidationErrorForErrorResponse() {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://example.com/file")!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        #expect(BackgroundDownloadManager.validationError(for: response) != nil)
+    }
+
+    @Test func testValidationErrorForNonHTTPResponse() {
+        #expect(BackgroundDownloadManager.validationError(for: nil) == nil)
+    }
+}

--- a/Tests/App/DownloadManager/BackgroundDownloadManagerTests.swift
+++ b/Tests/App/DownloadManager/BackgroundDownloadManagerTests.swift
@@ -21,6 +21,21 @@ struct BackgroundDownloadManagerTests {
         #expect(url.lastPathComponent == "my backup.tar")
     }
 
+    @Test func testDestinationURLStripsPathTraversal() throws {
+        let downloadsPrefix = AppConstants.DownloadsDirectory.absoluteString
+        let traversal = try #require(BackgroundDownloadManager.destinationURL(forSuggestedFilename: "../evil.tar"))
+        #expect(traversal.lastPathComponent == "evil.tar")
+        #expect(traversal.absoluteString.hasPrefix(downloadsPrefix))
+
+        let nested = try #require(BackgroundDownloadManager.destinationURL(forSuggestedFilename: "a/b/c.tar"))
+        #expect(nested.lastPathComponent == "c.tar")
+        #expect(nested.absoluteString.hasPrefix(downloadsPrefix))
+
+        let bare = try #require(BackgroundDownloadManager.destinationURL(forSuggestedFilename: ".."))
+        #expect(bare.lastPathComponent == "Unknown")
+        #expect(bare.absoluteString.hasPrefix(downloadsPrefix))
+    }
+
     @Test func testValidationErrorForSuccessResponse() {
         let response = HTTPURLResponse(
             url: URL(string: "https://example.com/file")!,

--- a/Tests/App/DownloadManager/DownloadManagerViewModelTests.swift
+++ b/Tests/App/DownloadManager/DownloadManagerViewModelTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+struct DownloadManagerViewModelTests {
+    private func cookie(
+        name: String = "session",
+        domain: String = "example.com",
+        path: String = "/",
+        secure: Bool = false
+    ) -> HTTPCookie {
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: "value",
+            .domain: domain,
+            .path: path,
+        ]
+        if secure {
+            properties[.secure] = "TRUE"
+        }
+        return HTTPCookie(properties: properties)!
+    }
+
+    @Test func testMatchingCookieIsAddedToRequest() {
+        let request = URLRequest(url: URL(string: "https://example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [cookie()])
+        #expect(result.value(forHTTPHeaderField: "Cookie") == "session=value")
+    }
+
+    @Test func testSubdomainCookieIsAddedForWildcardDomain() {
+        let request = URLRequest(url: URL(string: "https://ha.example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [cookie(domain: ".example.com")])
+        #expect(result.value(forHTTPHeaderField: "Cookie") == "session=value")
+    }
+
+    @Test func testCookieForOtherDomainIsNotAdded() {
+        let request = URLRequest(url: URL(string: "https://example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [cookie(domain: "other.com")])
+        #expect(result.value(forHTTPHeaderField: "Cookie") == nil)
+    }
+
+    @Test func testSecureCookieIsNotAddedOnPlainHTTP() {
+        let request = URLRequest(url: URL(string: "http://example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [cookie(secure: true)])
+        #expect(result.value(forHTTPHeaderField: "Cookie") == nil)
+    }
+
+    @Test func testCookieWithNonMatchingPathIsNotAdded() {
+        let request = URLRequest(url: URL(string: "https://example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [cookie(path: "/admin")])
+        #expect(result.value(forHTTPHeaderField: "Cookie") == nil)
+    }
+
+    @Test func testRequestWithoutCookiesIsUnchanged() {
+        let request = URLRequest(url: URL(string: "https://example.com/api/download")!)
+        let result = DownloadManagerViewModel.request(request, addingCookies: [])
+        #expect(result == request)
+    }
+}

--- a/Tests/App/DownloadManager/DownloadManagerViewModelTests.swift
+++ b/Tests/App/DownloadManager/DownloadManagerViewModelTests.swift
@@ -52,6 +52,21 @@ struct DownloadManagerViewModelTests {
         #expect(result.value(forHTTPHeaderField: "Cookie") == nil)
     }
 
+    @Test func testCookiePathMatchStopsAtSegmentBoundary() {
+        // RFC 6265 §5.1.4: a cookie for /admin matches /admin/download but not /administrator.
+        let boundary = URLRequest(url: URL(string: "https://example.com/administrator/download")!)
+        let boundaryResult = DownloadManagerViewModel.request(boundary, addingCookies: [cookie(path: "/admin")])
+        #expect(boundaryResult.value(forHTTPHeaderField: "Cookie") == nil)
+
+        let nested = URLRequest(url: URL(string: "https://example.com/admin/download")!)
+        let nestedResult = DownloadManagerViewModel.request(nested, addingCookies: [cookie(path: "/admin")])
+        #expect(nestedResult.value(forHTTPHeaderField: "Cookie") == "session=value")
+
+        let exact = URLRequest(url: URL(string: "https://example.com/admin")!)
+        let exactResult = DownloadManagerViewModel.request(exact, addingCookies: [cookie(path: "/admin")])
+        #expect(exactResult.value(forHTTPHeaderField: "Cookie") == "session=value")
+    }
+
     @Test func testRequestWithoutCookiesIsUnchanged() {
         let request = URLRequest(url: URL(string: "https://example.com/api/download")!)
         let result = DownloadManagerViewModel.request(request, addingCookies: [])


### PR DESCRIPTION
## AI Policy

Read our [AI policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] AI assistance was used for this contribution
- [x] AI took full control of the code generation for this contribution
- [ ] I have not used AI for this contribution

- [x] I have read the AI policy

## Summary
Downloads started from the frontend now run on a background `URLSession`, so they keep going when the app is suspended and finish even if the system relaunches the app. Previously they used `WKDownload`, which stops as soon as the app leaves the foreground. `blob:` downloads keep the existing `WKDownload` path.

## Screenshots
No UI changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
