### PR TITLE
Make sensor enablement an allowlist

### DIFF
--- a/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Servers/OnboardingServersListViewModel.swift
@@ -25,7 +25,6 @@ final class OnboardingServersListViewModel: ObservableObject {
 
     var pendingManualURL: URL?
 
-    private var webhookSensors: [WebhookSensor] = []
     private var discovery = Current.bonjour()
     private var cancellables = Set<AnyCancellable>()
     private let shouldDismissOnSuccess: Bool
@@ -35,7 +34,6 @@ final class OnboardingServersListViewModel: ObservableObject {
     init(shouldDismissOnSuccess: Bool) {
         self.shouldDismissOnSuccess = shouldDismissOnSuccess
         discovery.observer = self
-        Current.sensors.register(observer: self)
         Current.onboardingObservation.register(observer: self)
     }
 
@@ -137,28 +135,19 @@ final class OnboardingServersListViewModel: ObservableObject {
     private func authenticationSucceeded(server: Server) {
         discovery.stop()
         onboardingServer = server
-        disableNonEssentialSensors(server)
+        applyDefaultSensorSelection()
         // Advance the pushed auth flow directly into the permissions steps.
         authPresenter?.push(.permissions(server))
     }
 
-    private func disableNonEssentialSensors(_ server: Server) {
+    /// Sensors are enabled individually rather than all at once, so a first-time install only needs
+    /// to be pointed at the default selection — there is nothing left here to switch off.
+    private func applyDefaultSensorSelection() {
         guard Current.servers.all.count == 1 else {
             Current.Log.verbose("Avoid overriding sensors if user has already servers setup in place.")
             return
         }
-        let sensorsToKeepEnabled: [WebhookSensorId] = [
-            .appVersion,
-            .locationPermission,
-        ]
-        for sensor in webhookSensors {
-            if let uniqueId = sensor.UniqueID,
-               uniqueId.contains("battery") || sensorsToKeepEnabled.map(\.rawValue).contains(uniqueId) {
-                Current.sensors.setEnabled(true, for: sensor)
-            } else {
-                Current.sensors.setEnabled(false, for: sensor)
-            }
-        }
+        Current.sensors.applyFirstRunSensorDefaults()
     }
 }
 
@@ -176,22 +165,6 @@ extension OnboardingServersListViewModel: BonjourObserver {
     func bonjour(_ bonjour: Bonjour, didRemoveInstanceWithName name: String) {
         DispatchQueue.main.async { [weak self] in
             self?.discoveredInstances.removeAll { $0.bonjourName == name }
-        }
-    }
-}
-
-extension OnboardingServersListViewModel: SensorObserver {
-    func sensorContainer(
-        _ container: SensorContainer,
-        didSignalForUpdateBecause reason: SensorContainerUpdateReason,
-        lastUpdate: SensorObserverUpdate?
-    ) {
-        /* no-op */
-    }
-
-    func sensorContainer(_ container: SensorContainer, didUpdate update: SensorObserverUpdate) {
-        update.sensors.done { [weak self] sensors in
-            self?.webhookSensors = sensors
         }
     }
 }

--- a/Sources/Shared/API/Webhook/Sensors/CameraMotionSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CameraMotionSensor.swift
@@ -54,10 +54,6 @@ final class CameraMotionSensor: SensorProvider {
             return .init(error: CameraMotionError.unavailable)
         }
 
-        // The camera must never turn on (nor its permission prompt appear) without an
-        // explicit user opt-in, so this sensor starts disabled instead of enabled-by-default.
-        Current.sensors.disableInitially(sensorId: .cameraMotion)
-
         let isDetected = manager.isMotionDetected
 
         let sensor = WebhookSensor(

--- a/Sources/Shared/API/Webhook/Sensors/CameraStreamSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CameraStreamSensor.swift
@@ -53,10 +53,6 @@ final class CameraStreamSensor: SensorProvider {
             return .init(error: CameraStreamError.unavailable)
         }
 
-        // The camera must never turn on (nor its permission prompt appear) without an
-        // explicit user opt-in, so this sensor starts disabled instead of enabled-by-default.
-        Current.sensors.disableInitially(sensorId: .cameraStream)
-
         let server = Current.cameraStreamServer
         let isStreaming = server.isStreaming
 

--- a/Sources/Shared/API/Webhook/Sensors/PedometerSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/PedometerSensor.swift
@@ -9,6 +9,11 @@ public class PedometerSensor: SensorProvider {
         case noData
     }
 
+    /// The unique IDs of every pedometer sensor, for `SensorRegistry`.
+    public static var allSensorIDs: [String] {
+        PedometerSensor.allCases.map(\.rawValue)
+    }
+
     public let request: SensorProviderRequest
     public required init(request: SensorProviderRequest) {
         self.request = request

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -43,6 +43,7 @@ public class SensorContainer {
     private let providers = HAProtected<[SensorProvider.Type]>(value: [])
     private let observers = HAProtected<NSHashTable<AnyObject>>(value: .init(options: .weakMemory))
     private let providerDependencies: SensorProviderDependencies
+    private let enablement = SensorEnablementStore()
 
     init() {
         self.providerDependencies = SensorProviderDependencies()
@@ -67,23 +68,13 @@ public class SensorContainer {
         observers.mutate { $0.remove(observer) }
     }
 
-    private var disabledSensorIDs: Set<String> {
-        get {
-            Set(Current.settingsStore.prefs.object(forKey: "disabledSensors") as? [String] ?? [])
-        }
-        set {
-            Current.settingsStore.prefs.set(Array(newValue), forKey: "disabledSensors")
-            notifySignal(reason: .settingsChange)
-        }
-    }
-
     public func isEnabled(sensor: WebhookSensor) -> Bool {
         guard let id = sensor.UniqueID else { return false }
         return isEnabled(uniqueID: id)
     }
 
     public func isEnabled(uniqueID: String) -> Bool {
-        !disabledSensorIDs.contains(uniqueID)
+        enablement.isEnabled(uniqueID: uniqueID)
     }
 
     public func isAllowedToSend(sensor: WebhookSensor, for server: Server) -> Bool {
@@ -101,26 +92,15 @@ public class SensorContainer {
     }
 
     public func setEnabled(_ value: Bool, forUniqueID id: String) {
-        if value {
-            disabledSensorIDs.remove(id)
-        } else {
-            disabledSensorIDs.insert(id)
-        }
+        guard enablement.setEnabled(value, forUniqueID: id) else { return }
+        notifySignal(reason: .settingsChange)
     }
 
-    /// Disables a sensor the first time it is ever seen, so opt-in sensors (e.g. camera-based
-    /// ones, which must not prompt for permission unless the user asks) don't follow the
-    /// enabled-by-default behavior. Subsequent calls are no-ops, preserving the user's choice.
-    public func disableInitially(sensorId: WebhookSensorId) {
-        let key = Self.initialDisableKey(for: sensorId)
-        let prefs = Current.settingsStore.prefs
-        guard prefs.object(forKey: key) == nil else { return }
-        prefs.set(true, forKey: key)
-        setEnabled(false, forUniqueID: sensorId.rawValue)
-    }
-
-    static func initialDisableKey(for sensorId: WebhookSensorId) -> String {
-        "sensor_initially_disabled_\(sensorId.rawValue)"
+    /// Applies the sensor selection a first-time install starts with. Sensors outside it stay off
+    /// until the user enables them, so there is nothing to switch off here.
+    public func applyFirstRunSensorDefaults() {
+        guard enablement.applyFirstRunDefaults() else { return }
+        notifySignal(reason: .settingsChange)
     }
 
     private let lastUpdate = HAProtected<SensorObserverUpdate?>(value: nil)
@@ -197,6 +177,13 @@ public class SensorContainer {
                     return nil
                 }
             }.flatMap { $0 }
+        }.map { [weak self] sensors -> [WebhookSensor] in
+            // A limited run only asks some of the providers, so it can't stand in for the complete
+            // set the migration needs to decide the sensors whose IDs only exist at runtime.
+            if limitedTo == nil {
+                self?.enablement.seedDynamicIDsIfNeeded(from: Set(sensors.compactMap(\.UniqueID)))
+            }
+            return sensors
         }
 
         setLastUpdate(.init(sensors: generatedSensors.map { [lastSentSensors] new in

--- a/Sources/Shared/API/Webhook/Sensors/SensorEnablementStore.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorEnablementStore.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+/// Persists which sensors the user has enabled.
+///
+/// Enablement is an allowlist: a sensor reports to Home Assistant only while its unique ID is
+/// present in `enabledSensors`. Anything the app has never been told to enable — including sensors
+/// introduced by a later release — stays off until the user turns it on in settings.
+///
+/// Installs that predate the allowlist stored the inverse, a `disabledSensors` denylist, which the
+/// first run after upgrading carries across. See `prepareIfNeeded()`.
+public final class SensorEnablementStore {
+    private enum Key {
+        static let enabled = "enabledSensors"
+        static let legacyDisabled = "disabledSensors"
+        static let migrationState = "sensorEnablementMigrationState"
+        static let upgradeDetected = "sensorEnablementUpgradeDetected"
+        static let firstRunDefaultsApplied = "sensorFirstRunDefaultsApplied"
+
+        static func legacyInitialDisable(_ uniqueID: String) -> String {
+            "sensor_initially_disabled_\(uniqueID)"
+        }
+    }
+
+    /// How far the denylist-to-allowlist migration has got. Absent means it hasn't started.
+    private enum MigrationState: String {
+        /// An existing install's selection has been carried across for every statically-known ID.
+        /// Dynamic IDs — one per battery, SIM or audio device — still need picking up.
+        case upgradeAwaitingDynamicIDs
+        /// A first-time install has been seeded with the default selection, likewise still waiting
+        /// on dynamic IDs.
+        case freshInstallAwaitingDynamicIDs
+        case complete
+    }
+
+    /// Serialises the one-time migration. The state it guards lives in `prefs` rather than in
+    /// memory, so every process sharing the app group ends up with the same result.
+    private let migrationLock = NSLock()
+
+    public init() {}
+
+    private var prefs: UserDefaults {
+        Current.settingsStore.prefs
+    }
+
+    // MARK: - Reading and writing
+
+    public func isEnabled(uniqueID: String) -> Bool {
+        prepareIfNeeded()
+        return enabledSensorIDs.contains(uniqueID)
+    }
+
+    /// - Returns: whether the stored selection actually changed.
+    @discardableResult
+    public func setEnabled(_ value: Bool, forUniqueID uniqueID: String) -> Bool {
+        prepareIfNeeded()
+
+        var enabled = enabledSensorIDs
+        let didChangeSelection = value ? enabled.insert(uniqueID).inserted : enabled.remove(uniqueID) != nil
+        if didChangeSelection {
+            enabledSensorIDs = enabled
+        }
+
+        let didRecordChoice = recordChoiceForPendingMigration(value, forUniqueID: uniqueID)
+        return didChangeSelection || didRecordChoice
+    }
+
+    /// Mirrors an explicit choice into the legacy denylist while the migration is still waiting on
+    /// dynamic IDs, because that pass reads the denylist to decide them. Without this, turning a
+    /// per-battery or per-SIM sensor off before the app has produced it once would be undone.
+    ///
+    /// - Returns: whether the denylist changed.
+    private func recordChoiceForPendingMigration(_ value: Bool, forUniqueID uniqueID: String) -> Bool {
+        guard migrationState != .complete else { return false }
+
+        var disabled = legacyDisabledSensorIDs
+        let didChange = value ? disabled.remove(uniqueID) != nil : disabled.insert(uniqueID).inserted
+        guard didChange else { return false }
+
+        legacyDisabledSensorIDs = disabled
+        return true
+    }
+
+    // MARK: - Migration
+
+    /// Carries an existing install's sensor selection into the allowlist, once.
+    ///
+    /// An upgrade is assumed rather than detected, because nothing available at this point reliably
+    /// separates one from a first-time install, and guessing wrong in the other direction would
+    /// silently switch off every sensor the user relies on. A genuine first-time install corrects
+    /// the assumption from onboarding, via `applyFirstRunDefaults()`.
+    private func prepareIfNeeded() {
+        migrationLock.lock()
+        defer { migrationLock.unlock() }
+
+        guard migrationState == nil else { return }
+
+        // Only used to decide whether onboarding may still reset this install to the defaults;
+        // what to enable is decided by the safe assumption above, not by this.
+        prefs.set(hasEvidenceOfPriorInstall, forKey: Key.upgradeDetected)
+
+        enabledSensorIDs = SensorRegistry.staticSensorIDs
+            .subtracting(legacyDisabledSensorIDs)
+            .filter { uniqueID in
+                guard SensorRegistry.optInSensorIDs.contains(uniqueID) else { return true }
+                // Opt-in sensors only reached the denylist on devices that actually produced them,
+                // so an absent marker means "never seen" rather than "the user enabled it", and
+                // enabling one here would turn the camera on behind their back.
+                return prefs.object(forKey: Key.legacyInitialDisable(uniqueID)) != nil
+            }
+        migrationState = .upgradeAwaitingDynamicIDs
+    }
+
+    /// Whether this install carries sensor state written by a version that predates the allowlist.
+    private var hasEvidenceOfPriorInstall: Bool {
+        if prefs.object(forKey: Key.legacyDisabled) != nil {
+            return true
+        }
+        return SensorRegistry.optInSensorIDs.contains { uniqueID in
+            prefs.object(forKey: Key.legacyInitialDisable(uniqueID)) != nil
+        }
+    }
+
+    /// Seeds a first-time install with the sensors that are on out of the box.
+    ///
+    /// Runs at most once per install, and never for an install that arrived here by upgrading, so
+    /// setting a server up again later can't overwrite the user's choices.
+    ///
+    /// - Returns: whether the stored selection actually changed.
+    @discardableResult
+    public func applyFirstRunDefaults() -> Bool {
+        prepareIfNeeded()
+        guard !prefs.bool(forKey: Key.firstRunDefaultsApplied), !prefs.bool(forKey: Key.upgradeDetected) else {
+            return false
+        }
+        prefs.set(true, forKey: Key.firstRunDefaultsApplied)
+
+        enabledSensorIDs = enabledSensorIDs.filter(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID:))
+        // Reopened so the pass below still picks up this device's battery sensors, whose IDs
+        // depend on the hardware.
+        migrationState = .freshInstallAwaitingDynamicIDs
+        return true
+    }
+
+    /// Applies the migration to sensors whose unique IDs only exist at runtime — one per battery,
+    /// SIM or audio device — the first time the app produces them.
+    ///
+    /// - Parameter producedIDs: every ID from one complete sensor generation. A partial generation
+    ///   would finish the migration having missed whatever it left out.
+    func seedDynamicIDsIfNeeded(from producedIDs: Set<String>) {
+        prepareIfNeeded()
+        guard let state = migrationState else { return }
+
+        let dynamicIDs = producedIDs.subtracting(SensorRegistry.staticSensorIDs)
+        var enabled = enabledSensorIDs
+
+        switch state {
+        case .upgradeAwaitingDynamicIDs:
+            enabled.formUnion(dynamicIDs.subtracting(legacyDisabledSensorIDs))
+        case .freshInstallAwaitingDynamicIDs:
+            enabled.formUnion(dynamicIDs.filter(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID:)))
+        case .complete:
+            return
+        }
+
+        enabledSensorIDs = enabled
+        migrationState = .complete
+        removeLegacyKeys()
+    }
+
+    private func removeLegacyKeys() {
+        prefs.removeObject(forKey: Key.legacyDisabled)
+        for uniqueID in SensorRegistry.optInSensorIDs {
+            prefs.removeObject(forKey: Key.legacyInitialDisable(uniqueID))
+        }
+    }
+
+    // MARK: - Storage
+
+    private var enabledSensorIDs: Set<String> {
+        get {
+            Set(prefs.object(forKey: Key.enabled) as? [String] ?? [])
+        }
+        set {
+            prefs.set(newValue.sorted(), forKey: Key.enabled)
+        }
+    }
+
+    private var legacyDisabledSensorIDs: Set<String> {
+        get {
+            Set(prefs.object(forKey: Key.legacyDisabled) as? [String] ?? [])
+        }
+        set {
+            prefs.set(newValue.sorted(), forKey: Key.legacyDisabled)
+        }
+    }
+
+    private var migrationState: MigrationState? {
+        get {
+            prefs.string(forKey: Key.migrationState).flatMap(MigrationState.init(rawValue:))
+        }
+        set {
+            prefs.set(newValue?.rawValue, forKey: Key.migrationState)
+        }
+    }
+
+    // MARK: - Fakes
+
+    /// Puts sensor enablement back to how a clean install finds it.
+    ///
+    /// Every test target shares one set of app group defaults, so a test that leaves an allowlist
+    /// or a half-finished migration behind changes what the next one sees.
+    static func resetForTesting() {
+        let keys = [
+            Key.enabled,
+            Key.legacyDisabled,
+            Key.migrationState,
+            Key.upgradeDetected,
+            Key.firstRunDefaultsApplied,
+        ] + SensorRegistry.optInSensorIDs.map(Key.legacyInitialDisable)
+
+        for key in keys {
+            Current.settingsStore.prefs.removeObject(forKey: key)
+        }
+    }
+
+    /// Puts sensor enablement into the state an install that predates the allowlist would be in.
+    ///
+    /// - Parameter seenOptInSensorIDs: opt-in sensors this device had already produced at least
+    ///   once, which is what separates "the user turned it on" from "never seen".
+    static func seedLegacyStateForTesting(
+        disabledSensorIDs: [String],
+        seenOptInSensorIDs: [WebhookSensorId] = []
+    ) {
+        resetForTesting()
+        Current.settingsStore.prefs.set(disabledSensorIDs, forKey: Key.legacyDisabled)
+        for sensorId in seenOptInSensorIDs {
+            Current.settingsStore.prefs.set(true, forKey: Key.legacyInitialDisable(sensorId.rawValue))
+        }
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/SensorRegistry.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorRegistry.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The sensor unique IDs the app knows about at compile time.
+///
+/// Enablement is stored as an allowlist, so migrating an install that predates it needs to know
+/// every ID that used to be enabled by default. IDs that only exist at runtime — one per battery,
+/// SIM or audio device — can't be listed here; `SensorEnablementStore` picks those up from the
+/// first batch of sensors the app actually produces.
+public enum SensorRegistry {
+    public static let staticSensorIDs: Set<String> = {
+        var ids = Set(WebhookSensorId.allCases.map(\.rawValue))
+
+        // InputOutputDeviceSensor derives an "in use" and an "active" sensor from each of these.
+        for base in [WebhookSensorId.camera, .microphone, .audioOutput].map(\.rawValue) {
+            ids.insert("\(base)_in_use")
+            ids.insert("active_\(base)")
+        }
+
+        // BatterySensor keys off each battery's own identifier and falls back to this on devices
+        // that only report one battery.
+        ids.formUnion(["battery_level", "battery_state"])
+
+        ids.formUnion(PedometerSensor.allSensorIDs)
+
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        ids.formUnion(HealthKitSensor.Metric.allCases.map(\.uniqueID))
+        #endif
+
+        return ids
+    }()
+
+    /// Sensors that must never switch on without the user asking for them: both turn the camera on
+    /// and surface its permission prompt.
+    public static let optInSensorIDs: Set<String> = [
+        WebhookSensorId.cameraMotion.rawValue,
+        WebhookSensorId.cameraStream.rawValue,
+    ]
+
+    /// The sensors a first-time install starts with. Everything else stays off until the user
+    /// enables it in settings.
+    public static func isEnabledByDefaultOnFirstRun(uniqueID: String) -> Bool {
+        if uniqueID.contains("battery") {
+            return true
+        }
+        return [WebhookSensorId.appVersion, .locationPermission]
+            .map(\.rawValue)
+            .contains(uniqueID)
+    }
+}

--- a/Tests/App/Settings/SensorListViewModelHealthKitTests.swift
+++ b/Tests/App/Settings/SensorListViewModelHealthKitTests.swift
@@ -6,35 +6,25 @@ import XCTest
 class SensorListViewModelHealthKitTests: XCTestCase {
     private var originalHealthKitService: HealthKitService!
     private var originalSensors: SensorContainer!
-    private var previousDisabledSensors: Any?
 
     override func setUp() {
         super.setUp()
 
         originalHealthKitService = Current.healthKitService
         originalSensors = Current.sensors
-        previousDisabledSensors = Current.settingsStore.prefs.object(forKey: "disabledSensors")
 
         Current.sensors = SensorContainer()
-        Current.settingsStore.prefs.removeObject(forKey: "disabledSensors")
+        SensorEnablementStore.resetForTesting()
         Current.healthKitService.isAvailable = { true }
     }
 
     override func tearDown() {
-        restore(previousDisabledSensors, forKey: "disabledSensors")
+        SensorEnablementStore.resetForTesting()
         Current.healthKitService = originalHealthKitService
         Current.sensors = originalSensors
         originalHealthKitService = nil
         originalSensors = nil
         super.tearDown()
-    }
-
-    private func restore(_ value: Any?, forKey key: String) {
-        if let value {
-            Current.settingsStore.prefs.set(value, forKey: key)
-        } else {
-            Current.settingsStore.prefs.removeObject(forKey: key)
-        }
     }
 
     @MainActor

--- a/Tests/Shared/Sensors/CameraMotionSensor.test.swift
+++ b/Tests/Shared/Sensors/CameraMotionSensor.test.swift
@@ -18,19 +18,14 @@ class CameraMotionSensorTests: XCTestCase {
 
         motionDetection = FakeMotionDetectionManager()
         Current.motionDetection = motionDetection
-        resetSensorEnablement()
+        SensorEnablementStore.resetForTesting()
     }
 
     override func tearDown() {
         super.tearDown()
 
         Current.motionDetection = MotionDetectionManager()
-        resetSensorEnablement()
-    }
-
-    private func resetSensorEnablement() {
-        Current.settingsStore.prefs.removeObject(forKey: "disabledSensors")
-        Current.settingsStore.prefs.removeObject(forKey: SensorContainer.initialDisableKey(for: .cameraMotion))
+        SensorEnablementStore.resetForTesting()
     }
 
     func testNotAvailable() {
@@ -70,7 +65,7 @@ class CameraMotionSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].State as? Bool, false)
     }
 
-    func testDisabledInitiallyButUserChoiceSticks() throws {
+    func testDisabledByDefaultButUserChoiceSticks() throws {
         motionDetection.overrideCanDetectMotion = true
 
         _ = try hang(CameraMotionSensor(request: request).sensors())

--- a/Tests/Shared/Sensors/CameraStreamSensor.test.swift
+++ b/Tests/Shared/Sensors/CameraStreamSensor.test.swift
@@ -21,7 +21,7 @@ class CameraStreamSensorTests: XCTestCase {
         Current.motionDetection = motionDetection
         server = FakeCameraStreamServer()
         Current.cameraStreamServer = server
-        resetSensorEnablement()
+        SensorEnablementStore.resetForTesting()
     }
 
     override func tearDown() {
@@ -29,12 +29,7 @@ class CameraStreamSensorTests: XCTestCase {
 
         Current.motionDetection = MotionDetectionManager()
         Current.cameraStreamServer = CameraStreamServer()
-        resetSensorEnablement()
-    }
-
-    private func resetSensorEnablement() {
-        Current.settingsStore.prefs.removeObject(forKey: "disabledSensors")
-        Current.settingsStore.prefs.removeObject(forKey: SensorContainer.initialDisableKey(for: .cameraStream))
+        SensorEnablementStore.resetForTesting()
     }
 
     func testNotAvailable() {
@@ -78,7 +73,7 @@ class CameraStreamSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].Attributes?["Stream URL"] as? String, "http://192.168.1.2:8090/")
     }
 
-    func testDisabledInitiallyButUserChoiceSticks() throws {
+    func testDisabledByDefaultButUserChoiceSticks() throws {
         motionDetection.overrideCanDetectMotion = true
 
         _ = try hang(CameraStreamSensor(request: request).sensors())

--- a/Tests/Shared/Sensors/HealthKitSensor.test.swift
+++ b/Tests/Shared/Sensors/HealthKitSensor.test.swift
@@ -11,7 +11,6 @@ class HealthKitSensorTests: XCTestCase {
     private var originalCalendar: (() -> Calendar)!
     private var originalHealthKitService: HealthKitService!
     private var originalSensors: SensorContainer!
-    private var previousDisabledSensors: Any?
 
     override func setUp() {
         super.setUp()
@@ -20,7 +19,6 @@ class HealthKitSensorTests: XCTestCase {
         originalCalendar = Current.calendar
         originalHealthKitService = Current.healthKitService
         originalSensors = Current.sensors
-        previousDisabledSensors = Current.settingsStore.prefs.object(forKey: "disabledSensors")
 
         request = .init(
             reason: .trigger("unit-test"),
@@ -34,7 +32,7 @@ class HealthKitSensorTests: XCTestCase {
         Current.date = { Date(timeIntervalSince1970: 1_000_000) }
         Current.calendar = { Calendar(identifier: .gregorian) }
         Current.sensors = SensorContainer()
-        Current.settingsStore.prefs.removeObject(forKey: "disabledSensors")
+        SensorEnablementStore.resetForTesting()
         Current.sensors.setEnabled(true, forUniqueID: HealthKitSensor.Metric.steps.uniqueID)
         Current.sensors.setEnabled(true, forUniqueID: HealthKitSensor.Metric.restingHeartRate.uniqueID)
         Current.healthKitService.isAvailable = { true }
@@ -49,7 +47,7 @@ class HealthKitSensorTests: XCTestCase {
     }
 
     override func tearDown() {
-        restore(previousDisabledSensors, forKey: "disabledSensors")
+        SensorEnablementStore.resetForTesting()
         Current.date = originalDate
         Current.calendar = originalCalendar
         Current.healthKitService = originalHealthKitService
@@ -59,14 +57,6 @@ class HealthKitSensorTests: XCTestCase {
         originalHealthKitService = nil
         originalSensors = nil
         super.tearDown()
-    }
-
-    private func restore(_ value: Any?, forKey key: String) {
-        if let value {
-            Current.settingsStore.prefs.set(value, forKey: key)
-        } else {
-            Current.settingsStore.prefs.removeObject(forKey: key)
-        }
     }
 
     func testUnavailableHealthKitReturnsUnavailableSensorsAndDoesNotQueryHealthKit() throws {

--- a/Tests/Shared/Sensors/SensorContainer.test.swift
+++ b/Tests/Shared/Sensors/SensorContainer.test.swift
@@ -21,8 +21,15 @@ class SensorContainerTests: XCTestCase {
         server2 = servers.addFake()
         Current.servers = servers
 
+        SensorEnablementStore.resetForTesting()
         observer = MockSensorObserver()
         container = SensorContainer()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        SensorEnablementStore.resetForTesting()
     }
 
     func testNoProvidersNoCachedDoesntNotify() {

--- a/Tests/Shared/Sensors/SensorEnablement.test.swift
+++ b/Tests/Shared/Sensors/SensorEnablement.test.swift
@@ -141,8 +141,8 @@ class SensorEnablementTests: XCTestCase {
         let laterSensorID = "connectivity_sim_2"
         try generateSensors(withUniqueIDs: [dynamicSensorID, laterSensorID])
 
-        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
-        XCTAssertFalse(container.isEnabled(uniqueID: laterSensorID))
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID), storedEnablementState)
+        XCTAssertFalse(container.isEnabled(uniqueID: laterSensorID), storedEnablementState)
 
         container.setEnabled(true, forUniqueID: laterSensorID)
         XCTAssertTrue(container.isEnabled(uniqueID: laterSensorID))
@@ -152,12 +152,13 @@ class SensorEnablementTests: XCTestCase {
         SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
 
         try generateSensors(withUniqueIDs: ["some_other_sensor"], limitedToProvider: true)
-        // A limited run can't stand in for the complete set, so it decides nothing on its own.
-        XCTAssertFalse(container.isEnabled(uniqueID: "some_other_sensor"))
 
-        // Which leaves the battery below still able to carry over on the next full run.
-        try generateSensors(withUniqueIDs: [dynamicSensorID])
-        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID), storedEnablementState)
+        // A limited run only asks some of the providers, so it can't stand in for the complete set
+        // and must decide nothing: were it to seed, this sensor would come back enabled.
+        // Carrying dynamic IDs over on the next full run is covered by the first-generation test,
+        // which doesn't need a second `hang()` to get there — every one of those spins the run
+        // loop, letting another suite's in-flight generation finish this migration first.
+        XCTAssertFalse(container.isEnabled(uniqueID: "some_other_sensor"), storedEnablementState)
     }
 
     /// The persisted enablement state, for failure messages: the migration is driven entirely by

--- a/Tests/Shared/Sensors/SensorEnablement.test.swift
+++ b/Tests/Shared/Sensors/SensorEnablement.test.swift
@@ -215,14 +215,14 @@ class SensorEnablementTests: XCTestCase {
         )
         _ = try hang(Promise(response))
     }
-}
 
-private class MockEnablementSensorProvider: SensorProvider {
-    static var returnedSensors: [WebhookSensor] = []
+    private class MockEnablementSensorProvider: SensorProvider {
+        static var returnedSensors: [WebhookSensor] = []
 
-    required init(request: SensorProviderRequest) {}
+        required init(request: SensorProviderRequest) {}
 
-    func sensors() -> Promise<[WebhookSensor]> {
-        .value(Self.returnedSensors)
+        func sensors() -> Promise<[WebhookSensor]> {
+            .value(Self.returnedSensors)
+        }
     }
 }

--- a/Tests/Shared/Sensors/SensorEnablement.test.swift
+++ b/Tests/Shared/Sensors/SensorEnablement.test.swift
@@ -157,7 +157,17 @@ class SensorEnablementTests: XCTestCase {
 
         // Which leaves the battery below still able to carry over on the next full run.
         try generateSensors(withUniqueIDs: [dynamicSensorID])
-        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID), storedEnablementState)
+    }
+
+    /// The persisted enablement state, for failure messages: the migration is driven entirely by
+    /// these three keys, so they say which step went wrong.
+    private var storedEnablementState: String {
+        let prefs = Current.settingsStore.prefs
+        let enabled = prefs.object(forKey: "enabledSensors") as? [String] ?? []
+        let disabled = prefs.object(forKey: "disabledSensors") as? [String] ?? []
+        let state = prefs.string(forKey: "sensorEnablementMigrationState") ?? "nil"
+        return "migration=\(state) disabled=\(disabled) enabled(\(enabled.count))=\(enabled.suffix(6))"
     }
 
     // MARK: - First-time installs

--- a/Tests/Shared/Sensors/SensorEnablement.test.swift
+++ b/Tests/Shared/Sensors/SensorEnablement.test.swift
@@ -19,6 +19,7 @@ class SensorEnablementTests: XCTestCase {
 
         SensorEnablementStore.resetForTesting()
         container = SensorContainer()
+        container.register(provider: MockEnablementSensorProvider.self)
     }
 
     override func tearDown() {
@@ -151,10 +152,11 @@ class SensorEnablementTests: XCTestCase {
         SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
 
         try generateSensors(withUniqueIDs: ["some_other_sensor"], limitedToProvider: true)
-        try generateSensors(withUniqueIDs: [dynamicSensorID])
+        // A limited run can't stand in for the complete set, so it decides nothing on its own.
+        XCTAssertFalse(container.isEnabled(uniqueID: "some_other_sensor"))
 
-        // A run that only asked some of the providers can't stand in for the complete set, so the
-        // battery below still gets its chance to carry over.
+        // Which leaves the battery below still able to carry over on the next full run.
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
         XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
     }
 
@@ -206,7 +208,6 @@ class SensorEnablementTests: XCTestCase {
         MockEnablementSensorProvider.returnedSensors = uniqueIDs.map {
             WebhookSensor(name: $0, uniqueID: $0)
         }
-        container.register(provider: MockEnablementSensorProvider.self)
 
         let response = container.sensors(
             reason: .trigger("unit-test"),

--- a/Tests/Shared/Sensors/SensorEnablement.test.swift
+++ b/Tests/Shared/Sensors/SensorEnablement.test.swift
@@ -1,0 +1,228 @@
+import Foundation
+import PromiseKit
+@testable import Shared
+import XCTest
+
+class SensorEnablementTests: XCTestCase {
+    private var container: SensorContainer!
+    private var server: Server!
+
+    /// A battery whose unique ID comes from the hardware, so it can't be known ahead of time.
+    private let dynamicSensorID = "battery-serial-1234_level"
+
+    override func setUp() {
+        super.setUp()
+
+        let servers = FakeServerManager()
+        server = servers.addFake()
+        Current.servers = servers
+
+        SensorEnablementStore.resetForTesting()
+        container = SensorContainer()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        SensorEnablementStore.resetForTesting()
+    }
+
+    // MARK: - Migrating an install that predates the allowlist
+
+    func testUpgradeKeepsSensorsTheUserHadNotDisabled() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [WebhookSensorId.storage.rawValue])
+
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.activity.rawValue))
+        XCTAssertTrue(container.isEnabled(uniqueID: HealthKitSensor.Metric.steps.uniqueID))
+    }
+
+    func testUpgradeLeavesOptInSensorsOffWhenTheDeviceNeverProducedThem() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        // Absent from the denylist only because this device never ran them, not because the user
+        // asked for them.
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.cameraMotion.rawValue))
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.cameraStream.rawValue))
+    }
+
+    func testUpgradeKeepsOptInSensorsTheUserHadTurnedOn() {
+        SensorEnablementStore.seedLegacyStateForTesting(
+            disabledSensorIDs: [],
+            seenOptInSensorIDs: [.cameraMotion, .cameraStream]
+        )
+
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.cameraMotion.rawValue))
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.cameraStream.rawValue))
+    }
+
+    func testUpgradeKeepsEveryStaticallyKnownSensorFamily() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        // Sensor IDs that don't come from WebhookSensorId, and so are the ones a registry built
+        // only from that enum would silently switch off.
+        XCTAssertTrue(container.isEnabled(uniqueID: "pedometer_distance"))
+        XCTAssertTrue(container.isEnabled(uniqueID: "battery_level"))
+        XCTAssertTrue(container.isEnabled(uniqueID: "battery_state"))
+        XCTAssertTrue(container.isEnabled(uniqueID: "camera_in_use"))
+        XCTAssertTrue(container.isEnabled(uniqueID: "active_camera"))
+        XCTAssertTrue(container.isEnabled(uniqueID: HealthKitSensor.Metric.restingHeartRate.uniqueID))
+    }
+
+    func testUpgradeRunsOnlyOnce() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+
+        container.setEnabled(false, forUniqueID: WebhookSensorId.storage.rawValue)
+
+        // A second store over the same defaults must not treat this as a fresh migration and undo
+        // the choice above.
+        XCTAssertFalse(SensorContainer().isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+    }
+
+    func testUpgradeIsUnaffectedByDenylistEntriesForSensorsThatNoLongerExist() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [
+            "a_sensor_that_was_removed",
+            WebhookSensorId.storage.rawValue,
+        ])
+
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+        XCTAssertFalse(container.isEnabled(uniqueID: "a_sensor_that_was_removed"))
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.activity.rawValue))
+    }
+
+    func testUpgradeDropsTheLegacyKeysOnceComplete() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(
+            disabledSensorIDs: [WebhookSensorId.storage.rawValue],
+            seenOptInSensorIDs: [.cameraMotion]
+        )
+
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+
+        let prefs = Current.settingsStore.prefs
+        XCTAssertNil(prefs.object(forKey: "disabledSensors"))
+        XCTAssertNil(prefs.object(forKey: "sensor_initially_disabled_cameraMotion"))
+        // The user's choice survives the keys it used to be stored in.
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+    }
+
+    // MARK: - Sensors whose unique IDs only exist at runtime
+
+    func testDynamicSensorIDsCarryOverOnTheFirstGeneration() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
+    }
+
+    func testDynamicSensorIDsTheUserHadDisabledStayOff() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [dynamicSensorID])
+
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+
+        XCTAssertFalse(container.isEnabled(uniqueID: dynamicSensorID))
+    }
+
+    func testTurningADynamicSensorOffBeforeItIsEverProducedSticks() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        container.setEnabled(false, forUniqueID: dynamicSensorID)
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+
+        XCTAssertFalse(container.isEnabled(uniqueID: dynamicSensorID))
+    }
+
+    func testSensorsAppearingAfterTheMigrationStayOffUntilEnabled() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+        let laterSensorID = "connectivity_sim_2"
+        try generateSensors(withUniqueIDs: [dynamicSensorID, laterSensorID])
+
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
+        XCTAssertFalse(container.isEnabled(uniqueID: laterSensorID))
+
+        container.setEnabled(true, forUniqueID: laterSensorID)
+        XCTAssertTrue(container.isEnabled(uniqueID: laterSensorID))
+    }
+
+    func testALimitedGenerationDoesNotFinishTheMigration() throws {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [])
+
+        try generateSensors(withUniqueIDs: ["some_other_sensor"], limitedToProvider: true)
+        try generateSensors(withUniqueIDs: [dynamicSensorID])
+
+        // A run that only asked some of the providers can't stand in for the complete set, so the
+        // battery below still gets its chance to carry over.
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
+    }
+
+    // MARK: - First-time installs
+
+    func testFirstRunDefaultsEnableOnlyTheOutOfTheBoxSensors() {
+        container.applyFirstRunSensorDefaults()
+
+        XCTAssertTrue(container.isEnabled(uniqueID: "battery_level"))
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.appVersion.rawValue))
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.locationPermission.rawValue))
+
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.activity.rawValue))
+        XCTAssertFalse(container.isEnabled(uniqueID: WebhookSensorId.cameraMotion.rawValue))
+        XCTAssertFalse(container.isEnabled(uniqueID: HealthKitSensor.Metric.steps.uniqueID))
+    }
+
+    func testFirstRunDefaultsPickUpThisDevicesBatterySensors() throws {
+        container.applyFirstRunSensorDefaults()
+
+        try generateSensors(withUniqueIDs: [dynamicSensorID, "connectivity_sim_1"])
+
+        XCTAssertTrue(container.isEnabled(uniqueID: dynamicSensorID))
+        XCTAssertFalse(container.isEnabled(uniqueID: "connectivity_sim_1"))
+    }
+
+    func testFirstRunDefaultsLeaveAnUpgradedInstallAlone() {
+        SensorEnablementStore.seedLegacyStateForTesting(disabledSensorIDs: [WebhookSensorId.storage.rawValue])
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.activity.rawValue))
+
+        container.applyFirstRunSensorDefaults()
+
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.activity.rawValue))
+    }
+
+    func testFirstRunDefaultsDoNotComeBackWhenAServerIsSetUpAgain() {
+        container.applyFirstRunSensorDefaults()
+        container.setEnabled(true, forUniqueID: WebhookSensorId.storage.rawValue)
+
+        container.applyFirstRunSensorDefaults()
+
+        XCTAssertTrue(container.isEnabled(uniqueID: WebhookSensorId.storage.rawValue))
+    }
+
+    // MARK: - Helpers
+
+    private func generateSensors(withUniqueIDs uniqueIDs: [String], limitedToProvider: Bool = false) throws {
+        MockEnablementSensorProvider.returnedSensors = uniqueIDs.map {
+            WebhookSensor(name: $0, uniqueID: $0)
+        }
+        container.register(provider: MockEnablementSensorProvider.self)
+
+        let response = container.sensors(
+            reason: .trigger("unit-test"),
+            limitedTo: limitedToProvider ? [MockEnablementSensorProvider.self] : nil,
+            server: server
+        )
+        _ = try hang(Promise(response))
+    }
+}
+
+private class MockEnablementSensorProvider: SensorProvider {
+    static var returnedSensors: [WebhookSensor] = []
+
+    required init(request: SensorProviderRequest) {}
+
+    func sensors() -> Promise<[WebhookSensor]> {
+        .value(Self.returnedSensors)
+    }
+}

