### PR TITLE
Add clean cache and reload button to stuck loader

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -174,7 +174,8 @@ struct HomeAssistantView: View, WebFrontendView {
                 onGestureAction: { action in
                     viewModel.webViewController?.webViewGestureHandler.handleGestureAction(action)
                 },
-                onLogoDismiss: viewModel.forceDismissStandByView
+                onLogoDismiss: viewModel.forceDismissStandByView,
+                onCleanCacheAndReload: viewModel.cleanCacheAndReload
             )
             .transition(.opacity)
             .opacity(viewModel.standByOpacity)

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -140,6 +140,14 @@ final class HomeAssistantViewModel: ObservableObject {
         webViewResetID = UUID()
     }
 
+    func cleanCacheAndReload() {
+        Current.Log.info("Standby loader stuck; cleaning frontend cache and reloading")
+        Current.websiteDataStoreHandler
+            .cleanCache(dataTypes: WebsiteDataStoreHandlerImpl.frontendAssetDataTypes) { [weak self] in
+                self?.resetWebFrontend()
+            }
+    }
+
     func handleWebViewController(_ controller: WebViewController) {
         webViewController = controller
         onWebViewController?(controller)

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -128,7 +128,7 @@ struct HomeAssistantStandByView: View {
             if let emptyState {
                 actionButtons(for: emptyState)
                     .opacity(contentOpacity)
-            } else if showsCleanCacheButton {
+            } else if showsCleanCacheButton, onCleanCacheAndReload != nil {
                 cleanCacheButton
                     .transition(.opacity)
             }
@@ -178,7 +178,7 @@ struct HomeAssistantStandByView: View {
             withAnimation(DesignSystem.Animation.default) {
                 showsDelayedSettingsButton = true
             }
-            try? await Task.sleep(for: cleanCacheButtonDelay - delayedSettingsButtonDelay)
+            try? await Task.sleep(for: max(.zero, cleanCacheButtonDelay - delayedSettingsButtonDelay))
             guard !Task.isCancelled, !showsEmptyState else { return }
             withAnimation(DesignSystem.Animation.default) {
                 showsCleanCacheButton = true

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -11,7 +11,6 @@ struct HomeAssistantStandByView: View {
     private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
     private static let reauthenticationIconSize: CGFloat = 56
     private static let serverPillHeight: CGFloat = 44
-    private static let delayedSettingsButtonDelay: Duration = .seconds(5)
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
     static let serverSelectionTransitionID = "home-assistant-stand-by-server-selection"
     fileprivate static let launchScreenLogoPreviewOpacity = 0.55
@@ -23,6 +22,10 @@ struct HomeAssistantStandByView: View {
     let onSelectServerTapped: (() -> Void)?
     let onGestureAction: ((HAGestureAction) -> Void)?
     let onLogoDismiss: (() -> Void)?
+    let onCleanCacheAndReload: (() -> Void)?
+
+    private let delayedSettingsButtonDelay: Duration
+    private let cleanCacheButtonDelay: Duration
 
     @State private var selectedReauthURLType: ConnectionInfo.URLType
     @State private var showURLPicker = false
@@ -32,6 +35,8 @@ struct HomeAssistantStandByView: View {
     @State private var logoDismissTapCount = 0
     @State private var showsEmptyStateContent = false
     @State private var showsDelayedSettingsButton = false
+    @State private var showsCleanCacheButton = false
+    @State private var loaderCountdownRestartToken = 0
     @State private var hasAppeared = false
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
 
@@ -63,7 +68,10 @@ struct HomeAssistantStandByView: View {
         serverSelectionNamespace: Namespace.ID? = nil,
         onSelectServerTapped: (() -> Void)? = nil,
         onGestureAction: ((HAGestureAction) -> Void)? = nil,
-        onLogoDismiss: (() -> Void)? = nil
+        onLogoDismiss: (() -> Void)? = nil,
+        onCleanCacheAndReload: (() -> Void)? = nil,
+        delayedSettingsButtonDelay: Duration = .seconds(5),
+        cleanCacheButtonDelay: Duration = .seconds(15)
     ) {
         self.server = server
         self.emptyState = emptyState
@@ -72,6 +80,9 @@ struct HomeAssistantStandByView: View {
         self.onSelectServerTapped = onSelectServerTapped
         self.onGestureAction = onGestureAction
         self.onLogoDismiss = onLogoDismiss
+        self.onCleanCacheAndReload = onCleanCacheAndReload
+        self.delayedSettingsButtonDelay = delayedSettingsButtonDelay
+        self.cleanCacheButtonDelay = cleanCacheButtonDelay
         self._selectedReauthURLType = State(initialValue: emptyState?.availableReauthURLTypes.first ?? .external)
     }
 
@@ -117,6 +128,9 @@ struct HomeAssistantStandByView: View {
             if let emptyState {
                 actionButtons(for: emptyState)
                     .opacity(contentOpacity)
+            } else if showsCleanCacheButton {
+                cleanCacheButton
+                    .transition(.opacity)
             }
         }
         .alert(L10n.errorLabel, isPresented: .init(
@@ -155,13 +169,19 @@ struct HomeAssistantStandByView: View {
         ) { _ in
             networkType = Current.connectivity.simpleNetworkType()
         }
-        .task(id: showsEmptyState) {
+        .task(id: [AnyHashable(showsEmptyState), AnyHashable(loaderCountdownRestartToken)]) {
             showsDelayedSettingsButton = false
+            showsCleanCacheButton = false
             guard !showsEmptyState else { return }
-            try? await Task.sleep(for: Self.delayedSettingsButtonDelay)
+            try? await Task.sleep(for: delayedSettingsButtonDelay)
             guard !Task.isCancelled, !showsEmptyState else { return }
             withAnimation(DesignSystem.Animation.default) {
                 showsDelayedSettingsButton = true
+            }
+            try? await Task.sleep(for: cleanCacheButtonDelay - delayedSettingsButtonDelay)
+            guard !Task.isCancelled, !showsEmptyState else { return }
+            withAnimation(DesignSystem.Animation.default) {
+                showsCleanCacheButton = true
             }
         }
     }
@@ -173,6 +193,24 @@ struct HomeAssistantStandByView: View {
                 .transition(.opacity)
                 .padding(.bottom, DesignSystem.Spaces.eighteen)
         }
+    }
+
+    private var cleanCacheButton: some View {
+        Button(action: cleanCacheAndReload) {
+            Text(L10n.WebView.EmptyState.cleanCacheAndReloadButton)
+        }
+        .buttonStyle(.primaryButton)
+        .frame(maxWidth: Sizes.maxWidthForLargerScreens)
+        .padding(.horizontal, DesignSystem.Spaces.two)
+        .padding(.top)
+    }
+
+    private func cleanCacheAndReload() {
+        withAnimation(DesignSystem.Animation.default) {
+            showsCleanCacheButton = false
+        }
+        loaderCountdownRestartToken += 1
+        onCleanCacheAndReload?()
     }
 
     @ViewBuilder
@@ -644,6 +682,20 @@ private extension HomeAssistantStandByView {
             activeURLType: .external
         ),
         emptyState: nil
+    )
+}
+
+#Preview("Loading Stuck — Clean Cache Button") {
+    HomeAssistantStandByView(
+        server: HomeAssistantStandByView.previewServer(
+            name: "Reserva Aruanã",
+            configuredURLTypes: [.internal, .external, .remoteUI],
+            activeURLType: .remoteUI
+        ),
+        emptyState: nil,
+        onCleanCacheAndReload: {},
+        delayedSettingsButtonDelay: .seconds(0.2),
+        cleanCacheButtonDelay: .seconds(0.6)
     )
 }
 

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2198,6 +2198,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "web_view.add_to.option.MacToolbar.title" = "Mac Toolbar";
 "web_view.add_to.option.Widget.title" = "Widget";
 "web_view.empty_state.body" = "Please check your connection or try again later. If Home Assistant is restarting it will reconnect after it is back online.";
+"web_view.empty_state.clean_cache_and_reload_button" = "Clean cache and reload";
 "web_view.empty_state.open_settings_button" = "Open App settings";
 "web_view.empty_state.reauthenticate_button" = "Re-authenticate";
 "web_view.empty_state.retry_button" = "Retry";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7200,6 +7200,8 @@ public enum L10n {
     public enum EmptyState {
       /// Please check your connection or try again later. If Home Assistant is restarting it will reconnect after it is back online.
       public static var body: String { return L10n.tr("Localizable", "web_view.empty_state.body") }
+      /// Clean cache and reload
+      public static var cleanCacheAndReloadButton: String { return L10n.tr("Localizable", "web_view.empty_state.clean_cache_and_reload_button") }
       /// Open App settings
       public static var openSettingsButton: String { return L10n.tr("Localizable", "web_view.empty_state.open_settings_button") }
       /// Re-authenticate

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -154,9 +154,55 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertFalse(sut.shouldShowStandByView)
     }
 
+    func testCleanCacheAndReloadClearsFrontendAssetCacheThenResetsFrontend() {
+        let previousHandler = Current.websiteDataStoreHandler
+        defer { Current.websiteDataStoreHandler = previousHandler }
+        let handler = FakeWebsiteDataStoreHandler()
+        Current.websiteDataStoreHandler = handler
+
+        let overlayState = WebFrontendOverlayState()
+        overlayState.showsNoActiveURL = true
+        let sut = HomeAssistantViewModel(
+            server: Server.fake(),
+            overlayState: overlayState
+        )
+        let initialResetID = sut.webViewResetID
+
+        sut.cleanCacheAndReload()
+
+        XCTAssertEqual(handler.cleanCacheCallCount, 1)
+        XCTAssertEqual(handler.lastDataTypes, WebsiteDataStoreHandlerImpl.frontendAssetDataTypes)
+
+        handler.invokePendingCompletion()
+
+        XCTAssertNotEqual(sut.webViewResetID, initialResetID)
+        XCTAssertFalse(overlayState.showsNoActiveURL)
+        XCTAssertTrue(sut.isFullScreenLoaderMounted)
+    }
+
     private func server(version: Version) -> Server {
         Server.fake { info in
             info.version = version
         }
+    }
+}
+
+private final class FakeWebsiteDataStoreHandler: WebsiteDataStoreHandlerProtocol {
+    private(set) var cleanCacheCallCount = 0
+    private(set) var lastDataTypes: Set<String>?
+    private var pendingCompletion: (() -> Void)?
+
+    func cleanCache(dataTypes: Set<String>, completion: (() -> Void)?) {
+        cleanCacheCallCount += 1
+        lastDataTypes = dataTypes
+        pendingCompletion = completion
+    }
+
+    func cleanFrontendAssetCacheIfNeeded(completion: ((Bool) -> Void)?) {}
+
+    func invokePendingCompletion() {
+        let completion = pendingCompletion
+        pendingCompletion = nil
+        completion?()
     }
 }


### PR DESCRIPTION
When the web view loader stays visible for more than 15 seconds without reaching an empty or error state, a "Clean cache and reload" button appears at the bottom so the user can recover from a stuck frontend.