### PR TITLE
Skip watch complication reload when the snapshot model is unchanged

### DIFF
--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -661,8 +661,8 @@ enum WatchWidgetComplicationSnapshotStore {
     }
 
     private static func write(snapshots: [WatchWidgetComplicationSnapshot], defaults: UserDefaults?) {
-        guard let data = try? JSONEncoder().encode(snapshots), let defaults else {
-            Current.Log.error("Failed to encode watch widget complication snapshots")
+        guard let defaults else {
+            Current.Log.error("Missing app group defaults for watch widget complication snapshots")
             return
         }
         // Skip the write + WidgetKit reload when the model didn't change. Reloads are budgeted on
@@ -673,6 +673,10 @@ enum WatchWidgetComplicationSnapshotStore {
         if let stored = defaults.data(forKey: defaultsKey),
            let previous = try? JSONDecoder().decode([WatchWidgetComplicationSnapshot].self, from: stored),
            previous == snapshots {
+            return
+        }
+        guard let data = try? JSONEncoder().encode(snapshots) else {
+            Current.Log.error("Failed to encode watch widget complication snapshots")
             return
         }
         defaults.set(data, forKey: defaultsKey)

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -665,6 +665,16 @@ enum WatchWidgetComplicationSnapshotStore {
             Current.Log.error("Failed to encode watch widget complication snapshots")
             return
         }
+        // Skip the write + WidgetKit reload when the model didn't change. Reloads are budgeted on
+        // watchOS; spending one on identical content can get a later, real change throttled — the
+        // face then keeps showing a stale value even though the store holds the fresh one. The
+        // stored blob is decoded and compared as a model (not byte-wise) so JSON dictionary key
+        // ordering can't fake a change.
+        if let stored = defaults.data(forKey: defaultsKey),
+           let previous = try? JSONDecoder().decode([WatchWidgetComplicationSnapshot].self, from: stored),
+           previous == snapshots {
+            return
+        }
         defaults.set(data, forKey: defaultsKey)
         // Reload every kind rather than a single `kind` string: the widget registers its kind from the
         // extension's `Bundle.main.bundleIdentifier`, which can differ from this app-process-derived
@@ -777,7 +787,7 @@ private enum ComplicationStateFetcher {
     }
 }
 
-private struct WatchWidgetComplicationSnapshot: Codable {
+private struct WatchWidgetComplicationSnapshot: Codable, Equatable {
     // Watch screens are @2x, so this rasterizes to 112px — safely under WidgetKit's ~122px
     // complication-image archiving limit. Anything larger makes the complication render empty.
     static let iconRenderSize = CGSize(width: 56, height: 56)
@@ -786,7 +796,7 @@ private struct WatchWidgetComplicationSnapshot: Codable {
     /// `WatchComplicationConfig.Family.rawValue`. Must stay field-compatible with the widget
     /// extension's copy in `Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift` — the two
     /// only meet through the JSON in the app group.
-    struct PerFamily: Codable {
+    struct PerFamily: Codable, Equatable {
         let fraction: Double?
         let tint: String?
         let showValue: Bool


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The watch app rebuilds complication snapshots on launch, on every database mirror push and on background refreshes, and every write triggered a WidgetKit reload even when nothing changed. Timeline reloads are budgeted on watchOS, so redundant reloads could get a later, real change throttled — leaving the complication on the face showing a stale value while the store already holds the fresh one.

Now the stored snapshots are decoded and compared against the new ones before writing; when the model is identical, the write and the reload are skipped. The comparison is done on the decoded model (not raw bytes) so JSON dictionary key ordering can't fake a change. The widget's own timeline refresh cadence (self fetch every 15 minutes on its WidgetKit budget) is unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01LE6MLoTSdfCJp3ZgyBi4Vf)_