### PR TITLE
Disable sensors in Home Assistant when disabled in the app

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1633,6 +1633,10 @@ extension HomeAssistantAPI: SensorObserver {
                 }
                 // Carries the new enablement to Home Assistant, which only `register_sensor` can do.
                 return registerSensors(limitedToUniqueIDs: Set(changedUniqueIDs))
+            }.recover { error -> Promise<Void> in
+                // A failed registration must not stop the state update that follows it.
+                Current.Log.error("failed to register sensors after enablement change: \(error)")
+                return .value(())
             }.then {
                 self.UpdateSensors(trigger: .Signaled)
             }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -966,9 +966,14 @@ public class HomeAssistantAPI {
         }
     }
 
-    public func registerSensors() -> Promise<Void> {
+    /// - Parameter limitedToUniqueIDs: when given, only these sensors are registered. Used to push a
+    ///   single enablement change without re-registering everything.
+    public func registerSensors(limitedToUniqueIDs uniqueIDs: Set<String>? = nil) -> Promise<Void> {
         firstly {
             Current.sensors.sensors(reason: .registration, server: server).map(\.sensors)
+        }.map { sensors in
+            guard let uniqueIDs else { return sensors }
+            return sensors.filter { $0.UniqueID.map(uniqueIDs.contains) ?? false }
         }.get { sensors in
             Current.Log.verbose("Registering sensors \(sensors.map(\.UniqueID))")
         }.thenMap { [server] sensor in
@@ -1622,7 +1627,15 @@ extension HomeAssistantAPI: SensorObserver {
         lastUpdate: SensorObserverUpdate?
     ) {
         Current.backgroundTask(withName: BackgroundTask.signaledUpdateSensors.rawValue) { _ in
-            UpdateSensors(trigger: .Signaled)
+            firstly { () -> Promise<Void> in
+                guard case let .settingsChange(changedUniqueIDs) = reason, !changedUniqueIDs.isEmpty else {
+                    return .value(())
+                }
+                // Carries the new enablement to Home Assistant, which only `register_sensor` can do.
+                return registerSensors(limitedToUniqueIDs: Set(changedUniqueIDs))
+            }.then {
+                self.UpdateSensors(trigger: .Signaled)
+            }
         }.cauterize()
     }
 

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -971,9 +971,12 @@ public class HomeAssistantAPI {
     public func registerSensors(limitedToUniqueIDs uniqueIDs: Set<String>? = nil) -> Promise<Void> {
         firstly {
             Current.sensors.sensors(reason: .registration, server: server).map(\.sensors)
-        }.map { sensors in
+        }.map { (sensors: [WebhookSensor]) -> [WebhookSensor] in
             guard let uniqueIDs else { return sensors }
-            return sensors.filter { $0.UniqueID.map(uniqueIDs.contains) ?? false }
+            return sensors.filter { sensor in
+                guard let uniqueID = sensor.UniqueID else { return false }
+                return uniqueIDs.contains(uniqueID)
+            }
         }.get { sensors in
             Current.Log.verbose("Registering sensors \(sensors.map(\.UniqueID))")
         }.thenMap { [server] sensor in

--- a/Sources/Shared/API/Models/WebhookSensor.swift
+++ b/Sources/Shared/API/Models/WebhookSensor.swift
@@ -81,6 +81,10 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
     public var UnitOfMeasurement: String?
     public var entityCategory: String?
 
+    /// Whether Home Assistant should disable the matching entity. Only `register_sensor` acts on
+    /// this, so it's left out of state updates.
+    public var Disabled: Bool?
+
     public var Settings: [WebhookSensorSetting] = []
 
     /// Optional footer shown at the bottom of the sensor detail screen, e.g. setup
@@ -184,6 +188,7 @@ public class WebhookSensor: Mappable, Equatable, Comparable {
 
         if !isUpdate {
             DeviceClass <- map["device_class"]
+            Disabled <- map["disabled"]
             entityCategory <- map["entity_category"]
             Name <- map["name"]
             StateClass <- map["state_class"]

--- a/Sources/Shared/API/Webhook/Sensors/BaseSensorUpdateSignaler.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BaseSensorUpdateSignaler.swift
@@ -40,7 +40,7 @@ class BaseSensorUpdateSignaler: SensorObserver {
         didSignalForUpdateBecause reason: SensorContainerUpdateReason,
         lastUpdate: SensorObserverUpdate?
     ) {
-        guard reason == .settingsChange else { return }
+        guard case .settingsChange = reason else { return }
         updateObservation(sensorUpdates: lastUpdate)
     }
 

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -14,7 +14,10 @@ public struct SensorObserverUpdate {
 }
 
 public enum SensorContainerUpdateReason {
-    case settingsChange
+    /// - Parameter changedUniqueIDs: the sensors whose enablement changed, which need re-registering
+    ///   so Home Assistant enables or disables the matching entities. Empty when the change didn't
+    ///   come from a specific set of sensors.
+    case settingsChange(changedUniqueIDs: [String])
     case signal
 }
 
@@ -101,14 +104,14 @@ public class SensorContainer {
         // `filter` rather than a short-circuiting reduce, so every ID is actually written.
         let changed = ids.filter { enablement.setEnabled(value, forUniqueID: $0) }
         guard !changed.isEmpty else { return }
-        notifySignal(reason: .settingsChange)
+        notifySignal(reason: .settingsChange(changedUniqueIDs: changed))
     }
 
     /// Applies the sensor selection a first-time install starts with. Sensors outside it stay off
     /// until the user enables them, so there is nothing to switch off here.
     public func applyFirstRunSensorDefaults() {
         guard enablement.applyFirstRunDefaults() else { return }
-        notifySignal(reason: .settingsChange)
+        notifySignal(reason: .settingsChange(changedUniqueIDs: []))
     }
 
     private let lastUpdate = HAProtected<SensorObserverUpdate?>(value: nil)
@@ -224,11 +227,15 @@ public class SensorContainer {
         return generatedSensors.mapValues { [weak self] sensor -> WebhookSensor in
             guard let self else { return sensor }
 
-            if isAllowedToSend(sensor: sensor, for: server) {
-                return sensor
-            } else {
-                return WebhookSensor(redacting: sensor)
+            let outgoing = isAllowedToSend(sensor: sensor, for: server) ? sensor : WebhookSensor(redacting: sensor)
+
+            if request.reason == .registration {
+                // Registering is the only chance to tell Home Assistant to disable the entity, rather
+                // than leave it enabled and reporting `unavailable` forever.
+                outgoing.Disabled = !isEnabled(sensor: sensor)
             }
+
+            return outgoing
         }.map(SensorResponse.init(sensors:))
     }
 

--- a/Tests/App/Auth/OnboardingAuthStepSensors.test.swift
+++ b/Tests/App/Auth/OnboardingAuthStepSensors.test.swift
@@ -51,7 +51,7 @@ private enum TestError: Error {
 
 private class FakeHomeAssistantAPI: HomeAssistantAPI {
     var registerSensorsResolver: Resolver<Void>?
-    override func registerSensors() -> Promise<Void> {
+    override func registerSensors(limitedToUniqueIDs uniqueIDs: Set<String>?) -> Promise<Void> {
         let (promise, resolver) = Promise<Void>.pending()
         registerSensorsResolver = resolver
         return promise

--- a/Tests/Shared/Sensors/SensorContainer.test.swift
+++ b/Tests/Shared/Sensors/SensorContainer.test.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ObjectMapper
 import PromiseKit
 @testable import Shared
 import XCTest
@@ -376,6 +377,40 @@ class SensorContainerTests: XCTestCase {
         XCTAssertEqual(sensorS2.State as? String, "state")
         XCTAssertEqual(sensorS2.Attributes?["test"] as? Bool, true)
         XCTAssertEqual(sensorS2.Name, underlying.Name)
+    }
+
+    func testRegistrationCarriesEnablement() throws {
+        container.register(provider: MockSensorProvider.self)
+
+        let underlying = WebhookSensor(name: "test1a", uniqueID: "testEnablement")
+        container.setEnabled(false, for: underlying)
+
+        MockSensorProvider.returnedPromises = [.value([underlying])]
+        let disabled = try hang(Promise(container.sensors(reason: .registration, server: server1)))
+        let disabledSensor = try XCTUnwrap(disabled.sensors.first)
+        XCTAssertEqual(disabledSensor.Disabled, true)
+        XCTAssertEqual(disabledSensor.toJSON()["disabled"] as? Bool, true)
+
+        container.setEnabled(true, for: underlying)
+
+        MockSensorProvider.returnedPromises = [.value([underlying])]
+        let enabled = try hang(Promise(container.sensors(reason: .registration, server: server1)))
+        XCTAssertEqual(try XCTUnwrap(enabled.sensors.first).Disabled, false)
+    }
+
+    func testStateUpdateOmitsEnablement() throws {
+        container.register(provider: MockSensorProvider.self)
+
+        let underlying = WebhookSensor(name: "test1a", uniqueID: "testEnablementOmitted")
+        container.setEnabled(false, for: underlying)
+
+        MockSensorProvider.returnedPromises = [.value([underlying])]
+        let result = try hang(Promise(container.sensors(reason: .trigger("unit-test"), server: server1)))
+        let sensor = try XCTUnwrap(result.sensors.first)
+        XCTAssertNil(sensor.Disabled)
+
+        let updateJSON = Mapper<WebhookSensor>(context: WebhookSensorContext(update: true)).toJSON(sensor)
+        XCTAssertNil(updateJSON["disabled"])
     }
 
     func testSensorsLimitedTo() throws {


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Disabling a sensor in the app was only stored locally. The sensor kept being sent to Home Assistant with an `unavailable` state, so the entity stayed enabled and just showed as unavailable forever.

Now the app sends the `disabled` flag on `register_sensor`, and re-registers a sensor when its enablement changes, so the entity is disabled or enabled in Home Assistant to match.

## Screenshots
No UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`disabled` is only sent on registration, since `update_sensor_states` ignores it.