### PR TITLE
Restore Health Steps sensor

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric+Activity.swift
+++ b/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric+Activity.swift
@@ -2,8 +2,23 @@
 import Foundation
 
 public extension HealthKitMetric {
+    /// Shipped before the full Apple Health catalog existed; its ID must stay stable.
+    static let steps = HealthKitMetric(
+        uniqueID: "health_steps",
+        identifier: "HKQuantityTypeIdentifierStepCount",
+        name: "Health Steps",
+        icon: "mdi:walk",
+        unit: "steps",
+        queryUnit: .count,
+        aggregation: .cumulativeSum,
+        category: .activity,
+        stateClass: .totalIncreasing,
+        decimalPlaces: 0
+    )
+
     /// Movement, workouts and energy metrics.
     static let activityMetrics: [HealthKitMetric] = [
+        steps,
         HealthKitMetric(
             uniqueID: "health_distance_walking_running",
             identifier: "HKQuantityTypeIdentifierDistanceWalkingRunning",

--- a/Tests/Shared/Sensors/HealthKitMetricCatalog.test.swift
+++ b/Tests/Shared/Sensors/HealthKitMetricCatalog.test.swift
@@ -63,10 +63,10 @@ class HealthKitMetricCatalogTests: XCTestCase {
         }
     }
 
-    func testStepCountIsLeftToThePedometerSensor() {
-        // `PedometerSensor` has reported "Steps" for a long time; a HealthKit copy would duplicate it.
-        XCTAssertNil(HealthKitMetric.metric(uniqueID: "health_steps"))
-        XCTAssertFalse(HealthKitMetric.all.contains { $0.identifier == "HKQuantityTypeIdentifierStepCount" })
+    func testStepCountIsReportedFromHealthKit() {
+        // HealthKit's consolidated step count also sees an Apple Watch, unlike `PedometerSensor`.
+        XCTAssertEqual(HealthKitMetric.metric(uniqueID: "health_steps"), HealthKitMetric.steps)
+        XCTAssertTrue(HealthKitMetric.all.contains { $0.identifier == "HKQuantityTypeIdentifierStepCount" })
     }
 
     func testShippedMetricsKeepTheirIdentityStable() {
@@ -74,6 +74,11 @@ class HealthKitMetricCatalogTests: XCTestCase {
         XCTAssertEqual(HealthKitMetric.restingHeartRate.name, "Resting Heart Rate")
         XCTAssertEqual(HealthKitMetric.restingHeartRate.icon, "mdi:heart-pulse")
         XCTAssertEqual(HealthKitMetric.restingHeartRate.unit, "bpm")
+
+        XCTAssertEqual(HealthKitMetric.steps.uniqueID, "health_steps")
+        XCTAssertEqual(HealthKitMetric.steps.name, "Health Steps")
+        XCTAssertEqual(HealthKitMetric.steps.icon, "mdi:walk")
+        XCTAssertEqual(HealthKitMetric.steps.unit, "steps")
     }
 
     func testStateAppliesScaleAndRounding() throws {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Brings back the "Health Steps" sensor that was removed in #5272. It was dropped on the assumption it duplicated the existing CoreMotion pedometer steps, but CoreMotion only counts steps detected by the iPhone itself, whereas HealthKit reports the consolidated count including data from an Apple Watch, so it is generally more accurate.

The sensor keeps its original `health_steps` ID and lives on the Apple Health sensors screen. It stays off until the user enables it.

## Screenshots
N/A — re-adds a previously shipped sensor.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
