### PR TITLE
Fix pull-to-refresh being unreachable in landscape

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshObserver.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshObserver.swift
@@ -6,10 +6,15 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
     private enum Constants {
         static let hapticStepCount = 8
         static let minimumHapticIntensity: CGFloat = 0.35
+        /// UIScrollView's rubber-banding resists proportionally to the scroll view's height, so a fixed
+        /// threshold tuned for portrait needs an impossible single swipe on a short landscape viewport.
+        /// Scaling with the height keeps the required finger travel at a constant fraction of the screen.
+        static let thresholdHeightFraction: CGFloat = 0.2
+        static let minimumThreshold: CGFloat = 64
     }
 
     private weak var scrollView: UIScrollView?
-    private let threshold: CGFloat
+    private let maximumThreshold: CGFloat
     private let onStateChange: (CGFloat, Bool) -> Void
     private let onRefresh: () -> Void
 
@@ -23,12 +28,12 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
 
     init(
         webView: WKWebView,
-        threshold: CGFloat,
+        maximumThreshold: CGFloat,
         onStateChange: @escaping (CGFloat, Bool) -> Void,
         onRefresh: @escaping () -> Void
     ) {
         self.scrollView = webView.scrollView
-        self.threshold = threshold
+        self.maximumThreshold = maximumThreshold
         self.onStateChange = onStateChange
         self.onRefresh = onRefresh
 
@@ -74,12 +79,19 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
         onStateChange(0, false)
     }
 
+    /// Recomputed on every read so rotating the device immediately adopts the new viewport's threshold.
+    private var currentThreshold: CGFloat {
+        guard let scrollView, scrollView.bounds.height > 0 else { return maximumThreshold }
+        let heightBased = scrollView.bounds.height * Constants.thresholdHeightFraction
+        return min(maximumThreshold, max(Constants.minimumThreshold, heightBased))
+    }
+
     private func handleContentOffset(_ contentOffset: CGPoint) {
         guard let scrollView else { return }
 
         let topInset = scrollView.adjustedContentInset.top
         let pullDistance = max(0, -(contentOffset.y + topInset))
-        let progress = min(1, pullDistance / threshold)
+        let progress = min(1, pullDistance / currentThreshold)
 
         if !isRefreshing {
             emitPullProgressHapticIfNeeded(progress: progress, pullDistance: pullDistance)
@@ -124,7 +136,7 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
     @objc private func handlePanGesture(_ recognizer: UIPanGestureRecognizer) {
         switch recognizer.state {
         case .ended:
-            guard didCrossThreshold, currentPullDistance() >= threshold, !isRefreshing else {
+            guard didCrossThreshold, currentPullDistance() >= currentThreshold, !isRefreshing else {
                 didCrossThreshold = false
                 return
             }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -15,7 +15,9 @@ final class HomeAssistantViewModel: ObservableObject {
         }()
 
         static let loaderFadeOutDuration: Duration = .seconds(0.4)
-        static let pullToRefreshThreshold: CGFloat = 148
+        /// Upper bound for the pull distance; the observer shortens it on viewports too short to reach it
+        /// in a single swipe, such as iPhone landscape.
+        static let pullToRefreshMaximumThreshold: CGFloat = 148
     }
 
     let server: Server
@@ -157,7 +159,7 @@ final class HomeAssistantViewModel: ObservableObject {
         guard !Current.isCatalyst else { return }
         pullToRefreshObserver = HomeAssistantPullToRefreshObserver(
             webView: controller.webView,
-            threshold: Constants.pullToRefreshThreshold,
+            maximumThreshold: Constants.pullToRefreshMaximumThreshold,
             onStateChange: { [weak self] progress, isRefreshing in
                 self?.pullToRefreshProgress = progress
                 self?.isPullToRefreshActive = isRefreshing


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Pull-to-refresh used a fixed 148pt threshold. Scroll view rubber-banding resists in proportion to the viewport height, so on a short landscape screen that distance takes more finger travel than a single swipe allows.

The threshold is now the smaller of 148pt and 20% of the scroll view height, floored at 64pt, and recomputed on each read so rotation applies immediately. Portrait and iPad landscape are unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change, only the pull distance required to trigger the refresh.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Reported via TestFlight feedback.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CkGMjnso9xN2rwT2VdrEh)_