### PR TITLE
Fix mTLS certificate import flow on macOS server onboarding

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1152,6 +1152,7 @@
 				API/OnboardingAuthTokenExchange.swift,
 				API/OnboardingCertificateTrustRequest.swift,
 				API/OnboardingClientCertificateRequest.swift,
+				API/OnboardingConnectionErrorContext.swift,
 				API/OnboardingDestination.swift,
 				API/OnboardingDeviceNameRequest.swift,
 				API/Steps/OnboardingAuthStepConfig.swift,

--- a/Sources/App/Onboarding/API/OnboardingAuthPresenter.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthPresenter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Shared
+import SwiftUI
 
 /// Presentation state for the onboarding flow. Auth steps ask this object to show UI instead of
 /// presenting `UIViewController`s themselves; `OnboardingNavigationView` binds `path` to its
@@ -12,15 +13,36 @@ final class OnboardingAuthPresenter: ObservableObject {
     @Published var certificateTrustRequest: OnboardingCertificateTrustRequest?
     /// A client-certificate (mTLS) import prompt shown as a sheet.
     @Published var clientCertificateRequest: OnboardingClientCertificateRequest?
+    /// While true, the client-certificate sheet is held back. Screens that present their own sheet
+    /// (manual URL entry) set this so the prompt is only shown after their sheet fully dismissed —
+    /// presenting both at once leaves the prompt stranded behind the other sheet on Mac Catalyst.
+    /// Deliberately NOT `@Published`: it flips as that sheet presents, and publishing then re-renders
+    /// the container mid-transition, which desyncs the sheet from UIKit on Mac Catalyst and leaves
+    /// its buttons unresponsive. `releaseClientCertificateHold()` republishes once it's safe.
+    var holdClientCertificateSheet = false
+
+    /// Called when the sheet that was holding the prompt back has fully dismissed. If a certificate
+    /// request arrived while it was up, republish so the container presents it now.
+    func releaseClientCertificateHold() {
+        holdClientCertificateSheet = false
+        if clientCertificateRequest != nil {
+            onMain { self.objectWillChange.send() }
+        }
+    }
 
     func push(_ destination: OnboardingDestination) {
         onMain { self.path.append(destination) }
     }
 
     /// Pops every auth flow page, returning to the servers list — called when the flow ends in
-    /// failure or cancellation.
+    /// failure or cancellation. Pops without animation: a follow-up push (the error page on Mac
+    /// Catalyst) would be dropped if it lands while the pop transition is still running.
     func popAuthFlow() {
-        onMain { self.path.removeAll(where: \.isAuthFlowStep) }
+        onMain {
+            self.withoutAnimation {
+                self.path.removeAll(where: \.isAuthFlowStep)
+            }
+        }
     }
 
     func popToRoot() {
@@ -31,12 +53,39 @@ final class OnboardingAuthPresenter: ObservableObject {
         onMain { self.certificateTrustRequest = request }
     }
 
+    /// On Mac Catalyst the import step is pushed as a page — sheet content doesn't receive mouse
+    /// events reliably there; iOS keeps the sheet presentation.
     func present(clientCertificateRequest request: OnboardingClientCertificateRequest) {
-        onMain { self.clientCertificateRequest = request }
+        onMain {
+            if Current.isCatalyst {
+                self.path.append(.clientCertificate(request))
+            } else {
+                self.clientCertificateRequest = request
+            }
+        }
     }
 
     func dismissClientCertificateRequest() {
-        onMain { self.clientCertificateRequest = nil }
+        onMain {
+            if Current.isCatalyst {
+                // Without animation so the pages that follow (login on success, the error page on
+                // cancel) aren't dropped by landing mid-transition.
+                self.withoutAnimation {
+                    self.path.removeAll { destination in
+                        if case .clientCertificate = destination { return true }
+                        return false
+                    }
+                }
+            } else {
+                self.clientCertificateRequest = nil
+            }
+        }
+    }
+
+    private func withoutAnimation(_ block: () -> Void) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction, block)
     }
 
     /// Auth steps resolve on PromiseKit's main queue, but network delegates can call in from other

