### PR TITLE
Show settings button in standby server picker

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -60,7 +60,7 @@ struct HomeAssistantView: View, WebFrontendView {
             standByView
         }
         .sheet(isPresented: $showServerSelection) {
-            ServerSelectView(prompt: nil, includeSettings: false, selectAction: viewModel.selectServer)
+            ServerSelectView(prompt: nil, includeSettings: true, selectAction: viewModel.selectServer)
                 .presentationDetents([.medium, .large])
                 .presentationBackground(Color(uiColor: .systemBackground))
                 .modify { view in


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Tapping the server pill in the standby view opened the server picker without the settings gear icon. The picker now includes it, matching the other places where the server picker is presented.

## Screenshots

N/A

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXx1yYVqRq35vrDdH4KH2E)_