### PR TITLE
Log location-based server switch to client events

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1427,7 +1427,6 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.server_switching.how_it_works.title" = "How it works?";
 "settings.server_switching.how_it_works.wifi.body" = "If this device is connected to a Wi-Fi network that belongs to one of your servers, that server is considered closest. No location check is needed.";
 "settings.server_switching.how_it_works.wifi.title" = "Home network first";
-"settings.server_switching.switched_toast" = "Switched to %@";
 "settings.server_switching.title" = "Server Switching";
 "settings.status_section.header" = "Status";
 "settings.status_section.location_name_row.placeholder" = "My Home Assistant";

--- a/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
+++ b/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
@@ -16,8 +16,6 @@ import UIKit
 final class LocationBasedServerSwitcher {
     static let shared = LocationBasedServerSwitcher()
 
-    private static let toastID = "location-based-server-switch"
-    private static let toastDuration: TimeInterval = 4
     private static let locationTimeout: TimeInterval = 5
     /// How long the app must stay in the background before the once-per-visit memory expires and
     /// the matched server is applied again on the next activation.
@@ -105,17 +103,16 @@ final class LocationBasedServerSwitcher {
               matched.identifier != currentServer?.identifier else { return }
 
         Current.Log.info("location-based server switch to \(matched.identifier)")
+        Current.clientEventStore.addEvent(ClientEvent(
+            text: "Switched server based on location to \(matched.info.name)",
+            type: .locationUpdate,
+            payload: [
+                "server": matched.info.name,
+                "server_identifier": matched.identifier.rawValue,
+            ]
+        ))
         Current.sceneManager.appCoordinator.done { coordinator in
             coordinator.open(server: matched)
-        }
-        if #available(iOS 18, *) {
-            ToastPresenter.shared.show(
-                id: Self.toastID,
-                symbol: .arrowLeftArrowRight,
-                symbolForegroundStyle: (.white, .haPrimary),
-                title: L10n.Settings.ServerSwitching.switchedToast(matched.info.name),
-                duration: Self.toastDuration
-            )
         }
     }
 

--- a/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
+++ b/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
@@ -107,8 +107,8 @@ final class LocationBasedServerSwitcher {
             text: "Switched server based on location to \(matched.info.name)",
             type: .locationUpdate,
             payload: [
-                "server": matched.info.name,
-                "server_identifier": matched.identifier.rawValue,
+                "server_name": matched.info.name,
+                "server_id": matched.identifier.rawValue,
             ]
         ))
         Current.sceneManager.appCoordinator.done { coordinator in

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4723,10 +4723,6 @@ public enum L10n {
       public static var title: String { return L10n.tr("Localizable", "settings.server_select.title") }
     }
     public enum ServerSwitching {
-      /// Switched to %@
-      public static func switchedToast(_ p1: Any) -> String {
-        return L10n.tr("Localizable", "settings.server_switching.switched_toast", String(describing: p1))
-      }
       /// Server Switching
       public static var title: String { return L10n.tr("Localizable", "settings.server_switching.title") }
       public enum ByLocation {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Removes the toast shown when the app switches server based on location, and logs the switch to the client event logs instead.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — removes a toast, no new UI.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
