### PR TITLE
Fix custom colors toggle state when reopening a complication

### DIFF
--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
@@ -23,8 +23,18 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
     /// brand-new complication, so the form reveals itself step by step: source → server → entity /
     /// template → value options. Editing an existing config starts with its kind selected.
     @Published private(set) var selectedSource: WatchComplicationConfig.Kind?
-    /// Nested opt-in under "Customize": reveals the color pickers.
-    @Published var useCustomColors: Bool
+    /// Nested opt-in under "Customize": reveals the color pickers. Not stored on its own — it reads
+    /// back from the colors the config actually carries, so turning it off has to clear them. That
+    /// keeps the toggle honest in both directions: the complication stops being tinted, and the
+    /// toggle can't reopen on because of a color nothing is using any more.
+    @Published var useCustomColors: Bool {
+        didSet {
+            guard !useCustomColors else { return }
+            useTemplateColor = false
+            config.clearCustomColors()
+        }
+    }
+
     /// Opt-in for the template flow: the colors come from templates rendering hex strings — one per
     /// static color picker. Turning it off clears the stored templates so the static colors apply
     /// again.
@@ -53,8 +63,7 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
         )
         self.config = initial
         self.selectedSource = existing?.kind
-        self.useCustomColors = initial.iconColor != nil
-            || (initial.families?.values.contains { $0.tint != nil || $0.textColor != nil } ?? false)
+        self.useCustomColors = initial.usesCustomColors()
         self.useTemplateColor = [
             initial.customGaugeColorTemplate, initial.customIconColorTemplate, initial.customTextColorTemplate,
         ].contains { !($0 ?? "").isEmpty }

--- a/Sources/HAModels/Sources/WatchComplicationConfig.swift
+++ b/Sources/HAModels/Sources/WatchComplicationConfig.swift
@@ -224,6 +224,36 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         isCustomized ?? (families?.isEmpty == false)
     }
 
+    /// Whether any customizable color is set: the static pickers (the global icon color and the
+    /// per-size gauge tint / text color) or the color templates. This is what the editor's "Custom
+    /// colors" toggle reads, so the toggle always describes the complication rather than a separately
+    /// stored opinion about it — which is only true because turning the toggle off clears the colors
+    /// (see `clearCustomColors()`).
+    ///
+    /// The templates count too: a template-only color setup used to read as "off", hiding the very
+    /// template fields that were driving the complication's colors.
+    public func usesCustomColors() -> Bool {
+        if iconColor != nil { return true }
+        if families?.values.contains(where: { $0.tint != nil || $0.textColor != nil }) == true { return true }
+        return [customGaugeColorTemplate, customIconColorTemplate, customTextColorTemplate]
+            .contains { !($0 ?? "").isEmpty }
+    }
+
+    /// Clears every customizable color, so turning "Custom colors" off leaves nothing behind that would
+    /// keep tinting the complication (and would read back as the toggle being on).
+    public mutating func clearCustomColors() {
+        iconColor = nil
+        customGaugeColorTemplate = nil
+        customIconColorTemplate = nil
+        customTextColorTemplate = nil
+        families = families?.mapValues { options in
+            var options = options
+            options.tint = nil
+            options.textColor = nil
+            return options
+        }
+    }
+
     public var displayName: String {
         name ?? entityDisplayName ?? entityId ?? "Complication"
     }

--- a/Tests/App/Watch/WatchComplicationBuilderEditViewModel.test.swift
+++ b/Tests/App/Watch/WatchComplicationBuilderEditViewModel.test.swift
@@ -238,6 +238,95 @@ struct WatchComplicationBuilderEditViewModelTests {
         }
     }
 
