### PR TITLE
Fix stand-by loading logo animation not restarting after pull to refresh

### DIFF
--- a/Sources/App/Frontend/WebView/Views/AnimatedSVGWebViewCache.swift
+++ b/Sources/App/Frontend/WebView/Views/AnimatedSVGWebViewCache.swift
@@ -10,11 +10,16 @@ import WebKit
 /// hierarchy (e.g. two multi-window scenes show the loading logo at once), a fresh instance
 /// is created for the second caller, since a single `WKWebView` cannot live in two hierarchies
 /// at the same time.
+///
+/// Handing the warm instance out a second time reloads its SVG first: while it sat unparented
+/// between appearances, WebKit paused the page and may have suspended or terminated its web
+/// content process, which freezes the animation permanently. Reloading restarts the loop.
 @MainActor
 final class AnimatedSVGWebViewCache {
     static let shared = AnimatedSVGWebViewCache()
 
     private var warmWebViews: [String: WKWebView] = [:]
+    private var vendedResourceNames: Set<String> = []
 
     private init() {}
 
@@ -28,12 +33,21 @@ final class AnimatedSVGWebViewCache {
     /// otherwise creates and loads a fresh one so it can be parented independently.
     func webView(for resourceName: String) -> WKWebView {
         let warm = warmWebView(for: resourceName)
-        guard warm.superview != nil else {
-            return warm
+        guard warm.superview == nil else {
+            let webView = Self.makeWebView()
+            Self.loadSVG(named: resourceName, into: webView)
+            return webView
         }
-        let webView = Self.makeWebView()
-        Self.loadSVG(named: resourceName, into: webView)
-        return webView
+        if vendedResourceNames.contains(resourceName) {
+            // WebKit paused this page while it was unparented (and may have suspended or killed
+            // its content process), leaving the animation frozen — reload so it loops again.
+            // The first hand-out skips this: the preloaded document is still fresh, and reloading
+            // would forfeit the warm first paint the cache exists to provide.
+            Self.loadSVG(named: resourceName, into: warm)
+        } else {
+            vendedResourceNames.insert(resourceName)
+        }
+        return warm
     }
 
     private func warmWebView(for resourceName: String) -> WKWebView {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The animated SVG loading logo on the stand-by view played only on its first appearance. After the stand-by view was dismissed, the warm `WKWebView` kept by `AnimatedSVGWebViewCache` sat unparented, where WebKit pauses the page and may suspend or terminate its content process. When pull to refresh showed the stand-by view again, the same stale web view was returned untouched, so the logo appeared frozen.

The cache now reloads the SVG whenever the warm instance is handed out after a previous use, so the animation loops again on every appearance. The very first hand-out still skips the reload to keep the preloaded warm first paint.

## Screenshots
Not applicable: no layout or styling changes, only restarts the existing loading logo animation.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
To reproduce the original issue: open the app, wait for the frontend to load, then pull to refresh — the loading logo showed a static frame instead of animating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3yR8SZj3wtKvjeK7723ar)_