### PR TITLE
Fix manual URL connect on macOS server onboarding

### DIFF
--- a/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
@@ -45,8 +45,8 @@ struct ManualURLEntryView: View, KeyboardReadable {
             }, primaryActionTitle: L10n.Onboarding.ManualUrlEntry.PrimaryAction.title) {
                 guard !urlString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                 if let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)) {
-                    dismiss()
                     connectAction(url)
+                    dismiss()
                 } else {
                     showInvalidURLError = true
                 }

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -25,10 +25,6 @@ struct OnboardingServersListView: View {
 
     @State private var showDocumentation = false
     @State private var showManualInput = false
-    /// Connection typed in the manual entry sheet; the flow starts in the sheet's `onDismiss` so the
-    /// auth steps never present UI (e.g. the mTLS certificate prompt) while the sheet is still
-    /// animating out — a conflicting presentation gets torn down and reads as a user cancellation.
-    @State private var pendingManualURL: URL?
     @State private var screenLoaded = false
     @State private var autoConnectWorkItem: DispatchWorkItem?
     @State private var autoConnectInstance: DiscoveredHomeAssistant?
@@ -109,15 +105,17 @@ struct OnboardingServersListView: View {
                     minHeight: Constants.MacSheetSize.errorDetailsMinHeight
                 )
         }
+        // Start the flow only in `onDismiss`; mutating observed state while the sheet animates out left
+        // it stuck on Mac Catalyst with the mTLS prompt (presented by the container above) stranded behind.
         .sheet(isPresented: $showManualInput, onDismiss: {
-            if let connectURL = pendingManualURL {
-                pendingManualURL = nil
+            if let connectURL = viewModel.pendingManualURL {
+                viewModel.pendingManualURL = nil
+                viewModel.manualInputLoading = true
                 viewModel.selectInstance(.init(manualURL: connectURL), presenter: presenter)
             }
         }) {
             ManualURLEntryView { connectURL in
-                viewModel.manualInputLoading = true
-                pendingManualURL = connectURL
+                viewModel.pendingManualURL = connectURL
             }
             .macOnboardingSheetFrame(
                 minWidth: Constants.MacSheetSize.manualInputMinWidth,

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
@@ -23,6 +23,8 @@ final class OnboardingServersListViewModel: ObservableObject {
     @Published var invitationLoading = false
     @Published var showCenterLoader = true
 
+    var pendingManualURL: URL?
+
     private var webhookSensors: [WebhookSensor] = []
     private var discovery = Current.bonjour()
     private var cancellables = Set<AnyCancellable>()


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
On macOS, adding a server through manual URL entry left the Connect and Close buttons unresponsive: the entry sheet stayed on screen and the client certificate (mTLS) prompt ended up presented behind it.

The manual entry sheet mutated observed view-model state (the loading indicator) in the same update as its own dismissal, which desyncs the sheet from UIKit on Mac Catalyst and leaves the card stuck on screen while the flow continues underneath. The connection now starts only after the sheet has fully dismissed, and no observed state changes while it animates out, so both buttons behave correctly and the certificate prompt is presented on top.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