--- a/Sources/App/Onboarding/API/OnboardingAuthPresenter.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuthPresenter.swift
@@ -11,14 +11,15 @@ final class OnboardingAuthPresenter: ObservableObject {
     @Published var path: [OnboardingDestination] = []
     /// A server-trust confirmation the connectivity step wants answered via an alert.
     @Published var certificateTrustRequest: OnboardingCertificateTrustRequest?
-    /// A client-certificate (mTLS) import prompt shown as a sheet.
+    /// A client-certificate (mTLS) import prompt shown as a sheet. iOS only — Mac Catalyst pushes
+    /// the import step onto `path` instead.
     @Published var clientCertificateRequest: OnboardingClientCertificateRequest?
-    /// While true, the client-certificate sheet is held back. Screens that present their own sheet
-    /// (manual URL entry) set this so the prompt is only shown after their sheet fully dismissed —
-    /// presenting both at once leaves the prompt stranded behind the other sheet on Mac Catalyst.
-    /// Deliberately NOT `@Published`: it flips as that sheet presents, and publishing then re-renders
-    /// the container mid-transition, which desyncs the sheet from UIKit on Mac Catalyst and leaves
-    /// its buttons unresponsive. `releaseClientCertificateHold()` republishes once it's safe.
+    /// iOS only. While true, the client-certificate sheet is held back. Screens that present their
+    /// own sheet (manual URL entry) set this so the prompt is only shown after their sheet fully
+    /// dismissed — presenting both at once can leave the prompt stranded behind the other sheet.
+    /// Deliberately NOT `@Published`: it flips as that sheet presents, and publishing then would
+    /// re-render the container mid-transition. `releaseClientCertificateHold()` republishes once
+    /// it's safe.
     var holdClientCertificateSheet = false
 
     /// Called when the sheet that was holding the prompt back has fully dismissed. If a certificate

--- a/Sources/App/Onboarding/API/OnboardingConnectionErrorContext.swift
+++ b/Sources/App/Onboarding/API/OnboardingConnectionErrorContext.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Payload for the connection-error page pushed on Mac Catalyst when the auth flow fails —
+/// sheets don't receive mouse events reliably there, so the error is a page instead.
+/// Identity-based so it can live inside the `Hashable` `OnboardingDestination`.
+final class OnboardingConnectionErrorContext {
+    let error: Error
+
+    init(error: Error) {
+        self.error = error
+    }
+}

--- a/Sources/App/Onboarding/API/OnboardingDestination.swift
+++ b/Sources/App/Onboarding/API/OnboardingDestination.swift
@@ -9,12 +9,17 @@ enum OnboardingDestination: Hashable {
     case login(OnboardingAuthLoginViewModel)
     case deviceName(OnboardingDeviceNameRequest)
     case permissions(Server)
+    /// The client-certificate (mTLS) import step. Only used on Mac Catalyst, where sheet content
+    /// doesn't receive mouse events reliably; iOS presents the same view as a sheet instead.
+    case clientCertificate(OnboardingClientCertificateRequest)
+    /// The connection-error details. Only used on Mac Catalyst, for the same reason as above.
+    case connectionError(OnboardingConnectionErrorContext)
 
     /// Whether this page belongs to the auth flow (everything after the user picked a server).
     var isAuthFlowStep: Bool {
         switch self {
-        case .serversList: return false
-        case .login, .deviceName, .permissions: return true
+        case .serversList, .connectionError: return false
+        case .login, .deviceName, .permissions, .clientCertificate: return true
         }
     }
 
@@ -28,6 +33,10 @@ enum OnboardingDestination: Hashable {
             return lhsRequest === rhsRequest
         case let (.permissions(lhsServer), .permissions(rhsServer)):
             return lhsServer.identifier == rhsServer.identifier
+        case let (.clientCertificate(lhsRequest), .clientCertificate(rhsRequest)):
+            return lhsRequest === rhsRequest
+        case let (.connectionError(lhsContext), .connectionError(rhsContext)):
+            return lhsContext === rhsContext
         default:
             return false
         }
@@ -46,6 +55,12 @@ enum OnboardingDestination: Hashable {
         case let .permissions(server):
             hasher.combine(3)
             hasher.combine(server.identifier)
+        case let .clientCertificate(request):
+            hasher.combine(4)
+            hasher.combine(ObjectIdentifier(request))
+        case let .connectionError(context):
+            hasher.combine(5)
+            hasher.combine(ObjectIdentifier(context))
         }
     }
 }

