### PR TITLE
Add Fire Event App Intent

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 			membershipExceptions = (
 				/Localized/Intents/Resources/AppIntentVocabulary.plist,
 				AppIntents/AssistPromptAppIntent.swift,
+				AppIntents/FireEventAppIntent.swift,
 				AppIntents/GetCameraSnapshotAppIntent.swift,
 				AppIntents/IntentActionEntity.swift,
 				AppIntents/IntentCameraEntity.swift,

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -73,6 +73,13 @@
 "app_intents.fan.off_state_icon.title" = "Icon for off state";
 "app_intents.fan.on_state_icon.title" = "Icon for on state";
 "app_intents.fan.title" = "Fan";
+"app_intents.fire_event.description" = "Fire an event on a Home Assistant server";
+"app_intents.fire_event.error.invalid_payload" = "Unable to parse event data";
+"app_intents.fire_event.event_data.description" = "JSON data to send with the event";
+"app_intents.fire_event.event_data.title" = "Event data";
+"app_intents.fire_event.event_name.title" = "Event name";
+"app_intents.fire_event.response_success" = "Fired event %@";
+"app_intents.fire_event.title" = "Fire event";
 "app_intents.get_camera_snapshot.camera.title" = "Camera";
 "app_intents.get_camera_snapshot.description" = "Get a single still frame from a camera";
 "app_intents.get_camera_snapshot.error.png_conversion" = "Image could not be converted to PNG";

--- a/Sources/Extensions/AppIntents/FireEventAppIntent.swift
+++ b/Sources/Extensions/AppIntents/FireEventAppIntent.swift
@@ -1,0 +1,104 @@
+import AppIntents
+import Foundation
+import Shared
+
+@available(iOS 17.0, *)
+struct FireEventAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit FireEventIntent
+    static let intentClassName = "FireEventIntent"
+
+    static var title: LocalizedStringResource = .init(
+        "app_intents.fire_event.title",
+        defaultValue: "Fire event"
+    )
+
+    static var description = IntentDescription(.init(
+        "app_intents.fire_event.description",
+        defaultValue: "Fire an event on a Home Assistant server"
+    ))
+
+    static var parameterSummary: some ParameterSummary {
+        Summary {
+            \.$server
+            \.$eventName
+            \.$eventData
+        }
+    }
+
+    @Parameter(title: .init("app_intents.server.title", defaultValue: "Server"))
+    var server: IntentServerAppEntity
+
+    @Parameter(
+        title: .init("app_intents.fire_event.event_name.title", defaultValue: "Event name"),
+        inputOptions: .init(
+            capitalizationType: .none,
+            autocorrect: false,
+            smartQuotes: false,
+            smartDashes: false
+        )
+    )
+    var eventName: String
+
+    @Parameter(
+        title: .init("app_intents.fire_event.event_data.title", defaultValue: "Event data"),
+        description: .init(
+            "app_intents.fire_event.event_data.description",
+            defaultValue: "JSON data to send with the event"
+        ),
+        default: "{}",
+        inputOptions: .init(
+            capitalizationType: .none,
+            multiline: true,
+            autocorrect: false,
+            smartQuotes: false,
+            smartDashes: false
+        )
+    )
+    var eventData: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        await Current.connectivity.refreshNetworkInformation()
+        guard let server = server.getServer(),
+              let api = Current.api(for: server) else {
+            throw ShortcutAppIntentError(L10n.AppIntents.Error.noServer)
+        }
+
+        let (eventType, eventDataDict) = try Self.event(name: eventName, payload: eventData)
+        try await api.CreateEvent(eventType: eventType, eventData: eventDataDict).async()
+        return .result(value: L10n.AppIntents.FireEvent.responseSuccess(eventType))
+    }
+
+    // The payload may be the raw event data dictionary, or wrap it in an "eventData" key
+    // (optionally overriding the event name via "eventName"), matching what the
+    // deprecated SiriKit FireEventIntentHandler accepted so migrated shortcuts keep working.
+    private static func event(name: String, payload: String) throws -> (String, [String: Any]) {
+        guard payload.isEmpty == false else { return (name, [:]) }
+
+        guard let jsonObject = try? JSONSerialization.jsonObject(
+            with: Data(payload.utf8),
+            options: .allowFragments
+        ) as? [String: Any] else {
+            throw ShortcutAppIntentError(L10n.AppIntents.FireEvent.Error.invalidPayload)
+        }
+
+        var eventName = name
+        var eventDataDict: [String: Any] = [:]
+        var isGenericPayload = true
+
+        if let wrappedName = jsonObject["eventName"] as? String {
+            eventName = wrappedName
+            isGenericPayload = false
+        }
+
+        if let wrappedData = jsonObject["eventData"] as? [String: Any] {
+            eventDataDict = wrappedData
+            isGenericPayload = false
+        }
+
+        if isGenericPayload {
+            eventDataDict = jsonObject
+        }
+
+        return (eventName, eventDataDict)
+    }
+}

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -357,6 +357,30 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "app_intents.fan.on_state_icon.title") }
       }
     }
+    public enum FireEvent {
+      /// Fire an event on a Home Assistant server
+      public static var description: String { return L10n.tr("Localizable", "app_intents.fire_event.description") }
+      /// Fired event %@
+      public static func responseSuccess(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "app_intents.fire_event.response_success", String(describing: p1))
+      }
+      /// Fire event
+      public static var title: String { return L10n.tr("Localizable", "app_intents.fire_event.title") }
+      public enum Error {
+        /// Unable to parse event data
+        public static var invalidPayload: String { return L10n.tr("Localizable", "app_intents.fire_event.error.invalid_payload") }
+      }
+      public enum EventData {
+        /// JSON data to send with the event
+        public static var description: String { return L10n.tr("Localizable", "app_intents.fire_event.event_data.description") }
+        /// Event data
+        public static var title: String { return L10n.tr("Localizable", "app_intents.fire_event.event_data.title") }
+      }
+      public enum EventName {
+        /// Event name
+        public static var title: String { return L10n.tr("Localizable", "app_intents.fire_event.event_name.title") }
+      }
+    }
     public enum GetCameraSnapshot {
       /// Get a single still frame from a camera
       public static var description: String { return L10n.tr("Localizable", "app_intents.get_camera_snapshot.description") }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
When the old SiriKit intents were removed in #5068, Fire Event was the only shortcut action left without an App Intent replacement, so existing Shortcuts using it show "Unknown Action".

This adds `FireEventAppIntent`, which conforms to `CustomIntentMigratedAppIntent` with the old intent class name and parameter names so Shortcuts migrates existing actions in place. Event data parsing keeps the legacy handler behavior, including the wrapped `{ "eventName": ..., "eventData": ... }` payload format.

## Screenshots
No in-app UI changes; the intent appears as the "Fire event" action in the Shortcuts app.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01LiBcViWV8Md4RS21i6D6bu)_