### PR TITLE
Mirror HealthKit update usage description in InfoPlist.strings

### DIFF
--- a/Sources/App/Resources/en.lproj/InfoPlist.strings
+++ b/Sources/App/Resources/en.lproj/InfoPlist.strings
@@ -3,6 +3,7 @@
 "NSCrossWebsiteTrackingUsageDescription" = "Optionally enable cross-website tracking if your configuration requires it.";
 "NSFocusStatusUsageDescription" = "Report your focus status as a sensor.";
 "NSHealthShareUsageDescription" = "Read selected Apple Health metrics so they can be shared with Home Assistant as sensors.";
+"NSHealthUpdateUsageDescription" = "Home Assistant does not write any data to Apple Health.";
 "NSLocalNetworkUsageDescription" = "Locate and communicate with your Home Assistant instance.";
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "\n 🔵  We also need permission to access location 'Always' so the App can perform background operations. \n\n ⚠️  Without that, the App is unable to decide which connection (local or remote) to use in background and will use remote always.";
 "NSLocationAlwaysUsageDescription" = "We always need access to your location for features like iBeacons, geofences, background location updates and accurate reporting.";


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Follow-up to #5267, which added `NSHealthUpdateUsageDescription` to `Info.plist` but not to `en.lproj/InfoPlist.strings`. This adds the matching entry so the HealthKit purpose string stays consistent with `Info.plist` and remains translatable, alongside the other sensor purpose strings (Health, Motion, Focus) already mirrored there.

## Screenshots
No visual change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Follow-up to #4923 and #5267. Scoped to the HealthKit key only; a few other purpose strings (Bluetooth, Face ID, Reminders) are also unmirrored but are pre-existing and left for a separate cleanup.