--- a/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
+++ b/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
@@ -63,7 +63,7 @@ struct OnboardingNavigationView: View {
         } message: { request in
             Text(request.message)
         }
-        .sheet(item: $presenter.clientCertificateRequest) { request in
+        .sheet(item: clientCertificateSheetItem) { request in
             clientCertificateSheet(request: request)
         }
         .onChange(of: viewModel.shouldDismiss) { newValue in
@@ -102,6 +102,25 @@ struct OnboardingNavigationView: View {
             )
             .navigationBarBackButtonHidden(true)
             .toolbar(.hidden, for: .navigationBar)
+        case let .clientCertificate(request):
+            // Mac Catalyst only; the user resolves the step through the page's own buttons.
+            ClientCertificateOnboardingView(
+                onImport: { certificate in
+                    request.complete(with: certificate)
+                },
+                onCancel: {
+                    request.cancel()
+                }
+            )
+            .navigationBarBackButtonHidden(true)
+        case let .connectionError(context):
+            // Mac Catalyst only; iOS shows the same details as a sheet over the servers list.
+            ConnectionErrorDetailsView(
+                server: nil,
+                error: context.error,
+                showSettingsEntry: false,
+                expandMoreDetails: true
+            )
         }
     }
 
@@ -136,6 +155,20 @@ struct OnboardingNavigationView: View {
             set: { isPresented in
                 if !isPresented, presenter.certificateTrustRequest?.isAnswered == true {
                     presenter.certificateTrustRequest = nil
+                }
+            }
+        )
+    }
+
+    /// Held back while a screen below has its own sheet up (manual URL entry) — presenting on top
+    /// of it strands the mTLS prompt behind that sheet on Mac Catalyst. The request stays pending in
+    /// the presenter and is shown once the hold is released after the other sheet fully dismissed.
+    private var clientCertificateSheetItem: Binding<OnboardingClientCertificateRequest?> {
+        Binding(
+            get: { presenter.holdClientCertificateSheet ? nil : presenter.clientCertificateRequest },
+            set: { newValue in
+                if newValue == nil {
+                    presenter.clientCertificateRequest = nil
                 }
             }
         )

--- a/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
+++ b/Sources/App/Onboarding/Container/OnboardingNavigationView.swift
@@ -160,9 +160,10 @@ struct OnboardingNavigationView: View {
         )
     }
 
