### PR TITLE
Add hasSplashscreen to external bus config

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalBusMessage.swift
@@ -47,6 +47,7 @@ enum WebViewExternalBusMessage: String, CaseIterable {
             "canSetupImprov": true,
             "downloadFileSupported": true,
             "hasEntityAddTo": true,
+            "hasSplashscreen": true,
             "appVersion": "\(AppConstants.version) (\(AppConstants.build))",
             "toastComponentVersion": { // Frontend can use this to know if the version has what it needs
                 if #available(iOS 18, *), !Current.isCatalyst {

--- a/Tests/App/WebView/WebViewExternalBusMessageTests.swift
+++ b/Tests/App/WebView/WebViewExternalBusMessageTests.swift
@@ -84,6 +84,7 @@ final class WebViewExternalBusMessageTests: XCTestCase {
             "canSetupImprov",
             "downloadFileSupported",
             "hasEntityAddTo",
+            "hasSplashscreen",
             "appVersion",
             "toastComponentVersion",
         ]


### PR DESCRIPTION
Report `hasSplashscreen: true` in the `config/get` external bus response, so the frontend removes its launch screen without animation while the app's own loading screen covers it until `frontend/loaded`.

Frontend side: home-assistant/frontend#53171