### PR TITLE
Hide server pill and align loading logo with splash when single server

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -60,31 +60,30 @@ struct HomeAssistantStandByView: View {
 
     private var showsConnectionTypeIndicator: Bool { configuredURLTypes.count > 1 }
 
-    private var canSelectServer: Bool { Current.servers.all.count > 1 }
-
-    /// With a single server there is nothing to identify or switch to, so the pill row is hidden and the
+    /// Without another registered server there is nothing to identify or switch to (a zero count — as in
+    /// previews or a transiently empty registry — behaves the same), so the pill row is hidden and the
     /// loading logo mirrors the splash logo exactly (size and full-screen-centered position) so the
     /// splash-to-stand-by hand-off is a pure crossfade with no movement.
-    private var hasSingleServer: Bool { Current.servers.all.count <= 1 }
+    private var hasMultipleServers: Bool { Current.servers.all.count > 1 }
 
     private var logoSize: CGSize {
         if showsEmptyState {
             Self.emptyStateLogoSize
-        } else if hasSingleServer {
-            LaunchSplashOverlayView.Constants.splashLogoSize
-        } else {
+        } else if hasMultipleServers {
             Self.loadingLogoSize
+        } else {
+            LaunchSplashOverlayView.Constants.splashLogoSize
         }
     }
 
     private func contentOffset(safeAreaInsets: EdgeInsets) -> CGFloat {
         guard !showsEmptyState else { return 0 }
-        if hasSingleServer {
-            // The splash logo is centered against the full screen while this content is laid out inside
-            // the safe area; shift by the safe-area asymmetry so the two centers coincide.
-            return (safeAreaInsets.bottom - safeAreaInsets.top) / 2
+        if hasMultipleServers {
+            return -DesignSystem.Spaces.eight
         }
-        return -DesignSystem.Spaces.eight
+        // The splash logo is centered against the full screen while this content is laid out inside
+        // the safe area; shift by the safe-area asymmetry so the two centers coincide.
+        return (safeAreaInsets.bottom - safeAreaInsets.top) / 2
     }
 
     init(
@@ -123,7 +122,7 @@ struct HomeAssistantStandByView: View {
             iconView
             if let emptyState {
                 emptyStateBody(for: emptyState)
-            } else if !hasSingleServer {
+            } else if hasMultipleServers {
                 currentServerPill
             }
         }
@@ -294,7 +293,7 @@ struct HomeAssistantStandByView: View {
 
     @ViewBuilder
     private var serverNamePill: some View {
-        if canSelectServer {
+        if hasMultipleServers {
             Button {
                 onSelectServerTapped?()
             } label: {

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -204,20 +204,26 @@ struct HomeAssistantStandByView: View {
             showsCleanCacheButton = false
             loaderCountdownRestartToken += 1
         }
-        .task(id: [AnyHashable(showsEmptyState), AnyHashable(loaderCountdownRestartToken)]) {
-            showsDelayedSettingsButton = false
-            showsCleanCacheButton = false
-            guard !showsEmptyState else { return }
-            try? await Task.sleep(for: delayedSettingsButtonDelay)
-            guard !Task.isCancelled, !showsEmptyState else { return }
-            withAnimation(DesignSystem.Animation.default) {
-                showsDelayedSettingsButton = true
-            }
-            try? await Task.sleep(for: max(.zero, cleanCacheButtonDelay - delayedSettingsButtonDelay))
-            guard !Task.isCancelled, !showsEmptyState else { return }
-            withAnimation(DesignSystem.Animation.default) {
-                showsCleanCacheButton = true
-            }
+        .task(
+            id: [AnyHashable(showsEmptyState), AnyHashable(loaderCountdownRestartToken)],
+            runDelayedButtonsCountdown
+        )
+    }
+
+    @Sendable
+    private func runDelayedButtonsCountdown() async {
+        showsDelayedSettingsButton = false
+        showsCleanCacheButton = false
+        guard !showsEmptyState else { return }
+        try? await Task.sleep(for: delayedSettingsButtonDelay)
+        guard !Task.isCancelled, !showsEmptyState else { return }
+        withAnimation(DesignSystem.Animation.default) {
+            showsDelayedSettingsButton = true
+        }
+        try? await Task.sleep(for: max(.zero, cleanCacheButtonDelay - delayedSettingsButtonDelay))
+        guard !Task.isCancelled, !showsEmptyState else { return }
+        withAnimation(DesignSystem.Animation.default) {
+            showsCleanCacheButton = true
         }
     }
 

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -43,7 +43,6 @@ struct HomeAssistantStandByView: View {
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
 
     private var showsEmptyState: Bool { emptyState != nil }
-    private var loadingContentOffset: CGFloat { showsEmptyState ? 0 : -DesignSystem.Spaces.eight }
     private var standByContentOpacity: Double { hasAppeared ? 1.0 : 0.0 }
     private var contentOpacity: Double { showsEmptyStateContent ? 1.0 : 0.0 }
     private var configuredURLTypes: [ConnectionInfo.URLType] {
@@ -62,6 +61,31 @@ struct HomeAssistantStandByView: View {
     private var showsConnectionTypeIndicator: Bool { configuredURLTypes.count > 1 }
 
     private var canSelectServer: Bool { Current.servers.all.count > 1 }
+
+    /// With a single server there is nothing to identify or switch to, so the pill row is hidden and the
+    /// loading logo mirrors the splash logo exactly (size and full-screen-centered position) so the
+    /// splash-to-stand-by hand-off is a pure crossfade with no movement.
+    private var hasSingleServer: Bool { Current.servers.all.count <= 1 }
+
+    private var logoSize: CGSize {
+        if showsEmptyState {
+            Self.emptyStateLogoSize
+        } else if hasSingleServer {
+            LaunchSplashOverlayView.Constants.splashLogoSize
+        } else {
+            Self.loadingLogoSize
+        }
+    }
+
+    private func contentOffset(safeAreaInsets: EdgeInsets) -> CGFloat {
+        guard !showsEmptyState else { return 0 }
+        if hasSingleServer {
+            // The splash logo is centered against the full screen while this content is laid out inside
+            // the safe area; shift by the safe-area asymmetry so the two centers coincide.
+            return (safeAreaInsets.bottom - safeAreaInsets.top) / 2
+        }
+        return -DesignSystem.Spaces.eight
+    }
 
     init(
         server: Server,
@@ -89,11 +113,17 @@ struct HomeAssistantStandByView: View {
     }
 
     var body: some View {
+        GeometryReader { proxy in
+            content(safeAreaInsets: proxy.safeAreaInsets)
+        }
+    }
+
+    private func content(safeAreaInsets: EdgeInsets) -> some View {
         VStack(spacing: DesignSystem.Spaces.three) {
             iconView
             if let emptyState {
                 emptyStateBody(for: emptyState)
-            } else {
+            } else if !hasSingleServer {
                 currentServerPill
             }
         }
@@ -104,7 +134,7 @@ struct HomeAssistantStandByView: View {
             maxHeight: .infinity,
             alignment: showsEmptyState ? .top : .center
         )
-        .offset(y: loadingContentOffset)
+        .offset(y: contentOffset(safeAreaInsets: safeAreaInsets))
         .opacity(standByContentOpacity)
         // Sits in front of the background colour but behind the content, so swipes over empty areas reach it
         // while buttons keep priority.
@@ -398,10 +428,7 @@ struct HomeAssistantStandByView: View {
                 }
             }
         }
-        .frame(
-            width: showsEmptyState ? Self.emptyStateLogoSize.width : Self.loadingLogoSize.width,
-            height: showsEmptyState ? Self.emptyStateLogoSize.height : Self.loadingLogoSize.height
-        )
+        .frame(width: logoSize.width, height: logoSize.height)
         .launchSplashLogoAnchor()
         .contentShape(Rectangle())
         .onTapGesture(perform: registerLogoDismissTap)
@@ -752,16 +779,21 @@ private extension HomeAssistantStandByView {
         emptyState: nil
     )
     .overlay {
-        Image("launchScreen-logo")
-            .resizable()
-            .scaledToFit()
-            .frame(
-                width: LaunchSplashOverlayView.Constants.splashLogoSize.width,
-                height: LaunchSplashOverlayView.Constants.splashLogoSize.height
-            )
-            .opacity(HomeAssistantStandByView.launchScreenLogoPreviewOpacity)
-            .allowsHitTesting(false)
-            .ignoresSafeArea()
+        // Positioned with the same math as `LaunchSplashOverlayView`: centered against the full
+        // screen, not the safe area.
+        GeometryReader { proxy in
+            Image("launchScreen-logo")
+                .resizable()
+                .scaledToFit()
+                .frame(
+                    width: LaunchSplashOverlayView.Constants.splashLogoSize.width,
+                    height: LaunchSplashOverlayView.Constants.splashLogoSize.height
+                )
+                .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+        }
+        .ignoresSafeArea()
+        .opacity(HomeAssistantStandByView.launchScreenLogoPreviewOpacity)
+        .allowsHitTesting(false)
     }
 }
 


### PR DESCRIPTION
## Summary

When only one server is configured, the standby (loading) screen no longer shows the server name pill or the connection type icon, since there is nothing to identify or switch to.

In that case the animated loading logo now uses the same size (120x120) and full-screen-centered position as the logo in the launch splash screen, so the splash-to-standby hand-off is a pure crossfade with no logo movement.

Multi-server behavior is unchanged.