-    /// Held back while a screen below has its own sheet up (manual URL entry) — presenting on top
-    /// of it strands the mTLS prompt behind that sheet on Mac Catalyst. The request stays pending in
-    /// the presenter and is shown once the hold is released after the other sheet fully dismissed.
+    /// iOS only — Mac Catalyst pushes the import step as a page instead. Held back while a screen
+    /// below has its own sheet up (manual URL entry) so the mTLS prompt is never presented behind
+    /// it; the request stays pending in the presenter and is shown once the hold is released after
+    /// the other sheet fully dismissed.
     private var clientCertificateSheetItem: Binding<OnboardingClientCertificateRequest?> {
         Binding(
             get: { presenter.holdClientCertificateSheet ? nil : presenter.clientCertificateRequest },

--- a/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/ManualURLEntry/ManualURLEntryView.swift
@@ -26,52 +26,62 @@ struct ManualURLEntryView: View, KeyboardReadable {
     private let minCharsToActivateSection = URLScheme.allCases.map(\.rawValue.count).min() ?? 0
 
     var body: some View {
-        NavigationView {
-            BaseOnboardingView(illustration: {
-                Image(.Onboarding.pencil)
-            }, title: L10n.Onboarding.ManualUrlEntry.title, primaryDescription: "", content: {
-                VStack {
-                    HATextField(placeholder: L10n.Onboarding.ManualSetup.TextField.placeholder, text: $urlString)
-                        .keyboardType(.URL)
-                        .autocorrectionDisabled()
-                        .autocapitalization(.none)
-                        .focused($focused, equals: true)
-                        .onAppear {
-                            focused = true
+        // On Mac Catalyst this view is pushed as a page (the navigation bar provides Back), while
+        // iOS presents it as a sheet that brings its own navigation chrome and close button.
+        if Current.isCatalyst {
+            content
+        } else {
+            NavigationView {
+                content
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            CloseButton {
+                                dismiss()
+                            }
                         }
-
-                    httpOrHttpsSection
-                }
-            }, primaryActionTitle: L10n.Onboarding.ManualUrlEntry.PrimaryAction.title) {
-                guard !urlString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-                if let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)) {
-                    connectAction(url)
-                    dismiss()
-                } else {
-                    showInvalidURLError = true
-                }
-            }
-            .hideOnboardingTitle(isKeyboardVisible)
-            .hideOnboardingIcon(isKeyboardVisible)
-            .navigationViewStyle(.stack)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    CloseButton {
-                        dismiss()
                     }
-                }
             }
-            .alert(isPresented: $showInvalidURLError) {
-                Alert(
-                    title: Text(verbatim: L10n.Onboarding.ManualSetup.InputError.title),
-                    message: Text(verbatim: L10n.Onboarding.ManualSetup.InputError.message),
-                    dismissButton: .default(Text(verbatim: L10n.okLabel))
-                )
+            .navigationViewStyle(.stack)
+        }
+    }
+
+    private var content: some View {
+        BaseOnboardingView(illustration: {
+            Image(.Onboarding.pencil)
+        }, title: L10n.Onboarding.ManualUrlEntry.title, primaryDescription: "", content: {
+            VStack {
+                HATextField(placeholder: L10n.Onboarding.ManualSetup.TextField.placeholder, text: $urlString)
+                    .keyboardType(.URL)
+                    .autocorrectionDisabled()
+                    .autocapitalization(.none)
+                    .focused($focused, equals: true)
+                    .onAppear {
+                        focused = true
+                    }
+
+                httpOrHttpsSection
             }
-            onReceive(keyboardPublisher) { newIsKeyboardVisible in
-                isKeyboardVisible = newIsKeyboardVisible
+        }, primaryActionTitle: L10n.Onboarding.ManualUrlEntry.PrimaryAction.title) {
+            guard !urlString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            if let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                connectAction(url)
+                dismiss()
+            } else {
+                showInvalidURLError = true
             }
+        }
+        .hideOnboardingTitle(isKeyboardVisible)
+        .hideOnboardingIcon(isKeyboardVisible)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $showInvalidURLError) {
+            Alert(
+                title: Text(verbatim: L10n.Onboarding.ManualSetup.InputError.title),
+                message: Text(verbatim: L10n.Onboarding.ManualSetup.InputError.message),
+                dismissButton: .default(Text(verbatim: L10n.okLabel))
+            )
+        }
+        .onReceive(keyboardPublisher) { newIsKeyboardVisible in
+            isKeyboardVisible = newIsKeyboardVisible
         }
     }
 

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListView.swift
@@ -7,13 +7,6 @@ struct OnboardingServersListView: View {
         static let initialDelayUntilDismissCenterLoader: TimeInterval = 3
         static let minimumDelayUntilDismissCenterLoader: TimeInterval = 1.5
         static let delayUntilAutoconnect: TimeInterval = 2
-
-        enum MacSheetSize {
-            static let errorDetailsMinWidth: CGFloat = 760
-            static let errorDetailsMinHeight: CGFloat = 680
-            static let manualInputMinWidth: CGFloat = 720
-            static let manualInputMinHeight: CGFloat = 600
-        }
     }
 
     @Environment(\.dismiss) private var dismiss
@@ -25,6 +18,8 @@ struct OnboardingServersListView: View {
 
     @State private var showDocumentation = false
     @State private var showManualInput = false
+    /// Mac Catalyst pushes manual entry as a page instead of presenting the sheet above.
+    @State private var showManualInputPage = false
     @State private var screenLoaded = false
     @State private var autoConnectWorkItem: DispatchWorkItem?
     @State private var autoConnectInstance: DiscoveredHomeAssistant?
@@ -98,30 +93,48 @@ struct OnboardingServersListView: View {
                 )
             }
         }
