### PR TITLE
Adjust launch logo size and position

### DIFF
--- a/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
+++ b/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
@@ -10,9 +10,9 @@ struct LaunchSplashOverlayView: View {
     /// Tweak these to adjust the transition; the previews below replay it.
     enum Constants {
         /// Mirrors the icon constraints in `LaunchScreen.storyboard`.
-        static let splashLogoSize = CGSize(width: 120, height: 120)
+        static let splashLogoSize = CGSize(width: 110, height: 110)
         /// Mirrors the storyboard's icon centerY constraint constant (logo sits above screen center).
-        static let splashLogoCenterYOffset: CGFloat = -80
+        static let splashLogoCenterYOffset: CGFloat = -65
         /// Mirrors the OHF logo constraints in `LaunchScreen.storyboard`.
         static let ohfLogoSize = CGSize(width: 220, height: 25)
         /// Mirrors the storyboard's OHF-logo-bottom-to-safe-area constraint.

--- a/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="launchScreen-logo" translatesAutoresizingMaskIntoConstraints="NO" id="mQh-tn-BC1" userLabel="Icon">
-                                <rect key="frame" x="147" y="308" width="120" height="120"/>
+                                <rect key="frame" x="152" y="328" width="110" height="110"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="120" id="xXY-zT-zVi"/>
-                                    <constraint firstAttribute="height" constant="120" id="y4R-Bz-WCE"/>
+                                    <constraint firstAttribute="width" constant="110" id="xXY-zT-zVi"/>
+                                    <constraint firstAttribute="height" constant="110" id="y4R-Bz-WCE"/>
                                 </constraints>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ohf-inline" translatesAutoresizingMaskIntoConstraints="NO" id="pDB-na-0R2">
@@ -46,7 +46,7 @@
                             <constraint firstItem="9Kv-2m-Wq7" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="3Rp-8n-Lc4"/>
                             <constraint firstItem="pDB-na-0R2" firstAttribute="top" secondItem="9Kv-2m-Wq7" secondAttribute="bottom" id="7Tj-5w-Xa2"/>
                             <constraint firstItem="pDB-na-0R2" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="BRP-Fw-g6e"/>
-                            <constraint firstItem="mQh-tn-BC1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-80" id="gXx-Ta-dWp"/>
+                            <constraint firstItem="mQh-tn-BC1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-65" id="gXx-Ta-dWp"/>
                             <constraint firstItem="mQh-tn-BC1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="hcu-i7-wKs"/>
                             <constraint firstItem="ESo-tq-1hR" firstAttribute="bottom" secondItem="pDB-na-0R2" secondAttribute="bottom" constant="32" id="zkR-fD-4jl"/>
                         </constraints>


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Reduce the launch logo from 120pt to 110pt and move it slightly down (centerY offset -80 → -65) in the launch screen storyboard, and mirror the same values in the splash overlay and stand-by view constants so all three stay pixel-aligned.

## Screenshots
Not applicable, minor size/position tweak of the existing launch logo.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes