### PR TITLE
Watch complications: user naming, picker previews, cleaner built-ins

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1760,6 +1760,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.complications.builder.color" = "Gauge color";
 "watch.complications.builder.color_from_template" = "Color from template";
 "watch.complications.builder.colors" = "Colors";
+"watch.complications.builder.complication_name" = "Complication name";
 "watch.complications.builder.custom_colors" = "Custom colors";
 "watch.complications.builder.customize" = "Customize";
 "watch.complications.builder.customize_footer" = "Customize how each size shows its name, value, gauge, and colors.";

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
@@ -324,11 +324,24 @@ struct WatchComplicationBuilderEditView: View {
                 }
             }
 
-            // Step 3 (template): enter the templates, then the shared options reveal below. The text
-            // template stands in for the display name — same icon + row as the entity flow — showing
-            // its rendered result (or the template source) and opening the full editor in a sheet.
+            // Step 3 (template): name the complication, enter the templates, then the shared options
+            // reveal below. The text template stands in for the display name — same icon + row as
+            // the entity flow — showing its rendered result (or the template source) and opening the
+            // full editor in a sheet.
             if viewModel.selectedSource == .customTemplate, !viewModel.config.serverId.isEmpty,
                let server = viewModel.server {
+                // Without a name every template complication is listed as a generic
+                // "Complication"/"Template" in the iOS list and the watch gallery; the name labels
+                // it in both. Left empty, saving auto-generates "Complication-N" (the on-face text
+                // still comes from the text template below).
+                Section {
+                    TextField(text: stringBinding(\.name)) {
+                        Text(verbatim: L10n.Watch.Complications.Builder.complicationName)
+                    }
+                } header: {
+                    Text(L10n.Watch.Complications.Builder.complicationName)
+                }
+
                 Section {
                     HStack(spacing: DesignSystem.Spaces.two) {
                         IconPicker(

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
@@ -160,6 +160,7 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
     }
 
     func save() {
+        autoGenerateNameIfNeeded()
         do {
             try config.save()
         } catch {
@@ -168,5 +169,19 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
         NotificationCenter.default.post(name: WatchComplicationConfig.didChangeNotification, object: nil)
         HomeAssistantAPI.syncWatchContext()
         WatchMirrorPushCoordinator.schedule(reason: .complicationChanged)
+    }
+
+    /// A template complication saved without a name gets "Complication-N" (first free number), so it
+    /// never shows up as a generic "Complication" in the iOS list and the watch gallery. Entity
+    /// complications keep their entity-name fallback instead.
+    private func autoGenerateNameIfNeeded() {
+        guard config.kind == .customTemplate,
+              (config.name ?? "").trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        let existingNames = Set(((try? WatchComplicationConfig.all()) ?? []).compactMap(\.name))
+        var number = 1
+        while existingNames.contains("Complication-\(number)") {
+            number += 1
+        }
+        config.name = "Complication-\(number)"
     }
 }

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
@@ -176,7 +176,7 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
     /// complications keep their entity-name fallback instead.
     private func autoGenerateNameIfNeeded() {
         guard config.kind == .customTemplate,
-              (config.name ?? "").trimmingCharacters(in: .whitespaces).isEmpty else { return }
+              (config.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         let existingNames = Set(((try? WatchComplicationConfig.all()) ?? []).compactMap(\.name))
         var number = 1
         while existingNames.contains("Complication-\(number)") {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -5894,6 +5894,8 @@ public enum L10n {
         public static var colorFromTemplate: String { return L10n.tr("Localizable", "watch.complications.builder.color_from_template") }
         /// Colors
         public static var colors: String { return L10n.tr("Localizable", "watch.complications.builder.colors") }
+        /// Complication name
+        public static var complicationName: String { return L10n.tr("Localizable", "watch.complications.builder.complication_name") }
         /// Custom colors
         public static var customColors: String { return L10n.tr("Localizable", "watch.complications.builder.custom_colors") }
         /// Customize

--- a/Sources/WatchWidgets/Complications/CornerComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CornerComplicationView.swift
@@ -11,20 +11,26 @@ struct CornerComplicationView: View {
 
     var body: some View {
         if let complication {
-            Group {
-                if showsIconInCorner(complication), let iconImage = complication.iconImage {
-                    // The icon sits in the corner un-curved; curving a raster image collapses it.
-                    iconImage.renderingMode(.template).resizable().scaledToFit().widgetAccentable()
-                } else {
-                    // Curve the value/name along the outer edge of the corner; the system lays the
-                    // widget label on the inside of the same curve.
-                    Text(cornerText(complication))
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                        .widgetCurvesContent()
+            if complication.perFamily == nil {
+                // Built-ins (Home Assistant / Assist): the icon alone fills the corner, matching
+                // the circular family — no arc text and no bezel label.
+                ComplicationIconView(complication: complication)
+            } else {
+                Group {
+                    if showsIconInCorner(complication), let iconImage = complication.iconImage {
+                        // The icon sits in the corner un-curved; curving a raster image collapses it.
+                        iconImage.renderingMode(.template).resizable().scaledToFit().widgetAccentable()
+                    } else {
+                        // Curve the value/name along the outer edge of the corner; the system lays
+                        // the widget label on the inside of the same curve.
+                        Text(cornerText(complication))
+                            .minimumScaleFactor(0.5)
+                            .lineLimit(1)
+                            .widgetCurvesContent()
+                    }
                 }
+                .widgetLabel { bezelLabel(complication) }
             }
-            .widgetLabel { bezelLabel(complication) }
         } else {
             Text(WatchWidgetConstants.appName)
         }

--- a/Sources/WatchWidgets/Complications/RectangularComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/RectangularComplicationView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import WidgetKit
 
 /// Rectangular complication: optional icon + name, plus a progress bar (value follows the thumb,
-/// min/max at the edges) when a value exists. Legacy/built-ins keep the simpler primary/secondary layout.
+/// min/max at the edges) when a value exists. Built-ins show just their icon + title.
 @available(watchOS 10.0, *)
 struct RectangularComplicationView: View {
     let complication: WatchWidgetComplicationSnapshot?
@@ -63,26 +63,12 @@ struct RectangularComplicationView: View {
         }
     }
 
-    @ViewBuilder
+    /// Built-ins (Home Assistant / Assist): the title alone next to the icon — no subtitle line
+    /// and no gauge.
     private var legacyContent: some View {
-        VStack(alignment: .leading, spacing: WatchWidgetConstants.Layout.rectangularTextSpacing) {
-            Text(complication?.title ?? WatchWidgetConstants.appName)
-                .font(.caption2.weight(.semibold))
-                .lineLimit(1)
-            if let complication, let fraction = complication.fraction(for: family) {
-                Gauge(value: fraction) {
-                    EmptyView()
-                } currentValueLabel: {
-                    Text(complication.subtitle).lineLimit(1)
-                }
-                .gaugeStyle(.accessoryLinearCapacity)
-                .tint(complication.tintColor(for: family))
-            } else {
-                Text(complication?.subtitle ?? WatchWidgetConstants.placeholderSubtitle)
-                    .font(.caption2)
-                    .lineLimit(2)
-            }
-        }
+        Text(complication?.title ?? WatchWidgetConstants.appName)
+            .font(.caption2.weight(.semibold))
+            .lineLimit(1)
     }
 }
 

--- a/Sources/WatchWidgets/WatchWidgetAppIntent.swift
+++ b/Sources/WatchWidgets/WatchWidgetAppIntent.swift
@@ -32,7 +32,16 @@ struct WatchWidgetAppIntentProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: WatchWidgetConfigurationIntent, in context: Context) async -> WatchWidgetEntry {
-        entry(for: configuration, in: context)
+        let entry = entry(for: configuration, in: context)
+        // The complication picker/gallery asks for a preview snapshot: render the complication's
+        // identity (name, icon, gauge, colors) with a neutral value instead of whatever live value
+        // happens to be cached — no fetch, instant, and never presents stale data as current.
+        guard context.isPreview else { return entry }
+        return WatchWidgetEntry(
+            date: entry.date,
+            family: entry.family,
+            complication: entry.complication?.previewVariant
+        )
     }
 
     func timeline(

--- a/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
@@ -9,7 +9,7 @@ struct WatchWidgetComplicationSnapshot: Codable {
     /// Per-widget-family rendering values, keyed by `WatchComplicationConfig.Family.rawValue`
     /// ("circular"/"rectangular"/"inline"/"corner"). Absent for built-in/legacy complications.
     struct PerFamily: Codable {
-        let fraction: Double?
+        var fraction: Double?
         let tint: String?
         let showValue: Bool
         /// Whether to show the complication name (default true).
@@ -35,10 +35,10 @@ struct WatchWidgetComplicationSnapshot: Codable {
     let subtitle: String
     /// Mutable so the widget's live self-fetch can update the inline value in place.
     var inlineText: String
-    let fraction: Double?
+    var fraction: Double?
     let tint: String?
     let iconData: Data?
-    let perFamily: [String: PerFamily]?
+    var perFamily: [String: PerFamily]?
     /// The name shown in the complication picker (the value goes in `title` for on-face rendering).
     /// Optional so older payloads without it still decode.
     let menuName: String?
@@ -155,16 +155,26 @@ struct WatchWidgetComplicationSnapshot: Codable {
     }
 
     /// A static stand-in for the complication picker (`context.isPreview`): identity only — name,
-    /// icon, gauge shape and colors — with the value slot neutralized. The picker preview must
-    /// render instantly from whatever is cached and must not present a possibly-stale value as
-    /// current. Built-ins (placeholder/Assist) already carry static text and pass through as-is.
+    /// icon, gauge shape and colors — with both the value text and the gauge fill neutralized. The
+    /// picker preview must render instantly from whatever is cached and must not present a
+    /// possibly-stale value as current. Built-ins (placeholder/Assist) already carry static text and
+    /// pass through as-is.
     var previewVariant: Self {
         guard !isBuiltIn else { return self }
         var preview = self
         preview.title = WatchWidgetConstants.previewValueText
-        // Inline renders a single line of text: the name identifies the complication better than
-        // a bare "--".
         preview.inlineText = recommendationTitle
+        preview.fraction = fraction.map { _ in WatchWidgetConstants.previewGaugeFraction }
+        var families = perFamily?.mapValues { options -> PerFamily in
+            var options = options
+            options.fraction = options.fraction.map { _ in WatchWidgetConstants.previewGaugeFraction }
+            return options
+        }
+        if var inline = families?["inline"] {
+            inline.showName = true
+            families?["inline"] = inline
+        }
+        preview.perFamily = families
         return preview
     }
 

--- a/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
@@ -154,6 +154,20 @@ struct WatchWidgetComplicationSnapshot: Codable {
         return title.isEmpty ? WatchWidgetConstants.appName : title
     }
 
+    /// A static stand-in for the complication picker (`context.isPreview`): identity only — name,
+    /// icon, gauge shape and colors — with the value slot neutralized. The picker preview must
+    /// render instantly from whatever is cached and must not present a possibly-stale value as
+    /// current. Built-ins (placeholder/Assist) already carry static text and pass through as-is.
+    var previewVariant: Self {
+        guard !isBuiltIn else { return self }
+        var preview = self
+        preview.title = WatchWidgetConstants.previewValueText
+        // Inline renders a single line of text: the name identifies the complication better than
+        // a bare "--".
+        preview.inlineText = recommendationTitle
+        return preview
+    }
+
     var widgetURL: URL? {
         recommendationID == Self.assistID ? WatchWidgetConstants.DeepLink.assistURL : nil
     }

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -9,6 +9,9 @@ enum WatchWidgetConstants {
     static let templateLogoAssetName = "TemplateLogo"
     static let assistIconAssetName = "message-processing-outline"
     static let placeholderSubtitle = "Complication"
+    /// Neutral value shown in the complication picker's preview instead of a possibly-stale
+    /// live value (see `WatchWidgetComplicationSnapshot.previewVariant`).
+    static let previewValueText = "--"
     static let timelineRefreshInterval: TimeInterval = 15 * 60
 
     enum DeepLink {

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -12,6 +12,7 @@ enum WatchWidgetConstants {
     /// Neutral value shown in the complication picker's preview instead of a possibly-stale
     /// live value (see `WatchWidgetComplicationSnapshot.previewVariant`).
     static let previewValueText = "--"
+    static let previewGaugeFraction: Double = 0.5
     static let timelineRefreshInterval: TimeInterval = 15 * 60
 
     enum DeepLink {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
- Template complications can now be named: a "Complication name" field opens the template flow, and saving with it empty auto-generates `Complication-1`, `Complication-2`, … — so they no longer all show up as a generic "Complication"/"Template" in the iOS list and the watch gallery.
- The watch complication picker renders a static preview state (name, icon, gauge shape and colors, with a neutral `--` value) instead of possibly-stale live values, via `context.isPreview`.
- The built-in Home Assistant and Assist complications now show only their identity: icon alone on circular and corner, title alone on inline, icon + title on rectangular.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