+        // iOS only — on Mac Catalyst the view model pushes `.connectionError` instead, because
+        // sheet content doesn't receive mouse events reliably there.
         .sheet(isPresented: $viewModel.showError) {
             errorView
-                .macOnboardingSheetFrame(
-                    minWidth: Constants.MacSheetSize.errorDetailsMinWidth,
-                    minHeight: Constants.MacSheetSize.errorDetailsMinHeight
-                )
+        }
+        // If the mTLS prompt arrives while manual URL entry is still up, dismiss the entry sheet
+        // first; the container holds the prompt back until `onDismiss` below releases it.
+        .onChange(of: presenter.clientCertificateRequest?.id) { newValue in
+            if newValue != nil, showManualInput {
+                showManualInput = false
+            }
         }
         // Start the flow only in `onDismiss`; mutating observed state while the sheet animates out left
         // it stuck on Mac Catalyst with the mTLS prompt (presented by the container above) stranded behind.
         .sheet(isPresented: $showManualInput, onDismiss: {
-            if let connectURL = viewModel.pendingManualURL {
-                viewModel.pendingManualURL = nil
-                viewModel.manualInputLoading = true
-                viewModel.selectInstance(.init(manualURL: connectURL), presenter: presenter)
-            }
+            presenter.releaseClientCertificateHold()
+            startPendingManualConnection()
         }) {
             ManualURLEntryView { connectURL in
                 viewModel.pendingManualURL = connectURL
             }
-            .macOnboardingSheetFrame(
-                minWidth: Constants.MacSheetSize.manualInputMinWidth,
-                minHeight: Constants.MacSheetSize.manualInputMinHeight
-            )
         }
+        // On Mac Catalyst manual entry is a pushed page instead of a sheet: sheet content doesn't
+        // receive mouse events reliably there, and pages avoid the sheet-over-sheet ordering issues
+        // with the mTLS prompt entirely.
+        .navigationDestination(isPresented: $showManualInputPage) {
+            ManualURLEntryView { connectURL in
+                viewModel.pendingManualURL = connectURL
+            }
+            .onDisappear {
+                startPendingManualConnection()
+            }
+        }
+    }
+
+    /// Runs after manual URL entry goes away (sheet dismissed / page popped) so the flow never
+    /// starts while that UI is still on screen.
+    private func startPendingManualConnection() {
+        guard let connectURL = viewModel.pendingManualURL else { return }
+        viewModel.pendingManualURL = nil
+        viewModel.manualInputLoading = true
+        viewModel.selectInstance(.init(manualURL: connectURL), presenter: presenter)
     }
 
     @ViewBuilder
@@ -384,7 +397,14 @@ struct OnboardingServersListView: View {
 
     private var manualInputButton: some View {
         Button(action: {
-            showManualInput = true
+            if Current.isCatalyst {
+                showManualInputPage = true
+            } else {
+                // Hold back the container's mTLS sheet while ours is up; released in the sheet's
+                // `onDismiss` so the prompt is never presented behind it.
+                presenter.holdClientCertificateSheet = true
+                showManualInput = true
+            }
         }) {
             Text(L10n.Onboarding.Scanning.Manual.Button.title)
         }

--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
@@ -107,6 +107,12 @@ final class OnboardingServersListViewModel: ObservableObject {
                     if let pmkError = error as? PMKError, pmkError.isCancelled {
                         /* No action needed, user cancelled flow */
                         self?.resetFlow()
+                    } else if Current.isCatalyst {
+                        // Pushed in the same update as the pop above so the path change is atomic;
+                        // a sheet is not used here because sheets don't receive mouse events
+                        // reliably on Mac Catalyst.
+                        self?.resetFlow()
+                        presenter.push(.connectionError(.init(error: error)))
                     } else {
                         self?.error = error
                         self?.showError = true


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
On macOS, sheets presented during server onboarding don't receive mouse events reliably: the manual URL entry's Connect/close buttons were unresponsive and the client certificate (mTLS) prompt could end up behind the manual URL sheet or only appear after switching apps.

Manual URL entry, the client certificate import and the connection error details are now pushed as pages on the onboarding navigation stack on Mac Catalyst instead of being presented as sheets. iOS keeps the existing sheet presentations, with the certificate prompt held back until the manual URL sheet has fully dismissed so it's never presented behind it.

Also fixes a missing leading dot in `ManualURLEntryView` that embedded a second copy of the view inside its `NavigationView`.

## Screenshots

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes