### PR TITLE
Fix watch complications showing stale values after refresh

### DIFF
--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import PromiseKit
 import Shared
 import UIKit
@@ -518,6 +519,10 @@ enum WatchWidgetComplicationSnapshotStore {
 
     static let defaultsKey = "watchWidgetComplicationSnapshots"
     static let recordsKey = "watchComplicationRefreshRecords"
+    /// Fingerprint of the snapshot content this app last submitted to WidgetKit via
+    /// `reloadAllTimelines`, kept separate from the store itself: the store can hold content the
+    /// face was never re-rendered with (see `write`).
+    private static let reloadFingerprintKey = "watchWidgetComplicationSnapshotsReloadFingerprint"
 
     /// Fire-and-forget refresh for synchronous callers (launch, mirror receipt, home sync).
     static func update() {
@@ -756,27 +761,43 @@ enum WatchWidgetComplicationSnapshotStore {
             Current.Log.error("Missing app group defaults for watch widget complication snapshots")
             return
         }
-        // Skip the write + WidgetKit reload when the model didn't change. Reloads are budgeted on
-        // watchOS; spending one on identical content can get a later, real change throttled — the
-        // face then keeps showing a stale value even though the store holds the fresh one. The
-        // stored blob is decoded and compared as a model (not byte-wise) so JSON dictionary key
-        // ordering can't fake a change.
-        if let stored = defaults.data(forKey: defaultsKey),
-           let previous = try? JSONDecoder().decode([WatchWidgetComplicationSnapshot].self, from: stored),
-           previous == snapshots {
-            return
-        }
-        guard let data = try? JSONEncoder().encode(snapshots) else {
+        // Sorted keys so equal models always encode to identical bytes, keeping the reload
+        // fingerprint below stable across launches (dictionary key order is otherwise random).
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(snapshots) else {
             Current.Log.error("Failed to encode watch widget complication snapshots")
             return
         }
-        defaults.set(data, forKey: defaultsKey)
+        // Reloads are budgeted on watchOS, so identical content shouldn't burn one — but "the store
+        // already holds this content" is not proof the face is showing it: the widget's self fetch
+        // writes fresh values into the store without reloading the other widget instances, and a
+        // suspension between a write and its reload call leaves the store fresh while the face is
+        // stale. Skipping on store equality alone therefore made that staleness permanent — every
+        // later refresh fetched the same value, matched the store, and never re-requested the reload.
+        // The skip is instead keyed on the content this app last actually submitted to WidgetKit:
+        // only content that is both unchanged AND already submitted is safe to skip. The stored blob
+        // is decoded and compared as a model (not byte-wise) so writes from the widget process
+        // (whose encoder doesn't sort keys) can't fake a change.
+        let contentUnchanged = defaults.data(forKey: defaultsKey)
+            .flatMap { try? JSONDecoder().decode([WatchWidgetComplicationSnapshot].self, from: $0) }
+            .map { $0 == snapshots } ?? false
+        let fingerprint = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        if contentUnchanged, defaults.string(forKey: reloadFingerprintKey) == fingerprint {
+            return
+        }
+        if !contentUnchanged {
+            defaults.set(data, forKey: defaultsKey)
+        }
         // Reload every kind rather than a single `kind` string: the widget registers its kind from the
         // extension's `Bundle.main.bundleIdentifier`, which can differ from this app-process-derived
         // value (e.g. debug `.dev` suffixing), and a mismatched `ofKind:` is a silent no-op that leaves
         // the freshly-written snapshot unread. There is only one widget, so reloading all is equivalent.
         WidgetCenter.shared.reloadAllTimelines()
         WidgetCenter.shared.invalidateConfigurationRecommendations()
+        // Recorded only after the reload was requested, so a suspension in between retries the
+        // reload on the next refresh instead of losing it.
+        defaults.set(fingerprint, forKey: reloadFingerprintKey)
     }
 }
 

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -99,10 +99,11 @@ enum WatchWidgetLiveFetch {
         return (updates, details)
     }
 
-    /// A fresh formatted value plus the raw attributes, so slot formulas that reference attributes
-    /// can be re-resolved without another fetch.
+    /// A fresh formatted value plus the raw state and attributes, so slot formulas and gauge
+    /// fractions that reference them can be re-resolved without another fetch.
     private struct LiveValue {
         let value: String
+        let state: String
         let attributes: [String: Any]
     }
 
@@ -232,6 +233,7 @@ enum WatchWidgetLiveFetch {
         return (
             LiveValue(
                 value: format(rawValue, unit: unit, precision: config.valuePrecision),
+                state: state,
                 attributes: attributes
             ),
             nil
@@ -294,6 +296,12 @@ enum WatchWidgetLiveFetch {
                 attributeValue: { update.attributes[$0].map { String(describing: $0) } }
             )
             refreshSlotTexts(in: &snapshots[index], config: config, context: context)
+            refreshFractions(
+                in: &snapshots[index],
+                config: config,
+                state: update.state,
+                attributes: update.attributes
+            )
         }
         if let encoded = try? JSONEncoder().encode(snapshots) {
             defaults.set(encoded, forKey: WatchWidgetConstants.defaultsKey)
@@ -320,6 +328,65 @@ enum WatchWidgetLiveFetch {
             if options.value != nil { options.value = slotText(.value) }
             if options.bottomText != nil { options.bottomText = slotText(.bottomText) }
             snapshot.perFamily?[family.rawValue] = options
+        }
+    }
+
+    /// Re-computes a snapshot's gauge fractions from the fresh entity data. Without this the value
+    /// text updates but the gauge ring/bar keeps its previous position until the WatchApp's next
+    /// full refresh.
+    private static func refreshFractions(
+        in snapshot: inout WatchWidgetComplicationSnapshot,
+        config: WatchComplicationConfig,
+        state: String,
+        attributes: [String: Any]
+    ) {
+        snapshot.fraction = fraction(config: config, family: config.widgetFamily, state: state, attributes: attributes)
+        for family in WatchComplicationConfig.Family.allCases {
+            guard var options = snapshot.perFamily?[family.rawValue] else { continue }
+            options.fraction = fraction(config: config, family: family, state: state, attributes: attributes)
+            snapshot.perFamily?[family.rawValue] = options
+        }
+    }
+
+    /// The gauge fill for a family, mirroring the WatchApp's snapshot builder: the gauge attribute,
+    /// else the value attribute, else the state, scaled into the configured range.
+    private static func fraction(
+        config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family,
+        state: String,
+        attributes: [String: Any]
+    ) -> Double? {
+        guard let range = config.gaugeRange(for: family), range.max > range.min else { return nil }
+        let source: Any = config.gaugeAttribute(for: family).flatMap { attributes[$0] }
+            ?? config.valueAttribute.flatMap { attributes[$0] }
+            ?? state
+        guard let raw = number(from: source) else { return nil }
+        return min(max((raw - range.min) / (range.max - range.min), 0), 1)
+    }
+
+    /// Forgiving number parsing for states/attribute values, mirroring
+    /// `WatchComplication.percentileNumber` (which lives in the app-only Shared target).
+    private static func number(from source: Any) -> Double? {
+        switch source {
+        case let value as String:
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            // Non-locale-aware server strings ("0.33") first, then the user's locale ("0,33").
+            for locale in [Locale(identifier: "en_US_POSIX"), Locale.current] {
+                formatter.locale = locale
+                if let value = formatter.number(from: value)?.doubleValue {
+                    return value
+                }
+            }
+            return nil
+        case let value as Int:
+            return Double(value)
+        case let value as Double:
+            return value
+        case let value as Float:
+            return Double(value)
+        default:
+            return number(from: String(describing: value))
         }
     }
 }

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -386,7 +386,7 @@ enum WatchWidgetLiveFetch {
         case let value as Float:
             return Double(value)
         default:
-            return number(from: String(describing: value))
+            return number(from: String(describing: source))
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Complications could keep showing an old value even though every refresh fetched fresh data. The reload skip from #5236 compared the fetched snapshots against the app-group store and skipped `reloadAllTimelines()` when they matched — but the store can be newer than what the face renders (the widget's self fetch writes the store without reloading other widget instances, and a suspension between a write and its reload call loses the reload). Once that happened, every later refresh matched the store and skipped the reload, so the face never updated again.

The skip is now keyed on a fingerprint of the content last actually submitted to WidgetKit, recorded only after the reload request. Unchanged, already-submitted content still skips (keeping the reload budget savings); content WidgetKit was never asked to render gets its reload requested.

Also, the widget's self fetch now recomputes gauge fractions along with the value text, so rings/bars no longer hold their old fill until the watch app's next full refresh.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not applicable — bug fix, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsNfHCZJoHETgzL6DKUhL)_