### PR TITLE
Fix watch magic item execution hang

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -190,6 +190,15 @@ public class HomeAssistantAPI {
     /// `onStep` narrates TLS challenge handling (client certificate / server trust) for callers with
     /// a live diagnostic trace — a challenge handler blocking on a Keychain read stalls the request
     /// before any timeout applies, and these lines are the only way to see that stage.
+    ///
+    /// On watchOS the session's delegate/completion callbacks are delivered on the main queue. The
+    /// delegate queue is where URLSession schedules both the auth-challenge callbacks and the task
+    /// completion handlers; a `nil` queue makes it use a private serial queue backed by the shared
+    /// thread pool. That pool has been observed starved on watch hardware while a tap is handled and
+    /// SwiftUI presents, so the private queue never runs — neither the TLS challenge, the task
+    /// completion, nor even the request's own timeout is ever delivered and the request hangs
+    /// silently. The main queue is the one proven to stay serviced there. iOS/macOS keep the default
+    /// private queue (no reason to serialize this work onto the main thread there).
     public static func makeCertificateAwareURLSession(
         server: Server,
         configuration: URLSessionConfiguration = .ephemeral,
@@ -197,7 +206,12 @@ public class HomeAssistantAPI {
     ) -> URLSession {
         let certificateProvider = HomeAssistantCertificateProvider(server: server, onStep: onStep)
         let delegate = HAURLSessionDelegate(certificateProvider: certificateProvider)
-        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        #if os(watchOS)
+        let delegateQueue: OperationQueue? = .main
+        #else
+        let delegateQueue: OperationQueue? = nil
+        #endif
+        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
     }
 
     convenience init?() {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Running a magic item on the Apple Watch could hang, ending only with a "server didn't respond" failure and no result.

The watch REST request used a URLSession created with a nil delegate queue. That private serial queue can get starved on watch hardware, so none of the callbacks (the TLS challenge, the response, or even the request's own timeout) were ever delivered. The request now delivers its callbacks on the main queue, the one queue proven to stay serviced on the watch.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
