### PR TITLE
Fix deep links being ignored while a sheet is open

### DIFF
--- a/Sources/App/Container/AppContainerCoordinator.swift
+++ b/Sources/App/Container/AppContainerCoordinator.swift
@@ -41,8 +41,21 @@ final class AppContainerCoordinator: AppCoordinator {
 
     var window: UIWindow? { frontend?.presentationWindow }
 
+    /// The controller every presentation of this scene hangs off. Falls back to the active scene's key
+    /// window because a full-screen presentation detaches the frontend's own view, which would otherwise
+    /// leave us with no way to reach — or clear — what is on screen.
+    private var presentationRoot: UIViewController? {
+        if let root = window?.rootViewController {
+            return root
+        }
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        let keyWindow = scene?.windows.first { $0.isKeyWindow } ?? scene?.windows.first
+        return keyWindow?.rootViewController
+    }
+
     var presentedViewController: UIViewController? {
-        var current = frontend?.presentationWindow?.rootViewController
+        var current = presentationRoot
         while let next = current?.presentedViewController {
             current = next
         }
@@ -92,7 +105,11 @@ final class AppContainerCoordinator: AppCoordinator {
 
     func selectServer(prompt: String?, includeSettings: Bool, completion: @escaping (Server) -> Void) {
         pendingServerSelection = completion
-        onSelectServer?(prompt, includeSettings)
+        // The picker is a sheet on the container, so anything already presented (Settings, What's New, …)
+        // would swallow it — clear the screen first.
+        dismissPresentedContent { [weak self] in
+            self?.onSelectServer?(prompt, includeSettings)
+        }
     }
 
     /// Called by `ContainerView`'s server-picker sheet when the user picks a server.
@@ -113,10 +130,29 @@ final class AppContainerCoordinator: AppCoordinator {
             prefillURL: inviteURL,
             shouldDismissOnSuccess: true
         )
-        frontend.presentOverlayController(
-            controller: onboardingView.embeddedInHostingController(),
-            animated: true
-        )
+        // An invite link opens the app to launch something, so it takes over from whatever is on screen.
+        dismissPresentedContent {
+            frontend.presentOverlayController(
+                controller: onboardingView.embeddedInHostingController(),
+                animated: true
+            )
+        }
+    }
+
+    func dismissPresentedContent(completion: (() -> Void)?) {
+        // Clear the SwiftUI bindings before dismissing their controllers: left at `true` they strand the
+        // presentation state and block whatever wants to be presented next.
+        AppPresentationDismisser.shared.dismissAll()
+
+        // Dismissing from the root tears down the whole presentation chain, SwiftUI sheets included. The
+        // frontend's own overlays are the fallback for a link handled before there is a scene root.
+        if let root = presentationRoot, root.presentedViewController != nil {
+            root.dismiss(animated: true, completion: completion)
+        } else if let frontend {
+            frontend.dismissOverlayController(animated: true, completion: completion)
+        } else {
+            completion?()
+        }
     }
 
     func setup() {
@@ -193,13 +229,23 @@ final class AppContainerCoordinator: AppCoordinator {
     }
 
     private func navigate(to url: URL, on server: Server, avoidUnnecessaryReload: Bool, isComingFromAppIntent: Bool) {
-        open(server: server).done { frontend in
-            frontend.dismissOverlayController(animated: true, completion: nil)
-            if isComingFromAppIntent {
-                frontend.openPanel(url)
-            } else {
-                frontend.open(inline: url, avoidUnnecessaryReload: avoidUnnecessaryReload)
+        open(server: server).done { [weak self] frontend in
+            let performNavigation = {
+                if isComingFromAppIntent {
+                    frontend.openPanel(url)
+                } else {
+                    frontend.open(inline: url, avoidUnnecessaryReload: avoidUnnecessaryReload)
+                }
             }
+            guard let self else {
+                performNavigation()
+                return
+            }
+            // Everything on screen has to go first, not just the frontend's own overlays: a SwiftUI sheet
+            // left up would hide the navigation entirely and make the link look ignored. Navigating only
+            // once it's gone also keeps the sheet's teardown (which can refresh a stale web view) from
+            // landing on top of the destination.
+            dismissPresentedContent(completion: performNavigation)
         }
     }
 

--- a/Sources/App/Container/AppPresentationDismisser.swift
+++ b/Sources/App/Container/AppPresentationDismisser.swift
@@ -16,8 +16,10 @@ final class AppPresentationDismisser {
 
     /// Fires when the screen has to be cleared for an incoming navigation. Views observing it drop their
     /// own presentation state; they are only subscribed while they are in the hierarchy, so nothing that
-    /// isn't on screen is touched.
-    let dismissAllPublisher = PassthroughSubject<Void, Never>()
+    /// isn't on screen is touched. Read-only — clearing the screen goes through `dismissAll()`.
+    var dismissAllPublisher: AnyPublisher<Void, Never> { dismissAllSubject.eraseToAnyPublisher() }
+
+    private let dismissAllSubject = PassthroughSubject<Void, Never>()
 
     private init() {}
 
@@ -27,6 +29,6 @@ final class AppPresentationDismisser {
         // state, so it is cleared directly instead of through the publisher.
         AppSettingsPresenter.shared.isSheetPresented = false
         AppSettingsPresenter.shared.isPushPresented = false
-        dismissAllPublisher.send(())
+        dismissAllSubject.send(())
     }
 }

--- a/Sources/App/Container/AppPresentationDismisser.swift
+++ b/Sources/App/Container/AppPresentationDismisser.swift
@@ -1,0 +1,32 @@
+import Combine
+import Foundation
+
+/// Clears everything the app presents over its own content — SwiftUI sheets, full-screen covers and pushed
+/// destinations — so an incoming navigation (deep link, universal link, App Intent or notification tap)
+/// always lands on the frontend instead of happening invisibly behind whatever the user had open.
+///
+/// Before the SwiftUI migration every one of those overlays was a `UIViewController` presented over the web
+/// view, so `dismissOverlayController()` was enough to clear the screen. They are now driven by
+/// `@State`/`@Published` bindings, and dismissing their controllers through UIKit alone leaves the bindings
+/// stuck at `true`: the state is stranded and the next presentation is silently swallowed. Views therefore
+/// clear their own binding in response to `dismissAllPublisher` (see `View.dismissesOnAppNavigation(_:)`),
+/// and `AppCoordinator.dismissPresentedContent(completion:)` tears down whatever is still on screen.
+final class AppPresentationDismisser {
+    static let shared = AppPresentationDismisser()
+
+    /// Fires when the screen has to be cleared for an incoming navigation. Views observing it drop their
+    /// own presentation state; they are only subscribed while they are in the hierarchy, so nothing that
+    /// isn't on screen is touched.
+    let dismissAllPublisher = PassthroughSubject<Void, Never>()
+
+    private init() {}
+
+    /// Asks every presentation currently on screen to go away. Call on the main thread.
+    func dismissAll() {
+        // Settings lives above the kiosk/container swap in a shared presenter rather than in a view's own
+        // state, so it is cleared directly instead of through the publisher.
+        AppSettingsPresenter.shared.isSheetPresented = false
+        AppSettingsPresenter.shared.isPushPresented = false
+        dismissAllPublisher.send(())
+    }
+}

--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -63,6 +63,9 @@ struct ContainerView: View {
         .onChange(of: state.screen) { screen in
             fadeOutLaunchSplashIfNeeded(for: screen)
         }
+        // `fullScreenCover` is deliberately left alone: it carries the forced onboarding-permissions
+        // decision, which a deep link must not be able to skip.
+        .dismissesOnAppNavigation { viewModel.presentedSheet = nil }
         .sheet(item: $viewModel.presentedSheet) { sheet in
             switch sheet {
             case .assistSettings:

--- a/Sources/App/Container/View+DismissesOnAppNavigation.swift
+++ b/Sources/App/Container/View+DismissesOnAppNavigation.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+extension View {
+    /// Clears this view's own presentation state whenever an incoming navigation (deep link, universal link,
+    /// App Intent or notification tap) needs the frontend on screen. Pair it with every `.sheet`/`.fullScreenCover`
+    /// binding that can cover the web frontend, otherwise the navigation happens behind it and looks ignored.
+    func dismissesOnAppNavigation(perform dismiss: @escaping () -> Void) -> some View {
+        onReceive(AppPresentationDismisser.shared.dismissAllPublisher) { _ in dismiss() }
+    }
+}

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -513,8 +513,10 @@ class IncomingURLHandler {
     }
 
     private func showTagApproval(tag: String, type: TagManagerHandleResult.HandledType) {
-        let appCoordinator: AppCoordinator? = coordinator
-        let view = TagApprovalBottomSheet(
+        // Built empty first so `onDismiss` can weakly reference the controller it lives in: it has to dismiss
+        // this sheet specifically — not whatever is top-most, which may be an overlay that appeared above it.
+        let controller = UIHostingController(rootView: AnyView(EmptyView()))
+        controller.rootView = AnyView(TagApprovalBottomSheet(
             tag: tag,
             onAllowOnce: { [weak self] in
                 self?.fireApprovedTag(tag, type: type)
@@ -523,14 +525,10 @@ class IncomingURLHandler {
                 AllowedTag.add(tag)
                 self?.fireApprovedTag(tag, type: type)
             },
-            onDismiss: {
-                // The sheet presents on top of everything, so it is the top-most controller — dismissing
-                // the frontend's presented controller instead could tear down an unrelated sheet.
-                appCoordinator?.presentedViewController?.dismiss(animated: false)
+            onDismiss: { [weak controller] in
+                controller?.dismiss(animated: false)
             }
-        )
-
-        let controller = UIHostingController(rootView: view)
+        ))
         controller.modalPresentationStyle = .overFullScreen
         controller.view.backgroundColor = .clear
         presentOnTopmost(controller, animated: false)

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -89,15 +89,14 @@ class IncomingURLHandler {
                     Current.Log.error("No server found for open camera URL: \(url)")
                     return false
                 }
-                Current.sceneManager.webViewControllerPromise
-                    .done { webViewController in
-                        let view = CameraPlayerView(
-                            server: server,
-                            cameraEntityId: entityId
-                        ).embeddedInHostingController()
-                        view.modalPresentationStyle = .overFullScreen
-                        webViewController.present(view, animated: true)
-                    }
+                presentOverFrontend { webViewController in
+                    let view = CameraPlayerView(
+                        server: server,
+                        cameraEntityId: entityId
+                    ).embeddedInHostingController()
+                    view.modalPresentationStyle = .overFullScreen
+                    webViewController.present(view, animated: true)
+                }
             case .navigate: // homeassistant://navigate/lovelace/dashboard
                 guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                     return false
@@ -182,35 +181,33 @@ class IncomingURLHandler {
                     $0.identifier.rawValue == serverId
                 }) ?? Current.servers.all.first else { return false }
 
-                Current.sceneManager.webViewControllerPromise
-                    .done { webViewController in
-                        webViewController.webViewExternalMessageHandler.showAssist(
-                            server: server,
-                            pipeline: pipelineId,
-                            autoStartRecording: startlistening
-                        )
-                    }
+                presentOverFrontend { webViewController in
+                    webViewController.webViewExternalMessageHandler.showAssist(
+                        server: server,
+                        pipeline: pipelineId,
+                        autoStartRecording: startlistening
+                    )
+                }
             case .createCustomWidget:
-                Current.sceneManager.webViewControllerPromise
-                    .done { webViewController in
-                        let mainView = CustomWidgetsListView()
-                            .toolbar {
-                                ToolbarItem(placement: .topBarTrailing) {
-                                    CloseButton {
-                                        webViewController.dismissOverlayController(
-                                            animated: true,
-                                            completion: nil
-                                        )
-                                    }
+                presentOverFrontend { webViewController in
+                    let mainView = CustomWidgetsListView()
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                CloseButton {
+                                    webViewController.dismissOverlayController(
+                                        animated: true,
+                                        completion: nil
+                                    )
                                 }
                             }
-                        let controller = UIHostingController(rootView: AnyView(
-                            NavigationStack {
-                                mainView
-                            }
-                        ))
-                        webViewController.presentOverlayController(controller: controller, animated: true)
-                    }
+                        }
+                    let controller = UIHostingController(rootView: AnyView(
+                        NavigationStack {
+                            mainView
+                        }
+                    ))
+                    webViewController.presentOverlayController(controller: controller, animated: true)
+                }
             case .invite:
                 // homeassistant://invite#url=http%3A%2F%2Fhomeassistant.local%3A8123
                 Current.Log.verbose("Received Home Assistant invitation URL: \(url)")
@@ -452,6 +449,38 @@ class IncomingURLHandler {
         }
     }
 
+    /// Clears whatever is on screen — SwiftUI sheets included — before handing the frontend to `present`.
+    /// A link that opens the app to launch something has to take over from the content the user had open,
+    /// otherwise presenting over the web view fails and the link looks ignored.
+    private func presentOverFrontend(_ present: @escaping (WebViewController) -> Void) {
+        // The handler is a throwaway created per incoming link, so the coordinator is captured up front
+        // rather than reached through `self`, which is gone by the time the promise resolves.
+        let appCoordinator: AppCoordinator? = coordinator
+        Current.sceneManager.webViewControllerPromise.done { webViewController in
+            guard let appCoordinator else {
+                present(webViewController)
+                return
+            }
+            appCoordinator.dismissPresentedContent {
+                present(webViewController)
+            }
+        }
+    }
+
+    /// Presents on top of everything currently on screen. Used for the transient prompts (confirmations,
+    /// results, tag approval) that only need to be seen — unlike `presentOverFrontend(_:)` they don't take
+    /// the screen over, so a sheet the user opened stays where it was.
+    private func presentOnTopmost(_ controller: UIViewController, animated: Bool = true) {
+        let appCoordinator: AppCoordinator? = coordinator
+        Current.sceneManager.webViewControllerPromise.done { webViewController in
+            guard let appCoordinator else {
+                webViewController.present(controller, animated: animated, completion: nil)
+                return
+            }
+            appCoordinator.present(controller, animated: animated, completion: nil)
+        }
+    }
+
     private func confirmAction(
         title: String,
         message: String,
@@ -480,32 +509,31 @@ class IncomingURLHandler {
             }
         ))
 
-        Current.sceneManager.webViewControllerPromise.done {
-            $0.present(alert, animated: true, completion: nil)
-        }
+        presentOnTopmost(alert)
     }
 
     private func showTagApproval(tag: String, type: TagManagerHandleResult.HandledType) {
-        Current.sceneManager.webViewControllerPromise.done { [weak self] webViewController in
-            let view = TagApprovalBottomSheet(
-                tag: tag,
-                onAllowOnce: { [weak self] in
-                    self?.fireApprovedTag(tag, type: type)
-                },
-                onAllowAlways: { [weak self] in
-                    AllowedTag.add(tag)
-                    self?.fireApprovedTag(tag, type: type)
-                },
-                onDismiss: { [weak webViewController] in
-                    webViewController?.dismiss(animated: false)
-                }
-            )
+        let appCoordinator: AppCoordinator? = coordinator
+        let view = TagApprovalBottomSheet(
+            tag: tag,
+            onAllowOnce: { [weak self] in
+                self?.fireApprovedTag(tag, type: type)
+            },
+            onAllowAlways: { [weak self] in
+                AllowedTag.add(tag)
+                self?.fireApprovedTag(tag, type: type)
+            },
+            onDismiss: {
+                // The sheet presents on top of everything, so it is the top-most controller — dismissing
+                // the frontend's presented controller instead could tear down an unrelated sheet.
+                appCoordinator?.presentedViewController?.dismiss(animated: false)
+            }
+        )
 
-            let controller = UIHostingController(rootView: view)
-            controller.modalPresentationStyle = .overFullScreen
-            controller.view.backgroundColor = .clear
-            webViewController.present(controller, animated: false)
-        }
+        let controller = UIHostingController(rootView: view)
+        controller.modalPresentationStyle = .overFullScreen
+        controller.view.backgroundColor = .clear
+        presentOnTopmost(controller, animated: false)
     }
 
     private func fireApprovedTag(_ tag: String, type: TagManagerHandleResult.HandledType) {
@@ -541,9 +569,7 @@ class IncomingURLHandler {
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: L10n.okLabel, style: .default, handler: nil))
-        Current.sceneManager.webViewControllerPromise.done {
-            $0.present(alert, animated: true, completion: nil)
-        }
+        presentOnTopmost(alert)
     }
 
     private func showMy(for url: URL) -> Bool {

--- a/Sources/App/Frontend/WebView/ConnectionSecurityLevelBlock/ConnectionSecurityLevelBlockView.swift
+++ b/Sources/App/Frontend/WebView/ConnectionSecurityLevelBlock/ConnectionSecurityLevelBlockView.swift
@@ -46,6 +46,10 @@ struct ConnectionSecurityLevelBlockView: View {
             .onAppear {
                 viewModel.loadRequirements()
             }
+            .dismissesOnAppNavigation {
+                showHomeNetworkSettings = false
+                showConnectionSecurityPreferences = false
+            }
             #if targetEnvironment(macCatalyst)
             .fullScreenCover(isPresented: $showHomeNetworkSettings) {
                 homeNetworkView

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -98,6 +98,10 @@ struct HomeAssistantView: View, WebFrontendView {
             viewModel.updateReduceMotion(reduceMotion)
         }
         .onDisappear { viewModel.disappear(reduceMotion: reduceMotion) }
+        .dismissesOnAppNavigation {
+            showServerSelection = false
+            launchMessages.dismissAll()
+        }
         .sheet(item: $launchMessages.presented, onDismiss: { launchMessages.showNext() }) { message in
             switch message {
             case let .whatsNew(release):

--- a/Sources/App/Frontend/WebView/HomeAssistantView/LaunchMessagesState.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/LaunchMessagesState.swift
@@ -20,7 +20,8 @@ final class LaunchMessagesState: ObservableObject {
 
     @Published var presented: Message?
 
-    private var pending: [Message] = []
+    /// Non-private for tests.
+    var pending: [Message] = []
     /// Evaluated once per app session — `HomeAssistantView` is recreated on server switches, which
     /// should not re-present the launch messages.
     private static var didEvaluate = false
@@ -45,5 +46,13 @@ final class LaunchMessagesState: ObservableObject {
     func showNext() {
         guard presented == nil, !pending.isEmpty else { return }
         presented = pending.removeFirst()
+    }
+
+    /// Drops the whole queue when an incoming navigation takes over the screen. Clearing `pending` too
+    /// matters: the sheet's `onDismiss` calls `showNext()`, which would otherwise immediately cover the
+    /// destination the link just navigated to.
+    func dismissAll() {
+        pending = []
+        presented = nil
     }
 }

--- a/Sources/App/Scenes/SceneManager.swift
+++ b/Sources/App/Scenes/SceneManager.swift
@@ -64,6 +64,10 @@ protocol AppCoordinator: AnyObject {
         queryParameters: [URLQueryItem]?,
         isComingFromAppIntent: Bool
     )
+    /// Clears everything presented over the frontend — SwiftUI sheets and covers as well as UIKit overlays —
+    /// and runs `completion` once the screen is free. Anything that opens the app to launch something goes
+    /// through this, so it is never swallowed by content the user already had open.
+    func dismissPresentedContent(completion: (() -> Void)?)
 }
 
 extension AppCoordinator {

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -50,6 +50,9 @@ struct ConditionalContainerView: View {
         .onChange(of: appSettings.isPushPresented) { isPresented in
             refreshWebViewIfSettingsClosed(isPresented)
         }
+        // Settings itself is cleared by `AppPresentationDismisser` (it lives in a shared presenter); the
+        // kiosk settings sheet is view state, so it opts in here.
+        .dismissesOnAppNavigation { showKioskSettings = false }
         .sheet(isPresented: $showKioskSettings) {
             NavigationView {
                 KioskSettingsView()

--- a/Tests/App/Container/AppContainerCoordinatorTests.swift
+++ b/Tests/App/Container/AppContainerCoordinatorTests.swift
@@ -1,0 +1,94 @@
+@testable import HomeAssistant
+@testable import Shared
+import UIKit
+import XCTest
+
+@MainActor
+final class AppContainerCoordinatorTests: XCTestCase {
+    private var server: Server!
+    private var window: UIWindow!
+    private var frontend: MockWebFrontend!
+    private var coordinator: AppContainerCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        server = Server.fake()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = UIViewController()
+        frontend = MockWebFrontend(server: server, presentationWindow: window)
+        coordinator = AppContainerCoordinator()
+        coordinator.setFrontend(frontend)
+    }
+
+    override func tearDown() {
+        AppSettingsPresenter.shared.isSheetPresented = false
+        AppSettingsPresenter.shared.isPushPresented = false
+        super.tearDown()
+    }
+
+    func testDismissPresentedContentClearsSwiftUIPresentationStateAndCallsCompletion() {
+        AppSettingsPresenter.shared.isSheetPresented = true
+        var completed = false
+
+        coordinator.dismissPresentedContent { completed = true }
+
+        XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
+        XCTAssertTrue(completed)
+    }
+
+    func testDismissPresentedContentClearsTheFrontendsOwnOverlaysWhenNothingIsPresentedAtTheRoot() {
+        coordinator.dismissPresentedContent(completion: nil)
+
+        XCTAssertEqual(frontend.dismissOverlayControllerCallCount, 1)
+    }
+
+    func testDeepLinkNavigatesTheFrontendWhileASheetIsPresented() {
+        AppSettingsPresenter.shared.isSheetPresented = true
+        let navigated = expectation(description: "frontend navigated")
+        frontend.onOpen = { _ in navigated.fulfill() }
+
+        coordinator.open(
+            from: .deeplink,
+            server: server,
+            urlString: "/lovelace/dashboard",
+            skipConfirm: true,
+            isComingFromAppIntent: false
+        )
+
+        wait(for: [navigated], timeout: 5)
+        XCTAssertEqual(frontend.openedInlineURLs.last?.path, "/lovelace/dashboard")
+        XCTAssertTrue(frontend.openedPanelURLs.isEmpty)
+        XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
+    }
+
+    func testAppIntentOpensThePanelWhileASheetIsPresented() {
+        AppSettingsPresenter.shared.isSheetPresented = true
+        let navigated = expectation(description: "frontend navigated")
+        frontend.onOpen = { _ in navigated.fulfill() }
+
+        coordinator.open(
+            from: .deeplink,
+            server: server,
+            urlString: "/lovelace/dashboard",
+            skipConfirm: true,
+            isComingFromAppIntent: true
+        )
+
+        wait(for: [navigated], timeout: 5)
+        XCTAssertEqual(frontend.openedPanelURLs.last?.path, "/lovelace/dashboard")
+        XCTAssertTrue(frontend.openedInlineURLs.isEmpty)
+        XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
+    }
+
+    func testSelectingAServerClearsWhatIsAlreadyPresentedFirst() {
+        AppSettingsPresenter.shared.isSheetPresented = true
+        var settingsSheetWasClearedBeforePresenting: Bool?
+        coordinator.onSelectServer = { _, _ in
+            settingsSheetWasClearedBeforePresenting = !AppSettingsPresenter.shared.isSheetPresented
+        }
+
+        coordinator.selectServer(prompt: nil, includeSettings: false) { _ in }
+
+        XCTAssertEqual(settingsSheetWasClearedBeforePresenting, true)
+    }
+}

--- a/Tests/App/Container/AppPresentationDismisserTests.swift
+++ b/Tests/App/Container/AppPresentationDismisserTests.swift
@@ -1,0 +1,48 @@
+import Combine
+@testable import HomeAssistant
+import XCTest
+
+@MainActor
+final class AppPresentationDismisserTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        AppSettingsPresenter.shared.isSheetPresented = false
+        AppSettingsPresenter.shared.isPushPresented = false
+        super.tearDown()
+    }
+
+    func testDismissAllClearsSettingsPresentation() {
+        AppSettingsPresenter.shared.isSheetPresented = true
+        AppSettingsPresenter.shared.isPushPresented = true
+
+        AppPresentationDismisser.shared.dismissAll()
+
+        XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
+        XCTAssertFalse(AppSettingsPresenter.shared.isPushPresented)
+    }
+
+    func testDismissAllNotifiesViewsOwningTheirOwnPresentationState() {
+        var receivedCount = 0
+        AppPresentationDismisser.shared.dismissAllPublisher
+            .sink { receivedCount += 1 }
+            .store(in: &cancellables)
+
+        AppPresentationDismisser.shared.dismissAll()
+        AppPresentationDismisser.shared.dismissAll()
+
+        XCTAssertEqual(receivedCount, 2)
+    }
+
+    func testDismissAllDoesNotNotifyOnceAViewIsNoLongerObserving() {
+        var receivedCount = 0
+        let cancellable = AppPresentationDismisser.shared.dismissAllPublisher
+            .sink { receivedCount += 1 }
+        cancellable.cancel()
+
+        AppPresentationDismisser.shared.dismissAll()
+
+        XCTAssertEqual(receivedCount, 0)
+    }
+}

--- a/Tests/App/WebView/LaunchMessagesStateTests.swift
+++ b/Tests/App/WebView/LaunchMessagesStateTests.swift
@@ -1,0 +1,46 @@
+@testable import HomeAssistant
+@testable import Shared
+import SFSafeSymbols
+import XCTest
+
+@MainActor
+final class LaunchMessagesStateTests: XCTestCase {
+    func testDismissAllClearsThePresentedMessage() {
+        let sut = LaunchMessagesState()
+        sut.presented = .whatsNew(Self.release())
+
+        sut.dismissAll()
+
+        XCTAssertNil(sut.presented)
+    }
+
+    /// The launch-message sheet calls `showNext()` from `onDismiss`, so dropping only the presented message
+    /// would immediately cover whatever an incoming deep link just navigated to.
+    func testDismissAllStopsTheQueueFromRePresenting() {
+        let sut = LaunchMessagesState()
+        sut.presented = .whatsNew(Self.release(id: "first"))
+        sut.pending = [.whatsNew(Self.release(id: "second"))]
+
+        sut.dismissAll()
+        sut.showNext()
+
+        XCTAssertNil(sut.presented)
+        XCTAssertTrue(sut.pending.isEmpty)
+    }
+
+    private static func release(id: String = "test-release") -> WhatsNewRelease {
+        WhatsNewRelease(
+            id: WhatsNewReleaseId(id),
+            version: WhatsNewAppVersion(major: 2026, minor: 1, patch: 0),
+            targetPlatforms: [.iPhone],
+            items: [
+                WhatsNewItem(
+                    id: "item",
+                    title: "A change",
+                    body: "A user-facing change.",
+                    icon: .sfSymbol(.checkmark)
+                ),
+            ]
+        )
+    }
+}

--- a/Tests/App/WebView/LaunchMessagesStateTests.swift
+++ b/Tests/App/WebView/LaunchMessagesStateTests.swift
@@ -1,6 +1,5 @@
 @testable import HomeAssistant
 @testable import Shared
-import SFSafeSymbols
 import XCTest
 
 @MainActor

--- a/Tests/App/WebView/Mocks/MockAppCoordinator.swift
+++ b/Tests/App/WebView/Mocks/MockAppCoordinator.swift
@@ -8,6 +8,7 @@ final class MockAppCoordinator: AppCoordinator {
     private(set) var showSettingsCalled = false
     private(set) var showSettingsPushedOntoNavigationStack = false
     private(set) var showAssistSettingsCalled = false
+    private(set) var dismissPresentedContentCallCount = 0
     var onShowSettings: (() -> Void)?
     var onShowAssistSettings: (() -> Void)?
 
@@ -55,4 +56,9 @@ final class MockAppCoordinator: AppCoordinator {
         queryParameters: [URLQueryItem]?,
         isComingFromAppIntent: Bool
     ) {}
+
+    func dismissPresentedContent(completion: (() -> Void)?) {
+        dismissPresentedContentCallCount += 1
+        completion?()
+    }
 }

--- a/Tests/App/WebView/Mocks/MockWebFrontend.swift
+++ b/Tests/App/WebView/Mocks/MockWebFrontend.swift
@@ -1,0 +1,42 @@
+@testable import HomeAssistant
+import Shared
+import UIKit
+
+/// Test double for `WebFrontend`, recording what the app coordinator asks the running frontend to do.
+final class MockWebFrontend: WebFrontend {
+    let server: Server
+    var presentationWindow: UIWindow?
+
+    private(set) var openedInlineURLs: [URL] = []
+    private(set) var openedPanelURLs: [URL] = []
+    private(set) var dismissOverlayControllerCallCount = 0
+    private(set) var presentedOverlayControllers: [UIViewController] = []
+
+    var onOpen: ((URL) -> Void)?
+
+    init(server: Server, presentationWindow: UIWindow? = nil) {
+        self.server = server
+        self.presentationWindow = presentationWindow
+    }
+
+    func show(alert: ServerAlert) {}
+
+    func open(inline url: URL, avoidUnnecessaryReload: Bool) {
+        openedInlineURLs.append(url)
+        onOpen?(url)
+    }
+
+    func openPanel(_ url: URL) {
+        openedPanelURLs.append(url)
+        onOpen?(url)
+    }
+
+    func dismissOverlayController(animated: Bool, completion: (() -> Void)?) {
+        dismissOverlayControllerCallCount += 1
+        completion?()
+    }
+
+    func presentOverlayController(controller: UIViewController, animated: Bool) {
+        presentedOverlayControllers.append(controller)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Deep links, universal links and App Intents that open the app to launch something were ignored when a sheet was already open. This is a regression from the SwiftUI refactor: the content shown over the web view used to be UIKit controllers that `dismissOverlayController()` cleared, but it is now SwiftUI sheets and covers driven by bindings. Dismissing those through UIKit leaves the binding set, and presenting on the web view while one is up fails outright, so the link either happened invisibly behind the sheet or did nothing.

`AppCoordinator.dismissPresentedContent(completion:)` now clears the screen before an incoming link acts: the SwiftUI presentation state is dropped first (views opt in with `dismissesOnAppNavigation(perform:)`), then the presentation chain is dismissed from the scene root. Navigation, invitations, the server picker and the camera / assist / custom-widget deep links go through it. The forced onboarding-permissions cover is left alone so a link cannot skip it.

Transient prompts (URL-handler confirmations, results, NFC tag approval) now present on top of whatever is on screen instead, so they are seen without tearing down a sheet the user opened.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change — behaviour only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: N/A — bug fix, no documented behaviour changes.

## Any other notes
Adds unit tests for the dismisser, the coordinator's deep-link and App Intent paths, and the launch-message queue.


---
_Generated by [Claude Code](https://claude.ai/code/session_018foed8EfLtL6mxjw1zwh7H)_