### PR TITLE
Fix watch entity picker lag when showing the servers list

### DIFF
--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -10,12 +10,30 @@ public protocol MagicItemProviderProtocol {
 }
 
 final class MagicItemProvider: MagicItemProviderProtocol {
-    var entitiesPerServer: [String: [HAAppEntity]] = [:]
+    var entitiesPerServer: [String: [HAAppEntity]] = [:] {
+        didSet { rebuildEntityIndex() }
+    }
+
+    /// Per-server `entityId → entity` lookup, kept in sync with `entitiesPerServer`. Callers resolve
+    /// info one item at a time — and the watch add flow resolves *every* addable entity in a single
+    /// pass — so a linear search per lookup made that pass quadratic in the number of entities.
+    private var entityIndexPerServer: [String: [String: HAAppEntity]] = [:]
     /// Per-server entity→area and entity→device lookups, built once when entities are loaded so
     /// `getInfo` can attach the "Server • Area • Device" context line without a DB read per item.
     private var areasPerServer: [String: [String: AppArea]] = [:]
     private var devicesPerServer: [String: [String: AppDeviceRegistry]] = [:]
     private var floorNamesPerServer: [String: [String: String]] = [:]
+
+    private func rebuildEntityIndex() {
+        entityIndexPerServer = entitiesPerServer.mapValues { entities in
+            // First wins, matching the `first(where:)` lookups this index replaced.
+            Dictionary(entities.map { ($0.entityId, $0) }, uniquingKeysWith: { first, _ in first })
+        }
+    }
+
+    private func entity(serverId: String, entityId: String) -> HAAppEntity? {
+        entityIndexPerServer[serverId]?[entityId]
+    }
 
     func loadInformation(completion: @escaping ([String: [HAAppEntity]]) -> Void) {
         loadAppEntities { [weak self] in
@@ -178,13 +196,14 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                         .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
                         .fetchAll(db)
                 }
-                self?.entitiesPerServer[serverId] = entities
                 // Build the entity→area / entity→device lookups once per server (each is a small,
                 // fixed number of DB reads) so `getInfo` can attach the context line per item without
                 // a per-item database read.
                 self?.areasPerServer[serverId] = entities.areasMap(for: serverId)
                 self?.devicesPerServer[serverId] = entities.devicesMap(for: serverId)
                 self?.floorNamesPerServer[serverId] = entities.floorNamesMap(for: serverId)
+                // Assigned last: it rebuilds the entity index, which the lookups above don't need.
+                self?.entitiesPerServer[serverId] = entities
             } catch {
                 Current.Log.error("Failed to load covers from database: \(error.localizedDescription)")
             }
@@ -199,9 +218,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
     func getInfo(for item: MagicItem) -> MagicItem.Info? {
         switch item.type {
         case .script:
-            guard let scriptsForServer = entitiesPerServer[item.serverId]?
-                .filter({ $0.domain == Domain.script.rawValue }),
-                let scriptItem = scriptsForServer.first(where: { $0.entityId == item.id }) else {
+            guard let scriptItem = entity(serverId: item.serverId, entityId: item.id),
+                  scriptItem.domain == Domain.script.rawValue else {
                 Current.Log
                     .error(
                         "Failed to get magic item Script info for item id: \(item.id)"
@@ -217,9 +235,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                 contextSubtitle: entityContextSubtitle(for: scriptItem)
             )
         case .scene:
-            guard let scenesForServer = entitiesPerServer[item.serverId]?
-                .filter({ $0.domain == Domain.scene.rawValue }),
-                let sceneItem = scenesForServer.first(where: { $0.entityId == item.id }) else {
+            guard let sceneItem = entity(serverId: item.serverId, entityId: item.id),
+                  sceneItem.domain == Domain.scene.rawValue else {
                 Current.Log
                     .error(
                         "Failed to get magic item Script info for item id: \(item.id)"
@@ -235,8 +252,7 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                 contextSubtitle: entityContextSubtitle(for: sceneItem)
             )
         case .entity:
-            guard let entitiesForServer = entitiesPerServer[item.serverId],
-                  let entityItem = entitiesForServer.first(where: { $0.entityId == item.id }) else {
+            guard let entityItem = entity(serverId: item.serverId, entityId: item.id) else {
                 Current.Log
                     .error(
                         "Failed to get magic item entity info for item id: \(item.id)"
@@ -288,16 +304,28 @@ final class MagicItemProvider: MagicItemProviderProtocol {
     }
 
     func getAreaName(for item: MagicItem) -> String? {
-        guard let entitiesForServer = entitiesPerServer[item.serverId] else {
-            return nil
-        }
-
-        let areaName = entitiesForServer.areasMap(for: item.serverId)[item.id]?.name
+        let areaName = areaMap(for: item.serverId)[item.id]?.name
         if let areaName, !areaName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return areaName
         }
 
         return nil
+    }
+
+    /// The entity→area map for a server, reusing the one built by `loadAppEntities`. Built (and
+    /// cached) on demand when entities were assigned without going through that path, so it's still
+    /// resolved — but never once per item: rebuilding it meant a full areas fetch from the database
+    /// for every single item, which is what made the watch add flow's area resolution so slow.
+    private func areaMap(for serverId: String) -> [String: AppArea] {
+        if let areas = areasPerServer[serverId] {
+            return areas
+        }
+        guard let entitiesForServer = entitiesPerServer[serverId] else {
+            return [:]
+        }
+        let areas = entitiesForServer.areasMap(for: serverId)
+        areasPerServer[serverId] = areas
+        return areas
     }
 
     /// Builds the "Server • Area • Device" context line for an entity-backed item, reusing the

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -239,7 +239,7 @@ final class MagicItemProvider: MagicItemProviderProtocol {
                   sceneItem.domain == Domain.scene.rawValue else {
                 Current.Log
                     .error(
-                        "Failed to get magic item Script info for item id: \(item.id)"
+                        "Failed to get magic item Scene info for item id: \(item.id)"
                     )
                 return nil
             }

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
@@ -7,7 +7,11 @@ import SwiftUI
 /// The phone owns the entity database, so the entity list is fetched from it. Committing performs the
 /// mutation, persists, and dismisses the whole sheet via `finish`.
 struct WatchConfigAddView: View {
-    @ObservedObject var viewModel: WatchHomeViewModel
+    /// Held without `@ObservedObject` on purpose: the add flow only *calls* the view model (fetch and
+    /// mutate) and renders none of its published state, so observing it would rebuild this whole
+    /// navigation stack on every unrelated publish — a background sync alone republishes its progress
+    /// and status for every chunk it receives.
+    let viewModel: WatchHomeViewModel
     /// When set, added items go into this folder instead of the root. Folder creation is only offered
     /// at the root (folders don't nest on the watch).
     let folderId: String?
@@ -101,15 +105,18 @@ struct WatchConfigAddView: View {
     }
 }
 
-/// Fetches the addable entities from the phone and either shows the server picker (multiple servers)
-/// or jumps straight to the area picker (single server).
+/// Resolves the addable entities from the mirrored database and either shows the server picker
+/// (multiple servers) or jumps straight to the area picker (single server). The result is loaded once
+/// and kept for the lifetime of the flow — the mirror doesn't change while the sheet is open.
 private struct WatchConfigAddEntitySourceView: View {
-    @ObservedObject var viewModel: WatchHomeViewModel
+    let viewModel: WatchHomeViewModel
     let folderId: String?
     let finish: () -> Void
 
     @State private var available: WatchConfigAvailableItems?
     @State private var loadState: LoadState = .loading
+    /// Guards against a second fetch while one is already running (`onAppear` can fire more than once).
+    @State private var isFetching = false
 
     enum LoadState: Equatable {
         case loading
@@ -170,8 +177,15 @@ private struct WatchConfigAddEntitySourceView: View {
     }
 
     private func load() {
+        // `onAppear` fires again every time the user navigates back to this screen from a deeper one.
+        // Re-fetching there swapped the loaded list back to a spinner and rebuilt every candidate from
+        // the database just to show the same rows again, so a load that already succeeded is kept. A
+        // failed load still retries on the next appearance.
+        guard available == nil, !isFetching else { return }
+        isFetching = true
         loadState = .loading
         viewModel.fetchAvailableItems { result in
+            isFetching = false
             switch result {
             case let .success(items):
                 available = items
@@ -192,7 +206,7 @@ private struct WatchConfigAddEntitySourceView: View {
 /// entity lists stay navigable on the small screen.
 private struct WatchConfigAddAreaListView: View {
     let group: WatchConfigAvailableItems.ServerGroup
-    @ObservedObject var viewModel: WatchHomeViewModel
+    let viewModel: WatchHomeViewModel
     let folderId: String?
     let finish: () -> Void
 
@@ -231,7 +245,7 @@ private struct WatchConfigAddEntityListView: View {
     let group: WatchConfigAvailableItems.ServerGroup
     /// When set, only entities in this area are listed ("All areas" passes nil).
     let areaFilter: String?
-    @ObservedObject var viewModel: WatchHomeViewModel
+    let viewModel: WatchHomeViewModel
     let folderId: String?
     let finish: () -> Void
 

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
@@ -113,16 +113,12 @@ private struct WatchConfigAddEntitySourceView: View {
     let folderId: String?
     let finish: () -> Void
 
+    /// `nil` until the first load finishes, which is what puts the spinner on screen. Everything the
+    /// build can't resolve — an unreadable or not-yet-synced mirror included — comes back as no
+    /// candidates, which the empty state below covers.
     @State private var available: WatchConfigAvailableItems?
-    @State private var loadState: LoadState = .loading
     /// Guards against a second fetch while one is already running (`onAppear` can fire more than once).
     @State private var isFetching = false
-
-    enum LoadState: Equatable {
-        case loading
-        case loaded
-        case failed(String)
-    }
 
     private var groups: [WatchConfigAvailableItems.ServerGroup] {
         (available?.servers ?? []).filter { !$0.candidates.isEmpty }
@@ -130,47 +126,38 @@ private struct WatchConfigAddEntitySourceView: View {
 
     var body: some View {
         Group {
-            switch loadState {
-            case .loading:
+            if available == nil {
                 ProgressView()
                     .progressViewStyle(.circular)
-            case let .failed(message):
+            } else if groups.isEmpty {
                 List {
-                    Text(verbatim: message)
+                    Text(verbatim: L10n.Watch.Config.Add.empty)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
-            case .loaded:
-                if groups.isEmpty {
-                    List {
-                        Text(verbatim: L10n.Watch.Config.Add.empty)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                } else if groups.count == 1, let group = groups.first {
-                    WatchConfigAddAreaListView(
-                        group: group,
-                        viewModel: viewModel,
-                        folderId: folderId,
-                        finish: finish
-                    )
-                } else {
-                    List {
-                        ForEach(groups, id: \.serverId) { group in
-                            NavigationLink {
-                                WatchConfigAddAreaListView(
-                                    group: group,
-                                    viewModel: viewModel,
-                                    folderId: folderId,
-                                    finish: finish
-                                )
-                            } label: {
-                                Text(verbatim: group.serverName)
-                            }
+            } else if groups.count == 1, let group = groups.first {
+                WatchConfigAddAreaListView(
+                    group: group,
+                    viewModel: viewModel,
+                    folderId: folderId,
+                    finish: finish
+                )
+            } else {
+                List {
+                    ForEach(groups, id: \.serverId) { group in
+                        NavigationLink {
+                            WatchConfigAddAreaListView(
+                                group: group,
+                                viewModel: viewModel,
+                                folderId: folderId,
+                                finish: finish
+                            )
+                        } label: {
+                            Text(verbatim: group.serverName)
                         }
                     }
-                    .navigationTitle(Text(verbatim: L10n.Watch.Config.Assist.selectServer))
                 }
+                .navigationTitle(Text(verbatim: L10n.Watch.Config.Assist.selectServer))
             }
         }
         .onAppear(perform: load)
@@ -179,25 +166,12 @@ private struct WatchConfigAddEntitySourceView: View {
     private func load() {
         // `onAppear` fires again every time the user navigates back to this screen from a deeper one.
         // Re-fetching there swapped the loaded list back to a spinner and rebuilt every candidate from
-        // the database just to show the same rows again, so a load that already succeeded is kept. A
-        // failed load still retries on the next appearance.
+        // the database just to show the same rows again, so a finished load is kept.
         guard available == nil, !isFetching else { return }
         isFetching = true
-        loadState = .loading
-        viewModel.fetchAvailableItems { result in
+        viewModel.fetchAvailableItems { items in
+            available = items
             isFetching = false
-            switch result {
-            case let .success(items):
-                available = items
-                loadState = .loaded
-            case let .failure(error):
-                switch error {
-                case .notReachable:
-                    loadState = .failed(L10n.Watch.Config.Edit.Error.notReachable)
-                case .sendFailed, .decodeFailed:
-                    loadState = .failed(L10n.Watch.Config.Add.Error.fetchFailed)
-                }
-            }
         }
     }
 }

--- a/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
@@ -229,13 +229,34 @@ extension WatchHomeViewModel {
 
     // MARK: Available items
 
+    /// Serial queue the add flow's candidate build runs on. `loadInformation` and every info lookup
+    /// below are synchronous database work, so on the main thread they froze the UI until the whole
+    /// entity mirror had been resolved — which is exactly when the user is waiting for the picker to
+    /// appear. Serial (not a global concurrent queue) so repeated appearances queue behind each other
+    /// instead of contending for the same SQLite reader.
+    private static let availableItemsQueue = DispatchQueue(label: "watch-available-items", qos: .userInitiated)
+
     /// Build the list of addable items (watch-supported domains across all servers) from the
-    /// locally-mirrored database, so the add flow works without the phone nearby. Mirrors the
-    /// phone-side picker's domain filter; items are stored as `type: .entity`.
+    /// locally-mirrored database, so the add flow works without the phone nearby.
+    ///
+    /// The build runs off the main thread; `completion` is always delivered on the main queue.
     func fetchAvailableItems(
         completion: @escaping (Swift.Result<WatchConfigAvailableItems, WatchConfigEditError>)
             -> Void
     ) {
+        Self.availableItemsQueue.async {
+            Self.buildAvailableItems { items in
+                DispatchQueue.main.async {
+                    completion(.success(items))
+                }
+            }
+        }
+    }
+
+    /// Resolves every watch-supported entity across all servers into an addable candidate. Mirrors the
+    /// phone-side picker's domain filter; items are stored as `type: .entity`. Synchronous database
+    /// work throughout — call it on `availableItemsQueue`, never on the main thread.
+    private static func buildAvailableItems(completion: @escaping (WatchConfigAvailableItems) -> Void) {
         let allowedDomains = Set(Domain.watchSupported.map(\.rawValue))
         let magicItemProvider = Current.magicItemProvider()
         magicItemProvider.loadInformation { entitiesPerServer in
@@ -259,9 +280,7 @@ extension WatchHomeViewModel {
                     }
                 return .init(serverId: serverId, serverName: server.info.name, candidates: candidates)
             }
-            DispatchQueue.main.async {
-                completion(.success(WatchConfigAvailableItems(servers: groups)))
-            }
+            completion(WatchConfigAvailableItems(servers: groups))
         }
     }
 

--- a/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
@@ -5,12 +5,6 @@ import SwiftUI
 // MARK: - On-watch editing
 
 extension WatchHomeViewModel {
-    enum WatchConfigEditError: Error {
-        case notReachable
-        case sendFailed
-        case decodeFailed
-    }
-
     /// Edits are applied locally first (so they work offline) and pushed to the phone — the source of
     /// truth — only when it's immediately reachable, matching `WatchServerSync.request()`. The mutation
     /// methods below mirror the iPhone `WatchConfigurationViewModel`; they run on the main thread
@@ -239,15 +233,14 @@ extension WatchHomeViewModel {
     /// Build the list of addable items (watch-supported domains across all servers) from the
     /// locally-mirrored database, so the add flow works without the phone nearby.
     ///
-    /// The build runs off the main thread; `completion` is always delivered on the main queue.
-    func fetchAvailableItems(
-        completion: @escaping (Swift.Result<WatchConfigAvailableItems, WatchConfigEditError>)
-            -> Void
-    ) {
+    /// The build runs off the main thread; `completion` is always delivered on the main queue. It can't
+    /// fail: it reads the local mirror, and anything it can't resolve simply yields no candidates for
+    /// that server, which the add flow shows as its empty state.
+    func fetchAvailableItems(completion: @escaping (WatchConfigAvailableItems) -> Void) {
         Self.availableItemsQueue.async {
             Self.buildAvailableItems { items in
                 DispatchQueue.main.async {
-                    completion(.success(items))
+                    completion(items)
                 }
             }
         }

--- a/Tests/App/MagicItem/MagicItemProviderTests.swift
+++ b/Tests/App/MagicItem/MagicItemProviderTests.swift
@@ -8,6 +8,18 @@ struct MagicItemProviderTests {
         self.sut = MagicItemProvider()
     }
 
+    private static func entity(entityId: String, domain: String, name: String, icon: String?) -> HAAppEntity {
+        .init(
+            id: "1-\(entityId)",
+            entityId: entityId,
+            serverId: "1",
+            domain: domain,
+            name: name,
+            icon: icon,
+            rawDeviceClass: ""
+        )
+    }
+
     @Test mutating func migrateWatchItemsIfCurrentServerIdDoestMatchServersAvailable() async throws {
         var watchConfig = WatchConfig()
         var carPlayConfig = CarPlayConfig()
@@ -95,6 +107,44 @@ struct MagicItemProviderTests {
             // No replacement provided so item stays the same
             .init(id: "light.one", serverId: "1", type: .entity),
         ])
+    }
+
+    /// `getInfo` resolves entity-backed items through the per-server entity index rather than scanning
+    /// the entity list, which is what keeps resolving a whole picker's worth of items linear.
+    @Test mutating func getInfoResolvesEntityBackedItemsThroughTheIndex() {
+        sut.entitiesPerServer = [
+            "1": [
+                Self.entity(entityId: "light.one", domain: "light", name: "Light One", icon: "mdi:lightbulb"),
+                Self.entity(entityId: "script.one", domain: "script", name: "Script One", icon: "mdi:script"),
+                Self.entity(entityId: "scene.one", domain: "scene", name: "Scene One", icon: "mdi:palette"),
+            ],
+        ]
+
+        let entityInfo = sut.getInfo(for: .init(id: "light.one", serverId: "1", type: .entity))
+        #expect(entityInfo?.id == "1-light.one")
+        #expect(entityInfo?.name == "Light One")
+        #expect(entityInfo?.iconName == "mdi:lightbulb")
+
+        let scriptInfo = sut.getInfo(for: .init(id: "script.one", serverId: "1", type: .script))
+        #expect(scriptInfo?.id == "1-script.one")
+        #expect(scriptInfo?.name == "Script One")
+
+        let sceneInfo = sut.getInfo(for: .init(id: "scene.one", serverId: "1", type: .scene))
+        #expect(sceneInfo?.id == "1-scene.one")
+        #expect(sceneInfo?.name == "Scene One")
+    }
+
+    @Test mutating func getInfoReturnsNilWhenEntityIsMissingOrDomainDoesNotMatchItemType() {
+        sut.entitiesPerServer = [
+            "1": [Self.entity(entityId: "light.one", domain: "light", name: "Light One", icon: "mdi:lightbulb")],
+        ]
+
+        #expect(sut.getInfo(for: .init(id: "light.two", serverId: "1", type: .entity)) == nil)
+        // Right entity id, but on a server the provider knows nothing about.
+        #expect(sut.getInfo(for: .init(id: "light.one", serverId: "2", type: .entity)) == nil)
+        // The id exists, just not as a script/scene: the lookups stay domain-aware.
+        #expect(sut.getInfo(for: .init(id: "light.one", serverId: "1", type: .script)) == nil)
+        #expect(sut.getInfo(for: .init(id: "light.one", serverId: "1", type: .scene)) == nil)
     }
 
     @Test mutating func migrateCarPlayAssistItemsNormalizesUnsupportedCustomization() async throws {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The entity picker in the watch add flow froze the UI when showing the servers list, both when navigating to it and when navigating back to it.

The candidate list was built on the main thread, and building it did one full areas fetch from the database per candidate (`getAreaName` rebuilt the entity-to-area map on every call) plus a linear entity search per candidate (`getInfo`). On top of that, `onAppear` rebuilt the whole list again every time the user navigated back to the servers list.

Fixes:

- `getAreaName` reuses the per-server area map that `loadAppEntities` already builds instead of refetching it.
- `getInfo` resolves entities through a per-server `entityId` index instead of a linear search.
- `fetchAvailableItems` runs off the main thread and delivers its result on main.
- A successful load is kept for the lifetime of the add flow, so navigating back no longer reloads.
- The add-flow views no longer observe the home view model, which they never read published state from, so a background sync's progress updates no longer rebuild the navigation stack.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual changes, the picker looks the same and just stops hanging.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The provider changes also speed up the phone side (`WatchCommunicatorService`), the commonly used entities widget and the app icon shortcuts, which all call `getAreaName` in a loop.

Added tests cover the new entity lookup, including the domain mismatch and unknown server cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zyWMRZK4BwWnRiZHxKuSn)_