### PR TITLE
Skip local network configuration during onboarding when an HTTPS URL is available

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -10,17 +10,30 @@ extension WebViewController {
     func checkForLocalSecurityLevelDecisionNeeded() {
         let connection = server.info.connection
 
+        // Local network configuration is only needed when the server can exclusively be
+        // reached over non-HTTPS URLs; with an HTTPS URL available the active URL always
+        // has a secure option to use
+        guard !connection.hasHTTPSURLOption else {
+            if connection.connectionAccessSecurityLevel == .undefined {
+                Current.Log.verbose("Auto selecting most secure local access level because an HTTPS URL is available")
+                server.update { info in
+                    info.connection.connectionAccessSecurityLevel = .mostSecure
+                }
+            } else {
+                Current.Log.verbose("Skipping local access security level decision because an HTTPS URL is available")
+            }
+            return
+        }
+
         if Current.location.permissionStatus == .notDetermined, connection.hasNonHTTPSURLOptions {
             Current.Log.verbose("User has not decided location permission yet")
             showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
-        } else if connection.connectionAccessSecurityLevel == .undefined, !connection.hasOnlyHTTPSURLOptions {
+        } else if connection.connectionAccessSecurityLevel == .undefined {
             Current.Log.verbose("User has not decided local access security level yet")
             showOnboardingPermissions(
                 steps: OnboardingPermissionsNavigationViewModel.StepID
                     .updateLocalAccessSecurityLevelPreference
             )
-        } else if connection.hasOnlyHTTPSURLOptions {
-            Current.Log.verbose("Skipping local access security level decision because all configured URLs use HTTPS")
         } else {
             Current.Log
                 .verbose(

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
@@ -103,8 +103,27 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
                 defaultSteps = StepID.remoteConnectionCompatible
             }
 
-            if connection.hasOnlyHTTPSURLOptions {
-                defaultSteps.removeAll { $0 == .localAccess }
+            // Local network configuration (security level and home network name) is only
+            // relevant when the server can exclusively be reached over non-HTTPS URLs;
+            // with an HTTPS URL available the active URL always has a secure option to use
+            if connection.hasHTTPSURLOption {
+                defaultSteps.removeAll { $0 == .localAccess || $0 == .homeNetwork }
+
+                onboardingServer.update { info in
+                    // Since the user is not asked, auto select the most secure level:
+                    // non-HTTPS URLs are only used when the device is on the home network
+                    if info.connection.connectionAccessSecurityLevel == .undefined {
+                        info.connection.connectionAccessSecurityLevel = .mostSecure
+                    }
+
+                    // Discovery may have pinned the internal URL while the SSID was still unknown
+                    // (see `OnboardingAuth`); since the home network step is skipped, nothing will
+                    // set `internalSSIDs` to clear that override, so clear it here to avoid staying
+                    // pinned to the internal URL when off the home network
+                    if info.connection.overrideActiveURLType == .internal {
+                        info.connection.overrideActiveURLType = nil
+                    }
+                }
             }
             self.steps = defaultSteps
         }

--- a/Sources/HANetworking/Sources/ConnectionInfo.swift
+++ b/Sources/HANetworking/Sources/ConnectionInfo.swift
@@ -52,12 +52,10 @@ public struct ConnectionInfo: Codable, Equatable {
         configuredURLs.contains { $0.scheme?.lowercased() != "https" }
     }
 
-    public var hasOnlyHTTPSURLOptions: Bool {
-        guard !configuredURLs.isEmpty else {
-            return false
-        }
-
-        return configuredURLs.allSatisfy { $0.scheme?.lowercased() == "https" }
+    /// `true` when at least one configured URL uses HTTPS, meaning the active URL
+    /// always has a secure option to fall back on regardless of local network configuration
+    public var hasHTTPSURLOption: Bool {
+        configuredURLs.contains { $0.scheme?.lowercased() == "https" }
     }
 
     public var overrideActiveURLType: URLType?

--- a/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
+++ b/Tests/App/Onboarding/OnboardingPermissionsNavigationViewModelTests.swift
@@ -22,22 +22,103 @@ struct OnboardingPermissionsNavigationViewModelTests {
         #expect(viewModel.currentStep == .disclaimer)
     }
 
-    @Test("Initialization with remote connection setup")
+    @Test("Initialization with remote connection setup skips local network configuration")
     func initializationWithRemoteConnectionSetup() async throws {
+        ServerFixture.reset()
+        // Fixture has an HTTPS external URL and an HTTP internal URL, so the local
+        // network configuration steps are not needed
         let server = ServerFixture.withRemoteConnection
         let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
 
-        #expect(viewModel.steps == OnboardingPermissionsNavigationViewModel.StepID.remoteConnectionCompatible)
+        #expect(viewModel.steps == [.location, .completion])
         #expect(viewModel.currentStep == .location)
     }
 
-    @Test("Initialization with HTTPS-only URLs skips local access step")
-    func initializationWithHTTPSOnlyURLsSkipsLocalAccessStep() async throws {
+    @Test("Initialization with HTTPS-only URLs skips local access and home network steps")
+    func initializationWithHTTPSOnlyURLsSkipsLocalAccessAndHomeNetworkSteps() async throws {
+        let server = Self.makeServer(
+            identifier: "https-only",
+            externalURL: URL(string: "https://external.example.com")!,
+            internalURL: URL(string: "https://internal.example.com")!
+        )
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        #expect(viewModel.steps == [.location, .completion])
+        #expect(viewModel.steps.contains(.localAccess) == false)
+        #expect(viewModel.steps.contains(.homeNetwork) == false)
+        #expect(viewModel.currentStep == .location)
+        #expect(server.info.connection.connectionAccessSecurityLevel == .mostSecure)
+    }
+
+    @Test("Initialization with HTTPS-only internal URL and no remote connection skips local network configuration")
+    func initializationWithHTTPSOnlyInternalURLSkipsLocalNetworkConfiguration() async throws {
+        let server = Self.makeServer(
+            identifier: "https-only-internal",
+            externalURL: nil,
+            internalURL: URL(string: "https://internal.example.com")!
+        )
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        #expect(viewModel.steps == [.disclaimer, .location, .completion])
+        #expect(viewModel.steps.contains(.localAccess) == false)
+        #expect(viewModel.steps.contains(.homeNetwork) == false)
+    }
+
+    @Test("Initialization with HTTP-only URLs keeps local network configuration steps")
+    func initializationWithHTTPOnlyURLsKeepsLocalNetworkConfigurationSteps() async throws {
+        let server = Self.makeServer(
+            identifier: "http-only",
+            externalURL: nil,
+            internalURL: URL(string: "http://internal.example.com")!
+        )
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        #expect(viewModel.steps == OnboardingPermissionsNavigationViewModel.StepID.default)
+    }
+
+    @Test("Initialization clears internal URL override when local network configuration is skipped")
+    func initializationClearsInternalURLOverrideWhenLocalNetworkConfigurationIsSkipped() async throws {
+        // Discovery pins the internal URL when internal+external URLs exist but the SSID
+        // is unknown; skipping the home network step means internalSSIDs will never be set
+        // to clear that override, so the view model has to clear it
+        let server = Self.makeServer(
+            identifier: "override-cleared",
+            externalURL: URL(string: "https://external.example.com")!,
+            internalURL: URL(string: "http://internal.example.com")!
+        )
+        server.update { info in
+            info.connection.overrideActiveURLType = .internal
+        }
+
+        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        #expect(viewModel.steps.contains(.homeNetwork) == false)
+        #expect(server.info.connection.overrideActiveURLType == nil)
+        #expect(server.info.connection.connectionAccessSecurityLevel == .mostSecure)
+    }
+
+    @Test("Initialization keeps a previously selected security level when local network configuration is skipped")
+    func initializationKeepsPreviouslySelectedSecurityLevelWhenLocalNetworkConfigurationIsSkipped() async throws {
+        let server = Self.makeServer(
+            identifier: "level-already-decided",
+            externalURL: URL(string: "https://external.example.com")!,
+            internalURL: URL(string: "http://internal.example.com")!
+        )
+        server.update { info in
+            info.connection.connectionAccessSecurityLevel = .lessSecure
+        }
+
+        _ = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
+
+        #expect(server.info.connection.connectionAccessSecurityLevel == .lessSecure)
+    }
+
+    private static func makeServer(identifier: String, externalURL: URL?, internalURL: URL?) -> Server {
         var info = ServerInfo(
             name: "HTTPS Only Server",
             connection: .init(
-                externalURL: URL(string: "https://external.example.com")!,
-                internalURL: URL(string: "https://internal.example.com")!,
+                externalURL: externalURL,
+                internalURL: internalURL,
                 cloudhookURL: nil,
                 remoteUIURL: nil,
                 webhookID: "webhook-id",
@@ -55,17 +136,12 @@ struct OnboardingPermissionsNavigationViewModelTests {
             ),
             version: "2026.1.0"
         )
-        let server = Server(identifier: "https-only", getter: {
+        return Server(identifier: .init(rawValue: identifier), getter: {
             info
         }, setter: { newInfo in
             info = newInfo
             return true
         })
-        let viewModel = OnboardingPermissionsNavigationViewModel(onboardingServer: server)
-
-        #expect(viewModel.steps == [.location, .homeNetwork, .completion])
-        #expect(viewModel.steps.contains(.localAccess) == false)
-        #expect(viewModel.currentStep == .location)
     }
 
     @Test("Initialization with custom steps")

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -158,7 +158,7 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(urls.api, url?.appendingPathComponent("api"))
     }
 
-    func testHasOnlyHTTPSURLOptions() {
+    func testHasHTTPSURLOptionTrueWhenAllURLsUseHTTPS() {
         let info = ConnectionInfo(
             externalURL: URL(string: "https://external.example.com"),
             internalURL: URL(string: "https://internal.example.com"),
@@ -173,11 +173,11 @@ class ConnectionInfoTests: XCTestCase {
             connectionAccessSecurityLevel: .undefined
         )
 
-        XCTAssertTrue(info.hasOnlyHTTPSURLOptions)
+        XCTAssertTrue(info.hasHTTPSURLOption)
         XCTAssertFalse(info.hasNonHTTPSURLOptions)
     }
 
-    func testHasOnlyHTTPSURLOptionsFalseWhenHTTPURLExists() {
+    func testHasHTTPSURLOptionTrueWhenMixedURLSchemesExist() {
         let info = ConnectionInfo(
             externalURL: URL(string: "https://external.example.com"),
             internalURL: URL(string: "http://internal.example.com"),
@@ -192,7 +192,26 @@ class ConnectionInfoTests: XCTestCase {
             connectionAccessSecurityLevel: .undefined
         )
 
-        XCTAssertFalse(info.hasOnlyHTTPSURLOptions)
+        XCTAssertTrue(info.hasHTTPSURLOption)
+        XCTAssertTrue(info.hasNonHTTPSURLOptions)
+    }
+
+    func testHasHTTPSURLOptionFalseWhenOnlyHTTPURLsExist() {
+        let info = ConnectionInfo(
+            externalURL: URL(string: "http://external.example.com"),
+            internalURL: URL(string: "http://internal.example.com"),
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined
+        )
+
+        XCTAssertFalse(info.hasHTTPSURLOption)
         XCTAssertTrue(info.hasNonHTTPSURLOptions)
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Onboarding asked for a connection security level and home network name even when the server has an HTTPS URL to use. That local network configuration only matters when the instance can exclusively be reached over non-HTTPS URLs, so both steps are now skipped whenever any configured URL uses HTTPS. The same rule applies to the post-onboarding security level check in the web view.

Since the user is no longer asked, the most secure connection access level is auto-selected when an HTTPS URL is available, so non-HTTPS URLs are only used on the home network. The internal URL override pinned by discovery (when the SSID is unknown) is also cleared, because with the home network step skipped `internalSSIDs` would never be set to clear it, leaving the app locked to the internal URL away from home. Tests updated and extended accordingly.

## Screenshots
No UI changes; existing onboarding screens are only shown or skipped.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