+    // MARK: - Custom colors
+
+    @Test func customColorsToggleReadsBackFromTheStoredColors() throws {
+        try withBuilderTestWorld { _ in
+            // Any stored color reads as "on" — the toggle describes the complication, nothing else.
+            let iconColor = WatchComplicationConfig(serverId: "server-1", iconColor: "#FF0000")
+            #expect(WatchComplicationBuilderEditViewModel(existing: iconColor).useCustomColors)
+
+            let familyColor = WatchComplicationConfig(
+                serverId: "server-1",
+                families: ["circular": .init(textColor: "#00FF00")]
+            )
+            #expect(WatchComplicationBuilderEditViewModel(existing: familyColor).useCustomColors)
+
+            // Template-driven colors count too — otherwise the toggle hid the template fields that
+            // were actually coloring the complication.
+            let templateColor = WatchComplicationConfig(
+                serverId: "server-1",
+                kind: .customTemplate,
+                customTextTemplate: "{{ 1 }}",
+                customTextColorTemplate: "{{ '#FF0000' }}"
+            )
+            let viewModel = WatchComplicationBuilderEditViewModel(existing: templateColor)
+            #expect(viewModel.useCustomColors)
+            #expect(viewModel.useTemplateColor)
+
+            let noColors = WatchComplicationConfig(serverId: "server-1")
+            #expect(WatchComplicationBuilderEditViewModel(existing: noColors).useCustomColors == false)
+        }
+    }
+
+    @Test func disablingCustomColorsClearsEveryStoredColor() throws {
+        try withBuilderTestWorld { _ in
+            let existing = WatchComplicationConfig(
+                serverId: "server-1",
+                kind: .customTemplate,
+                iconColor: "#FF0000",
+                customTextTemplate: "{{ 1 }}",
+                customGaugeColorTemplate: "{{ '#00FF00' }}",
+                families: [
+                    "circular": .init(tint: "#0000FF", textColor: "#FFFFFF"),
+                    "rectangular": .init(showIcon: true, tint: "#AABBCC"),
+                ]
+            )
+            let viewModel = WatchComplicationBuilderEditViewModel(existing: existing)
+            #expect(viewModel.useCustomColors)
+
+            viewModel.useCustomColors = false
+
+            #expect(viewModel.config.iconColor == nil)
+            #expect(viewModel.config.customGaugeColorTemplate == nil)
+            #expect(viewModel.config.customIconColorTemplate == nil)
+            #expect(viewModel.config.customTextColorTemplate == nil)
+            #expect(viewModel.config.families?["circular"]?.tint == nil)
+            #expect(viewModel.config.families?["circular"]?.textColor == nil)
+            #expect(viewModel.config.families?["rectangular"]?.tint == nil)
+            // Only the colors are cleared — the other per-size options survive.
+            #expect(viewModel.config.families?["rectangular"]?.showIcon == true)
+            #expect(viewModel.useTemplateColor == false)
+        }
+    }
+
+    @Test func disablingCustomColorsSurvivesSaveAndReopen() throws {
+        try withBuilderTestWorld { database in
+            // The bug this guards: turning the toggle off left the colors on the row, so the saved
+            // complication stayed tinted and the editor reopened with the toggle back on.
+            let viewModel = WatchComplicationBuilderEditViewModel(existing: nil)
+            viewModel.selectSource(.entity)
+            viewModel.selectedEntity = Self.batteryEntity(serverId: "server-1")
+            viewModel.applySelectedEntity()
+            viewModel.config.iconColor = "#FF0000"
+            viewModel.save()
+
+            var saved = try database.read { db in
+                try WatchComplicationConfig.fetchOne(db, key: viewModel.config.id)
+            }
+            #expect(WatchComplicationBuilderEditViewModel(existing: saved).useCustomColors)
+
+            viewModel.useCustomColors = false
+            viewModel.save()
+
+            saved = try database.read { db in
+                try WatchComplicationConfig.fetchOne(db, key: viewModel.config.id)
+            }
+            #expect(saved?.iconColor == nil)
+            #expect(WatchComplicationBuilderEditViewModel(existing: saved).useCustomColors == false)
+        }
+    }
+
     @Test func normalizedHexColorAcceptsValidHexOnly() {
         #expect(WatchComplicationConfig.normalizedHexColor(from: "#ff9500") == "#FF9500")
         #expect(WatchComplicationConfig.normalizedHexColor(from: "ff9500") == "#FF9500")


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The complication builder's "Custom colors" toggle reads back from the colors the config carries, but turning it off never cleared them. So the icon color and the per-size tint/text color stayed on the row: the complication kept being tinted, and reopening the editor showed the toggle back on.

Turning the toggle off now clears the colors it controls — the icon color, the per-size tint and text color, and the three color templates — the same way the nested "Color from template" toggle already clears its templates. Other per-size options are untouched.

The read-back also ignored the color templates, so a template-only color setup reopened with the toggle off, hiding the template fields that were coloring the complication. Those now count as well.

No new stored state: the toggle still describes the complication rather than a separate saved opinion about it, which stays accurate now that turning it off clears the colors.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change — the toggle now shows the state it was saved in.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Covered by three new cases in `WatchComplicationBuilderEditViewModel.test.swift`: what the toggle reads back from (static colors, per-size colors, color templates, none), turning it off clearing every color while leaving other per-size options intact, and a save → reload → reopen round trip.
