### PR TITLE
Reduce watch complication refresh load

### DIFF
--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -569,15 +569,9 @@ enum WatchWidgetComplicationSnapshotStore {
         let previous = readSnapshots(defaults)
 
         // Write the synchronous set first so the face is never empty. Carry the last-known config
-        // snapshots through so their live values aren't dropped while the async refresh runs. When
-        // configs follow, this write only has to land in the store — the write below reloads with the
-        // fresh values, and reloading twice per refresh just burns budget and extension launches.
+        // snapshots through so their live values aren't dropped while the async refresh runs.
         let cachedConfigSnapshots = configs.compactMap { previous[$0.id] }
-        write(
-            snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots,
-            defaults: defaults,
-            requestReload: configs.isEmpty
-        )
+        write(snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots, defaults: defaults)
 
         guard !configs.isEmpty else { return [] }
         ComplicationRefreshDebugNotifier.notifyStarted(names: configs.map(\.displayName))
@@ -765,18 +759,7 @@ enum WatchWidgetComplicationSnapshotStore {
         return Dictionary(snapshots.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
-    /// Persists the snapshot set and asks WidgetKit to re-render it.
-    ///
-    /// `requestReload: false` persists without reloading, for a write that a second write is about to
-    /// supersede within the same refresh. Every reload launches the widget extension, so the
-    /// pre-write's reload was pure overhead: it re-rendered values the fresh write replaced moments
-    /// later. The fingerprint is left untouched too, so if the process is suspended before that second
-    /// write the content still counts as never-submitted and the next refresh reloads it.
-    private static func write(
-        snapshots: [WatchWidgetComplicationSnapshot],
-        defaults: UserDefaults?,
-        requestReload: Bool = true
-    ) {
+    private static func write(snapshots: [WatchWidgetComplicationSnapshot], defaults: UserDefaults?) {
         guard let defaults else {
             Current.Log.error("Missing app group defaults for watch widget complication snapshots")
             return
@@ -809,7 +792,6 @@ enum WatchWidgetComplicationSnapshotStore {
         if !contentUnchanged {
             defaults.set(data, forKey: defaultsKey)
         }
-        guard requestReload else { return }
         // Reload every kind rather than a single `kind` string: the widget registers its kind from the
         // extension's `Bundle.main.bundleIdentifier`, which can differ from this app-process-derived
         // value (e.g. debug `.dev` suffixing), and a mismatched `ofKind:` is a silent no-op that leaves

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -523,6 +523,9 @@ enum WatchWidgetComplicationSnapshotStore {
     /// `reloadAllTimelines`, kept separate from the store itself: the store can hold content the
     /// face was never re-rendered with (see `write`).
     private static let reloadFingerprintKey = "watchWidgetComplicationSnapshotsReloadFingerprint"
+    /// Identity of the complication set the picker was last told about, so `recommendations()` is only
+    /// re-queried when that set actually changed (see `invalidateRecommendationsIfNeeded`).
+    private static let recommendationsIdentityKey = "watchWidgetComplicationRecommendationsIdentity"
 
     /// Fire-and-forget refresh for synchronous callers (launch, mirror receipt, home sync).
     static func update() {
@@ -566,9 +569,15 @@ enum WatchWidgetComplicationSnapshotStore {
         let previous = readSnapshots(defaults)
 
         // Write the synchronous set first so the face is never empty. Carry the last-known config
-        // snapshots through so their live values aren't dropped while the async refresh runs.
+        // snapshots through so their live values aren't dropped while the async refresh runs. When
+        // configs follow, this write only has to land in the store — the write below reloads with the
+        // fresh values, and reloading twice per refresh just burns budget and extension launches.
         let cachedConfigSnapshots = configs.compactMap { previous[$0.id] }
-        write(snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots, defaults: defaults)
+        write(
+            snapshots: [.placeholder, .assist] + legacy + cachedConfigSnapshots,
+            defaults: defaults,
+            requestReload: configs.isEmpty
+        )
 
         guard !configs.isEmpty else { return [] }
         ComplicationRefreshDebugNotifier.notifyStarted(names: configs.map(\.displayName))
@@ -756,7 +765,18 @@ enum WatchWidgetComplicationSnapshotStore {
         return Dictionary(snapshots.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
-    private static func write(snapshots: [WatchWidgetComplicationSnapshot], defaults: UserDefaults?) {
+    /// Persists the snapshot set and asks WidgetKit to re-render it.
+    ///
+    /// `requestReload: false` persists without reloading, for a write that a second write is about to
+    /// supersede within the same refresh. Every reload launches the widget extension, so the
+    /// pre-write's reload was pure overhead: it re-rendered values the fresh write replaced moments
+    /// later. The fingerprint is left untouched too, so if the process is suspended before that second
+    /// write the content still counts as never-submitted and the next refresh reloads it.
+    private static func write(
+        snapshots: [WatchWidgetComplicationSnapshot],
+        defaults: UserDefaults?,
+        requestReload: Bool = true
+    ) {
         guard let defaults else {
             Current.Log.error("Missing app group defaults for watch widget complication snapshots")
             return
@@ -789,15 +809,31 @@ enum WatchWidgetComplicationSnapshotStore {
         if !contentUnchanged {
             defaults.set(data, forKey: defaultsKey)
         }
+        guard requestReload else { return }
         // Reload every kind rather than a single `kind` string: the widget registers its kind from the
         // extension's `Bundle.main.bundleIdentifier`, which can differ from this app-process-derived
         // value (e.g. debug `.dev` suffixing), and a mismatched `ofKind:` is a silent no-op that leaves
         // the freshly-written snapshot unread. There is only one widget, so reloading all is equivalent.
         WidgetCenter.shared.reloadAllTimelines()
-        WidgetCenter.shared.invalidateConfigurationRecommendations()
+        invalidateRecommendationsIfNeeded(for: snapshots, defaults: defaults)
         // Recorded only after the reload was requested, so a suspension in between retries the
         // reload on the next refresh instead of losing it.
         defaults.set(fingerprint, forKey: reloadFingerprintKey)
+    }
+
+    /// Re-queries the widget's `recommendations()` only when the *set* of complications changed.
+    /// Invalidating is a separate extension launch from the reload, and the recommendation list
+    /// depends on which complications exist — not on their values — so doing it on every value change
+    /// doubled the extension launches for no benefit.
+    private static func invalidateRecommendationsIfNeeded(
+        for snapshots: [WatchWidgetComplicationSnapshot],
+        defaults: UserDefaults
+    ) {
+        // Name included, not just the id: renaming a complication changes what the picker lists.
+        let identity = snapshots.map { "\($0.id)=\($0.menuName ?? "")" }.sorted().joined(separator: "|")
+        guard defaults.string(forKey: recommendationsIdentityKey) != identity else { return }
+        WidgetCenter.shared.invalidateConfigurationRecommendations()
+        defaults.set(identity, forKey: recommendationsIdentityKey)
     }
 }
 

--- a/Sources/WatchWidgets/WatchWidgetAppIntent.swift
+++ b/Sources/WatchWidgets/WatchWidgetAppIntent.swift
@@ -37,20 +37,26 @@ struct WatchWidgetAppIntentProvider: AppIntentTimelineProvider {
         // identity (name, icon, gauge, colors) with a neutral value instead of whatever live value
         // happens to be cached — no fetch, instant, and never presents stale data as current.
         guard context.isPreview else { return entry }
-        return WatchWidgetEntry(
-            date: entry.date,
-            family: entry.family,
-            complication: entry.complication?.previewVariant
-        )
+        return previewEntry(from: entry)
     }
 
     func timeline(
         for configuration: WatchWidgetConfigurationIntent,
         in context: Context
     ) async -> Timeline<WatchWidgetEntry> {
-        // Self-fetch live values on the widget's own WidgetKit budget so complications stay fresh even
-        // when the WatchApp isn't woken. This updates the app-group snapshot store that `entry(...)` reads.
-        await WatchWidgetLiveFetch.refresh(configuredID: configuration.complication?.id)
+        // Picking a complication renders one preview per candidate per family, so a fetch here would
+        // multiply into a burst of requests in a single extension process — while the picker is the one
+        // place a live value must not be shown anyway. Serve mocked identity-only data and never reload:
+        // the real timeline is built once the complication is actually placed on the face.
+        guard !context.isPreview else {
+            return Timeline(entries: [previewEntry(from: entry(for: configuration, in: context))], policy: .never)
+        }
+
+        // Fetch only the complication this instance renders, not every configured one. Each instance on
+        // the face gets its own `timeline(for:in:)` call, so fetching them all here squared the work and
+        // was what pushed the extension past its watchdog budget.
+        await WatchWidgetLiveFetch.refresh(complicationID: renderedSnapshot(for: configuration, in: context)?.id)
+
         return Timeline(
             entries: [entry(for: configuration, in: context)],
             policy: .after(Date().addingTimeInterval(WatchWidgetConstants.timelineRefreshInterval))
@@ -71,10 +77,28 @@ struct WatchWidgetAppIntentProvider: AppIntentTimelineProvider {
         WatchWidgetEntry(
             date: Date(),
             family: context.family,
-            complication: WatchWidgetComplicationSnapshotStore.complication(
-                for: context.family,
-                configuredID: configuration.complication?.id
-            ) ?? .placeholder
+            complication: renderedSnapshot(for: configuration, in: context) ?? .placeholder
+        )
+    }
+
+    /// The stored snapshot this instance actually renders. The configured id can no longer resolve (the
+    /// complication was deleted, or recreated with a new id), in which case the store falls back to a
+    /// family match — so this, not the configured id, is what the self fetch must target.
+    private func renderedSnapshot(
+        for configuration: WatchWidgetConfigurationIntent,
+        in context: Context
+    ) -> WatchWidgetComplicationSnapshot? {
+        WatchWidgetComplicationSnapshotStore.complication(
+            for: context.family,
+            configuredID: configuration.complication?.id
+        )
+    }
+
+    private func previewEntry(from entry: WatchWidgetEntry) -> WatchWidgetEntry {
+        WatchWidgetEntry(
+            date: entry.date,
+            family: entry.family,
+            complication: entry.complication?.previewVariant
         )
     }
 }

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -27,8 +27,9 @@ enum WatchWidgetConstants {
     /// change or a `reloadAllTimelines()` fires them together — without this, N instances of the same
     /// complication mean N simultaneous requests in one extension process.
     static let selfFetchThrottleInterval: TimeInterval = 60
-    /// App-group defaults key holding `[complicationID: lastFetchDate]` for the throttle above.
-    static let lastSelfFetchKey = "watchWidgetComplicationLastSelfFetch"
+    /// Prefix for the app-group defaults key holding a complication's last self-fetch date. One key per
+    /// complication, so concurrent claims never read-modify-write a shared blob.
+    static let lastSelfFetchKeyPrefix = "watchWidgetComplicationLastSelfFetch-"
 
     enum DeepLink {
         static let releaseScheme = "homeassistant"

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -18,6 +18,17 @@ enum WatchWidgetConstants {
     static let previewValueText = "--"
     static let previewGaugeFraction: Double = 0.5
     static let timelineRefreshInterval: TimeInterval = 15 * 60
+    /// Per-request and whole-resource ceiling for the widget's self fetch. The extension runs under a
+    /// short watchdog budget, so a request left on `URLSession`'s 60s default can outlive the process
+    /// it is running in — the system then kills the extension and WidgetKit stops reloading it.
+    static let selfFetchTimeout: TimeInterval = 8
+    /// How long a complication's freshly fetched value is reused before the widget hits the network
+    /// again. Every widget instance on the face gets its own `timeline(for:in:)` call, and a face
+    /// change or a `reloadAllTimelines()` fires them together — without this, N instances of the same
+    /// complication mean N simultaneous requests in one extension process.
+    static let selfFetchThrottleInterval: TimeInterval = 60
+    /// App-group defaults key holding `[complicationID: lastFetchDate]` for the throttle above.
+    static let lastSelfFetchKey = "watchWidgetComplicationLastSelfFetch"
 
     enum DeepLink {
         static let releaseScheme = "homeassistant"

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -15,17 +15,78 @@ import Security
 /// Everything degrades gracefully: if the configs, credentials, or a live value can't be read, it
 /// leaves the stored snapshot untouched and the widget renders the last known values.
 enum WatchWidgetLiveFetch {
-    /// Refresh the configured complication (or all, when `configuredID` is nil), updating the stored
+    /// Complications rendered entirely from static content, so there is nothing to fetch for them.
+    private static let builtInIDs = [
+        WatchWidgetComplicationSnapshot.placeholderID,
+        WatchWidgetComplicationSnapshot.assistID,
+    ]
+
+    /// Refresh a single complication — the one the calling widget instance renders — updating its stored
     /// snapshot's value text in the app group. Best-effort; never throws.
-    static func refresh(configuredID: String?) async {
+    ///
+    /// Deliberately scoped to one complication: every instance on the face runs its own
+    /// `timeline(for:in:)`, so refreshing all of them here meant N instances × N complications of
+    /// sequential networking inside a single extension process. The watch app's periodic refresh remains
+    /// responsible for the complications that aren't currently on screen.
+    static func refresh(complicationID: String?) async {
+        // The built-in placeholder and Assist complications have no live value to fetch.
+        guard let complicationID, !builtInIDs.contains(complicationID) else { return }
+
         let configs = readConfigs()
-        let targets = configuredID.flatMap { id in configs.filter { $0.id == id } } ?? configs
-        WatchWidgetRefreshNotifier.notifyStarted(names: targets.map(\.displayName))
+        guard let target = configs.first(where: { $0.id == complicationID }) else {
+            // Either the mirrored database couldn't be read, or the face still points at a
+            // complication that no longer exists (deleted, or recreated with a new id).
+            WatchWidgetRefreshNotifier.notifyFinished("Skipped: no complication configured for \(complicationID)")
+            return
+        }
+        guard !isThrottled(complicationID) else {
+            WatchWidgetRefreshNotifier.notifyFinished(
+                "Skipped \(target.displayName): fetched less than "
+                    + "\(Int(WatchWidgetConstants.selfFetchThrottleInterval))s ago"
+            )
+            return
+        }
+
+        // Claimed before the request, not after: WidgetKit can run several instances' timeline calls
+        // concurrently in one process, and marking on completion would let them all pass the throttle
+        // together — exactly the stampede this is here to prevent.
+        markFetched(complicationID)
+
+        WatchWidgetRefreshNotifier.notifyStarted(names: [target.displayName])
         let started = Date()
-        let summary = await performRefresh(configs: configs, targets: targets)
+        let summary = await performRefresh(configs: configs, targets: [target])
         WatchWidgetRefreshNotifier.notifyFinished(
             summary + String(format: " — total %.1fs", Date().timeIntervalSince(started))
         )
+    }
+
+    // MARK: - Throttle
+
+    /// Whether this complication was fetched recently enough that another network round trip would be
+    /// wasted work. Keyed per complication so an unrelated one is never held back.
+    private static func isThrottled(_ complicationID: String) -> Bool {
+        guard let last = lastFetchDates()[complicationID] else { return false }
+        let elapsed = Date().timeIntervalSince(last)
+        // A negative elapsed means the clock moved backwards; treat it as stale rather than blocking
+        // the fetch until the recorded date is reached.
+        return elapsed >= 0 && elapsed < WatchWidgetConstants.selfFetchThrottleInterval
+    }
+
+    private static func markFetched(_ complicationID: String) {
+        guard let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID) else { return }
+        var dates = lastFetchDates()
+        dates[complicationID] = Date()
+        guard let data = try? JSONEncoder().encode(dates) else { return }
+        defaults.set(data, forKey: WatchWidgetConstants.lastSelfFetchKey)
+    }
+
+    private static func lastFetchDates() -> [String: Date] {
+        guard let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID),
+              let data = defaults.data(forKey: WatchWidgetConstants.lastSelfFetchKey),
+              let dates = try? JSONDecoder().decode([String: Date].self, from: data) else {
+            return [:]
+        }
+        return dates
     }
 
     /// The actual refresh. Returns a human-readable outcome for the developer-option notification —
@@ -146,8 +207,7 @@ enum WatchWidgetLiveFetch {
             "client_id": credential.clientID,
         ]).data(using: .utf8)
 
-        let delegate = WatchWidgetTLSDelegate(credential: credential)
-        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        let session = makeSession(for: credential)
         defer { session.finishTasksAndInvalidate() }
 
         guard let (data, response) = try? await session.data(for: request),
@@ -183,6 +243,23 @@ enum WatchWidgetLiveFetch {
 
     // MARK: - Fetch
 
+    /// A session bounded by `selfFetchTimeout`. Extensions get a much shorter watchdog budget than the
+    /// app, so `URLSession`'s 60s request / 7-day resource defaults would let one unreachable server
+    /// hold the process open until the system kills it — which reads to WidgetKit as a crashing
+    /// extension and stops the reloads entirely.
+    private static func makeSession(for credential: WatchWidgetServerCredential) -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = WatchWidgetConstants.selfFetchTimeout
+        configuration.timeoutIntervalForResource = WatchWidgetConstants.selfFetchTimeout
+        // Fail fast instead of parking the request until the watch has a route to the server.
+        configuration.waitsForConnectivity = false
+        return URLSession(
+            configuration: configuration,
+            delegate: WatchWidgetTLSDelegate(credential: credential),
+            delegateQueue: nil
+        )
+    }
+
     /// Fetches the entity's live state. On failure the value is nil and `failure` says why
     /// (transport error, HTTP status, malformed body), so the developer notification can report the
     /// actual cause instead of a generic "fetch failed".
@@ -194,8 +271,7 @@ enum WatchWidgetLiveFetch {
         var request = URLRequest(url: credential.baseURL.appendingPathComponent("api/states/\(entityId)"))
         request.setValue("Bearer \(credential.token)", forHTTPHeaderField: "Authorization")
 
-        let delegate = WatchWidgetTLSDelegate(credential: credential)
-        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        let session = makeSession(for: credential)
         defer { session.finishTasksAndInvalidate() }
 
         let data: Data

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -39,18 +39,13 @@ enum WatchWidgetLiveFetch {
             WatchWidgetRefreshNotifier.notifyFinished("Skipped: no complication configured for \(complicationID)")
             return
         }
-        guard !isThrottled(complicationID) else {
+        guard claimFetchSlot(complicationID) else {
             WatchWidgetRefreshNotifier.notifyFinished(
                 "Skipped \(target.displayName): fetched less than "
                     + "\(Int(WatchWidgetConstants.selfFetchThrottleInterval))s ago"
             )
             return
         }
-
-        // Claimed before the request, not after: WidgetKit can run several instances' timeline calls
-        // concurrently in one process, and marking on completion would let them all pass the throttle
-        // together — exactly the stampede this is here to prevent.
-        markFetched(complicationID)
 
         WatchWidgetRefreshNotifier.notifyStarted(names: [target.displayName])
         let started = Date()
@@ -62,31 +57,35 @@ enum WatchWidgetLiveFetch {
 
     // MARK: - Throttle
 
-    /// Whether this complication was fetched recently enough that another network round trip would be
-    /// wasted work. Keyed per complication so an unrelated one is never held back.
-    private static func isThrottled(_ complicationID: String) -> Bool {
-        guard let last = lastFetchDates()[complicationID] else { return false }
-        let elapsed = Date().timeIntervalSince(last)
-        // A negative elapsed means the clock moved backwards; treat it as stale rather than blocking
-        // the fetch until the recorded date is reached.
-        return elapsed >= 0 && elapsed < WatchWidgetConstants.selfFetchThrottleInterval
-    }
+    /// Serializes the throttle's read-then-write. WidgetKit can run several instances'
+    /// `timeline(for:in:)` calls concurrently in one process, so checking the timestamp and recording
+    /// the claim as separate steps would let them all pass together — the stampede this exists to stop.
+    private static let throttleLock = NSLock()
 
-    private static func markFetched(_ complicationID: String) {
-        guard let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID) else { return }
-        var dates = lastFetchDates()
-        dates[complicationID] = Date()
-        guard let data = try? JSONEncoder().encode(dates) else { return }
-        defaults.set(data, forKey: WatchWidgetConstants.lastSelfFetchKey)
-    }
+    /// Claims this complication's fetch slot, returning false when it was fetched recently enough that
+    /// another round trip would be wasted work.
+    ///
+    /// The claim is recorded before the request rather than after it, so a slow fetch still holds the
+    /// slot against the instances reloading alongside it. Each complication gets its own defaults key:
+    /// a single shared dictionary would need a read-modify-write, and concurrent claims for different
+    /// complications would drop each other's timestamp.
+    private static func claimFetchSlot(_ complicationID: String) -> Bool {
+        throttleLock.lock()
+        defer { throttleLock.unlock() }
 
-    private static func lastFetchDates() -> [String: Date] {
-        guard let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID),
-              let data = defaults.data(forKey: WatchWidgetConstants.lastSelfFetchKey),
-              let dates = try? JSONDecoder().decode([String: Date].self, from: data) else {
-            return [:]
+        let defaults = UserDefaults(suiteName: WatchWidgetConstants.appGroupID)
+        let key = WatchWidgetConstants.lastSelfFetchKeyPrefix + complicationID
+        let now = Date()
+        if let last = defaults?.object(forKey: key) as? Date {
+            let elapsed = now.timeIntervalSince(last)
+            // A negative elapsed means the clock moved backwards; treat it as stale rather than
+            // blocking the fetch until the recorded date is reached.
+            if elapsed >= 0, elapsed < WatchWidgetConstants.selfFetchThrottleInterval {
+                return false
+            }
         }
-        return dates
+        defaults?.set(now, forKey: key)
+        return true
     }
 
     /// The actual refresh. Returns a human-readable outcome for the developer-option notification —


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Complications could get stuck showing an old value until the watch was restarted.

The widget's timeline provider fetched *every* configured complication whenever an instance had no explicit configuration, with no request timeouts and no coalescing between instances. A face with several complications ran that work repeatedly inside one extension process, and an unreachable server held a request open for `URLSession`'s 60s default — long enough for the system to kill the extension, after which WidgetKit stops reloading it.

Changes:
- Each timeline call now fetches only the complication that instance renders.
- Token refresh and state fetch are bounded by an 8s request/resource timeout.
- A complication's self fetch is throttled to once a minute. The check and the claim happen under a lock so concurrent timeline calls can't both pass it, and each complication's timestamp has its own defaults key.
- The complication picker no longer fetches anything — it serves the same identity-only preview data `snapshot()` already served, so browsing candidates costs no network and never presents a live value as an example.
- Fewer app-side extension launches: the complication recommendation list is only invalidated when the set of complications changes, rather than on every value change.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not applicable — bug fix, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Complications that aren't currently on a face now rely on the watch app's periodic refresh rather than being incidentally refreshed by another instance's timeline call.
