### PR TITLE
Show domain and group by filters in the watch entity picker

### DIFF
--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -277,9 +277,11 @@ struct EntityPicker: View {
         }
     }
 
+    // Shown whenever there is more than one domain to choose from, including contexts that preset a
+    // list of allowed domains (e.g. the watch, which supports every actionable domain).
     @ViewBuilder
     private var domainPicker: some View {
-        if viewModel.domainFilter == nil {
+        if viewModel.selectableDomains.count > 1 {
             EntityFilterPickerView(
                 title: L10n.EntityPicker.Filter.Domain.title,
                 icon: .tag,
@@ -287,7 +289,7 @@ struct EntityPicker: View {
                     id: "",
                     title: L10n.EntityPicker.Filter.Domain.All.title
                 )] +
-                    viewModel.entitiesByDomain.keys.map { key in
+                    viewModel.selectableDomains.map { key in
                         // Prefer the domain's localized name (backed by CoreStrings); fall back to the raw key.
                         EntityFilterPickerView.PickerItem(id: key, title: Domain(rawValue: key)?.name ?? key)
                     }
@@ -321,9 +323,10 @@ struct EntityPicker: View {
         }
     }
 
+    // Grouping by domain only says something when several domains are listed.
     @ViewBuilder
     private var groupByPicker: some View {
-        if viewModel.domainFilter == nil {
+        if viewModel.selectableDomains.count > 1 {
             EntityFilterPickerView(
                 title: L10n.EntityPicker.Filter.GroupBy.title,
                 icon: .listBulletRectangle,

--- a/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
@@ -41,10 +41,18 @@ final class EntityPickerViewModel: ObservableObject {
 
     /// Returns true if any filter (excluding server) has a non-default value
     var hasActiveFilters: Bool {
-        let isDomainFilterActive = domainFilter == nil && selectedDomainFilter != nil
+        let isDomainFilterActive = selectedDomainFilter != nil
         let isAreaFilterActive = selectedAreaFilter != nil
         let isGroupingFilterActive = selectedGrouping != .area
         return isDomainFilterActive || isAreaFilterActive || isGroupingFilterActive
+    }
+
+    /// The domains the user can narrow the list down to: the domains present in the current server's
+    /// entities, already restricted to the caller's preset `domainFilter` when one was given.
+    /// Contexts that allow a single domain (e.g. scripts) have nothing to pick, so the picker hides
+    /// itself when this holds fewer than two domains.
+    var selectableDomains: [String] {
+        Array(entitiesByDomain.keys)
     }
 
     /// Resets all filters (except server) to their default values
@@ -124,6 +132,12 @@ final class EntityPickerViewModel: ObservableObject {
             // Prime server cache for this server
             cachedEntitiesByServer[serverId] = entities.filter { $0.serverId == serverId }
             rebuildFuzzyIndex(for: serverId)
+            // The available domains belong to the server that is now selected, so a domain the
+            // previous server had but this one doesn't is dropped instead of emptying the list.
+            groupByDomain()
+            if let pickedDomain = selectedDomainFilter, !entitiesByDomain.keys.contains(pickedDomain) {
+                selectedDomainFilter = nil
+            }
             updateFilteredEntities()
         } catch {
             Current.Log.error("Failed to fetch server data for entity picker, error: \(error)")
@@ -138,13 +152,13 @@ final class EntityPickerViewModel: ObservableObject {
     func fetchEntities() {
         do {
             entities = try HAAppEntity.config()
-            groupByDomain()
 
-            // Rebuild caches with current data
+            // Rebuild caches with current data before grouping, which reads the server cache.
             rebuildAreaCaches()
             if let serverId = selectedServerId {
                 cachedEntitiesByServer[serverId] = entities.filter { $0.serverId == serverId }
             }
+            groupByDomain()
 
             // Fetch server-specific data if a server is already selected
             if let serverId = selectedServerId {
@@ -158,7 +172,10 @@ final class EntityPickerViewModel: ObservableObject {
     }
 
     private func groupByDomain() {
-        var groups = Dictionary(grouping: entities) { entity in
+        // Scoped to the selected server so the domain filter never offers a domain that only exists
+        // on another server (which would show an empty list).
+        let scopedEntities = selectedServerId == nil ? entities : entitiesForCurrentServer()
+        var groups = Dictionary(grouping: scopedEntities) { entity in
             entity.domain
         }
 

--- a/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
+++ b/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 @testable import HomeAssistant
 @testable import Shared
 import Testing
@@ -71,5 +72,49 @@ struct EntityPickerViewModelTests {
 
         #expect(vm.entitiesByDomain["light"]?.count == 2)
         #expect(vm.entitiesByDomain["switch"]?.count == 1)
+    }
+
+    @Test("Selectable domains keep only the preset domains that have entities")
+    func selectableDomainsRespectPresetFilter() async throws {
+        let entities: [HAAppEntity] = [
+            .make("light.kitchen", name: "Kitchen Light", domain: "light", serverId: "A"),
+            .make("switch.pump", name: "Pump", domain: "switch", serverId: "A"),
+            // Not supported by the watch, so it must not be offered as a filter.
+            .make("sensor.temperature", name: "Temperature", domain: "sensor", serverId: "A"),
+        ]
+        let vm = EntityPickerViewModel(domainFilter: Domain.watchSupported, selectedServerId: nil)
+        vm.entities = entities
+        vm._test_groupByDomain()
+
+        #expect(Set(vm.selectableDomains) == ["light", "switch"])
+    }
+
+    @Test("Selectable domains are scoped to the selected server")
+    func selectableDomainsScopedToSelectedServer() async throws {
+        let previousDatabase = Current.database
+        let database = try DatabaseQueue(path: ":memory:")
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        let entities: [HAAppEntity] = [
+            .make("light.kitchen", name: "Kitchen Light", domain: "light", serverId: "A"),
+            .make("switch.pump", name: "Pump", domain: "switch", serverId: "B"),
+        ]
+        let vm = EntityPickerViewModel(domainFilter: Domain.watchSupported, selectedServerId: "A")
+        vm.entities = entities
+        vm._test_groupByDomain()
+
+        #expect(vm.selectableDomains == ["light"])
+    }
+
+    @Test("A preset domain filter still reports a user picked domain as an active filter")
+    func hasActiveFiltersWithPresetDomainFilter() async throws {
+        let vm = EntityPickerViewModel(domainFilter: Domain.watchSupported, selectedServerId: nil)
+
+        #expect(vm.hasActiveFilters == false)
+        vm.selectedDomainFilter = Domain.light.rawValue
+        #expect(vm.hasActiveFilters)
+        vm.resetFilters()
+        #expect(vm.hasActiveFilters == false)
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The entity picker hid the Domain and Group by filters whenever the caller preset a list of allowed domains, which is the case for the watch. Now that the watch supports every actionable domain, that list is long and those filters are needed.

- Domain and Group by are shown whenever there is more than one domain to pick from, so the watch picker gets them. Pickers locked to a single domain (e.g. scripts) still hide them.
- The domain options are limited to the domains the context allows and that actually have entities.
- The domain options follow the selected server, so switching servers no longer offers a domain that only exists on another one.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Unit tests cover the preset domain restriction, the server scoping, and the reset button showing up for a picked domain.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NfVTyyEmf32ToqMw7Vg3b9)_