### PR TITLE
Fix Assist TTS playback over mTLS

### DIFF
--- a/Sources/App/Assist/AssistViewModel.swift
+++ b/Sources/App/Assist/AssistViewModel.swift
@@ -441,7 +441,7 @@ extension AssistViewModel: AssistServiceDelegate {
         }
 
         audioPlayer.delegate = self
-        audioPlayer.play(url: mediaUrl)
+        audioPlayer.play(url: mediaUrl, server: server)
     }
 
     func didReceiveError(code: String, message: String) {

--- a/Sources/App/Assist/Audio/AudioPlayer.swift
+++ b/Sources/App/Assist/Audio/AudioPlayer.swift
@@ -4,7 +4,7 @@ import Shared
 
 protocol AudioPlayerProtocol {
     var delegate: AudioPlayerDelegate? { get set }
-    func play(url: URL)
+    func play(url: URL, server: Server)
     func pause()
 }
 
@@ -16,8 +16,10 @@ protocol AudioPlayerDelegate: AnyObject {
 final class AudioPlayer: NSObject, AudioPlayerProtocol {
     weak var delegate: AudioPlayerDelegate?
     private let player = AVPlayer()
+    private var dataPlayer: AVAudioPlayer?
+    private var downloadTask: URLSessionDataTask?
 
-    func play(url: URL) {
+    func play(url: URL, server: Server) {
         let audioSession = AVAudioSession.sharedInstance()
 
         // Each step is attempted independently: if deactivation fails (e.g. while the
@@ -47,6 +49,28 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
             return
         }
 
+        if requiresCertificateAwareLoading(server: server) {
+            downloadAndPlay(url: url, server: server)
+        } else {
+            playStreaming(url: url)
+        }
+    }
+
+    func pause() {
+        player.pause()
+        dataPlayer?.pause()
+        downloadTask?.cancel()
+    }
+
+    /// AVPlayer loads media over its own connection, which can neither present the server's
+    /// client certificate (mTLS) nor apply the app's TLS security exceptions — so for servers
+    /// configured with either, streaming would always fail the handshake.
+    private func requiresCertificateAwareLoading(server: Server) -> Bool {
+        server.info.connection.clientCertificate != nil ||
+            server.info.connection.securityExceptions.hasExceptions
+    }
+
+    private func playStreaming(url: URL) {
         let playerItem = AVPlayerItem(url: url)
         player.replaceCurrentItem(with: playerItem)
         player.play()
@@ -59,8 +83,60 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
         )
     }
 
-    func pause() {
-        player.pause()
+    private func downloadAndPlay(url: URL, server: Server) {
+        downloadTask?.cancel()
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        let task = session.dataTask(with: url) { [weak self] data, response, error in
+            DispatchQueue.main.async {
+                self?.handleDownloadResult(data: data, response: response, error: error)
+            }
+        }
+        downloadTask = task
+        task.resume()
+        // The running task completes normally; afterwards the session releases its delegate,
+        // which URLSession otherwise retains forever.
+        session.finishTasksAndInvalidate()
+    }
+
+    private func handleDownloadResult(data: Data?, response: URLResponse?, error: Error?) {
+        if let error {
+            guard (error as? URLError)?.code != .cancelled else { return }
+            Current.Log.error("Failed to download TTS audio: \(error.localizedDescription)")
+            finishWithoutPlayback()
+            return
+        }
+
+        if let httpResponse = response as? HTTPURLResponse, !(200 ..< 300).contains(httpResponse.statusCode) {
+            Current.Log.error("TTS audio download failed with status code: \(httpResponse.statusCode)")
+            finishWithoutPlayback()
+            return
+        }
+
+        guard let data, !data.isEmpty else {
+            Current.Log.error("TTS audio download returned empty data")
+            finishWithoutPlayback()
+            return
+        }
+
+        do {
+            dataPlayer = try AVAudioPlayer(data: data)
+            dataPlayer?.delegate = self
+            dataPlayer?.prepareToPlay()
+            if dataPlayer?.play() != true {
+                Current.Log.error("AVAudioPlayer failed to start TTS playback")
+                finishWithoutPlayback()
+            }
+        } catch {
+            Current.Log.error("Failed to create AVAudioPlayer for TTS: \(error.localizedDescription)")
+            finishWithoutPlayback()
+        }
+    }
+
+    /// Failed playback reports as finished so a continue-conversation pipeline run resumes
+    /// listening instead of hanging on audio that will never end.
+    private func finishWithoutPlayback() {
+        delegate?.audioPlayerDidFinishPlaying(self)
     }
 
     @objc private func audioDidFinishPlaying(_ notification: Notification) {
@@ -69,5 +145,11 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+}
+
+extension AudioPlayer: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        delegate?.audioPlayerDidFinishPlaying(self)
     }
 }

--- a/Sources/App/Assist/Audio/AudioPlayer.swift
+++ b/Sources/App/Assist/Audio/AudioPlayer.swift
@@ -4,7 +4,7 @@ import Shared
 
 protocol AudioPlayerProtocol {
     var delegate: AudioPlayerDelegate? { get set }
-    func play(url: URL, server: Server)
+    func play(url: URL, server: Server?)
     func pause()
 }
 
@@ -19,7 +19,9 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
     private var dataPlayer: AVAudioPlayer?
     private var downloadTask: URLSessionDataTask?
 
-    func play(url: URL, server: Server) {
+    func play(url: URL, server: Server?) {
+        stopCurrentPlayback()
+
         let audioSession = AVAudioSession.sharedInstance()
 
         // Each step is attempted independently: if deactivation fails (e.g. while the
@@ -49,7 +51,9 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
             return
         }
 
-        if requiresCertificateAwareLoading(server: server) {
+        // Falls back to streaming when the server is unknown: for the servers streaming can
+        // handle, playback keeps working, and the certificate-requiring ones failed either way.
+        if let server, requiresCertificateAwareLoading(server: server) {
             downloadAndPlay(url: url, server: server)
         } else {
             playStreaming(url: url)
@@ -60,6 +64,18 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
         player.pause()
         dataPlayer?.pause()
         downloadTask?.cancel()
+    }
+
+    /// Stops whichever path is currently active so a new `play` never overlaps the previous
+    /// audio or receives its finish callbacks. `AVAudioPlayer.stop()` does not fire the
+    /// finished-playing delegate, so no spurious `audioPlayerDidFinishPlaying` results.
+    private func stopCurrentPlayback() {
+        downloadTask?.cancel()
+        downloadTask = nil
+        dataPlayer?.stop()
+        dataPlayer = nil
+        NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: nil)
+        player.replaceCurrentItem(with: nil)
     }
 
     /// AVPlayer loads media over its own connection, which can neither present the server's
@@ -87,13 +103,16 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
         downloadTask?.cancel()
 
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
-        let task = session.dataTask(with: url) { [weak self] data, response, error in
+        var task: URLSessionDataTask?
+        task = session.dataTask(with: url) { [weak self] data, response, error in
             DispatchQueue.main.async {
-                self?.handleDownloadResult(data: data, response: response, error: error)
+                guard let self, downloadTask === task else { return }
+                downloadTask = nil
+                handleDownloadResult(data: data, response: response, error: error)
             }
         }
         downloadTask = task
-        task.resume()
+        task?.resume()
         // The running task completes normally; afterwards the session releases its delegate,
         // which URLSession otherwise retains forever.
         session.finishTasksAndInvalidate()

--- a/Sources/App/Assist/Audio/AudioPlayer.swift
+++ b/Sources/App/Assist/Audio/AudioPlayer.swift
@@ -105,8 +105,9 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
         var task: URLSessionDataTask?
         task = session.dataTask(with: url) { [weak self] data, response, error in
-            DispatchQueue.main.async {
-                guard let self, downloadTask === task else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard downloadTask === task else { return }
                 downloadTask = nil
                 handleDownloadResult(data: data, response: response, error: error)
             }

--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
@@ -90,6 +90,7 @@ final class CarPlayAssistSession: NSObject {
     private var isStopped = false
     private var postDismissAction: (() -> Void)?
 
+    private let server: Server
     private let pipelineId: String
     private let prompt: String?
 
@@ -172,6 +173,7 @@ final class CarPlayAssistSession: NSObject {
         tonePlayer: CarPlayAssistTonePlayerProtocol = CarPlayAssistTonePlayer()
     ) {
         self.interfaceController = interfaceController
+        self.server = server
         self.pipelineId = pipelineId
         self.prompt = prompt
         self.audioRecorder = audioRecorder
@@ -574,10 +576,16 @@ final class CarPlayAssistSession: NSObject {
         configureAudioSessionForTTSIfNeeded()
         logCurrentAudioRoute(context: "before tts playback")
 
+        // AVPlayer loads media over its own connection, which can neither present the server's
+        // client certificate (mTLS) nor apply the app's TLS security exceptions, so for servers
+        // configured with either the streaming strategy can never succeed.
+        let requiresCertificateAwareLoading = server.info.connection.clientCertificate != nil ||
+            server.info.connection.securityExceptions.hasExceptions
+
         switch Current.settingsStore.carPlayAssistDebugSettings.ttsPlaybackStrategy {
-        case .avPlayer:
+        case .avPlayer where !requiresCertificateAwareLoading:
             playTTSWithAVPlayer(url: url)
-        case .downloadedAVAudioPlayer:
+        case .avPlayer, .downloadedAVAudioPlayer:
             playTTSWithDownloadedAudioPlayer(url: url)
         }
     }
@@ -624,7 +632,11 @@ final class CarPlayAssistSession: NSObject {
     private func playTTSWithDownloadedAudioPlayer(url: URL) {
         Current.Log.info("CarPlay Assist downloading TTS audio for AVAudioPlayer: \(url.absoluteString)")
 
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+        // Downloaded through the certificate-aware session so the fetch presents the server's
+        // client certificate (mTLS) and applies its TLS security exceptions, which
+        // URLSession.shared cannot do.
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        session.dataTask(with: url) { [weak self] data, _, error in
             guard let self else { return }
 
             if let error {
@@ -661,6 +673,9 @@ final class CarPlayAssistSession: NSObject {
                 }
             }
         }.resume()
+        // The running task completes normally; afterwards the session releases its delegate,
+        // which URLSession otherwise retains forever.
+        session.finishTasksAndInvalidate()
     }
 
     private func observeTTSPlayer(item: AVPlayerItem, url: URL) {

--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayAssistSession.swift
@@ -645,7 +645,7 @@ final class CarPlayAssistSession: NSObject {
                 return
             }
 
-            guard let data else {
+            guard let data, !data.isEmpty else {
                 Current.Log.error("CarPlay Assist downloaded empty TTS audio data")
                 enterErrorState(message: "Downloaded empty TTS audio data")
                 return

--- a/Sources/WatchApp/Assist/WatchAssistService.swift
+++ b/Sources/WatchApp/Assist/WatchAssistService.swift
@@ -16,6 +16,13 @@ final class WatchAssistService: ObservableObject {
 
     private let serverId: String
     private let pipelineId: String
+
+    /// The server this Assist session talks to; playback needs it to present the server's
+    /// client certificate and TLS security exceptions when fetching TTS audio.
+    var server: Server? {
+        Current.servers.server(forServerIdentifier: serverId)
+    }
+
     private var reachabilityObservation: HAWatchConnectivity.ObservationToken?
     private var cancellable: Cancellable?
 

--- a/Sources/WatchApp/Assist/WatchAssistView.swift
+++ b/Sources/WatchApp/Assist/WatchAssistView.swift
@@ -296,7 +296,7 @@ private final class PreviewWatchAudioRecorder: ObservableObject, WatchAudioRecor
 private final class PreviewAudioPlayer: AudioPlayerProtocol {
     weak var delegate: AudioPlayerDelegate?
 
-    func play(url: URL, server: Server) {}
+    func play(url: URL, server: Server?) {}
 
     func pause() {}
 }

--- a/Sources/WatchApp/Assist/WatchAssistView.swift
+++ b/Sources/WatchApp/Assist/WatchAssistView.swift
@@ -296,7 +296,7 @@ private final class PreviewWatchAudioRecorder: ObservableObject, WatchAudioRecor
 private final class PreviewAudioPlayer: AudioPlayerProtocol {
     weak var delegate: AudioPlayerDelegate?
 
-    func play(url: URL) {}
+    func play(url: URL, server: Server) {}
 
     func pause() {}
 }

--- a/Sources/WatchApp/Assist/WatchAssistViewModel.swift
+++ b/Sources/WatchApp/Assist/WatchAssistViewModel.swift
@@ -181,9 +181,9 @@ extension WatchAssistViewModel: ImmediateCommunicatorServiceDelegate {
     }
 
     func didReceiveTTS(url: URL) {
-        guard let server = assistService.server else {
-            Current.Log.error("Watch Assist TTS playback skipped: could not resolve the session's server")
-            return
+        let server = assistService.server
+        if server == nil {
+            Current.Log.error("Watch Assist could not resolve the session's server, TTS playback will stream")
         }
         audioPlayer.play(url: url, server: server)
     }

--- a/Sources/WatchApp/Assist/WatchAssistViewModel.swift
+++ b/Sources/WatchApp/Assist/WatchAssistViewModel.swift
@@ -181,7 +181,11 @@ extension WatchAssistViewModel: ImmediateCommunicatorServiceDelegate {
     }
 
     func didReceiveTTS(url: URL) {
-        audioPlayer.play(url: url)
+        guard let server = assistService.server else {
+            Current.Log.error("Watch Assist TTS playback skipped: could not resolve the session's server")
+            return
+        }
+        audioPlayer.play(url: url, server: server)
     }
 
     func didReceiveError(code: String, message: String) {

--- a/Tests/App/Assist/Mocks/MockAudioPlayer.swift
+++ b/Tests/App/Assist/Mocks/MockAudioPlayer.swift
@@ -10,7 +10,7 @@ final class MockAudioPlayer: AudioPlayerProtocol {
     var playCalled = false
     var pauseCalled = false
 
-    func play(url: URL, server: Server) {
+    func play(url: URL, server: Server?) {
         playUrl = url
         playServer = server
         playCalled = true

--- a/Tests/App/Assist/Mocks/MockAudioPlayer.swift
+++ b/Tests/App/Assist/Mocks/MockAudioPlayer.swift
@@ -1,15 +1,18 @@
 import Foundation
 @testable import HomeAssistant
+import Shared
 
 final class MockAudioPlayer: AudioPlayerProtocol {
     var delegate: (any HomeAssistant.AudioPlayerDelegate)?
 
     var playUrl: URL?
+    var playServer: Server?
     var playCalled = false
     var pauseCalled = false
 
-    func play(url: URL) {
+    func play(url: URL, server: Server) {
         playUrl = url
+        playServer = server
         playCalled = true
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Assist TTS playback fails on servers behind mTLS (or with app-level TLS security exceptions): the audio was fetched by AVPlayer (in-app and Watch Assist) or `URLSession.shared` (CarPlay downloaded strategy), neither of which can present the server's client certificate or apply the stored trust exceptions, so the TLS handshake failed and playback ended silently.

TTS audio is now fetched through the certificate-aware `URLSession` already used for REST calls and played from the downloaded data. Servers without a client certificate or trust exceptions keep the existing streaming path unchanged.

## Screenshots
No UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Bug fix only, no functionality change, so no documentation PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JjTbT4bTpvBe1vTPDyBfY)_