### PR TITLE
Protect legacy model cleanup from 0xdead10cc suspension kills

### DIFF
--- a/Sources/Shared/API/Models/LegacyModelManager.swift
+++ b/Sources/Shared/API/Models/LegacyModelManager.swift
@@ -163,7 +163,21 @@ public class LegacyModelManager: ServerObserver {
             }
         }
 
-        return promise
+        // Hold a background task while the writes run: cleanup is triggered by `serversDidChange`,
+        // which can fire while the app is backgrounded. The expiring-activity protection in the
+        // database accessor cannot abort a statement that is already executing, so without
+        // protected time a write caught mid-statement at the process freeze holds the app-group
+        // SQLite file lock and the system kills the app with 0xdead10cc.
+        return Current.backgroundTask(withName: BackgroundTask.legacyModelCleanup.rawValue) { _ in promise }
+            .recover { error -> Promise<Void> in
+                // Out of background time: suspend GRDB right away, aborting any in-flight write so
+                // the file lock is released before the process is frozen. Ordinary write failures
+                // (rethrown below) must not suspend the database.
+                if case BackgroundTaskError.outOfTime = error {
+                    AppDatabaseSuspension.suspend()
+                }
+                throw error
+            }
     }
 
     public struct SubscribeDefinition {

--- a/Sources/Shared/Common/BackgroundTask.swift
+++ b/Sources/Shared/Common/BackgroundTask.swift
@@ -23,6 +23,7 @@ public enum BackgroundTask: String {
     case realmWrite = "realm-write"
     case pushLocationRequest = "push-location-request"
     case remindersSync = "reminders-sync"
+    case legacyModelCleanup = "legacy-model-cleanup"
 }
 
 public enum BackgroundTaskError: Error {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes a TestFlight crash (2026.8.0/2026.2512): `RUNNINGBOARD 0xdead10cc` — the OS killed the app for holding the app-group SQLite file lock while being suspended, with a `LegacyModelManager.cleanup()` write (`WatchComplication.deleteOrphans`) mid-statement on a background queue.

`cleanup()` is triggered by `serversDidChange`, which can fire while the app is backgrounded. The expiring-activity protection in the database accessor can't abort a statement that is already executing, so the write was caught holding the file lock when the process froze.

`cleanup()` now holds a background task for the duration of its writes (same pattern as reminders sync), and if background time runs out it suspends GRDB right away so the in-flight write aborts and releases the file lock before the freeze.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Follow-up to #5164 / #5165, which protected `Current.database()` accesses and reminders sync from the same crash cluster.