### PR TITLE
Keep stand-by logo aligned with splash and fix empty-state logo transition

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -189,25 +189,8 @@ struct HomeAssistantStandByView: View {
                 showsEmptyStateContent = emptyState != nil
             }
         }
-        .onChange(of: emptyState != nil) { showsEmptyState in
-            if showsEmptyState {
-                // Un-animated, so the WKWebView-backed loading logo is gone before the move-to-top
-                // starts and only the pixel-identical static logo underneath runs the transition —
-                // the webview can't track animated frame changes and would show a second logo.
-                showsAnimatedLogo = false
-            }
-            withAnimation(DesignSystem.Animation.default) {
-                showsEmptyStateContent = showsEmptyState
-            }
-        }
-        .task(id: showsEmptyState) {
-            guard !showsEmptyState, !showsAnimatedLogo else { return }
-            // Restore the animated logo only after the move back to center settled; re-inserting
-            // the webview mid-animation would desync it from the static logo again.
-            try? await Task.sleep(for: .milliseconds(400))
-            guard !Task.isCancelled else { return }
-            showsAnimatedLogo = true
-        }
+        .onChange(of: emptyState != nil, perform: handleEmptyStateChange)
+        .task(id: showsEmptyState, restoreAnimatedLogoIfNeeded)
         .onChange(of: emptyState?.availableReauthURLTypes ?? []) { availableReauthURLTypes in
             selectedReauthURLType = availableReauthURLTypes.first ?? .external
         }
@@ -219,12 +202,7 @@ struct HomeAssistantStandByView: View {
         }
         // `$phase` replays its current value on subscription, so when the splash already finished
         // (server switches, reloads) the pill fades in immediately on appear.
-        .onReceive(LaunchSplashOverlayState.shared.$phase) { phase in
-            guard phase == .finished, !showsServerPill else { return }
-            withAnimation(DesignSystem.Animation.default) {
-                showsServerPill = true
-            }
-        }
+        .onReceive(LaunchSplashOverlayState.shared.$phase, perform: fadeInServerPillIfNeeded)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             guard !showsEmptyState else { return }
             showsDelayedSettingsButton = false
@@ -235,6 +213,35 @@ struct HomeAssistantStandByView: View {
             id: [AnyHashable(showsEmptyState), AnyHashable(loaderCountdownRestartToken)],
             runDelayedButtonsCountdown
         )
