### PR TITLE
Add make default and delete actions to server context menu

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1208,6 +1208,7 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.connection_section.location_send_type.setting.zone_only" = "Zone only";
 "settings.connection_section.location_send_type.title" = "Location Sent";
 "settings.connection_section.logged_in_as" = "Logged in as";
+"settings.connection_section.make_default" = "Make default";
 "settings.connection_section.no_base_url.title" = "No URL";
 "settings.connection_section.refresh_server" = "Update server information";
 "settings.connection_section.remote_ui_url.title" = "Remote UI URL";

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -1,7 +1,6 @@
 import Combine
 import Foundation
 import HAKit
-import PromiseKit
 import Shared
 import UIKit
 
@@ -269,24 +268,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
         isDeleting = true
         defer { isDeleting = false }
 
-        let waitAtLeast = after(seconds: 3.0)
-
-        // Revoke only this server's token — revoking every server's token would sign the
-        // user out of the servers that are staying.
-        let revocations = [Current.api(for: server)?.tokenManager.revokeToken()].compactMap { $0 }
-        await race(
-            when(resolved: revocations).asVoid(),
-            after(seconds: 10.0)
-        ).async()
-
-        await waitAtLeast.async()
-
-        Current.api(for: server)?.connection.disconnect()
-        Current.servers.remove(identifier: server.identifier)
-        // Drop the cached API so stale Server references can't fetch it back and keep a
-        // live connection to a deleted server.
-        Current.resetAPICache(for: [server.identifier])
-        Current.onboardingObservation.needed(.logout)
+        await server.deleteFromApp(minimumDuration: 3.0)
     }
 
     // MARK: - Client Certificate

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import HAKit
+import PromiseKit
 import Shared
 import UIKit
 

