### PR TITLE
Trace watch magic item execution stages and guard hang points

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1944,7 +1944,9 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.home.run.confirmation.title" = "Are you sure you want to run \"%@\"?";
 "watch.home.run.error.message" = "The action couldn't be run. The Apple Watch may not be able to reach this server directly.";
 "watch.home.run.error.no_active_url_hint" = "Open Settings → Servers on this watch to review the server's URL options.";
+"watch.home.run.error.no_response" = "The server didn't respond in time.";
 "watch.home.run.error.title" = "Couldn't run action";
+"watch.home.run.error.token_timeout" = "Couldn't get an access token from the server in time. Try again; restarting the app clears a stuck connection.";
 "watch.home.sync.syncing" = "Syncing with iPhone…";
 "watch.home.sync.waiting" = "Waiting for iPhone…";
 "watch.interaction.toast.action" = "Ran an action";

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -187,11 +187,15 @@ public class HomeAssistantAPI {
     /// Keychain read fell back to the sanitized GRDB mirror), yet is usable moments later. Gating
     /// session construction on that snapshot would leave the session permanently without the
     /// certificate, so every external, mTLS-protected request 403s for the process's lifetime.
+    /// `onStep` narrates TLS challenge handling (client certificate / server trust) for callers with
+    /// a live diagnostic trace — a challenge handler blocking on a Keychain read stalls the request
+    /// before any timeout applies, and these lines are the only way to see that stage.
     public static func makeCertificateAwareURLSession(
         server: Server,
-        configuration: URLSessionConfiguration = .ephemeral
+        configuration: URLSessionConfiguration = .ephemeral,
+        onStep: ((String) -> Void)? = nil
     ) -> URLSession {
-        let certificateProvider = HomeAssistantCertificateProvider(server: server)
+        let certificateProvider = HomeAssistantCertificateProvider(server: server, onStep: onStep)
         let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
         return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
     }
@@ -1394,9 +1398,13 @@ private extension URL {
 /// Certificate provider implementation for Home Assistant servers
 private class HomeAssistantCertificateProvider: HACertificateProvider {
     private let server: Server
+    /// Optional live narration of challenge handling; announced BEFORE the potentially blocking
+    /// work (Keychain read, trust evaluation) so a hang names the step it never returned from.
+    private let onStep: ((String) -> Void)?
 
-    init(server: Server) {
+    init(server: Server, onStep: ((String) -> Void)? = nil) {
         self.server = server
+        self.onStep = onStep
     }
 
     func provideClientCertificate(
@@ -1411,12 +1419,15 @@ private class HomeAssistantCertificateProvider: HACertificateProvider {
             return
         }
 
+        onStep?("TLS: client certificate requested — reading it from the Keychain…")
         do {
             let credential = try ClientCertificateManager.shared.urlCredential(for: clientCertificate)
             Current.Log.info("[mTLS HAKit] Using client certificate: \(clientCertificate.displayName)")
+            onStep?("TLS: using client certificate \(clientCertificate.displayName)")
             completionHandler(.useCredential, credential)
         } catch {
             Current.Log.error("[mTLS HAKit] Failed to get credential: \(error)")
+            onStep?("TLS: client certificate unavailable (\(error.localizedDescription))")
             completionHandler(.cancelAuthenticationChallenge, nil)
         }
     }
@@ -1428,13 +1439,16 @@ private class HomeAssistantCertificateProvider: HACertificateProvider {
     ) {
         Current.Log.info("[mTLS HAKit] Evaluating server trust for: \(host)")
 
+        onStep?("TLS: evaluating server trust for \(host)…")
         do {
             try server.info.connection.securityExceptions.evaluate(serverTrust)
             Current.Log.info("[mTLS HAKit] Server trust validation successful")
+            onStep?("TLS: server trust accepted")
             let credential = URLCredential(trust: serverTrust)
             completionHandler(.useCredential, credential)
         } catch {
             Current.Log.error("[mTLS HAKit] Server trust validation failed: \(error)")
+            onStep?("TLS: server trust rejected (\(error.localizedDescription))")
             completionHandler(.rejectProtectionSpace, nil)
         }
     }

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -399,14 +399,18 @@ public extension MagicItem {
     /// via the webhook API (`CallService`) and entity/lock actions over the WebSocket connection.
     ///
     /// `currentItemState` is used only for the lock domain, since it can't be toggled.
+    ///
+    /// `onStep` narrates the run's progress (resolved service call, URL, token stage, request,
+    /// TLS challenges) for the watch's verbose execution trace. Ignored on non-watch platforms.
     func execute(
         on server: Server,
         source: AppTriggerSource,
         currentItemState: String = "",
+        onStep: ((String) -> Void)? = nil,
         completion: @escaping (Bool, Error?) -> Void
     ) {
         #if os(watchOS)
-        executeViaREST(on: server, currentItemState: currentItemState, completion: completion)
+        executeViaREST(on: server, currentItemState: currentItemState, onStep: onStep, completion: completion)
         #else
         executeViaWebSocket(
             on: server,
@@ -537,12 +541,19 @@ public extension MagicItem {
         let data: [String: Any]
     }
 
+    /// How long the run waits for a bearer token before failing. The refresh request has no
+    /// watchdog of its own, and `TokenManager` caches the in-flight refresh promise — a refresh
+    /// that never resolves (started by any earlier request) would otherwise hang every run
+    /// silently, with `completion` never called.
+    private static var tokenDeadline: TimeInterval { 10 }
+
     /// watchOS executes via the REST API — see `execute(on:source:currentItemState:completion:)`.
     /// The request reuses the server's mTLS-aware `URLSession` and bearer token (token refresh already
     /// works over `URLSession` on the watch), so no WebSocket is involved.
     private func executeViaREST(
         on server: Server,
         currentItemState: String,
+        onStep: ((String) -> Void)?,
         completion: @escaping (Bool, Error?) -> Void
     ) {
         let serviceCall: WatchServiceCall?
@@ -559,6 +570,7 @@ public extension MagicItem {
             completion(true, nil)
             return
         }
+        onStep?("Service call: \(serviceCall.domain).\(serviceCall.service)")
 
         // No Swift concurrency on this path: watchOS gives the cooperative pool a single thread,
         // and a starved pool left taps hanging before the request ever started. The synchronous
@@ -568,17 +580,47 @@ public extension MagicItem {
             completion(false, ServerConnectionError.noActiveURL(server.info.name))
             return
         }
+        onStep?("URL: \(baseURL.absoluteString)")
+
+        // Narrate the token stage: an expired token forces a refresh over REST, the least protected
+        // leg of the run — so the trace should say up front whether that leg is in play.
+        let expiration = server.info.token.expiration
+        let now = Current.date()
+        if expiration.addingTimeInterval(-60) > now {
+            onStep?("Access token valid for another \(Int(expiration.timeIntervalSince(now)))s")
+        } else {
+            onStep?("Access token expired — refreshing over REST (reuses any refresh already in flight)…")
+        }
 
         let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
-        tokenManager.bearerToken.done { token, _ in
+        let tokenStarted = Current.date()
+        onStep?("Requesting bearer token (\(Int(Self.tokenDeadline))s deadline)…")
+        // Deadline so a stuck refresh fails the run instead of silencing it. The loser of the race
+        // is discarded; a late token still lands in the shared cache for the next run.
+        let deadline = after(seconds: Self.tokenDeadline)
+            .then { Promise<(String, Date)>(error: WatchRESTExecutionError.tokenTimeout) }
+        race(tokenManager.bearerToken, deadline).done { token, _ in
+            onStep?(String(
+                format: "Token ready in %.2fs",
+                Current.date().timeIntervalSince(tokenStarted)
+            ))
             self.sendRESTServiceCall(
                 baseURL: baseURL,
                 server: server,
                 token: token,
                 serviceCall: serviceCall,
+                onStep: onStep,
                 completion: completion
             )
         }.catch { error in
+            if let restError = error as? WatchRESTExecutionError, case .tokenTimeout = restError {
+                onStep?(
+                    "No token after \(Int(Self.tokenDeadline))s — giving up. The refresh appears " +
+                        "stuck; it stays cached, so later runs will fail fast too until the app restarts."
+                )
+            } else {
+                onStep?("Token failed: \(error.localizedDescription)")
+            }
             Current.Log.error("Token unavailable executing magic item \(self.id): \(error.localizedDescription)")
             completion(false, error)
         }
@@ -629,11 +671,18 @@ public extension MagicItem {
         }
     }
 
+    /// Request timeout, and how long past it the run waits before declaring the session dead:
+    /// URLSession has been observed never calling the data task back on watch hardware, even past
+    /// `timeoutInterval` — its delivery queue itself can be starved.
+    private static var requestTimeout: TimeInterval { 15 }
+    private static var sessionCallbackFallback: TimeInterval { requestTimeout + 2 }
+
     private func sendRESTServiceCall(
         baseURL: URL,
         server: Server,
         token: String,
         serviceCall: WatchServiceCall,
+        onStep: ((String) -> Void)?,
         completion: @escaping (Bool, Error?) -> Void
     ) {
         let url = baseURL
@@ -646,7 +695,7 @@ public extension MagicItem {
         request.httpMethod = "POST"
         // Bound the wait so a dead route fails visibly instead of hanging the row for the default 60s
         // (the UI resets after ~4s, but the task would otherwise keep a session + tokens alive).
-        request.timeoutInterval = 15
+        request.timeoutInterval = Self.requestTimeout
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
@@ -660,39 +709,81 @@ public extension MagicItem {
 
         Current.Log.info("Executing magic item \(id) via REST: POST \(url.absoluteString)")
 
-        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        let lock = NSLock()
+        var finished = false
+        // First caller wins; the loser's work is discarded so `completion` runs exactly once.
+        func finishOnce(_ body: () -> Void) {
+            lock.lock()
+            let shouldRun = !finished
+            finished = true
+            lock.unlock()
+            if shouldRun { body() }
+        }
+
+        let started = Current.date()
+        onStep?(
+            "POST /api/services/\(serviceCall.domain)/\(serviceCall.service) " +
+                "(\(Int(Self.requestTimeout))s timeout)…"
+        )
+
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server, onStep: onStep)
         let task = session.dataTask(with: request) { [session] data, response, error in
             // The session strongly retains its delegate until invalidated; do it once the task ends.
             defer { session.finishTasksAndInvalidate() }
+            let elapsed = String(format: "%.2fs", Current.date().timeIntervalSince(started))
+            finishOnce {
+                if let error {
+                    Current.Log
+                        .error("REST execution of magic item \(self.id) failed: \(error.localizedDescription)")
+                    onStep?("Request failed after \(elapsed): \(error.localizedDescription)")
+                    completion(false, error)
+                    return
+                }
 
-            if let error {
-                Current.Log.error("REST execution of magic item \(self.id) failed: \(error.localizedDescription)")
-                completion(false, error)
-                return
-            }
+                guard let http = response as? HTTPURLResponse else {
+                    onStep?("Non-HTTP response after \(elapsed)")
+                    completion(false, WatchRESTExecutionError.invalidResponse)
+                    return
+                }
 
-            guard let http = response as? HTTPURLResponse else {
-                completion(false, WatchRESTExecutionError.invalidResponse)
-                return
-            }
-
-            if (200 ..< 300).contains(http.statusCode) {
-                Current.Log.verbose("Success executing magic item \(self.id) via REST")
-                completion(true, nil)
-            } else {
-                let body = data.flatMap { String(data: $0, encoding: .utf8) }
-                Current.Log.error(
-                    "REST execution of magic item \(self.id) returned \(http.statusCode): \(body ?? "<no body>")"
-                )
-                completion(false, WatchRESTExecutionError.httpStatus(http.statusCode, body: body))
+                onStep?("Response \(http.statusCode) after \(elapsed)")
+                if (200 ..< 300).contains(http.statusCode) {
+                    Current.Log.verbose("Success executing magic item \(self.id) via REST")
+                    completion(true, nil)
+                } else {
+                    let body = data.flatMap { String(data: $0, encoding: .utf8) }
+                    Current.Log.error(
+                        "REST execution of magic item \(self.id) returned \(http.statusCode): \(body ?? "<no body>")"
+                    )
+                    completion(false, WatchRESTExecutionError.httpStatus(http.statusCode, body: body))
+                }
             }
         }
         task.resume()
+        // Fallback for a URLSession that never calls back — not even with its timeout error. Main
+        // queue on purpose: it is the one queue proven to stay serviced on watch hardware (the GCD
+        // global and Swift-concurrency pools have both been observed starved there).
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.sessionCallbackFallback) {
+            finishOnce {
+                Current.Log.error("REST execution of magic item \(self.id) got no URLSession callback")
+                onStep?(
+                    "No answer from URLSession after \(Int(Self.sessionCallbackFallback))s — treating as " +
+                        "failed. Either the network went silent past its own timeout, or the callback " +
+                        "queue is starved and couldn't deliver the result."
+                )
+                session.invalidateAndCancel()
+                completion(false, WatchRESTExecutionError.noURLSessionCallback)
+            }
+        }
     }
 
     private enum WatchRESTExecutionError: LocalizedError {
         case invalidResponse
         case httpStatus(_ statusCode: Int, body: String?)
+        /// No bearer token within `tokenDeadline` — a token refresh is most likely stuck.
+        case tokenTimeout
+        /// URLSession never called the data task back, not even past `timeoutInterval`.
+        case noURLSessionCallback
 
         var errorDescription: String? {
             switch self {
@@ -704,6 +795,10 @@ public extension MagicItem {
                     return body
                 }
                 return L10n.Watch.Home.Run.Error.message
+            case .tokenTimeout:
+                return L10n.Watch.Home.Run.Error.tokenTimeout
+            case .noURLSessionCallback:
+                return L10n.Watch.Home.Run.Error.noResponse
             }
         }
     }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6431,8 +6431,12 @@ public enum L10n {
           public static var message: String { return L10n.tr("Localizable", "watch.home.run.error.message") }
           /// Open Settings → Servers on this watch to review the server's URL options.
           public static var noActiveUrlHint: String { return L10n.tr("Localizable", "watch.home.run.error.no_active_url_hint") }
+          /// The server didn't respond in time.
+          public static var noResponse: String { return L10n.tr("Localizable", "watch.home.run.error.no_response") }
           /// Couldn't run action
           public static var title: String { return L10n.tr("Localizable", "watch.home.run.error.title") }
+          /// Couldn't get an access token from the server in time. Try again; restarting the app clears a stuck connection.
+          public static var tokenTimeout: String { return L10n.tr("Localizable", "watch.home.run.error.token_timeout") }
         }
       }
       public enum Sync {

--- a/Sources/WatchApp/Home/MagicItemRow/MagicItemExecutionTrace.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/MagicItemExecutionTrace.swift
@@ -51,19 +51,24 @@ final class MagicItemExecutionTrace: ObservableObject {
         String(format: "+%.2fs", entry.date.timeIntervalSince(startDate))
     }
 
+    /// Safe to call from any thread — steps arrive from URLSession and PromiseKit callbacks. The
+    /// client-event write happens inside the main-queue hop because `ClientEventStore.addEvent` is
+    /// an unsynchronized read-modify-write of a JSON file: concurrent calls from quick successive
+    /// steps would race and drop entries.
     func log(_ level: Level, _ message: String, isProgress: Bool = true) {
         Current.Log.info("[ItemExecutionTrace] \(message)")
-        if recordsClientEvents {
-            Current.clientEventStore.addEvent(.init(
-                text: message,
-                type: .serviceCall,
-                payload: [
-                    "source": "watch_magic_item_verbose_execution",
-                    "level": level.clientEventValue,
-                ]
-            ))
-        }
+        let recordsClientEvents = recordsClientEvents
         DispatchQueue.main.async { [weak self] in
+            if recordsClientEvents {
+                Current.clientEventStore.addEvent(.init(
+                    text: message,
+                    type: .serviceCall,
+                    payload: [
+                        "source": "watch_magic_item_verbose_execution",
+                        "level": level.clientEventValue,
+                    ]
+                ))
+            }
             self?.entries.append(.init(date: Current.date(), level: level, message: message))
             if isProgress {
                 self?.lastProgressMessage = message

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -90,7 +90,11 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         Current.Log.info("Executing watch magic item directly via API")
         trace?.log(.info, "Executing via REST from the watch on \"\(server.info.name)\"…")
 
-        magicItem.execute(on: server, source: .Watch) { [weak self] success, error in
+        magicItem.execute(on: server, source: .Watch, onStep: { [weak self] step in
+            // Each REST stage (service call, URL, token, request, TLS) announces itself before it
+            // runs, so a hang's last trace line names the exact step that never returned.
+            self?.trace?.log(.info, step)
+        }) { [weak self] success, error in
             if success {
                 self?.trace?.log(.success, "Server accepted the request")
             } else {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Follow-up to #5210. Each stage of the watch's REST execution (service call, URL, token, request, TLS challenges) now announces itself in the verbose execution trace, so a stuck run names the exact step that never returned. It also guards the two legs that could previously hang without ever succeeding or failing: a 10s deadline on the bearer token (a stuck cached refresh otherwise silences every later run too) and a fallback timer for a URLSession that never calls the data task back.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes