### PR TITLE
Show re-authentication screen when the server rejects the refresh token

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Alerts.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Alerts.swift
@@ -471,8 +471,16 @@ extension WebViewController {
             return
         }
 
+        // Repeated token failures (e.g. app and web view both retrying) collapse into one prompt.
+        guard connectionState != .authInvalid else {
+            return
+        }
+
+        Current.Log.info("showing re-auth prompt for server \(serverId), status code \(code)")
+
         // Avoid retrying from Home Assistant UI since this is a dead end
         connectionState = .authInvalid
+        overlayState?.connectionState = .authInvalid
         load(request: URLRequest(url: URL(string: "about:blank")!))
         showEmptyState()
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
@@ -3,6 +3,19 @@ import Shared
 import SwiftUI
 import UIKit
 
+extension WebViewController: OnboardingStateObserver {
+    /// Surfaces the re-authentication empty state when the server rejects this server's refresh
+    /// token (e.g. HTTP 401 from `/auth/token` after the token was revoked server-side).
+    /// `OnboardingStateObservation` may notify from a non-main thread, so hop to the main actor
+    /// before touching the web view.
+    nonisolated func onboardingStateDidChange(to state: OnboardingState) {
+        guard case let .needed(.unauthenticated(serverId, code)) = state else { return }
+        Task { @MainActor [weak self] in
+            self?.showReAuthPopup(serverId: serverId, code: code)
+        }
+    }
+}
+
 extension WebViewController {
     func performReauthentication(using urlType: ConnectionInfo.URLType) {
         let connectionInfo = server.info.connection

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
@@ -218,6 +218,8 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
         observeConnectionNotifications()
         setupKioskModeObservation()
+        // Weakly held; surfaces re-authentication when this server's refresh token is rejected.
+        Current.onboardingObservation.register(observer: self)
 
         let statusBarView = setupStatusBarView()
 

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -279,6 +279,44 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual((sut.latestLoadError as? URLError)?.code, .badServerResponse)
     }
 
+    func testShowReAuthPopupMarksAuthInvalidAndShowsReauthEmptyState() {
+        let server = Server.fake()
+        let sut = makeSUT(server: server)
+        sut.webView = WKWebView(frame: .zero)
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.showReAuthPopup(serverId: server.identifier.rawValue, code: 401)
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.emptyState?.style, .unauthenticated)
+    }
+
+    func testShowReAuthPopupIgnoresEventsForOtherServers() {
+        let sut = makeSUT(server: .fake())
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.showReAuthPopup(serverId: Server.fake().identifier.rawValue, code: 401)
+
+        XCTAssertEqual(sut.connectionState, .unknown)
+        XCTAssertNil(overlayState.emptyState)
+    }
+
+    func testUnauthenticatedOnboardingStateShowsReauthEmptyState() async {
+        let server = Server.fake()
+        let sut = makeSUT(server: server)
+        sut.webView = WKWebView(frame: .zero)
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.onboardingStateDidChange(to: .needed(.unauthenticated(server.identifier.rawValue, 401)))
+
+        await waitUntil { sut.connectionState == .authInvalid }
+        XCTAssertEqual(overlayState.emptyState?.style, .unauthenticated)
+    }
+
     func testRestoredURLRebuildsSavedPathOntoLiveBaseIgnoringSavedHost() throws {
         // A path saved on the internal base is restored against whatever base is active now (e.g. remote
         // UI), so only path/query/fragment carry over -- never the host.
@@ -313,6 +351,19 @@ final class WebViewControllerTests: XCTestCase {
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
         sut.setValue(containerView, forKey: "view")
         return sut
+    }
+
+    private func waitUntil(
+        _ condition: @escaping () -> Bool,
+        timeout: TimeInterval = 2,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(condition(), "condition not met within \(timeout)s", file: file, line: line)
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
When the server rejects the app's refresh token (e.g. HTTP 401 from `/auth/token` after the token was revoked), the app kept retrying with invalid credentials and only showed the generic "disconnected" screen, causing repeated `http.ban` "invalid authentication" warnings on the server.

The `.unauthenticated` event fired by `TokenManager` had no consumer: `WebViewController.showReAuthPopup` existed but was never called. This wires the active `WebViewController` up as an `OnboardingStateObserver` so that event now stops further retries and shows the existing unauthenticated empty state with the Re-authenticate button. Duplicate token-failure events collapse into a single prompt, and the SwiftUI overlay connection state stays in sync. Adds unit tests for the new wiring.

## Screenshots
No new UI — this surfaces the existing "You are unauthenticated" empty state and re-authentication flow.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behavior change for servers other than the one currently displayed; those keep the existing guard.