--- a/Sources/App/Settings/Settings/ServersListView.swift
+++ b/Sources/App/Settings/Settings/ServersListView.swift
@@ -40,7 +40,7 @@ struct ServersListView: View {
                 titleVisibility: .visible
             ) {
                 Button(L10n.Settings.ConnectionSection.DeleteServer.title, role: .destructive) {
-                    Task { await observer.deleteServer(server) }
+                    Task { await server.deleteFromApp() }
                 }
                 Button(L10n.cancelLabel, role: .cancel) {}
             } message: {

--- a/Sources/App/Settings/Settings/ServersListView.swift
+++ b/Sources/App/Settings/Settings/ServersListView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ServersListView: View {
     @StateObject private var observer = ServersObserver()
     @State private var showAddServer = false
+    @State private var serverPendingDeletion: Server?
     @Environment(\.editMode) private var editMode
 
     var body: some View {
@@ -17,6 +18,33 @@ struct ServersListView: View {
                 } label: {
                     Label(L10n.Settings.ConnectionSection.refreshServer, systemSymbol: .arrowClockwise)
                 }
+                if observer.servers.first?.identifier != server.identifier {
+                    Button {
+                        observer.makeDefault(server)
+                    } label: {
+                        Label(L10n.Settings.ConnectionSection.makeDefault, systemSymbol: .star)
+                    }
+                }
+                Button(role: .destructive) {
+                    serverPendingDeletion = server
+                } label: {
+                    Label(L10n.Settings.ConnectionSection.DeleteServer.title, systemSymbol: .trash)
+                }
+            }
+            .confirmationDialog(
+                L10n.Settings.ConnectionSection.DeleteServer.title,
+                isPresented: Binding(
+                    get: { serverPendingDeletion?.identifier == server.identifier },
+                    set: { if !$0 { serverPendingDeletion = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button(L10n.Settings.ConnectionSection.DeleteServer.title, role: .destructive) {
+                    Task { await observer.deleteServer(server) }
+                }
+                Button(L10n.cancelLabel, role: .cancel) {}
+            } message: {
+                Text(L10n.Settings.ConnectionSection.DeleteServer.message)
             }
         }
         .onMove { source, destination in

--- a/Sources/App/Settings/Settings/ServersObserver.swift
+++ b/Sources/App/Settings/Settings/ServersObserver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PromiseKit
 import Shared
 
 final class ServersObserver: ObservableObject, ServerObserver {
@@ -35,5 +36,26 @@ final class ServersObserver: ObservableObject, ServerObserver {
 
         // Update local array immediately for responsive UI
         servers = updatedServers
+    }
+
+    func makeDefault(_ server: Server) {
+        guard let index = servers.firstIndex(where: { $0.identifier == server.identifier }), index != 0 else {
+            return
+        }
+        moveServers(from: IndexSet(integer: index), to: 0)
+    }
+
+    @MainActor
+    func deleteServer(_ server: Server) async {
+        let revocations = [Current.api(for: server)?.tokenManager.revokeToken()].compactMap { $0 }
+        await race(
+            when(resolved: revocations).asVoid(),
+            after(seconds: 10.0)
+        ).async()
+
+        Current.api(for: server)?.connection.disconnect()
+        Current.servers.remove(identifier: server.identifier)
+        Current.resetAPICache(for: [server.identifier])
+        Current.onboardingObservation.needed(.logout)
     }
 }

--- a/Sources/App/Settings/Settings/ServersObserver.swift
+++ b/Sources/App/Settings/Settings/ServersObserver.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PromiseKit
 import Shared
 
 final class ServersObserver: ObservableObject, ServerObserver {
@@ -43,19 +42,5 @@ final class ServersObserver: ObservableObject, ServerObserver {
             return
         }
         moveServers(from: IndexSet(integer: index), to: 0)
-    }
-
-    @MainActor
-    func deleteServer(_ server: Server) async {
-        let revocations = [Current.api(for: server)?.tokenManager.revokeToken()].compactMap { $0 }
-        await race(
-            when(resolved: revocations).asVoid(),
-            after(seconds: 10.0)
-        ).async()
-
-        Current.api(for: server)?.connection.disconnect()
-        Current.servers.remove(identifier: server.identifier)
-        Current.resetAPICache(for: [server.identifier])
-        Current.onboardingObservation.needed(.logout)
     }
 }

--- a/Sources/Shared/API/Authentication/Server+Deletion.swift
+++ b/Sources/Shared/API/Authentication/Server+Deletion.swift
@@ -1,0 +1,26 @@
+#if os(iOS)
+import Foundation
+import HAKit
+import HANetworking
+import PromiseKit
+
+public extension Server {
+    @MainActor
+    func deleteFromApp(minimumDuration: TimeInterval = 0) async {
+        let waitAtLeast = after(seconds: minimumDuration)
+
+        let revocations = [Current.api(for: self)?.tokenManager.revokeToken()].compactMap { $0 }
+        await race(
+            when(resolved: revocations).asVoid(),
+            after(seconds: 10.0)
+        ).async()
+
+        await waitAtLeast.async()
+
+        Current.api(for: self)?.connection.disconnect()
+        Current.servers.remove(identifier: identifier)
+        Current.resetAPICache(for: [identifier])
+        Current.onboardingObservation.needed(.logout)
+    }
+}
+#endif

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3873,6 +3873,8 @@ public enum L10n {
       public static var localPushDescription: String { return L10n.tr("Localizable", "settings.connection_section.local_push_description") }
       /// Logged in as
       public static var loggedInAs: String { return L10n.tr("Localizable", "settings.connection_section.logged_in_as") }
+      /// Make default
+      public static var makeDefault: String { return L10n.tr("Localizable", "settings.connection_section.make_default") }
       /// Update server information
       public static var refreshServer: String { return L10n.tr("Localizable", "settings.connection_section.refresh_server") }
       /// Servers


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Long pressing a server in Settings now offers two more actions alongside "Update server information":

- **Make default**: moves the server to the top of the list so it becomes the default. Hidden when the server is already first.
- **Delete**: destructive action that removes the server after a confirmation dialog, using the same deletion flow as the server detail screen.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
