### PR TITLE
Fix camera stream sensor footer copy

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1124,7 +1124,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "sensors.camera_motion.setting.changed_area_threshold" = "Changed area threshold";
 "sensors.camera_motion.setting.clear_delay" = "Clear delay";
 "sensors.camera_motion.setting.frame_rate" = "Frame rate";
-"sensors.camera_stream.footer" = "To watch this camera in Home Assistant, add the “MJPEG IP Camera” integration and use the stream URL above. The stream is plain HTTP with no encryption; set a username and password below to require authentication, otherwise anyone on your local network can view it. It is only available while the app is open in the foreground.";
+"sensors.camera_stream.detail_footer" = "To watch this camera in Home Assistant, add the “MJPEG IP Camera” integration and use the stream URL above. The stream is plain HTTP with no encryption; set a username and password in the settings above to require authentication, otherwise anyone on your local network can view it. It is only available while the app is open in the foreground.";
 "sensors.camera_stream.setting.credentials_footer" = "Leave both blank to allow anyone on your network to view the stream. When set, configure the MJPEG integration in Home Assistant with the same username and password.";
 "sensors.camera_stream.setting.credentials_placeholder" = "Optional";
 "sensors.camera_stream.setting.frame_rate" = "Frame rate";

--- a/Sources/Shared/API/Webhook/Sensors/CameraStreamSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CameraStreamSensor.swift
@@ -71,7 +71,7 @@ final class CameraStreamSensor: SensorProvider {
             "Clients": server.clientCount,
             "Stream URL": server.streamURL ?? "unavailable (no Wi-Fi address)",
         ]
-        sensor.detailFooter = L10n.Sensors.CameraStream.footer
+        sensor.detailFooter = L10n.Sensors.CameraStream.detailFooter
 
         sensor.Settings = [
             .init(

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3799,8 +3799,8 @@ public enum L10n {
       }
     }
     public enum CameraStream {
-      /// To watch this camera in Home Assistant, add the “MJPEG IP Camera” integration and use the stream URL above. The stream is plain HTTP with no encryption; set a username and password below to require authentication, otherwise anyone on your local network can view it. It is only available while the app is open in the foreground.
-      public static var footer: String { return L10n.tr("Localizable", "sensors.camera_stream.footer") }
+      /// To watch this camera in Home Assistant, add the “MJPEG IP Camera” integration and use the stream URL above. The stream is plain HTTP with no encryption; set a username and password in the settings above to require authentication, otherwise anyone on your local network can view it. It is only available while the app is open in the foreground.
+      public static var detailFooter: String { return L10n.tr("Localizable", "sensors.camera_stream.detail_footer") }
       public enum Setting {
         /// Leave both blank to allow anyone on your network to view the stream. When set, configure the MJPEG integration in Home Assistant with the same username and password.
         public static var credentialsFooter: String { return L10n.tr("Localizable", "sensors.camera_stream.setting.credentials_footer") }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The camera stream sensor detail footer said "set a username and password below to require authentication", but the footer is rendered at the bottom of the page, after the username/password settings. Reworded to "in the settings above". The string moved to a new localization key (`sensors.camera_stream.detail_footer`) so it is picked up as a fresh string in Lokalise instead of keeping stale translations.

## Screenshots
Text-only change. Before: "set a username and password below to require authentication" — After: "set a username and password in the settings above to require authentication".

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No functionality change, copy fix only. The old key remains in the non-English `.lproj` files until the next Lokalise sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXenE4HpmiDVjU5SrsVcCG)_