--- a/Tests/Shared/Sensors/SensorRegistry.test.swift
+++ b/Tests/Shared/Sensors/SensorRegistry.test.swift
@@ -1,0 +1,64 @@
+import Foundation
+@testable import Shared
+import XCTest
+
+class SensorRegistryTests: XCTestCase {
+    /// The migration seeds the allowlist from this, so anything missing here is a sensor an
+    /// upgrading user would silently lose.
+    func testStaticSensorIDsCoverEveryWebhookSensorId() {
+        for sensorId in WebhookSensorId.allCases {
+            XCTAssertTrue(
+                SensorRegistry.staticSensorIDs.contains(sensorId.rawValue),
+                "\(sensorId.rawValue) is missing from the registry"
+            )
+        }
+    }
+
+    func testStaticSensorIDsCoverTheSensorsDerivedFromOtherIDs() {
+        for base in [WebhookSensorId.camera, .microphone, .audioOutput].map(\.rawValue) {
+            XCTAssertTrue(SensorRegistry.staticSensorIDs.contains("\(base)_in_use"))
+            XCTAssertTrue(SensorRegistry.staticSensorIDs.contains("active_\(base)"))
+        }
+    }
+
+    func testStaticSensorIDsCoverSensorsOutsideWebhookSensorId() {
+        XCTAssertTrue(SensorRegistry.staticSensorIDs.contains("battery_level"))
+        XCTAssertTrue(SensorRegistry.staticSensorIDs.contains("battery_state"))
+
+        for uniqueID in PedometerSensor.allSensorIDs {
+            XCTAssertTrue(SensorRegistry.staticSensorIDs.contains(uniqueID))
+        }
+        for metric in HealthKitSensor.Metric.allCases {
+            XCTAssertTrue(SensorRegistry.staticSensorIDs.contains(metric.uniqueID))
+        }
+    }
+
+    func testOptInSensorsAreTheCameraOnes() {
+        XCTAssertEqual(SensorRegistry.optInSensorIDs, [
+            WebhookSensorId.cameraMotion.rawValue,
+            WebhookSensorId.cameraStream.rawValue,
+        ])
+    }
+
+    func testOptInSensorsAreNeverOnByDefault() {
+        for uniqueID in SensorRegistry.optInSensorIDs {
+            XCTAssertFalse(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: uniqueID))
+        }
+    }
+
+    func testFirstRunDefaultsMatchWhatOnboardingUsedToKeepEnabled() {
+        for uniqueID in ["battery_level", "battery_state", "watch-battery", "watch-battery-state"] {
+            XCTAssertTrue(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: uniqueID))
+        }
+        XCTAssertTrue(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: WebhookSensorId.appVersion.rawValue))
+        XCTAssertTrue(
+            SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: WebhookSensorId.locationPermission.rawValue)
+        )
+
+        XCTAssertFalse(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: WebhookSensorId.storage.rawValue))
+        XCTAssertFalse(SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: WebhookSensorId.activity.rawValue))
+        XCTAssertFalse(
+            SensorRegistry.isEnabledByDefaultOnFirstRun(uniqueID: HealthKitSensor.Metric.steps.uniqueID)
+        )
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Sensors were stored as a `disabledSensors` denylist, so every sensor — including ones added in a later release — reported to Home Assistant until the user turned it off. They are now stored as an `enabledSensors` allowlist, so a sensor the app has never been told to enable stays off until the user enables it in Settings → Sensors.

