### PR TITLE
Add watch developer option for complication reload notifications

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1968,6 +1968,13 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.configurator.sections.icon.header" = "Icon";
 "watch.configurator.sections.ring.footer" = "The ring showing progress surrounding the text.";
 "watch.configurator.sections.ring.header" = "Ring";
+"watch.debug.complication_refresh.finished.failed_line" = "%1$@ failed: %2$@";
+"watch.debug.complication_refresh.finished.kept_previous_line" = "%1$@ failed, kept previous value: %2$@";
+"watch.debug.complication_refresh.finished.summary" = "%li succeeded, %li failed";
+"watch.debug.complication_refresh.finished.title" = "Complications reload finished";
+"watch.debug.complication_refresh.finished.unknown_reason" = "unknown reason";
+"watch.debug.complication_refresh.started.body" = "Reloading %li complication(s)";
+"watch.debug.complication_refresh.started.title" = "Complications reload started";
 "watch.debug.delete_db.alert.failed.message" = "Failed to delete configuration, error: %@";
 "watch.debug.delete_db.alert.title" = "Are you sure you want to delete watch configuration? This can't be reverted";
 "watch.debug.delete_db.reset.title" = "Reset configuration";
@@ -2193,6 +2200,8 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.settings.developer.allow_choosing_route.title" = "Allow choosing route";
 "watch.settings.developer.audio_probe.footer" = "Experiment: keep an audio session active during the direct sync to test whether it lets the websocket connect on this watch. Plays a quiet tone while syncing.";
 "watch.settings.developer.audio_probe.title" = "Audio session probe";
+"watch.settings.developer.complication_refresh_notifications.footer" = "Posts a notification when complications start reloading their data and when they finish, saying whether each reload succeeded or why it failed. Covers reloads by the app and by the widget itself.";
+"watch.settings.developer.complication_refresh_notifications.title" = "Complication reload alerts";
 "watch.settings.developer.direct_sync.footer" = "Fetch this watch's data directly from Home Assistant over websocket instead of syncing through the iPhone. Experimental: most watches don't allow websocket connections, in which case data stops updating until this is turned off.";
 "watch.settings.developer.direct_sync.title" = "Direct server sync";
 "watch.settings.developer.iphone_unreachable_icon.footer" = "Shows an iPhone icon with a slash in the Home header while the paired iPhone is unreachable. Actions run from the watch itself, so this is only useful when debugging the iPhone link.";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1968,12 +1968,13 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "watch.configurator.sections.icon.header" = "Icon";
 "watch.configurator.sections.ring.footer" = "The ring showing progress surrounding the text.";
 "watch.configurator.sections.ring.header" = "Ring";
-"watch.debug.complication_refresh.finished.failed_line" = "%1$@ failed: %2$@";
-"watch.debug.complication_refresh.finished.kept_previous_line" = "%1$@ failed, kept previous value: %2$@";
-"watch.debug.complication_refresh.finished.summary" = "%li succeeded, %li failed";
+"watch.debug.complication_refresh.finished.failed_line" = "%1$@ failed in %2$@: %3$@";
+"watch.debug.complication_refresh.finished.kept_previous_line" = "%1$@ failed in %2$@ (%3$@) — still showing %4$@";
+"watch.debug.complication_refresh.finished.summary" = "%1$li succeeded, %2$li failed in %3$@";
 "watch.debug.complication_refresh.finished.title" = "Complications reload finished";
 "watch.debug.complication_refresh.finished.unknown_reason" = "unknown reason";
-"watch.debug.complication_refresh.started.body" = "Reloading %li complication(s)";
+"watch.debug.complication_refresh.finished.updated_line" = "%1$@ updated to %2$@ in %3$@";
+"watch.debug.complication_refresh.started.body" = "Reloading %1$li complication(s): %2$@";
 "watch.debug.complication_refresh.started.title" = "Complications reload started";
 "watch.debug.delete_db.alert.failed.message" = "Failed to delete configuration, error: %@";
 "watch.debug.delete_db.alert.title" = "Are you sure you want to delete watch configuration? This can't be reverted";

