### PR TITLE
Allow multiple selection in entity picker

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -435,6 +435,7 @@
 "download_manager.downloading.title" = "Downloading";
 "download_manager.failed.title" = "Failed to download file, error: %@";
 "download_manager.finished.title" = "Download finished";
+"entity_picker.add_selected" = "Add %lld";
 "entity_picker.filter.area.all.title" = "All areas";
 "entity_picker.filter.area.title" = "Area";
 "entity_picker.filter.domain.all.title" = "All domains";

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/FolderDetailView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/FolderDetailView.swift
@@ -45,7 +45,7 @@ struct FolderDetailView: View {
             }
         }
         .sheet(isPresented: $showAddItem) {
-            MagicItemAddView(context: .watch) { itemToAdd in
+            MagicItemAddView(context: .watch, allowMultipleSelection: true) { itemToAdd in
                 guard let itemToAdd else { return }
                 viewModel.addItemToFolder(folderId: folderId, item: itemToAdd)
             }

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -68,7 +68,7 @@ struct WatchConfigurationView: View {
             }
         })
         .sheet(isPresented: $viewModel.showAddItem, content: {
-            MagicItemAddView(context: .watch) { itemToAdd in
+            MagicItemAddView(context: .watch, allowMultipleSelection: true) { itemToAdd in
                 guard let itemToAdd else { return }
                 viewModel.addItem(itemToAdd)
             }

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -73,7 +73,8 @@ struct CarPlayConfigurationView: View {
                     MagicItemAddView(
                         context: .carPlay,
                         initialItemType: magicItemType,
-                        visiblePickerOptions: [pickerOption]
+                        visiblePickerOptions: [pickerOption],
+                        allowMultipleSelection: true
                     ) { itemToAdd in
                         guard let itemToAdd else { return }
                         viewModel.addItem(itemToAdd)

--- a/Sources/App/Settings/CarPlay/CarPlayFolderDetailView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayFolderDetailView.swift
@@ -52,7 +52,8 @@ struct CarPlayFolderDetailView: View {
                     MagicItemAddView(
                         context: .carPlay,
                         initialItemType: magicItemType,
-                        visiblePickerOptions: [pickerOption]
+                        visiblePickerOptions: [pickerOption],
+                        allowMultipleSelection: true
                     ) { itemToAdd in
                         guard let itemToAdd else { return }
                         viewModel.addItemToFolder(folderId: folderId, item: itemToAdd)

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -17,12 +17,24 @@ struct EntityPicker: View {
     @Binding private var selectedEntity: HAAppEntity?
     private let mode: Mode
 
+    /// When `true` the picker lets the user select several entities and only reports them once the
+    /// user confirms. A single selection still flows through `selectedEntity` so callers can keep
+    /// their existing single-selection behaviour (e.g. showing a customization screen).
+    private let allowMultipleSelection: Bool
+    /// Called when the user confirms a selection of two or more entities. Single selections are
+    /// reported through `selectedEntity` instead.
+    private let onMultipleSelectionConfirmed: (([HAAppEntity]) -> Void)?
+
+    @State private var selectedEntities: [HAAppEntity] = []
+
     init(
         selectedServerId: String? = nil,
         selectedEntity: Binding<HAAppEntity?>,
         domainFilter: [Domain]?,
         mode: Mode = .button,
-        initialSearchTerm: String? = nil
+        initialSearchTerm: String? = nil,
+        allowMultipleSelection: Bool = false,
+        onMultipleSelectionConfirmed: (([HAAppEntity]) -> Void)? = nil
     ) {
         self._selectedEntity = selectedEntity
         self._viewModel = .init(wrappedValue: EntityPickerViewModel(
@@ -31,6 +43,8 @@ struct EntityPicker: View {
             initialSearchTerm: initialSearchTerm
         ))
         self.mode = mode
+        self.allowMultipleSelection = allowMultipleSelection
+        self.onMultipleSelectionConfirmed = onMultipleSelectionConfirmed
     }
 
     var body: some View {
@@ -108,12 +122,16 @@ struct EntityPicker: View {
                 Section(group.title.uppercased()) {
                     ForEach(group.entities, id: \.id) { entity in
                         Button(action: {
-                            selectedEntity = entity
-                            viewModel.showList = false
+                            if allowMultipleSelection {
+                                toggleSelection(entity)
+                            } else {
+                                selectedEntity = entity
+                                viewModel.showList = false
+                            }
                         }, label: {
                             EntityRowView(
                                 entity: entity,
-                                isSelected: selectedEntity == entity
+                                isSelected: isSelected(entity)
                             )
                         })
                         .tint(.accentColor)
@@ -122,12 +140,56 @@ struct EntityPicker: View {
             }
         }
         .listStyle(.plain)
+        .safeAreaInset(edge: .bottom) {
+            multipleSelectionConfirmButton
+        }
         .onAppear {
             viewModel.fetchEntities()
             if viewModel.selectedServerId == nil {
                 viewModel.selectedServerId = Current.servers.all.first?.identifier.rawValue
             }
             isSearchFocused = true
+        }
+    }
+
+    @ViewBuilder
+    private var multipleSelectionConfirmButton: some View {
+        if allowMultipleSelection, !selectedEntities.isEmpty {
+            Button(action: confirmMultipleSelection) {
+                Text(L10n.EntityPicker.addSelected(selectedEntities.count))
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.haPrimary)
+            .padding()
+            .background(.ultraThinMaterial)
+        }
+    }
+
+    private func isSelected(_ entity: HAAppEntity) -> Bool {
+        if allowMultipleSelection {
+            selectedEntities.contains(where: { $0.id == entity.id })
+        } else {
+            selectedEntity == entity
+        }
+    }
+
+    private func toggleSelection(_ entity: HAAppEntity) {
+        if let index = selectedEntities.firstIndex(where: { $0.id == entity.id }) {
+            selectedEntities.remove(at: index)
+        } else {
+            selectedEntities.append(entity)
+        }
+    }
+
+    private func confirmMultipleSelection() {
+        // A single entity keeps the normal flow (e.g. customization) via the selectedEntity binding;
+        // two or more are reported directly so callers can add them with their default configuration.
+        if selectedEntities.count == 1 {
+            selectedEntity = selectedEntities.first
+        } else {
+            onMultipleSelectionConfirmed?(selectedEntities)
         }
     }
 

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -191,6 +191,8 @@ struct EntityPicker: View {
         } else {
             onMultipleSelectionConfirmed?(selectedEntities)
         }
+        // Close the sheet when the picker presents its own (`.button` mode).
+        viewModel.showList = false
     }
 
     @ViewBuilder

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
@@ -19,6 +19,7 @@ struct MagicItemAddView: View {
     @StateObject private var viewModel: MagicItemAddViewModel
     @State private var selectedEntity: HAAppEntity?
     private let visiblePickerOptions: [PickerOption]
+    private let allowMultipleSelection: Bool
 
     let context: Context
     let itemToAdd: (MagicItem?) -> Void
@@ -27,9 +28,11 @@ struct MagicItemAddView: View {
         context: Context,
         initialItemType: MagicItemAddType? = nil,
         visiblePickerOptions: [PickerOption]? = nil,
+        allowMultipleSelection: Bool = false,
         itemToAdd: @escaping (MagicItem?) -> Void
     ) {
         self.context = context
+        self.allowMultipleSelection = allowMultipleSelection
         self.itemToAdd = itemToAdd
 
         let resolvedPickerOptions = visiblePickerOptions ?? {
@@ -125,7 +128,15 @@ struct MagicItemAddView: View {
                 .first(where: { $0.identifier.rawValue == viewModel.selectedServerId })?.identifier.rawValue,
             selectedEntity: $selectedEntity,
             domainFilter: domainFilter,
-            mode: .inline
+            mode: .inline,
+            allowMultipleSelection: allowMultipleSelection,
+            onMultipleSelectionConfirmed: { entities in
+                // Two or more entities skip customization and are added with their default configuration.
+                for entity in entities {
+                    itemToAdd(.init(id: entity.entityId, serverId: entity.serverId, type: .entity))
+                }
+                dismiss()
+            }
         )
         .background(
             NavigationLink("", isActive: .init(get: {

--- a/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
@@ -59,7 +59,7 @@ struct WidgetCreationView: View {
             }
         }
         .sheet(isPresented: $viewModel.showAddItem) {
-            MagicItemAddView(context: .widget) { magicItem in
+            MagicItemAddView(context: .widget, allowMultipleSelection: true) { magicItem in
                 guard let magicItem else { return }
                 viewModel.addItem(magicItem)
             }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1621,6 +1621,10 @@ public enum L10n {
   }
 
   public enum EntityPicker {
+    /// Add %lld
+    public static func addSelected(_ p1: Int) -> String {
+      return L10n.tr("Localizable", "entity_picker.add_selected", p1)
+    }
     /// Pick entity
     public static var placeholder: String { return L10n.tr("Localizable", "entity_picker.placeholder") }
     public enum Filter {


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The entity picker now supports multiple selection, and each caller decides whether to enable it. Selecting a single entity keeps the existing flow (customization screen). Selecting two or more adds them directly with their default configuration, skipping customization.

Enabled for Apple Watch, CarPlay and Widgets.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
