### PR TITLE
Fix deleted servers reappearing after deletion

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
@@ -132,6 +132,7 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
                 .revokeToken() ?? .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
         }.done { [weak self, server] _ in
             Current.servers.remove(identifier: server.identifier)
+            Current.resetAPICache(for: [server.identifier])
             let script = "\(callbackName)(true)"
 
             Current.Log.verbose("Running revoke external auth callback \(script)")

--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -233,6 +233,7 @@ class OnboardingAuth {
         }.done {
             api.connection.disconnect()
             Current.servers.remove(identifier: api.server.identifier)
+            Current.resetAPICache(for: [api.server.identifier])
         }
     }
 }

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -271,8 +271,11 @@ final class ConnectionSettingsViewModel: ObservableObject {
 
         let waitAtLeast = after(seconds: 3.0)
 
+        // Revoke only this server's token — revoking every server's token would sign the
+        // user out of the servers that are staying.
+        let revocations = [Current.api(for: server)?.tokenManager.revokeToken()].compactMap { $0 }
         await race(
-            when(resolved: Current.apis.map { $0.tokenManager.revokeToken() }).asVoid(),
+            when(resolved: revocations).asVoid(),
             after(seconds: 10.0)
         ).async()
 
@@ -280,6 +283,9 @@ final class ConnectionSettingsViewModel: ObservableObject {
 
         Current.api(for: server)?.connection.disconnect()
         Current.servers.remove(identifier: server.identifier)
+        // Drop the cached API so stale Server references can't fetch it back and keep a
+        // live connection to a deleted server.
+        Current.resetAPICache(for: [server.identifier])
         Current.onboardingObservation.needed(.logout)
     }
 

--- a/Sources/App/Settings/DebugView.swift
+++ b/Sources/App/Settings/DebugView.swift
@@ -595,9 +595,11 @@ struct DebugView: View {
             api.connection.disconnect()
         }
         resetAppToastMessage = L10n.Settings.Debugging.ResetApp.Toast.removingServers
-        for server in Current.servers.all {
-            Current.servers.remove(identifier: server.identifier)
+        let removedServerIdentifiers = Current.servers.all.map(\.identifier)
+        for identifier in removedServerIdentifiers {
+            Current.servers.remove(identifier: identifier)
         }
+        Current.resetAPICache(for: removedServerIdentifiers)
         resetAppToastMessage = L10n.Settings.Debugging.ResetApp.Toast.clearingDatabases
         resetStores()
         setDefaults()

--- a/Sources/App/Utilities/Utils.swift
+++ b/Sources/App/Utilities/Utils.swift
@@ -23,10 +23,20 @@ func resetStores() {
         Current.Log.error("Error when trying to delete everything from Keychain!")
     }
 
+    // Wiping the app-group domain would also wipe the deleted-server tombstones, and
+    // without them a late writer holding a Server reference — e.g. the local-push
+    // extension refreshing a token in its own process — re-creates the entry in the
+    // shared Keychain and the "deleted" servers come back on next launch.
+    let deletedServerTombstones = prefs.array(forKey: ServerManagerImpl.deletedServersPrefsKey)
+
     let bundleId = Bundle.main.bundleIdentifier!
     UserDefaults.standard.removePersistentDomain(forName: bundleId)
     UserDefaults.standard.removePersistentDomain(forName: AppConstants.AppGroupID)
     prefs.removePersistentDomain(forName: AppConstants.AppGroupID)
+
+    if let deletedServerTombstones {
+        prefs.set(deletedServerTombstones, forKey: ServerManagerImpl.deletedServersPrefsKey)
+    }
 
     do {
         try Current.database().eraseAllData()

--- a/Sources/HANetworking/Sources/ServerManager.swift
+++ b/Sources/HANetworking/Sources/ServerManager.swift
@@ -88,6 +88,12 @@ private struct ServerCache {
 public final class ServerManagerImpl: ServerManager {
     private static let restoredMirroredServersKey = "restoredMirroredServers"
 
+    /// Prefs key holding tombstones for deleted server identifiers. Every persistence write
+    /// checks this list first, so it must survive an app-data reset (see `resetStores()` in the
+    /// app target) — otherwise an in-flight writer, like the local-push extension refreshing a
+    /// token, can resurrect a just-deleted server in the shared Keychain.
+    public static let deletedServersPrefsKey = "deletedServers"
+
     private var keychain: ServerManagerKeychain
     private var historicKeychain: ServerManagerKeychain
     private var mirrorStore: ServerManagerMirrorStore
@@ -110,11 +116,12 @@ public final class ServerManagerImpl: ServerManager {
 
     private var deletedServers: Set<Identifier<Server>> {
         get {
-            let identifiers = HANetworkingEnvironment.current.prefs.array(forKey: "deletedServers") as? [String] ?? []
+            let identifiers = HANetworkingEnvironment.current.prefs
+                .array(forKey: Self.deletedServersPrefsKey) as? [String] ?? []
             return Set(identifiers.map { Identifier<Server>(rawValue: $0) })
         }
         set {
-            HANetworkingEnvironment.current.prefs.set(newValue.map(\.rawValue), forKey: "deletedServers")
+            HANetworkingEnvironment.current.prefs.set(newValue.map(\.rawValue), forKey: Self.deletedServersPrefsKey)
         }
     }
 
@@ -185,13 +192,15 @@ public final class ServerManagerImpl: ServerManager {
                 lhs.1.sortOrder < rhs.1.sortOrder
             })
 
-        let deletedServersUnchanged = self.deletedServers == deletedServers
         if let cachedOrFreshServers = cache.mutate(using: { cache -> [Server]? in
             if !cache.restrictCaching, let cachedServers = cache.all {
                 return cachedServers
             }
 
-            guard deletedServersUnchanged else {
+            // Compare tombstones inside the lock: remove() writes its tombstone before it
+            // mutates the cache, so a pre-lock comparison could pass and then cache a stale
+            // list that still contains a just-deleted server.
+            guard self.deletedServers == deletedServers else {
                 return nil
             }
 
@@ -350,11 +359,13 @@ public final class ServerManagerImpl: ServerManager {
                 return cached
             }
 
-            let deletedServers = self.deletedServers
             return cache.mutate { cache -> ServerInfo in
                 if !cache.restrictCaching, let info = cache.info[identifier] {
                     return info
                 } else {
+                    // Read tombstones inside the lock so a remove() completing between the
+                    // read and the cache write can't get its deletion re-cached here.
+                    let deletedServers = self.deletedServers
                     // Prefer live Keychain data, but fall back to the last startup
                     // snapshot in GRDB when the Keychain entry is gone.
                     let keychainInfo = keychain.getServerInfo(key: identifier.keychainKey, decoder: decoder)
@@ -387,8 +398,12 @@ public final class ServerManagerImpl: ServerManager {
             // intentionally not in the lock
             _ = serverInfo.connection.evaluateActiveURL()
 
-            let deletedServers = self?.deletedServers ?? []
             return cache.mutate { cache in
+                // Read tombstones inside the lock: remove() writes its tombstone before it
+                // deletes the Keychain entry, so an update racing a deletion (e.g. a token
+                // refresh finishing while the user deletes the server) sees the tombstone
+                // here and can't write the server back into the Keychain.
+                let deletedServers = self?.deletedServers ?? []
                 guard !deletedServers.contains(identifier) else {
                     HANetworkingEnvironment.current.log.verbose("ignoring update to deleted server \(identifier)")
                     return false

--- a/Tests/Shared/ServerManager.test.swift
+++ b/Tests/Shared/ServerManager.test.swift
@@ -561,6 +561,19 @@ class ServerManagerTests: XCTestCase {
         XCTAssertEqual(keychain.data[server1.identifier.rawValue]?.count, try encoder.encode(newInfo).count)
     }
 
+    func testRemoveWritesTombstoneUnderStablePrefsKey() throws {
+        try setupRegular()
+
+        let server1 = servers.add(identifier: "fake1", serverInfo: .fake())
+        servers.remove(identifier: server1.identifier)
+
+        // resetStores() preserves this key across the app-data wipe so late writers can't
+        // resurrect deleted servers; the raw value must stay stable for stored tombstones.
+        XCTAssertEqual(ServerManagerImpl.deletedServersPrefsKey, "deletedServers")
+        let tombstones = Current.settingsStore.prefs.array(forKey: "deletedServers") as? [String]
+        XCTAssertEqual(tombstones, ["fake1"])
+    }
+
     func testSetupBackfillsMirrorForExistingKeychainServers() throws {
         let securityExceptionTrust = try SecTrust.unitTestDotExampleDotCom1
         let info = with(ServerInfo.fake()) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Deleted servers could come back after "delete server" or "delete all app data":

- The deleted-server tombstones were checked outside the cache lock, so an update racing a deletion (e.g. a token refresh finishing while the server is deleted) could write the server back into the Keychain or re-cache a stale server list. The tombstone checks now happen inside the lock.
- "Delete all app data" wiped the app-group defaults, erasing the tombstones it had just written; a late writer (e.g. the local-push extension refreshing a token in its own process) could then re-create the server in the shared Keychain. The tombstones are now preserved across the wipe.
- Deleting a single server revoked every server's token; now only the deleted server's token is revoked.
- The removed server's cached API instance is now evicted in all delete paths.

## Screenshots
Not applicable, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bcxr4bxMXiaXHYfNWgrEmn)_