### PR TITLE
Add Smart back gesture action

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -51,10 +51,11 @@ final class WebViewGestureHandler {
             .cauterize()
     }
 
-    private func webViewNavigateBack() {
-        if webView?.canGoBack ?? false {
-            webView?.goBack()
-        }
+    @discardableResult
+    private func webViewNavigateBack() -> Bool {
+        guard webView?.canGoBack ?? false else { return false }
+        webView?.goBack()
+        return true
     }
 
     private func webViewNavigateForward() {
@@ -64,9 +65,7 @@ final class WebViewGestureHandler {
     }
 
     private func smartBack() {
-        if webView?.canGoBack ?? false {
-            webView?.goBack()
-        } else {
+        if !webViewNavigateBack() {
             showSidebar()
         }
     }

--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -19,6 +19,8 @@ final class WebViewGestureHandler {
             webViewNavigateBack()
         case .nextPage:
             webViewNavigateForward()
+        case .smartBack:
+            smartBack()
         case .showServersList:
             showServersList()
         case .nextServer:
@@ -58,6 +60,14 @@ final class WebViewGestureHandler {
     private func webViewNavigateForward() {
         if webView?.canGoForward ?? false {
             webView?.goForward()
+        }
+    }
+
+    private func smartBack() {
+        if webView?.canGoBack ?? false {
+            webView?.goBack()
+        } else {
+            showSidebar()
         }
     }
 

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -72,8 +72,7 @@ extension MacWebViewTitleBar {
         private static let gestureActions: [HAGestureAction] = HAGestureAction.allCases.filter { ![
             .none,
             .nextPage,
-            .backPage,
-            .smartBack
+            .backPage
         ].contains($0) }
 
         private weak var webViewController: WebViewController?

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -68,11 +68,13 @@ extension MacWebViewTitleBar {
             static let serverPickerHorizontalPadding: CGFloat = 8
         }
 
-        // Gestures excluding no-op and already existing toolbar actions
+        // Gestures excluding no-op, already existing toolbar actions and
+        // Smart back, which is not available as a toolbar action
         private static let gestureActions: [HAGestureAction] = HAGestureAction.allCases.filter { ![
             .none,
             .nextPage,
-            .backPage
+            .backPage,
+            .smartBack
         ].contains($0) }
 
         private weak var webViewController: WebViewController?

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -72,7 +72,8 @@ extension MacWebViewTitleBar {
         private static let gestureActions: [HAGestureAction] = HAGestureAction.allCases.filter { ![
             .none,
             .nextPage,
-            .backPage
+            .backPage,
+            .smartBack
         ].contains($0) }
 
         private weak var webViewController: WebViewController?
@@ -403,6 +404,8 @@ extension MacWebViewTitleBar {
                 .arrowUturnBackward
             case .nextPage:
                 .arrowUturnForward
+            case .smartBack:
+                .arrowUturnBackward
             case .showServersList:
                 .serverRack
             case .nextServer:

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -494,6 +494,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.value.option.more_info.search_commands" = "Search commands";
 "gestures.value.option.more_info.search_devices" = "Search devices";
 "gestures.value.option.more_info.search_entities" = "Search entities";
+"gestures.value.option.more_info.smart_back" = "Goes back to the previous page, or shows the sidebar when there is no page to go back to";
 "gestures.value.option.next_page" = "Go to next page";
 "gestures.value.option.next_server" = "Next server";
 "gestures.value.option.none" = "None";
@@ -506,6 +507,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.value.option.servers_list" = "Servers list";
 "gestures.value.option.show_settings" = "Open App settings";
 "gestures.value.option.show_sidebar" = "Show sidebar";
+"gestures.value.option.smart_back" = "Smart back";
 "grdb.config.migration_error.failed_access_grdb" = "Failed to access database (GRDB), error: %@";
 "grdb.config.migration_error.failed_to_save" = "Failed to save new config, error: %@";
 "ha_api.api_error.cant_build_url" = "Cant build API URL";

--- a/Sources/App/Settings/Gestures/GesturesSetupView.swift
+++ b/Sources/App/Settings/Gestures/GesturesSetupView.swift
@@ -91,7 +91,11 @@ struct GesturesSetupView: View {
         var sections: [ListPickerContent.Section] = []
         for category in HAGestureActionCategory.allCases {
             let items = HAGestureAction.allCases.filter({ $0.category == category }).map { action in
-                ListPickerContent.Item(id: action.rawValue, title: action.localizedString)
+                ListPickerContent.Item(
+                    id: action.rawValue,
+                    title: action.localizedString,
+                    subtitle: action.moreInfo
+                )
             }
             sections.append(.init(id: category.rawValue, title: category.localizedString, items: items))
         }

--- a/Sources/App/Settings/Gestures/GesturesSetupView.swift
+++ b/Sources/App/Settings/Gestures/GesturesSetupView.swift
@@ -94,7 +94,8 @@ struct GesturesSetupView: View {
                 ListPickerContent.Item(
                     id: action.rawValue,
                     title: action.localizedString,
-                    subtitle: action.moreInfo
+                    subtitle: action.moreInfo,
+                    showsLabsLabel: action.isLabsFeature
                 )
             }
             sections.append(.init(id: category.rawValue, title: category.localizedString, items: items))

--- a/Sources/App/Settings/Gestures/ListPicker.swift
+++ b/Sources/App/Settings/Gestures/ListPicker.swift
@@ -18,6 +18,13 @@ struct ListPickerContent {
     struct Item {
         let id: String
         let title: String
+        let subtitle: String?
+
+        init(id: String, title: String, subtitle: String? = nil) {
+            self.id = id
+            self.title = title
+            self.subtitle = subtitle
+        }
     }
 }
 
@@ -57,8 +64,15 @@ struct ListPickerContentView: View {
                             selection = item
                         } label: {
                             HStack {
-                                Text(item.title)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                VStack(alignment: .leading) {
+                                    Text(item.title)
+                                    if let subtitle = item.subtitle {
+                                        Text(subtitle)
+                                            .font(.footnote)
+                                            .foregroundColor(Color(uiColor: .secondaryLabel))
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
                                 if selection.id == item.id {
                                     Image(systemSymbol: .checkmark)
                                         .foregroundColor(.accentColor)

--- a/Sources/App/Settings/Gestures/ListPicker.swift
+++ b/Sources/App/Settings/Gestures/ListPicker.swift
@@ -1,4 +1,5 @@
 import SFSafeSymbols
+import Shared
 import SwiftUI
 
 protocol ListPickerSelectable: Identifiable {
@@ -19,11 +20,13 @@ struct ListPickerContent {
         let id: String
         let title: String
         let subtitle: String?
+        let showsLabsLabel: Bool
 
-        init(id: String, title: String, subtitle: String? = nil) {
+        init(id: String, title: String, subtitle: String? = nil, showsLabsLabel: Bool = false) {
             self.id = id
             self.title = title
             self.subtitle = subtitle
+            self.showsLabsLabel = showsLabsLabel
         }
     }
 }
@@ -73,6 +76,9 @@ struct ListPickerContentView: View {
                                     }
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                if item.showsLabsLabel {
+                                    LabsLabel()
+                                }
                                 if selection.id == item.id {
                                     Image(systemSymbol: .checkmark)
                                         .foregroundColor(.accentColor)

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -96,6 +96,16 @@ public enum HAGestureAction: String, Codable, CaseIterable {
         }
     }
 
+    /// Whether the action is experimental and should display a Labs label
+    public var isLabsFeature: Bool {
+        switch self {
+        case .smartBack:
+            true
+        default:
+            false
+        }
+    }
+
     public var moreInfo: String? {
         switch self {
         case .showSidebar:

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -35,6 +35,7 @@ public enum HAGestureAction: String, Codable, CaseIterable {
     // Page
     case backPage
     case nextPage
+    case smartBack
     // Servers
     case showServersList
     case nextServer
@@ -49,7 +50,7 @@ public enum HAGestureAction: String, Codable, CaseIterable {
         switch self {
         case .showSidebar, .quickSearch, .searchEntities, .searchDevices, .searchCommands, .assist:
             .homeAssistant
-        case .backPage, .nextPage:
+        case .backPage, .nextPage, .smartBack:
             .page
         case .showServersList, .nextServer, .previousServer:
             .servers
@@ -68,6 +69,8 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             L10n.Gestures.Value.Option.backPage
         case .nextPage:
             L10n.Gestures.Value.Option.nextPage
+        case .smartBack:
+            L10n.Gestures.Value.Option.smartBack
         case .quickSearch:
             L10n.Gestures.Value.Option.quickSearch
         case .searchEntities:
@@ -101,6 +104,8 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             nil
         case .nextPage:
             nil
+        case .smartBack:
+            L10n.Gestures.Value.Option.MoreInfo.smartBack
         case .quickSearch:
             L10n.Gestures.Value.Option.MoreInfo.quickSearch
         case .searchEntities:

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1844,6 +1844,8 @@ public enum L10n {
         public static var showSettings: String { return L10n.tr("Localizable", "gestures.value.option.show_settings") }
         /// Show sidebar
         public static var showSidebar: String { return L10n.tr("Localizable", "gestures.value.option.show_sidebar") }
+        /// Smart back
+        public static var smartBack: String { return L10n.tr("Localizable", "gestures.value.option.smart_back") }
         public enum MoreInfo {
           /// Quick search
           public static var quickSearch: String { return L10n.tr("Localizable", "gestures.value.option.more_info.quick_search") }
@@ -1853,6 +1855,8 @@ public enum L10n {
           public static var searchDevices: String { return L10n.tr("Localizable", "gestures.value.option.more_info.search_devices") }
           /// Search entities
           public static var searchEntities: String { return L10n.tr("Localizable", "gestures.value.option.more_info.search_entities") }
+          /// Goes back to the previous page, or shows the sidebar when there is no page to go back to
+          public static var smartBack: String { return L10n.tr("Localizable", "gestures.value.option.more_info.smart_back") }
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new "Smart back" gesture action. It navigates back in the webview when possible; when there is no page to go back to, it opens the frontend sidebar instead. It combines the existing "Back to previous page" and "Show sidebar" actions.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_015QEX3JQeek2VPzS9ybj4sd)_