### PR TITLE
Reset stuck-loader button countdown on foreground

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -1,6 +1,7 @@
 import SFSafeSymbols
 import Shared
 import SwiftUI
+import UIKit
 
 struct HomeAssistantStandByView: View {
     static let dismissTapThreshold = 5
@@ -168,6 +169,12 @@ struct HomeAssistantStandByView: View {
                 .publisher(for: Current.connectivity.connectivityDidChangeNotification())
         ) { _ in
             networkType = Current.connectivity.simpleNetworkType()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            guard !showsEmptyState else { return }
+            showsDelayedSettingsButton = false
+            showsCleanCacheButton = false
+            loaderCountdownRestartToken += 1
         }
         .task(id: [AnyHashable(showsEmptyState), AnyHashable(loaderCountdownRestartToken)]) {
             showsDelayedSettingsButton = false


### PR DESCRIPTION
The stuck-loader "Clean cache and reload" button could appear immediately when returning from the background, because its 15s countdown kept counting while the app was suspended. Restart the countdown when the app returns to the foreground so it only counts time the loader is actually visible, letting a quick reload finish before the button shows.