### PR TITLE
Enable location-based server switching on Mac

### DIFF
--- a/Sources/App/Settings/Settings/ServerSwitchingSettingsView.swift
+++ b/Sources/App/Settings/Settings/ServerSwitchingSettingsView.swift
@@ -80,15 +80,16 @@ struct ServerSwitchingSettingsView: View {
 }
 
 extension ServerSwitchingSettingsView: SettingsScreenSearchable {
-    /// Only index rows the screen can actually present: the whole entry is absent on Catalyst,
+    /// Only index rows the screen can actually present: the restoration toggle is absent on Catalyst,
     /// and the by-location toggle only shows with more than one server.
     static var settingsSearchEntries: [SettingsSearchEntry] {
-        guard !Current.isCatalyst else { return [] }
         var entries = [
             SettingsSearchEntry(L10n.Settings.ServerSwitching.title),
-            SettingsSearchEntry(L10n.SettingsDetails.General.Restoration.title),
             SettingsSearchEntry(L10n.Settings.ServerSwitching.HowItWorks.title),
         ]
+        if !Current.isCatalyst {
+            entries.append(SettingsSearchEntry(L10n.SettingsDetails.General.Restoration.title))
+        }
         if Current.servers.all.count > 1 {
             entries.append(SettingsSearchEntry(L10n.Settings.ServerSwitching.ByLocation.title))
         }

--- a/Sources/App/Settings/Settings/ServersListView.swift
+++ b/Sources/App/Settings/Settings/ServersListView.swift
@@ -51,13 +51,10 @@ struct ServersListView: View {
             observer.moveServers(from: source, to: destination)
         }
 
-        // Mac has system-level state restoration and doesn't roam between homes.
-        if !Current.isCatalyst {
-            NavigationLink(destination: ServerSwitchingSettingsView()) {
-                HStack {
-                    Label(L10n.Settings.ServerSwitching.title, systemSymbol: .arrowLeftArrowRight)
-                    LabsLabel()
-                }
+        NavigationLink(destination: ServerSwitchingSettingsView()) {
+            HStack {
+                Label(L10n.Settings.ServerSwitching.title, systemSymbol: .arrowLeftArrowRight)
+                LabsLabel()
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Makes the location-based Server Switching feature available on Mac. The switching engine already ran on Catalyst, so this only surfaces the settings entry (and its search entries) there. The separate state-restoration toggle stays hidden on Mac, as macOS handles state restoration at the system level.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
