### PR TITLE
Add HealthKit update usage description to Info.plist

### DIFF
--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -88,6 +88,8 @@
 	<string>Report your focus status as a sensor.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Read selected Apple Health metrics so they can be shared with Home Assistant as sensors.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Home Assistant does not write any data to Apple Health.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Locate and communicate with your Home Assistant instance.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The App Store upload of the iOS build fails with error 90683 because the app now ships the HealthKit entitlement but is missing the `NSHealthUpdateUsageDescription` key in its Info.plist:

> Missing purpose string in Info.plist. ... The Info.plist file for the "Home Assistant.app" bundle should contain a NSHealthUpdateUsageDescription key with a user-facing purpose string...

Apple requires this key whenever the HealthKit entitlement is present, even for read-only usage. The app only reads Health data (`requestAuthorization` uses an empty `toShare` set), so the purpose string states that no data is written.

## Screenshots
No visual change. The string is only shown if write access is ever requested, which the app never does.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Follow-up to #4923 and #5264.
