### PR TITLE
Fix Apple Watch database sync races

### DIFF
--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -130,39 +130,60 @@ public extension HomeAssistantAPI {
     private static let watchContextSyncQueue = DispatchQueue(label: "watch-context-sync", qos: .utility)
     private static let watchContextSyncGate = NSLock()
     private static var watchContextSyncInFlight = false
+    /// The newest context that arrived while an update was in flight, delivered as soon as that update
+    /// returns. Only the newest is kept — the ones it replaces are already obsolete.
+    private static var pendingWatchContext: HAWatchConnectivity.Context?
 
     /// Hand the context to `updateApplicationContext` off the caller's thread, keeping at most one
-    /// update in flight: when WCSession is stalled the stuck call already carries the freshest
-    /// context that could be delivered, and stacking more would just park more threads behind it.
+    /// update in flight: a call stuck inside WCSession would otherwise park a thread per caller.
+    /// Later contexts are coalesced rather than dropped — the in-flight call is carrying an *older*
+    /// snapshot, so discarding the new one would strand the watch on stale data until some unrelated
+    /// trigger happened to sync again.
     private static func enqueueWatchContextSync(_ context: HAWatchConnectivity.Context) {
         watchContextSyncGate.lock()
-        let alreadyInFlight = watchContextSyncInFlight
-        watchContextSyncInFlight = true
-        watchContextSyncGate.unlock()
-        guard !alreadyInFlight else {
-            Current.Log.info("Skipping watch context sync: previous update still in flight (WCSession stalled?)")
+        guard !watchContextSyncInFlight else {
+            pendingWatchContext = context
+            watchContextSyncGate.unlock()
+            Current.Log.info("Coalescing watch context sync: previous update still in flight (WCSession stalled?)")
             return
         }
+        watchContextSyncInFlight = true
+        watchContextSyncGate.unlock()
+
         watchContextSyncQueue.async {
-            defer {
+            var next: HAWatchConnectivity.Context? = context
+            while let current = next {
+                syncWatchContextNow(current)
+                // Claim the next context (or stand down) under the same lock the producer takes, so a
+                // context enqueued right as this update finishes can't be stranded.
                 watchContextSyncGate.lock()
-                watchContextSyncInFlight = false
+                if let pending = pendingWatchContext {
+                    next = pending
+                    pendingWatchContext = nil
+                } else {
+                    next = nil
+                    watchContextSyncInFlight = false
+                }
                 watchContextSyncGate.unlock()
             }
-            do {
-                try syncRespectingSizeLimit(context)
-                Current.Log.info("updated context")
-                Current.clientEventStore.addEvent(.init(
-                    text: "Synced watch context to Apple Watch (updateApplicationContext)",
-                    type: .database
-                ))
-            } catch {
-                Current.Log.error("Updating the context failed: \(error)")
-                Current.clientEventStore.addEvent(.init(
-                    text: "Failed to sync watch context: \(error.localizedDescription)",
-                    type: .database
-                ))
-            }
+        }
+    }
+
+    /// The blocking `updateApplicationContext` call itself, always on `watchContextSyncQueue`.
+    private static func syncWatchContextNow(_ context: HAWatchConnectivity.Context) {
+        do {
+            try syncRespectingSizeLimit(context)
+            Current.Log.info("updated context")
+            Current.clientEventStore.addEvent(.init(
+                text: "Synced watch context to Apple Watch (updateApplicationContext)",
+                type: .database
+            ))
+        } catch {
+            Current.Log.error("Updating the context failed: \(error)")
+            Current.clientEventStore.addEvent(.init(
+                text: "Failed to sync watch context: \(error.localizedDescription)",
+                type: .database
+            ))
         }
     }
     #endif

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -10,10 +10,18 @@ public protocol ClientEventStoreProtocol {
 
 final class ClientEventStore: ClientEventStoreProtocol {
     static var jsonCacheName = "databases/clientEvents.json"
+    /// Events are recorded from every queue in the app (main, the WatchConnectivity callbacks, the
+    /// expiring-activity queue, cooperative pool tasks). Appending is a read-modify-write of one shared
+    /// file, so without this lock concurrent writers lose each other's events — and a reader landing
+    /// mid-write decodes a truncated file, which throws away the whole history.
+    private static let fileLock = NSLock()
+
     public func addEvent(_ event: ClientEvent) {
         Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")
         let eventsCacheLimit = 1000
-        var events = getEvents()
+        Self.fileLock.lock()
+        defer { Self.fileLock.unlock() }
+        var events = readEvents()
         events.append(event)
         if events.count > eventsCacheLimit {
             events = events.suffix(eventsCacheLimit)
@@ -22,6 +30,13 @@ final class ClientEventStore: ClientEventStoreProtocol {
     }
 
     public func getEvents() -> [ClientEvent] {
+        Self.fileLock.lock()
+        defer { Self.fileLock.unlock() }
+        return readEvents()
+    }
+
+    /// Unsynchronized read; callers must hold `fileLock`.
+    private func readEvents() -> [ClientEvent] {
         guard let containerURL = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID) else {
             Current.Log.error("Failed to get container URL for get client events")
@@ -31,7 +46,8 @@ final class ClientEventStore: ClientEventStoreProtocol {
         let fileURL = containerURL.appendingPathComponent(ClientEventStore.jsonCacheName)
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            Current.Log.error("Client events cache file doesn't exist at path: \(fileURL.absoluteString)")
+            // Expected until the first event is recorded after a fresh install or a cache clear.
+            Current.Log.info("Client events cache file doesn't exist yet at path: \(fileURL.absoluteString)")
             return []
         }
 
@@ -47,14 +63,19 @@ final class ClientEventStore: ClientEventStoreProtocol {
     }
 
     public func clearAllEvents() {
+        Self.fileLock.lock()
+        defer { Self.fileLock.unlock() }
         saveJSONData([])
     }
 
+    /// Unsynchronized write; callers must hold `fileLock`.
     private func saveJSONData(_ events: [ClientEvent]) {
         do {
             let fileURL = AppConstants.clientEventsFile
             let jsonData = try JSONEncoder().encode(events)
-            try jsonData.write(to: fileURL)
+            // Atomic: the app group file is also read by the other processes sharing it (widgets, the
+            // watch app), which must never observe a half-written array.
+            try jsonData.write(to: fileURL, options: .atomic)
             Current.Log.verbose("JSON saved successfully for client events, file URL: \(fileURL.absoluteString)")
         } catch {
             Current.Log.error("Error saving JSON for client events: \(error)")

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -145,6 +145,11 @@ public final class AppDatabaseSuspension {
     private var wantsSuspension = false
     /// Parks the thread of the currently-armed expiring activity; nil when none is armed.
     private var activitySemaphore: DispatchSemaphore?
+    /// How many background accesses are currently running under `beginProtectedAccess()`. Suspension
+    /// is only re-applied once this reaches zero: suspending is process-wide, so letting the first
+    /// access to finish suspend would abort a sibling's in-flight statement ("SQLite error 4:
+    /// Database is suspended") and roll back its transaction.
+    private var protectedAccessCount = 0
 
     private let performExpiringActivity: (String, @escaping (Bool) -> Void) -> Void
     private let postNotification: (Notification.Name) -> Void
@@ -169,6 +174,51 @@ public final class AppDatabaseSuspension {
 
     public static func resume() {
         shared.resume()
+    }
+
+    public static func beginProtectedAccess() {
+        shared.beginProtectedAccess()
+    }
+
+    public static func endProtectedAccess(suspend shouldSuspend: Bool) {
+        shared.endProtectedAccess(suspend: shouldSuspend)
+    }
+
+    public static func suspendIfIdle() {
+        shared.suspendIfIdle()
+    }
+
+    /// Resume the database for one background access and register it as in flight. Every call must be
+    /// balanced with `endProtectedAccess(suspend:)`, which re-suspends only once the last access ends.
+    func beginProtectedAccess() {
+        lock.lock()
+        protectedAccessCount += 1
+        lock.unlock()
+        resume()
+    }
+
+    /// End one access started by `beginProtectedAccess()`. `shouldSuspend` says whether this caller
+    /// still wants the database suspended (i.e. the app is backgrounded); it only takes effect when no
+    /// other access is left running.
+    func endProtectedAccess(suspend shouldSuspend: Bool) {
+        lock.lock()
+        if protectedAccessCount > 0 {
+            protectedAccessCount -= 1
+        }
+        let isIdle = protectedAccessCount == 0
+        lock.unlock()
+        guard isIdle, shouldSuspend else { return }
+        suspend()
+    }
+
+    /// Suspend unless a protected access is still running. Used when an expiring activity is denied or
+    /// expires without having claimed an access of its own.
+    func suspendIfIdle() {
+        lock.lock()
+        let isIdle = protectedAccessCount == 0
+        lock.unlock()
+        guard isIdle else { return }
+        suspend()
     }
 
     func suspend() {

--- a/Sources/Shared/Watch/Connectivity/HAWatchConnectivityError.swift
+++ b/Sources/Shared/Watch/Connectivity/HAWatchConnectivityError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WatchConnectivity
 
 public extension HAWatchConnectivity {
     enum ConnectivityError: LocalizedError {
@@ -28,6 +29,30 @@ public extension HAWatchConnectivity {
                 return underlying.localizedDescription
             }
         }
+    }
+}
+
+public extension HAWatchConnectivity.ConnectivityError {
+    /// Whether `error` means "the counterpart wasn't reachable at that instant" rather than a real
+    /// failure — either our own pre-send check (`.notReachable`) or WatchConnectivity's own
+    /// `WCError.notReachable` (7007), which arrives wrapped in `.deliveryFailed` or raw depending on
+    /// the call site.
+    ///
+    /// Reachability flaps constantly on watchOS: it can flip between a caller's pre-send check and the
+    /// send itself, and the counterpart is usually back within a second. Callers use this to retry in
+    /// the background instead of reporting a failure the user can't act on.
+    static func isCounterpartUnreachable(_ error: Error) -> Bool {
+        if let connectivityError = error as? Self {
+            if case .notReachable = connectivityError {
+                return true
+            }
+            if case let .deliveryFailed(underlying) = connectivityError {
+                return isCounterpartUnreachable(underlying)
+            }
+            return false
+        }
+        let nsError = error as NSError
+        return nsError.domain == WCErrorDomain && nsError.code == WCError.Code.notReachable.rawValue
     }
 }
 

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -35,7 +35,10 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
         let options: UNAuthorizationOptions = [.alert, .badge, .sound, .criticalAlert, .providesAppNotificationSettings]
 
-        WKApplication.shared().registerForRemoteNotifications()
+        // No `registerForRemoteNotifications()` here: the watch target carries no `aps-environment`
+        // entitlement (see Configuration/Entitlements/WatchApp.entitlements), so registration could
+        // only ever fail with "no valid aps-environment entitlement string found for application" on
+        // every launch. Notifications reach the watch forwarded from the paired iPhone.
 
         UNUserNotificationCenter.current().requestAuthorization(options: options) { granted, error in
             Current.Log.verbose("Requested notifications access \(granted), \(String(describing: error))")
@@ -87,26 +90,34 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     /// Runs database work delivered while the app may be backgrounded/suspending (WCSession callbacks)
     /// inside an expiring background activity, so the system keeps the process alive for the write
     /// instead of suspending it mid-commit (0xdead10cc). If the activity expires, GRDB is re-suspended,
-    /// which aborts the in-flight write and releases the file lock. `completion` runs on the main queue
-    /// after the work finished (not when it expired).
+    /// which aborts the in-flight write and releases the file lock.
+    ///
+    /// The claim is refcounted because these callbacks arrive in bursts — the phone can deliver several
+    /// mirror blobs within milliseconds, and each gets its own activity. Suspension is process-wide, so
+    /// without the refcount the first block to finish would abort the writes still running behind it.
+    ///
+    /// `work` reports whether it succeeded; `completion` runs on the main queue only for a successful
+    /// run, so callers don't publish side effects for a write that rolled back.
     private static func performProtectedDatabaseWork(
         reason: String,
-        _ work: @escaping () -> Void,
+        _ work: @escaping () -> Bool,
         completion: (() -> Void)? = nil
     ) {
         ProcessInfo.processInfo.performExpiringActivity(withReason: reason) { expired in
             if expired {
-                AppDatabaseSuspension.suspend()
+                // Nothing was claimed on this path, so only suspend if no sibling is mid-write.
+                AppDatabaseSuspension.suspendIfIdle()
                 return
             }
-            AppDatabaseSuspension.resume()
-            work()
+            AppDatabaseSuspension.beginProtectedAccess()
+            let didSucceed = work()
             DispatchQueue.main.async {
-                // Re-suspend when still backgrounded; harmless when active (any `Current.database()`
-                // access resumes it again).
-                if WKApplication.shared().applicationState == .background {
-                    AppDatabaseSuspension.suspend()
-                }
+                // Re-suspend when this was the last access in flight and we're still backgrounded;
+                // harmless when active (any `Current.database()` access resumes it again).
+                AppDatabaseSuspension.endProtectedAccess(
+                    suspend: WKApplication.shared().applicationState == .background
+                )
+                guard didSucceed else { return }
                 completion?()
             }
         }
@@ -239,7 +250,12 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         }
 
         Communicator.shared.guaranteedMessage.observations.store[.init(queue: .main)] = { [weak self] message in
-            Current.Log.verbose("Received guaranteed message! \(message)")
+            // Identifier and shape only. Interpolating the message itself dumped the whole payload —
+            // tens of KB of serialized plist per config response, carrying the user's entity ids,
+            // script names and server names — into a log file users attach to bug reports.
+            Current.Log.verbose(
+                "Received guaranteed message! \(message.identifier) (keys: \(message.content.keys.sorted()))"
+            )
 
             if message.identifier == GuaranteedMessages.sync.rawValue {
                 HomeAssistantAPI.syncWatchContext()
@@ -264,7 +280,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         // the application context; those keys are simply ignored.
 
         Communicator.shared.complicationInfo.observations.store[.init(queue: .main)] = { complicationInfo in
-            Current.Log.verbose("Received complication info: \(complicationInfo)")
+            // Count only — the payload carries user-identifying complication content (see above).
+            Current.Log.verbose("Received complication info: \(complicationInfo.content.count) key(s)")
 
             self.updateComplications()
         }
@@ -349,12 +366,16 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                     text: "Applied pushed watch database mirror from iPhone (\(data.count) bytes)",
                     type: .database
                 ))
+                return true
             } catch {
+                // `apply()` is one transaction, so a failure here left the database untouched. Report
+                // it and skip the completion below rather than republishing the unchanged data.
                 Current.Log.error("Failed to apply pushed watch database mirror: \(error)")
                 Current.clientEventStore.addEvent(.init(
                     text: "Failed to apply pushed watch database mirror (\(data.count) bytes): \(error)",
                     type: .database
                 ))
+                return false
             }
         } completion: { [weak self] in
             // The mirror also carries the servers; keep them in step with the reference tables.
@@ -383,15 +404,6 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
             WatchWidgetComplicationSnapshotStore.update()
             endWatchConnectivityBackgroundTaskIfNecessary()
         }.cauterize()
-    }
-
-    func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
-        let apnsToken = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
-        Current.Log.verbose("Successfully registered for push notifications! APNS token: \(apnsToken)")
-    }
-
-    func didFailToRegisterForRemoteNotificationsWithError(_ error: Error) {
-        Current.Log.error("Error when trying to register for push: \(error)")
     }
 }
 
@@ -466,8 +478,8 @@ extension ExtensionDelegate: UNUserNotificationCenterDelegate {
 
 /// Result of refreshing a single modern complication, surfaced to the watch's on-device diagnostics
 /// (the "Refresh complications" button in Settings).
-struct ComplicationRefreshOutcome: Identifiable {
-    enum Status: String, Codable {
+struct ComplicationRefreshOutcome: Identifiable, Sendable {
+    enum Status: String, Codable, Sendable {
         case live
         case cached
         case failed
@@ -527,13 +539,43 @@ enum WatchWidgetComplicationSnapshotStore {
         WatchWidgetServerCredential.write(credentials, to: defaults)
     }
 
+    /// Serializes `refresh()` so overlapping triggers share one run instead of racing.
+    private actor RefreshCoordinator {
+        static let shared = RefreshCoordinator()
+
+        private var inFlight: Task<[ComplicationRefreshOutcome], Never>?
+
+        /// Callers arriving while a refresh is running await that run rather than starting a competing
+        /// one. Triggers land in bursts — one per pushed database mirror, plus the complication reload
+        /// that follows each — and running them concurrently multiplies the REST round-trips (each on
+        /// its own mTLS handshake) while they race to write the same snapshot list into the app group.
+        func run(
+            _ body: @escaping @Sendable () async -> [ComplicationRefreshOutcome]
+        ) async -> [ComplicationRefreshOutcome] {
+            if let inFlight {
+                return await inFlight.value
+            }
+            let task = Task { await body() }
+            inFlight = task
+            let outcomes = await task.value
+            inFlight = nil
+            return outcomes
+        }
+    }
+
     /// Rebuilds every complication snapshot. Legacy complications render synchronously from their
     /// server-rendered data; modern configs fetch their live value directly from Home Assistant over
     /// REST — no paired iPhone required, so this also refreshes when the watch is on its own (e.g. on
     /// LTE), provided the server has a reachable URL. `async` so a background task can await it before
     /// completing (otherwise the app may be suspended before the REST fetch returns).
+    ///
+    /// Coalesced: concurrent callers join the run already in flight (see `RefreshCoordinator`).
     @discardableResult
     static func refresh() async -> [ComplicationRefreshOutcome] {
+        await RefreshCoordinator.shared.run { await performRefresh() }
+    }
+
+    private static func performRefresh() async -> [ComplicationRefreshOutcome] {
         MaterialDesignIcons.register()
         let defaults = UserDefaults(suiteName: AppConstants.AppGroupID)
 

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -169,17 +169,8 @@ final class WatchHomeViewModel: ObservableObject {
         }
         homeType = .undefined
         guard Communicator.shared.currentReachability != .notReachable else {
-            Current.Log.error("iPhone reachability is not immediate reachable")
-            loadCache()
-            // Queue a background pull so the phone answers once it's reachable again, then updates the
-            // screen via the guaranteed-response reconcile — no need for the phone to be foreground.
-            setLoadingStatus(L10n.Watch.Home.Sync.waiting)
-            enqueueGuaranteedConfigPull()
-            // An explicit reload can't refresh now: tell the user the data will catch up in the
-            // background once the phone is reachable again (the automatic sync stays silent).
-            if userInitiated {
-                showNotReachableAlert = true
-            }
+            Current.Log.info("iPhone reachability is not immediate reachable")
+            degradeToBackgroundPull(userInitiated: userInitiated)
             return
         }
         isSyncInFlight = true
@@ -193,6 +184,27 @@ final class WatchHomeViewModel: ObservableObject {
         // Full reference-database sync (chunked, ordered, acknowledged). On completion it pulls the
         // watch config and clears loading; on failure it surfaces a friendly error.
         startDatabaseSync()
+    }
+
+    /// Fall back to a background pull when the phone isn't reachable, instead of failing the sync.
+    ///
+    /// Used both by the pre-send reachability check and by a send that came back with
+    /// `WCError.notReachable`: the two are the same situation, only observed a few milliseconds apart.
+    /// The queued guaranteed pull is answered whenever the phone comes back — no foreground needed —
+    /// and updates the screen through the reconcile path.
+    @MainActor
+    private func degradeToBackgroundPull(userInitiated: Bool) {
+        resetSyncState()
+        // Clears `isSyncInFlight` too, so a later reload isn't blocked by this abandoned sync.
+        updateLoading(isLoading: false)
+        loadCache()
+        setLoadingStatus(L10n.Watch.Home.Sync.waiting)
+        enqueueGuaranteedConfigPull()
+        // An explicit reload can't refresh now: tell the user the data will catch up in the
+        // background once the phone is reachable again (the automatic sync stays silent).
+        if userInitiated {
+            showNotReachableAlert = true
+        }
     }
 
     /// Pull the watch config from the phone and reconcile it (adopt / push offline edits / conflict).
@@ -360,11 +372,11 @@ final class WatchHomeViewModel: ObservableObject {
     private static let syncPipelineWindow = 3
 
     /// Kick off a full database sync. Requires the phone reachable (interactive request/reply); if it
-    /// isn't, surface a friendly message rather than hang, and still try the config pull from cache.
+    /// isn't, fall back to the background pull rather than hang or fail loudly.
     @MainActor
     private func startDatabaseSync() {
         guard Communicator.shared.currentReachability == .immediatelyReachable else {
-            failSync(L10n.Watch.Sync.Error.unreachable)
+            degradeToBackgroundPull(userInitiated: isSyncUserInitiated)
             return
         }
         resetSyncState()
@@ -381,9 +393,17 @@ final class WatchHomeViewModel: ObservableObject {
             }
         ), priority: .background, errorHandler: { [weak self] error in
             Task { @MainActor in
+                guard let self else { return }
+                // Reachability flipped between the guard above and the send. That's transient, not a
+                // failure worth alerting on — degrade to the background pull like the pre-check does.
+                guard !HAWatchConnectivity.ConnectivityError.isCounterpartUnreachable(error) else {
+                    Current.Log.info("Database sync start deferred: iPhone became unreachable mid-send")
+                    degradeToBackgroundPull(userInitiated: isSyncUserInitiated)
+                    return
+                }
                 Current.Log.error("Database sync start failed: \(error.localizedDescription)")
-                self?.failSync(
-                    L10n.Watch.Sync.Error.unreachable,
+                failSync(
+                    L10n.Watch.Sync.Error.generic,
                     detail: "sync start request failed: \(error.localizedDescription)"
                 )
             }

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -401,11 +401,11 @@ final class WatchHomeViewModel: ObservableObject {
                 // failure worth alerting on — degrade to the background pull like the pre-check does.
                 guard !HAWatchConnectivity.ConnectivityError.isCounterpartUnreachable(error) else {
                     Current.Log.info("Database sync start deferred: iPhone became unreachable mid-send")
-                    degradeToBackgroundPull(userInitiated: isSyncUserInitiated)
+                    self.degradeToBackgroundPull(userInitiated: self.isSyncUserInitiated)
                     return
                 }
                 Current.Log.error("Database sync start failed: \(error.localizedDescription)")
-                failSync(
+                self.failSync(
                     L10n.Watch.Sync.Error.generic,
                     detail: "sync start request failed: \(error.localizedDescription)"
                 )

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -169,7 +169,7 @@ final class WatchHomeViewModel: ObservableObject {
         }
         homeType = .undefined
         guard Communicator.shared.currentReachability != .notReachable else {
-            Current.Log.info("iPhone reachability is not immediate reachable")
+            Current.Log.info("iPhone is not immediately reachable")
             degradeToBackgroundPull(userInitiated: userInitiated)
             return
         }
@@ -195,8 +195,11 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func degradeToBackgroundPull(userInitiated: Bool) {
         resetSyncState()
-        // Clears `isSyncInFlight` too, so a later reload isn't blocked by this abandoned sync.
-        updateLoading(isLoading: false)
+        // Cleared here rather than through `updateLoading`, which hops through the main queue: that
+        // block would land after the status set below and blank it. Clearing `isSyncInFlight` also
+        // keeps this abandoned sync from blocking a later reload.
+        isLoading = false
+        isSyncInFlight = false
         loadCache()
         setLoadingStatus(L10n.Watch.Home.Sync.waiting)
         enqueueGuaranteedConfigPull()
@@ -665,20 +668,25 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func finishCacheLoad() {
         guard !isSyncInFlight else { return }
-        updateLoading(isLoading: false)
+        // The cache finishing rendering is not what ends a wait, so any status the caller deliberately
+        // left up — "waiting for iPhone" after a deferred sync — stays on screen.
+        updateLoading(isLoading: false, clearStatus: false)
     }
 
-    private func updateLoading(isLoading: Bool) {
+    private func updateLoading(isLoading: Bool, clearStatus: Bool = true) {
         DispatchQueue.main.async { [weak self] in
             self?.isLoading = isLoading
             if !isLoading {
                 // Loading is over — the sync (if any) has reached a terminal state, so a new reload may
-                // start. Cancel any pending throttled status update and clear immediately.
+                // start.
                 self?.isSyncInFlight = false
-                self?.pendingStatusWork?.cancel()
-                self?.pendingStatusWork = nil
-                self?.loadingStatus = nil
                 self?.syncProgress = nil
+                if clearStatus {
+                    // Cancel any pending throttled status update and clear immediately.
+                    self?.pendingStatusWork?.cancel()
+                    self?.pendingStatusWork = nil
+                    self?.loadingStatus = nil
+                }
             }
         }
     }

--- a/Tests/Shared/Database/AppDatabaseSuspension.test.swift
+++ b/Tests/Shared/Database/AppDatabaseSuspension.test.swift
@@ -105,6 +105,48 @@ struct AppDatabaseSuspensionTests {
         #expect(finished.wait(timeout: .now() + 5) == .success)
     }
 
+    @Test("Suspension waits for the last in-flight protected access")
+    func protectedAccessesAreRefcounted() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.beginProtectedAccess()
+        suspension.beginProtectedAccess()
+        #expect(recorder.posted == [Database.resumeNotification, Database.resumeNotification])
+
+        // The first access finishing must not suspend — the second is still writing, and suspending
+        // aborts its statement mid-transaction ("SQLite error 4: Database is suspended").
+        suspension.endProtectedAccess(suspend: true)
+        #expect(recorder.posted.last == Database.resumeNotification)
+
+        suspension.endProtectedAccess(suspend: true)
+        #expect(recorder.posted.last == Database.suspendNotification)
+    }
+
+    @Test("An expiring activity does not suspend while another access is still running")
+    func suspendIfIdleRespectsInFlightAccess() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.beginProtectedAccess()
+        suspension.suspendIfIdle()
+        #expect(recorder.posted == [Database.resumeNotification])
+
+        suspension.endProtectedAccess(suspend: true)
+        #expect(recorder.posted.last == Database.suspendNotification)
+    }
+
+    @Test("An access that ends while foregrounded leaves the database resumed")
+    func endProtectedAccessCanKeepDatabaseResumed() {
+        let (suspension, recorder) = makeSuspension()
+
+        suspension.beginProtectedAccess()
+        suspension.endProtectedAccess(suspend: false)
+        #expect(recorder.posted == [Database.resumeNotification])
+
+        // The count still returned to zero, so a later idle check can suspend.
+        suspension.suspendIfIdle()
+        #expect(recorder.posted.last == Database.suspendNotification)
+    }
+
     @Test("A stale expiration after foreground resume does not re-suspend")
     func staleExpirationDoesNotSuspend() throws {
         let (suspension, recorder) = makeSuspension()

--- a/Tests/Shared/WatchConnectivity.test.swift
+++ b/Tests/Shared/WatchConnectivity.test.swift
@@ -574,4 +574,21 @@ struct WatchConnectivityQueue_test {
         manager.send(interactive("d"))
         #expect(sentIdentifiers(fake) == ["d"])
     }
+
+    /// Callers degrade to a background retry on these instead of showing the user an error, so the
+    /// classification has to hold for every shape the unreachable error arrives in.
+    @Test func unreachableErrorsAreRecognisedThroughEveryWrapping() {
+        let unreachable = WCError(.notReachable)
+        typealias Subject = HAWatchConnectivity.ConnectivityError
+
+        #expect(Subject.isCounterpartUnreachable(Subject.notReachable))
+        #expect(Subject.isCounterpartUnreachable(unreachable))
+        #expect(Subject.isCounterpartUnreachable(Subject.deliveryFailed(underlying: unreachable)))
+
+        // Real failures must stay failures.
+        #expect(!Subject.isCounterpartUnreachable(Subject.replyTimedOut))
+        #expect(!Subject.isCounterpartUnreachable(Subject.payloadTooLarge))
+        #expect(!Subject.isCounterpartUnreachable(WCError(.payloadTooLarge)))
+        #expect(!Subject.isCounterpartUnreachable(Subject.deliveryFailed(underlying: WCError(.deliveryFailed))))
+    }
 }

--- a/Tests/Shared/WatchConnectivity.test.swift
+++ b/Tests/Shared/WatchConnectivity.test.swift
@@ -578,8 +578,12 @@ struct WatchConnectivityQueue_test {
     /// Callers degrade to a background retry on these instead of showing the user an error, so the
     /// classification has to hold for every shape the unreachable error arrives in.
     @Test func unreachableErrorsAreRecognisedThroughEveryWrapping() {
-        let unreachable = WCError(.notReachable)
         typealias Subject = HAWatchConnectivity.ConnectivityError
+        // The shape WCSession itself hands back (domain WCErrorDomain, code 7007).
+        func wcError(_ code: WCError.Code) -> NSError {
+            NSError(domain: WCErrorDomain, code: code.rawValue)
+        }
+        let unreachable = wcError(.notReachable)
 
         #expect(Subject.isCounterpartUnreachable(Subject.notReachable))
         #expect(Subject.isCounterpartUnreachable(unreachable))
@@ -588,7 +592,7 @@ struct WatchConnectivityQueue_test {
         // Real failures must stay failures.
         #expect(!Subject.isCounterpartUnreachable(Subject.replyTimedOut))
         #expect(!Subject.isCounterpartUnreachable(Subject.payloadTooLarge))
-        #expect(!Subject.isCounterpartUnreachable(WCError(.payloadTooLarge)))
-        #expect(!Subject.isCounterpartUnreachable(Subject.deliveryFailed(underlying: WCError(.deliveryFailed))))
+        #expect(!Subject.isCounterpartUnreachable(wcError(.payloadTooLarge)))
+        #expect(!Subject.isCounterpartUnreachable(Subject.deliveryFailed(underlying: wcError(.deliveryFailed))))
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ lx] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A watch log showed three of six pushed database mirrors failing with `SQLite error 4: Database is suspended`, eight complication refreshes running within one second, and a "Can't reach your iPhone" error raised a second before the sync actually succeeded. This fixes those and a few related issues:

- Refcount database suspension, so the first protected write to finish no longer suspends GRDB out from under the writes still running behind it.
- Skip the mirror's completion side effects when the apply failed — the transaction rolled back, so the data is unchanged.
- Coalesce complication refreshes: concurrent callers join the run already in flight instead of racing to write the same snapshot list.
- Coalesce watch context syncs by keeping the newest pending context rather than dropping it, so the watch isn't stranded on an older snapshot.
- Treat a mid-send `WCError.notReachable` as a background retry, like the pre-send reachability check already does, instead of failing the sync.
- Serialize `ClientEventStore` and write atomically, so concurrent recorders stop losing events and readers can't decode a half-written file.
- Drop watch push registration: the target has no `aps-environment` entitlement, so it only ever logged an error on every launch.
- Log WatchConnectivity message identifiers instead of whole payloads, which were writing entity ids, script names and server names into the log file.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: N/A — bug fixes only, no documented behaviour changes.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
`watch.sync.error.unreachable` is now unused, but the string is left in place rather than touching Lokalise-managed translations.

One related issue is deliberately not addressed here: `ComplicationStateFetcher` creates and invalidates a `URLSession` per request, so every complication fetch pays a full mTLS handshake. Most of that cost came from the refresh storm fixed above; reusing sessions is a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015t7YS1XtkzyapV4zUFK9Gv)_