### PR TITLE
Fix webview stuck on "Reconnecting…" after getExternalAuth is dropped in background

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
@@ -35,9 +35,12 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
             // The frontend caches the pending getExternalAuth promise and never asks again while it
             // stays unsettled, so the callback must be rejected instead of dropped - otherwise the
             // frontend can never reconnect until the web view is reloaded.
-            if WKUserContentControllerMessage(rawValue: messageName) == .getExternalAuth,
-               let callbackName = messageBody["callback"] {
-                sendGetExternalAuthFailure(callbackName: callbackName)
+            if WKUserContentControllerMessage(rawValue: messageName) == .getExternalAuth {
+                if let callbackName = messageBody["callback"] as? String {
+                    sendGetExternalAuthFailure(callbackName: callbackName)
+                } else {
+                    Current.Log.error("getExternalAuth message without a string callback name")
+                }
             }
             return
         }
@@ -83,7 +86,7 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
 
     /// Retrieves an authentication token for the web view and invokes a JavaScript callback with the result.
     private func handleGetExternalAuth(_ messageBody: [String: Any]) {
-        guard let callbackName = messageBody["callback"], let server = webView?.server else { return }
+        guard let callbackName = messageBody["callback"] as? String, let server = webView?.server else { return }
         let force = messageBody["force"] as? Bool ?? false
 
         Current.Log.verbose("getExternalAuth called, forced: \(force)")
@@ -110,7 +113,7 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     /// Rejects a getExternalAuth request so the frontend can clear its pending token promise and retry.
-    private func sendGetExternalAuthFailure(callbackName: Any) {
+    private func sendGetExternalAuthFailure(callbackName: String) {
         webView?.evaluateJavaScript("\(callbackName)(false, 'Token unavailable')") { _, error in
             if let error {
                 Current.Log.error("Failed to trigger getExternalAuth callback: \(error)")

--- a/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
@@ -13,6 +13,7 @@ enum WKUserContentControllerMessage: String, CaseIterable {
 
 final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
     weak var webView: WebViewControllerProtocol?
+    var isAppInBackground: @MainActor () -> Bool = { UIApplication.shared.applicationState == .background }
 
     @MainActor func userContentController(
         _ userContentController: WKUserContentController,
@@ -25,12 +26,23 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
 
         Current.Log.verbose("message \(message.body)".replacingOccurrences(of: "\n", with: " "))
 
-        guard UIApplication.shared.applicationState != .background else {
-            Current.Log.verbose("Ignoring WKUserContentController message \(message.name) because app is in background")
+        handle(messageName: message.name, messageBody: messageBody)
+    }
+
+    @MainActor func handle(messageName: String, messageBody: [String: Any]) {
+        guard !isAppInBackground() else {
+            Current.Log.verbose("Ignoring WKUserContentController message \(messageName) because app is in background")
+            // The frontend caches the pending getExternalAuth promise and never asks again while it
+            // stays unsettled, so the callback must be rejected instead of dropped - otherwise the
+            // frontend can never reconnect until the web view is reloaded.
+            if WKUserContentControllerMessage(rawValue: messageName) == .getExternalAuth,
+               let callbackName = messageBody["callback"] {
+                sendGetExternalAuthFailure(callbackName: callbackName)
+            }
             return
         }
 
-        switch WKUserContentControllerMessage(rawValue: message.name) {
+        switch WKUserContentControllerMessage(rawValue: messageName) {
         case .externalBus:
             handleExternalBus(messageBody)
         case .updateThemeColors:
@@ -42,7 +54,7 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
         case .logError:
             handleLogError(messageBody)
         default:
-            Current.Log.error("unknown message: \(message.name)")
+            Current.Log.error("unknown message: \(messageName)")
         }
     }
 
@@ -92,13 +104,17 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
                 })
             }
         }.catch { [weak self] error in
-            self?.webView?.evaluateJavaScript("\(callbackName)(false, 'Token unavailable')") {
-                _, error in
-                if let error {
-                    Current.Log.error("Failed to trigger getExternalAuth callback: \(error)")
-                }
-            }
+            self?.sendGetExternalAuthFailure(callbackName: callbackName)
             Current.Log.error("Failed to authenticate webview: \(error)")
+        }
+    }
+
+    /// Rejects a getExternalAuth request so the frontend can clear its pending token promise and retry.
+    private func sendGetExternalAuthFailure(callbackName: Any) {
+        webView?.evaluateJavaScript("\(callbackName)(false, 'Token unavailable')") { _, error in
+            if let error {
+                Current.Log.error("Failed to trigger getExternalAuth callback: \(error)")
+            }
         }
     }
 

--- a/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
@@ -40,6 +40,14 @@ final class WebViewScriptMessageHandlerTests: XCTestCase {
         XCTAssertFalse(mockWebViewController.evaluateJavaScriptCalled)
     }
 
+    @MainActor func testGetExternalAuthInBackgroundWithNonStringCallbackDoesNothing() {
+        sut.isAppInBackground = { true }
+
+        sut.handle(messageName: "getExternalAuth", messageBody: ["callback": 123])
+
+        XCTAssertFalse(mockWebViewController.evaluateJavaScriptCalled)
+    }
+
     @MainActor func testExternalBusInBackgroundIsIgnored() {
         sut.isAppInBackground = { true }
 

--- a/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
@@ -1,0 +1,60 @@
+@testable import HomeAssistant
+import Shared
+import XCTest
+
+final class WebViewScriptMessageHandlerTests: XCTestCase {
+    private var sut: WebViewScriptMessageHandler!
+    private var mockWebViewController: MockWebViewController!
+    private var mockExternalMessageHandler: MockWebViewExternalMessageHandler!
+
+    override func setUp() async throws {
+        mockWebViewController = MockWebViewController()
+        mockExternalMessageHandler = MockWebViewExternalMessageHandler()
+        mockWebViewController.webViewExternalMessageHandler = mockExternalMessageHandler
+        sut = WebViewScriptMessageHandler()
+        sut.webView = mockWebViewController
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        mockWebViewController = nil
+        mockExternalMessageHandler = nil
+    }
+
+    @MainActor func testGetExternalAuthInBackgroundRejectsCallback() {
+        sut.isAppInBackground = { true }
+
+        sut.handle(messageName: "getExternalAuth", messageBody: ["callback": "window.externalAuthSetToken"])
+
+        XCTAssertEqual(
+            mockWebViewController.lastEvaluatedJavaScriptScript,
+            "window.externalAuthSetToken(false, 'Token unavailable')"
+        )
+    }
+
+    @MainActor func testGetExternalAuthInBackgroundWithoutCallbackDoesNothing() {
+        sut.isAppInBackground = { true }
+
+        sut.handle(messageName: "getExternalAuth", messageBody: ["force": false])
+
+        XCTAssertFalse(mockWebViewController.evaluateJavaScriptCalled)
+    }
+
+    @MainActor func testExternalBusInBackgroundIsIgnored() {
+        sut.isAppInBackground = { true }
+
+        sut.handle(messageName: "externalBus", messageBody: ["id": 1])
+
+        XCTAssertFalse(mockExternalMessageHandler.handleExternalMessageCalled)
+        XCTAssertFalse(mockWebViewController.evaluateJavaScriptCalled)
+    }
+
+    @MainActor func testExternalBusInForegroundIsHandled() {
+        sut.isAppInBackground = { false }
+
+        sut.handle(messageName: "externalBus", messageBody: ["id": 1])
+
+        XCTAssertTrue(mockExternalMessageHandler.handleExternalMessageCalled)
+        XCTAssertEqual(mockExternalMessageHandler.handleExternalMessageParams?["id"] as? Int, 1)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #5233

While the app is backgrounded, `WebViewScriptMessageHandler` drops all script messages without replying. For `getExternalAuth` this leaves the frontend's cached token promise pending forever, so it never asks for a token again and the page shows "Connection lost. Reconnecting…" until a full reload.

Now a `getExternalAuth` received in the background is answered with the existing failure callback (`callback(false, 'Token unavailable')`), so the frontend rejects its pending promise and retries. Other messages are still ignored in the background as before. Also makes the background check injectable and adds unit tests.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a — no UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_0149B73d81bm8XeyHGnGQqtU)_