Existing installs migrate their selection across on first launch. Statically known IDs come from a new `SensorRegistry`; sensors whose IDs only exist at runtime (one per battery, SIM or audio device) are carried over from the first complete sensor generation, which also removes the legacy keys. Camera sensors a device never produced stay off, since their absence from the old denylist meant "never seen" rather than "the user asked for it".

A first-time install starts with battery, app version and location permission enabled, matching what onboarding used to leave on.

Two pieces of code exist only to work around the old default and are removed:
- `SensorContainer.disableInitially`, which the camera sensors called to switch themselves off the first time they were seen.
- `OnboardingServersListViewModel.disableNonEssentialSensors`, which force-disabled every sensor it didn't recognise. Onboarding now just points a first-time install at the default selection, and no longer observes the sensor container at all.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual changes; the sensor list looks the same, only which sensors start enabled differs.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Hardware that first appears after the migration finishes (a SIM swapped in later, for example) starts disabled, which is the same rule that now applies to any newly seen sensor.

New tests cover the migration: preserving an existing selection, keeping never-seen camera sensors off, restoring camera sensors the user had turned on, carrying over runtime-only IDs, honouring a sensor turned off before it was ever produced, sensors appearing after the migration staying off, and the first-run defaults.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGr1RQJsWbZNuntnhQ4Lb7)_