+    }
+
+    private func handleEmptyStateChange(_ showsEmptyState: Bool) {
+        if showsEmptyState {
+            // Un-animated, so the WKWebView-backed loading logo is gone before the move-to-top
+            // starts and only the pixel-identical static logo underneath runs the transition —
+            // the webview can't track animated frame changes and would show a second logo.
+            showsAnimatedLogo = false
+        }
+        withAnimation(DesignSystem.Animation.default) {
+            showsEmptyStateContent = showsEmptyState
+        }
+    }
+
+    @Sendable
+    private func restoreAnimatedLogoIfNeeded() async {
+        guard !showsEmptyState, !showsAnimatedLogo else { return }
+        // Restore the animated logo only after the move back to center settled; re-inserting
+        // the webview mid-animation would desync it from the static logo again.
+        try? await Task.sleep(for: .milliseconds(400))
+        guard !Task.isCancelled else { return }
+        showsAnimatedLogo = true
+    }
+
+    private func fadeInServerPillIfNeeded(for phase: LaunchSplashOverlayState.Phase) {
+        guard phase == .finished, !showsServerPill else { return }
+        withAnimation(DesignSystem.Animation.default) {
+            showsServerPill = true
+        }
     }
 
     @Sendable

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -8,7 +8,6 @@ struct HomeAssistantStandByView: View {
     static let logoDismissTapThreshold = 10
 
     private static let headerAccessorySize = CGSize(width: 44, height: 44)
-    private static let loadingLogoSize = CGSize(width: 110, height: 110)
     static let loadingLogoResourceName = "home-assistant-logo-loading"
     private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
     private static let reauthenticationIconSize: CGFloat = 56
@@ -40,6 +39,8 @@ struct HomeAssistantStandByView: View {
     @State private var showsCleanCacheButton = false
     @State private var loaderCountdownRestartToken = 0
     @State private var hasAppeared = false
+    @State private var showsServerPill = false
+    @State private var showsAnimatedLogo: Bool
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
 
     private var showsEmptyState: Bool { emptyState != nil }
@@ -61,26 +62,19 @@ struct HomeAssistantStandByView: View {
     private var showsConnectionTypeIndicator: Bool { configuredURLTypes.count > 1 }
 
     /// Without another registered server there is nothing to identify or switch to (a zero count — as in
-    /// previews or a transiently empty registry — behaves the same), so the pill row is hidden and the
-    /// loading logo mirrors the splash logo exactly (size and full-screen-centered position) so the
-    /// splash-to-stand-by hand-off is a pure crossfade with no movement.
+    /// previews or a transiently empty registry — behaves the same), so the pill row is hidden. The pill
+    /// hangs below the logo as an overlay so it never shifts the logo away from the splash position.
     private var hasMultipleServers: Bool { Current.servers.all.count > 1 }
 
     private var logoSize: CGSize {
-        if showsEmptyState {
-            Self.emptyStateLogoSize
-        } else if hasMultipleServers {
-            Self.loadingLogoSize
-        } else {
-            LaunchSplashOverlayView.Constants.splashLogoSize
-        }
+        // While loading, the logo mirrors the splash logo exactly (size and full-screen-centered
+        // position) so the launch-screen → splash → stand-by hand-off is a pure crossfade with no
+        // movement; the logo only moves (to the top, smaller) for the empty/error state.
+        showsEmptyState ? Self.emptyStateLogoSize : LaunchSplashOverlayView.Constants.splashLogoSize
     }
 
     private func contentOffset(safeAreaInsets: EdgeInsets) -> CGFloat {
         guard !showsEmptyState else { return 0 }
-        if hasMultipleServers {
-            return -DesignSystem.Spaces.eight
-        }
         // The splash logo is centered against the full screen while this content is laid out inside
         // the safe area; shift by the safe-area asymmetry so the two centers coincide.
         return (safeAreaInsets.bottom - safeAreaInsets.top) / 2
@@ -109,6 +103,7 @@ struct HomeAssistantStandByView: View {
         self.delayedSettingsButtonDelay = delayedSettingsButtonDelay
         self.cleanCacheButtonDelay = cleanCacheButtonDelay
         self._selectedReauthURLType = State(initialValue: emptyState?.availableReauthURLTypes.first ?? .external)
+        self._showsAnimatedLogo = State(initialValue: emptyState == nil)
     }
 
     var body: some View {
@@ -122,8 +117,6 @@ struct HomeAssistantStandByView: View {
             iconView
             if let emptyState {
                 emptyStateBody(for: emptyState)
-            } else if hasMultipleServers {
-                currentServerPill
             }
         }
         .padding(.horizontal, DesignSystem.Spaces.three)
@@ -133,6 +126,19 @@ struct HomeAssistantStandByView: View {
             maxHeight: .infinity,
             alignment: showsEmptyState ? .top : .center
         )
+        .overlay {
+            // Overlaid (not a stack sibling) so the pill takes no layout space and the loading logo
+            // stays exactly at the splash position; it hangs below the screen-centered logo.
+            if !showsEmptyState, hasMultipleServers {
+                currentServerPill
+                    .padding(.horizontal, DesignSystem.Spaces.three)
+                    .offset(y: logoSize.height / 2 + DesignSystem.Spaces.three + Self.serverPillHeight / 2)
+                    // Held invisible until the launch splash overlay is gone, then faded in, so it
+                    // never pops in fully formed behind the splash fade.
+                    .opacity(showsServerPill ? 1 : 0)
+                    .transition(.opacity)
+            }
+        }
         .offset(y: contentOffset(safeAreaInsets: safeAreaInsets))
         .opacity(standByContentOpacity)
         // Sits in front of the background colour but behind the content, so swipes over empty areas reach it
@@ -184,9 +190,23 @@ struct HomeAssistantStandByView: View {
             }
         }
         .onChange(of: emptyState != nil) { showsEmptyState in
+            if showsEmptyState {
+                // Un-animated, so the WKWebView-backed loading logo is gone before the move-to-top
+                // starts and only the pixel-identical static logo underneath runs the transition —
+                // the webview can't track animated frame changes and would show a second logo.
+                showsAnimatedLogo = false
+            }
             withAnimation(DesignSystem.Animation.default) {
                 showsEmptyStateContent = showsEmptyState
             }
+        }
+        .task(id: showsEmptyState) {
+            guard !showsEmptyState, !showsAnimatedLogo else { return }
+            // Restore the animated logo only after the move back to center settled; re-inserting
+            // the webview mid-animation would desync it from the static logo again.
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            showsAnimatedLogo = true
         }
         .onChange(of: emptyState?.availableReauthURLTypes ?? []) { availableReauthURLTypes in
             selectedReauthURLType = availableReauthURLTypes.first ?? .external
@@ -196,6 +216,14 @@ struct HomeAssistantStandByView: View {
                 .publisher(for: Current.connectivity.connectivityDidChangeNotification())
         ) { _ in
             networkType = Current.connectivity.simpleNetworkType()
+        }
+        // `$phase` replays its current value on subscription, so when the splash already finished
+        // (server switches, reloads) the pill fades in immediately on appear.
+        .onReceive(LaunchSplashOverlayState.shared.$phase) { phase in
+            guard phase == .finished, !showsServerPill else { return }
+            withAnimation(DesignSystem.Animation.default) {
+                showsServerPill = true
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             guard !showsEmptyState else { return }
@@ -419,13 +447,17 @@ struct HomeAssistantStandByView: View {
                     // Keep the static logo behind the animated SVG while loading: the launch-splash
                     // hero morphs into a pixel-identical `Image(.logo)` (matched geometry), and it
                     // also fills any frame before the WKWebView paints. The animated SVG sits on top
-                    // once loaded.
+                    // once loaded, and is swapped out for the static logo around the empty-state
+                    // move since the webview can't track animated frame changes.
                     Image(.logo)
                         .resizable()
                         .scaledToFit()
-                    if !showsEmptyState {
-                        AnimatedSVGView(resourceName: Self.loadingLogoResourceName)
-                    }
+                    // Hidden via opacity (never removed) with animation explicitly disabled, so the
+                    // swap to the static logo is always instantaneous — a conditional removal would
+                    // inherit the surrounding empty-state animation and fade out mid-move.
+                    AnimatedSVGView(resourceName: Self.loadingLogoResourceName)
+                        .opacity(showsAnimatedLogo ? 1 : 0)
+                        .animation(nil, value: showsAnimatedLogo)
                     if case .inFlight = emptyState?.style {
                         inFlightIcon
                             .offset(x: 15, y: 15)
@@ -772,6 +804,9 @@ private extension HomeAssistantStandByView {
     Current.servers = FakeServerManager(initial: 2)
     // swiftlint:enable prohibit_environment_assignment
     let server = Current.servers.all.first ?? ServerFixture.standard
+    // No launch splash overlay in this preview; finish its state so the server pill fades in.
+    LaunchSplashOverlayState.shared.fadeOut()
+    LaunchSplashOverlayState.shared.finish()
     return HomeAssistantStandByView(
         server: server,
         emptyState: nil

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -134,8 +134,11 @@ struct HomeAssistantStandByView: View {
                     .padding(.horizontal, DesignSystem.Spaces.three)
                     .offset(y: logoSize.height / 2 + DesignSystem.Spaces.three + Self.serverPillHeight / 2)
                     // Held invisible until the launch splash overlay is gone, then faded in, so it
-                    // never pops in fully formed behind the splash fade.
+                    // never pops in fully formed behind the splash fade. Opacity alone keeps the
+                    // view tappable and visible to VoiceOver, so disable both while hidden.
                     .opacity(showsServerPill ? 1 : 0)
+                    .allowsHitTesting(showsServerPill)
+                    .accessibilityHidden(!showsServerPill)
                     .transition(.opacity)
             }
         }
@@ -465,6 +468,9 @@ struct HomeAssistantStandByView: View {
                     AnimatedSVGView(resourceName: Self.loadingLogoResourceName)
                         .opacity(showsAnimatedLogo ? 1 : 0)
                         .animation(nil, value: showsAnimatedLogo)
+                        // Decorative duplicate of the static logo; its webview is already
+                        // non-interactive, this also keeps it out of VoiceOver.
+                        .accessibilityHidden(true)
                     if case .inFlight = emptyState?.style {
                         inFlightIcon
                             .offset(x: 15, y: 15)


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The stand-by loading logo now always matches the launch splash logo position and size (previously the multi-server case shrank and shifted it up, causing a visible jump during the splash hand-off). The server pill hangs below the logo as an overlay and fades in once the splash is gone. The logo only moves when transitioning to the empty/error state, and that transition now swaps the webview-backed animated logo for the static one before animating, so a second logo no longer appears mid-transition.

## Screenshots
No static layout changes; the changes affect launch/transition animations only.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
