### PR TITLE
Move launch logo above screen center

### DIFF
--- a/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
+++ b/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
@@ -11,6 +11,8 @@ struct LaunchSplashOverlayView: View {
     enum Constants {
         /// Mirrors the icon constraints in `LaunchScreen.storyboard`.
         static let splashLogoSize = CGSize(width: 120, height: 120)
+        /// Mirrors the storyboard's icon centerY constraint constant (logo sits above screen center).
+        static let splashLogoCenterYOffset: CGFloat = -80
         /// Mirrors the OHF logo constraints in `LaunchScreen.storyboard`.
         static let ohfLogoSize = CGSize(width: 220, height: 25)
         /// Mirrors the storyboard's OHF-logo-bottom-to-safe-area constraint.
@@ -113,11 +115,11 @@ struct LaunchSplashOverlayView: View {
         }
     }
 
-    /// Centered like the storyboard's centerX/centerY constraints against the full screen.
+    /// Positioned like the storyboard's centerX/centerY(+offset) constraints against the full screen.
     private func splashLogoFrame(in size: CGSize) -> CGRect {
         CGRect(
             x: (size.width - Constants.splashLogoSize.width) / 2,
-            y: (size.height - Constants.splashLogoSize.height) / 2,
+            y: (size.height - Constants.splashLogoSize.height) / 2 + Constants.splashLogoCenterYOffset,
             width: Constants.splashLogoSize.width,
             height: Constants.splashLogoSize.height
         )

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -75,9 +75,11 @@ struct HomeAssistantStandByView: View {
 
     private func contentOffset(safeAreaInsets: EdgeInsets) -> CGFloat {
         guard !showsEmptyState else { return 0 }
-        // The splash logo is centered against the full screen while this content is laid out inside
-        // the safe area; shift by the safe-area asymmetry so the two centers coincide.
+        // The splash logo sits at an offset from the full-screen center while this content is laid
+        // out inside the safe area; shift by the safe-area asymmetry plus the splash offset so the
+        // two logos coincide.
         return (safeAreaInsets.bottom - safeAreaInsets.top) / 2
+            + LaunchSplashOverlayView.Constants.splashLogoCenterYOffset
     }
 
     init(
@@ -842,7 +844,10 @@ private extension HomeAssistantStandByView {
                     width: LaunchSplashOverlayView.Constants.splashLogoSize.width,
                     height: LaunchSplashOverlayView.Constants.splashLogoSize.height
                 )
-                .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                .position(
+                    x: proxy.size.width / 2,
+                    y: proxy.size.height / 2 + LaunchSplashOverlayView.Constants.splashLogoCenterYOffset
+                )
         }
         .ignoresSafeArea()
         .opacity(HomeAssistantStandByView.launchScreenLogoPreviewOpacity)

--- a/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="launchScreen-logo" translatesAutoresizingMaskIntoConstraints="NO" id="mQh-tn-BC1" userLabel="Icon">
-                                <rect key="frame" x="147" y="388" width="120" height="120"/>
+                                <rect key="frame" x="147" y="308" width="120" height="120"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="120" id="xXY-zT-zVi"/>
                                     <constraint firstAttribute="height" constant="120" id="y4R-Bz-WCE"/>
@@ -46,7 +46,7 @@
                             <constraint firstItem="9Kv-2m-Wq7" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="3Rp-8n-Lc4"/>
                             <constraint firstItem="pDB-na-0R2" firstAttribute="top" secondItem="9Kv-2m-Wq7" secondAttribute="bottom" id="7Tj-5w-Xa2"/>
                             <constraint firstItem="pDB-na-0R2" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="BRP-Fw-g6e"/>
-                            <constraint firstItem="mQh-tn-BC1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="gXx-Ta-dWp"/>
+                            <constraint firstItem="mQh-tn-BC1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-80" id="gXx-Ta-dWp"/>
                             <constraint firstItem="mQh-tn-BC1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="hcu-i7-wKs"/>
                             <constraint firstItem="ESo-tq-1hR" firstAttribute="bottom" secondItem="pDB-na-0R2" secondAttribute="bottom" constant="32" id="zkR-fD-4jl"/>
                         </constraints>


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Moves the launch screen logo 80pt above the screen center, and mirrors the same offset in the launch splash overlay and the stand-by loading view so the launch → splash → stand-by hand-off remains a seamless crossfade.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