--- a/Sources/Shared/Environment/WatchUserDefaults.swift
+++ b/Sources/Shared/Environment/WatchUserDefaults.swift
@@ -26,6 +26,11 @@ public enum WatchUserDefaultsKey: String {
     /// EXPERIMENT: hold a playback audio session open during the direct sync, to test whether
     /// watchOS's audio-streaming exception unlocks the websocket on real hardware (TN3135).
     case directSyncAudioSessionProbeEnabled
+    /// Developer option: post a local notification when a complication reload (self fetch) starts
+    /// and finishes, saying whether each complication succeeded and why it failed. Stored in the
+    /// shared app group (unlike the other keys) so the watch widget extension's own self fetch can
+    /// read it too.
+    case complicationRefreshNotificationsEnabled
 }
 
 public final class WatchUserDefaults {
@@ -106,6 +111,22 @@ public final class WatchUserDefaults {
     public var directSyncAudioSessionProbeEnabled: Bool {
         get { userDefaults.bool(forKey: WatchUserDefaultsKey.directSyncAudioSessionProbeEnabled.rawValue) }
         set { userDefaults.set(newValue, forKey: WatchUserDefaultsKey.directSyncAudioSessionProbeEnabled.rawValue) }
+    }
+
+    /// Developer option: post a local notification when a complication reload (self fetch) starts
+    /// and finishes, saying whether each complication succeeded and why it failed. Defaults to
+    /// false. Lives in the shared app-group defaults — not the standard suite the other developer
+    /// options use — because the watch widget extension also self-fetches (on its own WidgetKit
+    /// budget) and must be able to read the flag.
+    public var complicationRefreshNotificationsEnabled: Bool {
+        get {
+            UserDefaults(suiteName: AppConstants.AppGroupID)?
+                .bool(forKey: WatchUserDefaultsKey.complicationRefreshNotificationsEnabled.rawValue) ?? false
+        }
+        set {
+            UserDefaults(suiteName: AppConstants.AppGroupID)?
+                .set(newValue, forKey: WatchUserDefaultsKey.complicationRefreshNotificationsEnabled.rawValue)
+        }
     }
 
     // MARK: - Per-server URL override (watch-local)

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6477,27 +6477,31 @@ public enum L10n {
     public enum Debug {
       public enum ComplicationRefresh {
         public enum Finished {
-          /// %1$@ failed: %2$@
-          public static func failedLine(_ p1: Any, _ p2: Any) -> String {
-            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.failed_line", String(describing: p1), String(describing: p2))
+          /// %1$@ failed in %2$@: %3$@
+          public static func failedLine(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.failed_line", String(describing: p1), String(describing: p2), String(describing: p3))
           }
-          /// %1$@ failed, kept previous value: %2$@
-          public static func keptPreviousLine(_ p1: Any, _ p2: Any) -> String {
-            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.kept_previous_line", String(describing: p1), String(describing: p2))
+          /// %1$@ failed in %2$@ (%3$@) — still showing %4$@
+          public static func keptPreviousLine(_ p1: Any, _ p2: Any, _ p3: Any, _ p4: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.kept_previous_line", String(describing: p1), String(describing: p2), String(describing: p3), String(describing: p4))
           }
-          /// %li succeeded, %li failed
-          public static func summary(_ p1: Int, _ p2: Int) -> String {
-            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.summary", p1, p2)
+          /// %1$li succeeded, %2$li failed in %3$@
+          public static func summary(_ p1: Int, _ p2: Int, _ p3: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.summary", p1, p2, String(describing: p3))
           }
           /// Complications reload finished
           public static var title: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.title") }
           /// unknown reason
           public static var unknownReason: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.unknown_reason") }
+          /// %1$@ updated to %2$@ in %3$@
+          public static func updatedLine(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.updated_line", String(describing: p1), String(describing: p2), String(describing: p3))
+          }
         }
         public enum Started {
-          /// Reloading %li complication(s)
-          public static func body(_ p1: Int) -> String {
-            return L10n.tr("Localizable", "watch.debug.complication_refresh.started.body", p1)
+          /// Reloading %1$li complication(s): %2$@
+          public static func body(_ p1: Int, _ p2: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.started.body", p1, String(describing: p2))
           }
           /// Complications reload started
           public static var title: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.started.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6475,6 +6475,34 @@ public enum L10n {
       }
     }
     public enum Debug {
+      public enum ComplicationRefresh {
+        public enum Finished {
+          /// %1$@ failed: %2$@
+          public static func failedLine(_ p1: Any, _ p2: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.failed_line", String(describing: p1), String(describing: p2))
+          }
+          /// %1$@ failed, kept previous value: %2$@
+          public static func keptPreviousLine(_ p1: Any, _ p2: Any) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.kept_previous_line", String(describing: p1), String(describing: p2))
+          }
+          /// %li succeeded, %li failed
+          public static func summary(_ p1: Int, _ p2: Int) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.summary", p1, p2)
+          }
+          /// Complications reload finished
+          public static var title: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.title") }
+          /// unknown reason
+          public static var unknownReason: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.finished.unknown_reason") }
+        }
+        public enum Started {
+          /// Reloading %li complication(s)
+          public static func body(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "watch.debug.complication_refresh.started.body", p1)
+          }
+          /// Complications reload started
+          public static var title: String { return L10n.tr("Localizable", "watch.debug.complication_refresh.started.title") }
+        }
+      }
       public enum DeleteDb {
         /// Delete watch configuration
         public static var title: String { return L10n.tr("Localizable", "watch.debug.delete_db.title") }
@@ -7171,6 +7199,12 @@ public enum L10n {
           public static var footer: String { return L10n.tr("Localizable", "watch.settings.developer.audio_probe.footer") }
           /// Audio session probe
           public static var title: String { return L10n.tr("Localizable", "watch.settings.developer.audio_probe.title") }
+        }
+        public enum ComplicationRefreshNotifications {
+          /// Posts a notification when complications start reloading their data and when they finish, saying whether each reload succeeded or why it failed. Covers reloads by the app and by the widget itself.
+          public static var footer: String { return L10n.tr("Localizable", "watch.settings.developer.complication_refresh_notifications.footer") }
+          /// Complication reload alerts
+          public static var title: String { return L10n.tr("Localizable", "watch.settings.developer.complication_refresh_notifications.title") }
         }
         public enum DirectSync {
           /// Fetch this watch's data directly from Home Assistant over websocket instead of syncing through the iPhone. Experimental: most watches don't allow websocket connections, in which case data stops updating until this is turned off.

--- a/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
+++ b/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
@@ -40,8 +40,13 @@ enum ComplicationRefreshDebugNotifier {
         content.title = title
         content.body = body
         UNUserNotificationCenter.current().add(
-            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil),
-            withCompletionHandler: nil
-        )
+            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        ) { error in
+            // Never affects the refresh itself; surfacing the error explains a silent toggle (e.g.
+            // notifications not authorized on this watch).
+            if let error {
+                Current.Log.error("Failed to post complication refresh debug notification: \(error)")
+            }
+        }
     }
 }

--- a/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
+++ b/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
@@ -7,32 +7,59 @@ import UserNotifications
 /// observable on the wrist without a tethered debugger; off by default, so regular users never see
 /// these.
 enum ComplicationRefreshDebugNotifier {
-    static func notifyStarted(count: Int) {
+    static func notifyStarted(names: [String]) {
         guard WatchUserDefaults.shared.complicationRefreshNotificationsEnabled else { return }
         post(
             title: L10n.Watch.Debug.ComplicationRefresh.Started.title,
-            body: L10n.Watch.Debug.ComplicationRefresh.Started.body(count)
+            body: L10n.Watch.Debug.ComplicationRefresh.Started.body(names.count, names.joined(separator: ", "))
         )
     }
 
-    static func notifyFinished(_ outcomes: [ComplicationRefreshOutcome]) {
+    static func notifyFinished(_ outcomes: [ComplicationRefreshOutcome], duration: TimeInterval) {
         guard WatchUserDefaults.shared.complicationRefreshNotificationsEnabled else { return }
         let succeeded = outcomes.filter { $0.status == .live }.count
-        var lines = [L10n.Watch.Debug.ComplicationRefresh.Finished.summary(succeeded, outcomes.count - succeeded)]
-        // One line per non-live complication: a cached outcome also failed its live fetch — the
-        // face just keeps showing the previous value instead of going blank.
-        for outcome in outcomes where outcome.status != .live {
-            let reason = outcome.reason ?? L10n.Watch.Debug.ComplicationRefresh.Finished.unknownReason
-            if outcome.status == .cached {
-                lines.append(L10n.Watch.Debug.ComplicationRefresh.Finished.keptPreviousLine(outcome.name, reason))
-            } else {
-                lines.append(L10n.Watch.Debug.ComplicationRefresh.Finished.failedLine(outcome.name, reason))
-            }
-        }
+        // A summary line, then one line per complication — updated value and fetch time for
+        // successes, elapsed time and cause for failures — so the notification alone tells the
+        // whole story of the reload.
+        var lines = [L10n.Watch.Debug.ComplicationRefresh.Finished.summary(
+            succeeded,
+            outcomes.count - succeeded,
+            seconds(duration)
+        )]
+        lines.append(contentsOf: outcomes.map(line(for:)))
         post(
             title: L10n.Watch.Debug.ComplicationRefresh.Finished.title,
             body: lines.joined(separator: "\n")
         )
+    }
+
+    private static func line(for outcome: ComplicationRefreshOutcome) -> String {
+        let label = outcome.entityId.map { "\(outcome.name) (\($0))" } ?? outcome.name
+        let duration = seconds(outcome.duration)
+        let reason = outcome.reason ?? L10n.Watch.Debug.ComplicationRefresh.Finished.unknownReason
+        switch outcome.status {
+        case .live:
+            return L10n.Watch.Debug.ComplicationRefresh.Finished.updatedLine(
+                label,
+                outcome.value ?? "",
+                duration
+            )
+        case .cached:
+            // A cached outcome also failed its live fetch — the face just keeps showing the
+            // previous value instead of going blank.
+            return L10n.Watch.Debug.ComplicationRefresh.Finished.keptPreviousLine(
+                label,
+                duration,
+                reason,
+                outcome.value ?? ""
+            )
+        case .failed:
+            return L10n.Watch.Debug.ComplicationRefresh.Finished.failedLine(label, duration, reason)
+        }
+    }
+
+    private static func seconds(_ interval: TimeInterval) -> String {
+        String(format: "%.1fs", interval)
     }
 
     private static func post(title: String, body: String) {

--- a/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
+++ b/Sources/WatchApp/ComplicationRefreshDebugNotifier.swift
@@ -1,0 +1,47 @@
+import Shared
+import UserNotifications
+
+/// Posts local notifications tracing complication reloads (self fetch) while the developer option in
+/// Settings → Troubleshooting → Developer is enabled: one when a reload starts and one when it
+/// finishes, saying whether each complication succeeded and why it failed. Makes background reloads
+/// observable on the wrist without a tethered debugger; off by default, so regular users never see
+/// these.
+enum ComplicationRefreshDebugNotifier {
+    static func notifyStarted(count: Int) {
+        guard WatchUserDefaults.shared.complicationRefreshNotificationsEnabled else { return }
+        post(
+            title: L10n.Watch.Debug.ComplicationRefresh.Started.title,
+            body: L10n.Watch.Debug.ComplicationRefresh.Started.body(count)
+        )
+    }
+
+    static func notifyFinished(_ outcomes: [ComplicationRefreshOutcome]) {
+        guard WatchUserDefaults.shared.complicationRefreshNotificationsEnabled else { return }
+        let succeeded = outcomes.filter { $0.status == .live }.count
+        var lines = [L10n.Watch.Debug.ComplicationRefresh.Finished.summary(succeeded, outcomes.count - succeeded)]
+        // One line per non-live complication: a cached outcome also failed its live fetch — the
+        // face just keeps showing the previous value instead of going blank.
+        for outcome in outcomes where outcome.status != .live {
+            let reason = outcome.reason ?? L10n.Watch.Debug.ComplicationRefresh.Finished.unknownReason
+            if outcome.status == .cached {
+                lines.append(L10n.Watch.Debug.ComplicationRefresh.Finished.keptPreviousLine(outcome.name, reason))
+            } else {
+                lines.append(L10n.Watch.Debug.ComplicationRefresh.Finished.failedLine(outcome.name, reason))
+            }
+        }
+        post(
+            title: L10n.Watch.Debug.ComplicationRefresh.Finished.title,
+            body: lines.joined(separator: "\n")
+        )
+    }
+
+    private static func post(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil),
+            withCompletionHandler: nil
+        )
+    }
+}

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -535,6 +535,7 @@ enum WatchWidgetComplicationSnapshotStore {
         write(snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots, defaults: defaults)
 
         guard !configs.isEmpty else { return [] }
+        ComplicationRefreshDebugNotifier.notifyStarted(count: configs.count)
         var configSnapshots: [WatchWidgetComplicationSnapshot] = []
         var outcomes: [ComplicationRefreshOutcome] = []
         for config in configs {
@@ -576,6 +577,7 @@ enum WatchWidgetComplicationSnapshotStore {
             type: .backgroundOperation,
             payload: ["live": liveCount, "cached": cachedCount, "failed": failedCount]
         ))
+        ComplicationRefreshDebugNotifier.notifyFinished(outcomes)
         return outcomes
     }
 
@@ -593,6 +595,7 @@ enum WatchWidgetComplicationSnapshotStore {
         let legacy = ((try? WatchComplication.all()) ?? [])
             .map(WatchWidgetComplicationSnapshot.init(complication:))
 
+        ComplicationRefreshDebugNotifier.notifyStarted(count: 1)
         let result = await WatchWidgetComplicationSnapshot.make(config: config)
         let snapshot: WatchWidgetComplicationSnapshot
         let outcome: ComplicationRefreshOutcome
@@ -613,6 +616,7 @@ enum WatchWidgetComplicationSnapshotStore {
         }
         write(snapshots: [.placeholder, .assist] + legacy + configSnapshots, defaults: defaults)
         persistRecords([outcome], keepingIds: configs.map(\.id), defaults: defaults)
+        ComplicationRefreshDebugNotifier.notifyFinished([outcome])
         return outcome
     }
 

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -468,6 +468,13 @@ struct ComplicationRefreshOutcome: Identifiable {
     let name: String
     let status: Status
     let reason: String?
+    /// The entity backing the complication, when it has one — identifies exactly what was fetched.
+    let entityId: String?
+    /// The value now shown on the face: the freshly fetched value when live, the retained previous
+    /// value when cached, nil when there's nothing to show.
+    let value: String?
+    /// How long this complication's fetch took.
+    let duration: TimeInterval
 }
 
 /// Persisted record of a complication's last refresh attempt, shown on the watch's per-complication
@@ -535,19 +542,38 @@ enum WatchWidgetComplicationSnapshotStore {
         write(snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots, defaults: defaults)
 
         guard !configs.isEmpty else { return [] }
-        ComplicationRefreshDebugNotifier.notifyStarted(count: configs.count)
+        ComplicationRefreshDebugNotifier.notifyStarted(names: configs.map(\.displayName))
+        let refreshStarted = Date()
         var configSnapshots: [WatchWidgetComplicationSnapshot] = []
         var outcomes: [ComplicationRefreshOutcome] = []
         for config in configs {
             let name = config.name ?? config.entityDisplayName ?? config.entityId ?? "Complication"
+            let fetchStarted = Date()
             let result = await WatchWidgetComplicationSnapshot.make(config: config)
+            let duration = Date().timeIntervalSince(fetchStarted)
             if result.isLive {
                 configSnapshots.append(result.snapshot)
-                outcomes.append(.init(id: config.id, name: name, status: .live, reason: nil))
+                outcomes.append(.init(
+                    id: config.id,
+                    name: name,
+                    status: .live,
+                    reason: nil,
+                    entityId: config.entityId,
+                    value: result.snapshot.title,
+                    duration: duration
+                ))
             } else if let cached = previous[config.id] {
                 // Live fetch failed but we have a previous value — keep it rather than overwrite.
                 configSnapshots.append(cached)
-                outcomes.append(.init(id: config.id, name: name, status: .cached, reason: result.failureReason))
+                outcomes.append(.init(
+                    id: config.id,
+                    name: name,
+                    status: .cached,
+                    reason: result.failureReason,
+                    entityId: config.entityId,
+                    value: cached.title,
+                    duration: duration
+                ))
                 Current.clientEventStore.addEvent(ClientEvent(
                     text: "Watch complication “\(name)” is showing a cached "
                         + "value; live refresh failed (\(result.failureReason ?? "unknown"))",
@@ -557,7 +583,15 @@ enum WatchWidgetComplicationSnapshotStore {
             } else {
                 // Nothing cached (e.g. just added) — show the name-only snapshot and record the error.
                 configSnapshots.append(result.snapshot)
-                outcomes.append(.init(id: config.id, name: name, status: .failed, reason: result.failureReason))
+                outcomes.append(.init(
+                    id: config.id,
+                    name: name,
+                    status: .failed,
+                    reason: result.failureReason,
+                    entityId: config.entityId,
+                    value: nil,
+                    duration: duration
+                ))
                 Current.clientEventStore.addEvent(ClientEvent(
                     text: "Watch complication “\(name)” "
                         + "could not load live data (\(result.failureReason ?? "unknown"))",
@@ -577,7 +611,10 @@ enum WatchWidgetComplicationSnapshotStore {
             type: .backgroundOperation,
             payload: ["live": liveCount, "cached": cachedCount, "failed": failedCount]
         ))
-        ComplicationRefreshDebugNotifier.notifyFinished(outcomes)
+        ComplicationRefreshDebugNotifier.notifyFinished(
+            outcomes,
+            duration: Date().timeIntervalSince(refreshStarted)
+        )
         return outcomes
     }
 
@@ -595,19 +632,45 @@ enum WatchWidgetComplicationSnapshotStore {
         let legacy = ((try? WatchComplication.all()) ?? [])
             .map(WatchWidgetComplicationSnapshot.init(complication:))
 
-        ComplicationRefreshDebugNotifier.notifyStarted(count: 1)
+        ComplicationRefreshDebugNotifier.notifyStarted(names: [name])
+        let fetchStarted = Date()
         let result = await WatchWidgetComplicationSnapshot.make(config: config)
+        let duration = Date().timeIntervalSince(fetchStarted)
         let snapshot: WatchWidgetComplicationSnapshot
         let outcome: ComplicationRefreshOutcome
         if result.isLive {
             snapshot = result.snapshot
-            outcome = .init(id: config.id, name: name, status: .live, reason: nil)
+            outcome = .init(
+                id: config.id,
+                name: name,
+                status: .live,
+                reason: nil,
+                entityId: config.entityId,
+                value: result.snapshot.title,
+                duration: duration
+            )
         } else if let cached = previous[config.id] {
             snapshot = cached
-            outcome = .init(id: config.id, name: name, status: .cached, reason: result.failureReason)
+            outcome = .init(
+                id: config.id,
+                name: name,
+                status: .cached,
+                reason: result.failureReason,
+                entityId: config.entityId,
+                value: cached.title,
+                duration: duration
+            )
         } else {
             snapshot = result.snapshot
-            outcome = .init(id: config.id, name: name, status: .failed, reason: result.failureReason)
+            outcome = .init(
+                id: config.id,
+                name: name,
+                status: .failed,
+                reason: result.failureReason,
+                entityId: config.entityId,
+                value: nil,
+                duration: duration
+            )
         }
 
         // Rebuild the full set: keep every other complication's last snapshot, replace just this one.
@@ -616,7 +679,7 @@ enum WatchWidgetComplicationSnapshotStore {
         }
         write(snapshots: [.placeholder, .assist] + legacy + configSnapshots, defaults: defaults)
         persistRecords([outcome], keepingIds: configs.map(\.id), defaults: defaults)
-        ComplicationRefreshDebugNotifier.notifyFinished([outcome])
+        ComplicationRefreshDebugNotifier.notifyFinished([outcome], duration: duration)
         return outcome
     }
 
@@ -700,46 +763,51 @@ private enum ComplicationStateFetcher {
     }
 
     /// Performs `request` on the server's mTLS/self-signed-aware session (so local servers work),
-    /// invalidating the session afterwards as `MagicItem.sendRESTServiceCall` does.
-    private static func data(for request: URLRequest, server: Server) async -> Data? {
+    /// invalidating the session afterwards as `MagicItem.sendRESTServiceCall` does. On failure the
+    /// data is nil and `failure` says why (transport error, HTTP status), so diagnostics can show
+    /// the actual cause instead of a generic "unavailable".
+    private static func data(for request: URLRequest, server: Server) async -> (data: Data?, failure: String?) {
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
         defer { session.finishTasksAndInvalidate() }
         do {
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 Current.Log.error("[Complication] no HTTP response for \(request.url?.absoluteString ?? "?")")
-                return nil
+                return (nil, "no HTTP response")
             }
             guard (200 ..< 300).contains(http.statusCode) else {
                 Current.Log.error("[Complication] HTTP \(http.statusCode) for \(request.url?.absoluteString ?? "?")")
-                return nil
+                return (nil, "HTTP \(http.statusCode)")
             }
-            return data
+            return (data, nil)
         } catch {
             Current.Log.error("[Complication] request failed \(request.url?.absoluteString ?? "?"): \(error)")
-            return nil
+            return (nil, error.localizedDescription)
         }
     }
 
-    static func fetchState(entityId: String, server: Server) async -> EntityState? {
+    static func fetchState(entityId: String, server: Server) async -> (state: EntityState?, failure: String?) {
         guard let baseURL = await server.activeURL() else {
             Current.Log.error("[Complication] no active URL for server \(server.identifier.rawValue)")
-            return nil
+            return (nil, "no server URL reachable from the watch")
         }
         guard let token = await bearerToken(for: server) else {
             Current.Log.error("[Complication] no bearer token for server \(server.identifier.rawValue)")
-            return nil
+            return (nil, "couldn't get an access token")
         }
         Current.Log.info("[Complication] fetching state for \(entityId) at \(baseURL.absoluteString)")
         var request = URLRequest(url: baseURL.appendingPathComponent("api/states/\(entityId)"))
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
-        guard let data = await data(for: request, server: server),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let state = json["state"] as? String else {
-            return nil
+        let result = await data(for: request, server: server)
+        guard let data = result.data else {
+            return (nil, result.failure)
         }
-        return EntityState(state: state, attributes: json["attributes"] as? [String: Any] ?? [:])
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let state = json["state"] as? String else {
+            return (nil, "unexpected response body")
+        }
+        return (EntityState(state: state, attributes: json["attributes"] as? [String: Any] ?? [:]), nil)
     }
 
     /// Snapshot everything the watch-widget extension needs to self-fetch this server over REST on its
@@ -776,7 +844,7 @@ private enum ComplicationStateFetcher {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["template": template])
-        guard let data = await data(for: request, server: server) else { return nil }
+        guard let data = await data(for: request, server: server).data else { return nil }
         return String(data: data, encoding: .utf8)
     }
 }
@@ -933,7 +1001,8 @@ private struct WatchWidgetComplicationSnapshot: Codable {
                 failureReason = "no entity configured"
                 break
             }
-            if let result = await ComplicationStateFetcher.fetchState(entityId: entityId, server: server) {
+            let fetched = await ComplicationStateFetcher.fetchState(entityId: entityId, server: server)
+            if let result = fetched.state {
                 rawState = result.state
                 attributes = result.attributes
                 // Unit comes from the live state; precision comes from the entity registry in GRDB (synced
@@ -967,7 +1036,7 @@ private struct WatchWidgetComplicationSnapshot: Codable {
                 valueText = formatValue(rawValue, unit: unit, precision: precision)
                 isLive = true
             } else {
-                failureReason = "live state unavailable"
+                failureReason = fetched.failure ?? "live state unavailable"
             }
         case .customTemplate:
             guard let server else {

--- a/Sources/WatchApp/WatchDeveloperSettingsView.swift
+++ b/Sources/WatchApp/WatchDeveloperSettingsView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 struct WatchDeveloperSettingsView: View {
     @State private var verboseExecution = WatchUserDefaults.shared.verboseItemExecution
     @State private var showIPhoneUnreachableIcon = WatchUserDefaults.shared.showIPhoneUnreachableIcon
+    @State private var complicationRefreshNotifications = WatchUserDefaults.shared
+        .complicationRefreshNotificationsEnabled
     @State private var directDatabaseSync = WatchUserDefaults.shared.directDatabaseSyncEnabled
     @State private var directSyncAudioProbe = WatchUserDefaults.shared.directSyncAudioSessionProbeEnabled
     /// True on entry so the warning alert shows as soon as the screen is pushed.
@@ -34,6 +36,17 @@ struct WatchDeveloperSettingsView: View {
                 }
             } footer: {
                 Text(verbatim: L10n.Watch.Settings.Developer.IphoneUnreachableIcon.footer)
+            }
+
+            Section {
+                Toggle(isOn: $complicationRefreshNotifications) {
+                    Text(verbatim: L10n.Watch.Settings.Developer.ComplicationRefreshNotifications.title)
+                }
+                .onChange(of: complicationRefreshNotifications) { newValue in
+                    WatchUserDefaults.shared.complicationRefreshNotificationsEnabled = newValue
+                }
+            } footer: {
+                Text(verbatim: L10n.Watch.Settings.Developer.ComplicationRefreshNotifications.footer)
             }
 
             Section {

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -5,6 +5,10 @@ enum WatchWidgetConstants {
     static let appName = "Home Assistant"
     static let defaultBundleID = "io.robbie.HomeAssistant.watchkitapp.WatchWidgets"
     static let defaultsKey = "watchWidgetComplicationSnapshots"
+    /// App-group defaults key for the developer option that posts local notifications when a
+    /// complication reload (self fetch) starts and finishes. Written by the watch app's developer
+    /// settings; must match `WatchUserDefaultsKey.complicationRefreshNotificationsEnabled`.
+    static let refreshNotificationsKey = "complicationRefreshNotificationsEnabled"
     static let logoAssetName = "Logo"
     static let templateLogoAssetName = "TemplateLogo"
     static let assistIconAssetName = "message-processing-outline"

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -18,15 +18,23 @@ enum WatchWidgetLiveFetch {
     /// Refresh the configured complication (or all, when `configuredID` is nil), updating the stored
     /// snapshot's value text in the app group. Best-effort; never throws.
     static func refresh(configuredID: String?) async {
+        WatchWidgetRefreshNotifier.notifyStarted(configuredID: configuredID)
+        let summary = await performRefresh(configuredID: configuredID)
+        WatchWidgetRefreshNotifier.notifyFinished(summary)
+    }
+
+    /// The actual refresh. Returns a short human-readable outcome — what succeeded, what failed,
+    /// and why — for the developer-option notification; ignored when the option is off.
+    private static func performRefresh(configuredID: String?) async -> String {
         let configs = readConfigs()
-        guard !configs.isEmpty else { return }
+        guard !configs.isEmpty else { return "Failed: no complication configurations found" }
 
         let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID)
         let stored = Dictionary(
             WatchWidgetServerCredential.read(from: defaults).map { ($0.serverId, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-        guard !stored.isEmpty else { return }
+        guard !stored.isEmpty else { return "Failed: no server credentials stored by the watch app" }
 
         // Ensure each server's access token is valid before touching `/api/states`. If it's at/near
         // expiry we refresh it ourselves (a plain `POST /auth/token`); if we can't get a valid token we
@@ -34,22 +42,41 @@ enum WatchWidgetLiveFetch {
         // is what the server logs as invalid auth and eventually IP-bans.
         let (usable, persist) = await validated(stored)
         if let persist { WatchWidgetServerCredential.write(persist, to: defaults) }
-        guard !usable.isEmpty else { return }
+        guard !usable.isEmpty else { return "Failed: no server has a valid access token" }
 
         let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
         var updates: [String: LiveValue] = [:] // config.id -> fresh value
+        var failures: [String] = []
 
         for config in targets where config.kind == .entity {
-            guard let entityId = config.entityId,
-                  let credential = usable[config.serverId],
-                  let value = await fetchValue(config: config, entityId: entityId, credential: credential) else {
+            guard let entityId = config.entityId else {
+                failures.append("\(config.displayName): no entity configured")
+                continue
+            }
+            guard let credential = usable[config.serverId] else {
+                failures.append("\(config.displayName): no valid credential for its server")
+                continue
+            }
+            guard let value = await fetchValue(config: config, entityId: entityId, credential: credential) else {
+                failures.append("\(config.displayName): live state fetch failed")
                 continue
             }
             updates[config.id] = value
         }
 
-        guard !updates.isEmpty else { return }
+        guard !updates.isEmpty else {
+            // Template complications can't self-fetch (rendering needs the server's template API via
+            // the app), so an all-template target set legitimately has nothing to do here.
+            if failures.isEmpty {
+                return "Nothing to fetch: no entity complications targeted"
+            }
+            return "Failed: " + failures.joined(separator: "; ")
+        }
         applyUpdates(updates, configs: configs)
+        if failures.isEmpty {
+            return "Succeeded: updated \(updates.count) complication(s)"
+        }
+        return "Updated \(updates.count) complication(s); failed: " + failures.joined(separator: "; ")
     }
 
     /// A fresh formatted value plus the raw attributes, so slot formulas that reference attributes

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -18,15 +18,23 @@ enum WatchWidgetLiveFetch {
     /// Refresh the configured complication (or all, when `configuredID` is nil), updating the stored
     /// snapshot's value text in the app group. Best-effort; never throws.
     static func refresh(configuredID: String?) async {
-        WatchWidgetRefreshNotifier.notifyStarted(configuredID: configuredID)
-        let summary = await performRefresh(configuredID: configuredID)
-        WatchWidgetRefreshNotifier.notifyFinished(summary)
+        let configs = readConfigs()
+        let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
+        WatchWidgetRefreshNotifier.notifyStarted(names: targets.map(\.displayName))
+        let started = Date()
+        let summary = await performRefresh(configs: configs, targets: targets)
+        WatchWidgetRefreshNotifier.notifyFinished(
+            summary + String(format: " — total %.1fs", Date().timeIntervalSince(started))
+        )
     }
 
-    /// The actual refresh. Returns a short human-readable outcome — what succeeded, what failed,
-    /// and why — for the developer-option notification; ignored when the option is off.
-    private static func performRefresh(configuredID: String?) async -> String {
-        let configs = readConfigs()
+    /// The actual refresh. Returns a human-readable outcome for the developer-option notification —
+    /// per complication: the fresh value and how long its fetch took, or why it failed; ignored when
+    /// the option is off.
+    private static func performRefresh(
+        configs: [WatchComplicationConfig],
+        targets: [WatchComplicationConfig]
+    ) async -> String {
         guard !configs.isEmpty else { return "Failed: no complication configurations found" }
 
         let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID)
@@ -42,50 +50,53 @@ enum WatchWidgetLiveFetch {
         // is what the server logs as invalid auth and eventually IP-bans.
         let (usable, persist) = await validated(stored)
         if let persist { WatchWidgetServerCredential.write(persist, to: defaults) }
-        guard !usable.isEmpty else { return "Failed: no server has a valid access token" }
-
-        let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
-        let (updates, failures) = await fetchUpdates(targets: targets, usable: usable)
-
-        guard !updates.isEmpty else {
-            // Template complications can't self-fetch (rendering needs the server's template API via
-            // the app), so an all-template target set legitimately has nothing to do here.
-            if failures.isEmpty {
-                return "Nothing to fetch: no entity complications targeted"
-            }
-            return "Failed: " + failures.joined(separator: "; ")
+        guard !usable.isEmpty else {
+            return "Failed: no valid access token for server(s) " + stored.keys.sorted().joined(separator: ", ")
         }
-        applyUpdates(updates, configs: configs)
-        if failures.isEmpty {
-            return "Succeeded: updated \(updates.count) complication(s)"
-        }
-        return "Updated \(updates.count) complication(s); failed: " + failures.joined(separator: "; ")
+
+        let (updates, details) = await fetchUpdates(targets: targets, usable: usable)
+        if !updates.isEmpty { applyUpdates(updates, configs: configs) }
+
+        let entityCount = targets.filter { $0.kind == .entity }.count
+        var summary = "Updated \(updates.count) of \(entityCount) complication(s)"
+        if !details.isEmpty { summary += "\n" + details.joined(separator: "\n") }
+        return summary
     }
 
-    /// Fetches each entity complication's live value, collecting a failure line for the developer
-    /// notification whenever one can't be updated.
+    /// Fetches each entity complication's live value, collecting a detail line per complication for
+    /// the developer notification: the fresh value and fetch time on success, the elapsed time and
+    /// cause on failure.
     private static func fetchUpdates(
         targets: [WatchComplicationConfig],
         usable: [String: WatchWidgetServerCredential]
-    ) async -> (updates: [String: LiveValue], failures: [String]) {
+    ) async -> (updates: [String: LiveValue], details: [String]) {
         var updates: [String: LiveValue] = [:] // config.id -> fresh value
-        var failures: [String] = []
-        for config in targets where config.kind == .entity {
+        var details: [String] = []
+        for config in targets {
+            let label = config.entityId.map { "\(config.displayName) (\($0))" } ?? config.displayName
+            guard config.kind == .entity else {
+                details.append("\(label): skipped — template complications can't self-fetch")
+                continue
+            }
             guard let entityId = config.entityId else {
-                failures.append("\(config.displayName): no entity configured")
+                details.append("\(label): failed — no entity configured")
                 continue
             }
             guard let credential = usable[config.serverId] else {
-                failures.append("\(config.displayName): no valid credential for its server")
+                details.append("\(label): failed — no valid credential for its server")
                 continue
             }
-            guard let value = await fetchValue(config: config, entityId: entityId, credential: credential) else {
-                failures.append("\(config.displayName): live state fetch failed")
-                continue
+            let started = Date()
+            let result = await fetchValue(config: config, entityId: entityId, credential: credential)
+            let elapsed = String(format: "%.1fs", Date().timeIntervalSince(started))
+            if let value = result.value {
+                updates[config.id] = value
+                details.append("\(label): updated to \(value.value) in \(elapsed)")
+            } else {
+                details.append("\(label): failed in \(elapsed) — \(result.failure ?? "unknown reason")")
             }
-            updates[config.id] = value
         }
-        return (updates, failures)
+        return (updates, details)
     }
 
     /// A fresh formatted value plus the raw attributes, so slot formulas that reference attributes
@@ -171,11 +182,14 @@ enum WatchWidgetLiveFetch {
 
     // MARK: - Fetch
 
+    /// Fetches the entity's live state. On failure the value is nil and `failure` says why
+    /// (transport error, HTTP status, malformed body), so the developer notification can report the
+    /// actual cause instead of a generic "fetch failed".
     private static func fetchValue(
         config: WatchComplicationConfig,
         entityId: String,
         credential: WatchWidgetServerCredential
-    ) async -> LiveValue? {
+    ) async -> (value: LiveValue?, failure: String?) {
         var request = URLRequest(url: credential.baseURL.appendingPathComponent("api/states/\(entityId)"))
         request.setValue("Bearer \(credential.token)", forHTTPHeaderField: "Authorization")
 
@@ -183,11 +197,18 @@ enum WatchWidgetLiveFetch {
         let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
         defer { session.finishTasksAndInvalidate() }
 
-        guard let (data, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let data: Data
+        do {
+            let (body, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return (nil, "no HTTP response") }
+            guard (200 ..< 300).contains(http.statusCode) else { return (nil, "HTTP \(http.statusCode)") }
+            data = body
+        } catch {
+            return (nil, error.localizedDescription)
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let state = json["state"] as? String else {
-            return nil
+            return (nil, "unexpected response body")
         }
         let attributes = json["attributes"] as? [String: Any] ?? [:]
 
@@ -208,9 +229,12 @@ enum WatchWidgetLiveFetch {
         }
         let effectiveUnit = config.unitOverride.flatMap { $0.isEmpty ? nil : $0 } ?? resolvedUnit
         let unit = config.showsUnit() ? effectiveUnit : nil
-        return LiveValue(
-            value: format(rawValue, unit: unit, precision: config.valuePrecision),
-            attributes: attributes
+        return (
+            LiveValue(
+                value: format(rawValue, unit: unit, precision: config.valuePrecision),
+                attributes: attributes
+            ),
+            nil
         )
     }
 

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -45,9 +45,31 @@ enum WatchWidgetLiveFetch {
         guard !usable.isEmpty else { return "Failed: no server has a valid access token" }
 
         let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
+        let (updates, failures) = await fetchUpdates(targets: targets, usable: usable)
+
+        guard !updates.isEmpty else {
+            // Template complications can't self-fetch (rendering needs the server's template API via
+            // the app), so an all-template target set legitimately has nothing to do here.
+            if failures.isEmpty {
+                return "Nothing to fetch: no entity complications targeted"
+            }
+            return "Failed: " + failures.joined(separator: "; ")
+        }
+        applyUpdates(updates, configs: configs)
+        if failures.isEmpty {
+            return "Succeeded: updated \(updates.count) complication(s)"
+        }
+        return "Updated \(updates.count) complication(s); failed: " + failures.joined(separator: "; ")
+    }
+
+    /// Fetches each entity complication's live value, collecting a failure line for the developer
+    /// notification whenever one can't be updated.
+    private static func fetchUpdates(
+        targets: [WatchComplicationConfig],
+        usable: [String: WatchWidgetServerCredential]
+    ) async -> (updates: [String: LiveValue], failures: [String]) {
         var updates: [String: LiveValue] = [:] // config.id -> fresh value
         var failures: [String] = []
-
         for config in targets where config.kind == .entity {
             guard let entityId = config.entityId else {
                 failures.append("\(config.displayName): no entity configured")
@@ -63,20 +85,7 @@ enum WatchWidgetLiveFetch {
             }
             updates[config.id] = value
         }
-
-        guard !updates.isEmpty else {
-            // Template complications can't self-fetch (rendering needs the server's template API via
-            // the app), so an all-template target set legitimately has nothing to do here.
-            if failures.isEmpty {
-                return "Nothing to fetch: no entity complications targeted"
-            }
-            return "Failed: " + failures.joined(separator: "; ")
-        }
-        applyUpdates(updates, configs: configs)
-        if failures.isEmpty {
-            return "Succeeded: updated \(updates.count) complication(s)"
-        }
-        return "Updated \(updates.count) complication(s); failed: " + failures.joined(separator: "; ")
+        return (updates, failures)
     }
 
     /// A fresh formatted value plus the raw attributes, so slot formulas that reference attributes

--- a/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
+++ b/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
@@ -11,10 +11,12 @@ enum WatchWidgetRefreshNotifier {
     // Unlocalized on purpose: the widget target carries no strings tables (see the plain-text
     // constants in `WatchWidgetConstants`), and this developer-only tracing never shows for
     // regular users.
-    static func notifyStarted(configuredID: String?) {
+    static func notifyStarted(names: [String]) {
         post(
             title: "Widget reload started",
-            body: configuredID == nil ? "Self fetch: all complications" : "Self fetch: one complication"
+            body: names.isEmpty
+                ? "Self fetch: no complications configured"
+                : "Self fetch: reloading \(names.count) — \(names.joined(separator: ", "))"
         )
     }
 

--- a/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
+++ b/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import UserNotifications
 
 /// Posts local notifications tracing the widget's own complication self fetch while the developer
@@ -28,8 +29,13 @@ enum WatchWidgetRefreshNotifier {
         content.title = title
         content.body = body
         UNUserNotificationCenter.current().add(
-            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil),
-            withCompletionHandler: nil
-        )
+            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        ) { error in
+            // Never affects the refresh itself; the log explains a silent toggle (e.g. notifications
+            // not authorized, or the system refusing delivery from the widget extension).
+            if let error {
+                Logger().error("Failed to post widget refresh debug notification: \(error.localizedDescription)")
+            }
+        }
     }
 }

--- a/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
+++ b/Sources/WatchWidgets/WatchWidgetRefreshNotifier.swift
@@ -1,0 +1,35 @@
+import Foundation
+import UserNotifications
+
+/// Posts local notifications tracing the widget's own complication self fetch while the developer
+/// option (watch Settings → Troubleshooting → Developer) is enabled. The widget extension has no UI
+/// of its own, so notifications are the only way to observe when WidgetKit actually runs a refresh
+/// and whether the fetch succeeded or why it failed. Off by default; best-effort — if the system
+/// declines to deliver from the extension, the refresh itself is unaffected.
+enum WatchWidgetRefreshNotifier {
+    // Unlocalized on purpose: the widget target carries no strings tables (see the plain-text
+    // constants in `WatchWidgetConstants`), and this developer-only tracing never shows for
+    // regular users.
+    static func notifyStarted(configuredID: String?) {
+        post(
+            title: "Widget reload started",
+            body: configuredID == nil ? "Self fetch: all complications" : "Self fetch: one complication"
+        )
+    }
+
+    static func notifyFinished(_ summary: String) {
+        post(title: "Widget reload finished", body: summary)
+    }
+
+    private static func post(title: String, body: String) {
+        guard UserDefaults(suiteName: WatchWidgetConstants.appGroupID)?
+            .bool(forKey: WatchWidgetConstants.refreshNotificationsKey) == true else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil),
+            withCompletionHandler: nil
+        )
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a "Complication reload alerts" developer toggle to the watch app (Settings → Troubleshooting → Developer). While enabled, complication reloads (self fetch) post a local notification when they start and when they finish, saying whether each complication succeeded or why it failed.

Both self-fetch paths are covered: the watch app's snapshot refresh and the widget extension's own WidgetKit-budget fetch (which now tracks failure reasons instead of degrading silently). The flag is stored in the shared app group so the widget extension can read it. Off by default; behavior is unchanged when the toggle is off.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Developer-only toggle, no screenshots.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01LE6MLoTSdfCJp3ZgyBi4Vf)_