### PR TITLE
Exclude configuration and diagnostic entities from watch entity picker

### DIFF
--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -51,6 +51,7 @@ public enum DatabaseTables {
         case name
         case icon
         case rawDeviceClass
+        case entityCategory
     }
 
     public enum WatchConfig: String, CaseIterable {

--- a/Sources/HAModels/Sources/HAAppEntity.swift
+++ b/Sources/HAModels/Sources/HAAppEntity.swift
@@ -7,7 +7,9 @@ import GRDB
 /// from `config/entity_registry/list_for_display`):
 /// - `HAAppEntity` is every entity that currently has a state — including ones with no registry entry
 ///   (YAML/template/command-line entities, etc.) — and carries `domain` + `rawDeviceClass`, which the
-///   registry does not. It's what pickers/widgets enumerate as "all selectable entities".
+///   registry does not. It's what pickers/widgets enumerate as "all selectable entities". It also
+///   copies the registry's `entityCategory` at write time so consumers that never receive the full
+///   registry (the watch) can still exclude config/diagnostic entities.
 /// - The registry is config metadata (area, hidden, decimal precision, the user's name) for the
 ///   registered, non-disabled subset, and is only consulted to filter/enrich those entities.
 ///
@@ -30,6 +32,9 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
     public let name: String
     public let icon: String?
     public let rawDeviceClass: String?
+    /// The registry entity category index (config / diagnostic), copied from
+    /// `EntityRegistryListForDisplay.Entity.entityCategory` at write time; `nil` for ordinary entities.
+    public let entityCategory: Int?
 
     public init(
         id: String,
@@ -39,6 +44,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         name: String,
         icon: String?,
         rawDeviceClass: String?,
+        entityCategory: Int? = nil,
     ) {
         self.id = id
         self.entityId = entityId
@@ -47,6 +53,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         self.name = name
         self.icon = icon
         self.rawDeviceClass = rawDeviceClass
+        self.entityCategory = entityCategory
     }
 
     public enum ConfigInclude {

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -68,13 +68,15 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
         // `name` afterwards — is also what keeps the skip-write below correct: both the freshly built
         // and the cached rows carry the same display name, so an unchanged refresh compares equal and
         // is skipped (no per-cycle rewrite churn).
-        let registryNames: [String: String] = (try? EntityRegistryListForDisplay.Entity.config(serverId: serverId))
-            .map { rows in
-                Dictionary(
-                    rows.compactMap { row in row.name.map { (row.entityId, $0) } },
-                    uniquingKeysWith: { first, _ in first }
-                )
-            } ?? [:]
+        let registryRows = (try? EntityRegistryListForDisplay.Entity.config(serverId: serverId)) ?? []
+        let registryNames: [String: String] = Dictionary(
+            registryRows.compactMap { row in row.name.map { (row.entityId, $0) } },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let registryEntityCategories: [String: Int] = Dictionary(
+            registryRows.compactMap { row in row.entityCategory.map { (row.entityId, $0) } },
+            uniquingKeysWith: { first, _ in first }
+        )
 
         let appEntities = appRelatedEntities.map({ HAAppEntity(
             id: ServerEntity.uniqueId(serverId: serverId, entityId: $0.entityId),
@@ -83,7 +85,8 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
             domain: $0.domain,
             name: registryNames[$0.entityId] ?? $0.attributes.friendlyName ?? $0.entityId,
             icon: $0.attributes.icon,
-            rawDeviceClass: $0.attributes.dictionary["device_class"] as? String
+            rawDeviceClass: $0.attributes.dictionary["device_class"] as? String,
+            entityCategory: registryEntityCategories[$0.entityId]
         ) }).sorted(by: { $0.id < $1.id })
 
         do {

--- a/Sources/Shared/Database/Tables/HAppEntityTable.swift
+++ b/Sources/Shared/Database/Tables/HAppEntityTable.swift
@@ -20,6 +20,7 @@ final class HAppEntityTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.AppEntity.name.rawValue, .text).notNull()
                     t.column(DatabaseTables.AppEntity.icon.rawValue, .text)
                     t.column(DatabaseTables.AppEntity.rawDeviceClass.rawValue, .text)
+                    t.column(DatabaseTables.AppEntity.entityCategory.rawValue, .integer)
                 }
             }
         } else {

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -475,7 +475,7 @@ final class WatchCommunicatorService {
                 // `getInfo` adds to the context line when multiple servers are configured.
                 let serverPrefix = "\(server.info.name) • "
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { allowedDomains.contains($0.domain) }
+                    .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }

--- a/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
@@ -257,7 +257,7 @@ extension WatchHomeViewModel {
                 let serverId = server.identifier.rawValue
                 let serverPrefix = "\(server.info.name) • "
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { allowedDomains.contains($0.domain) }
+                    .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }

--- a/Tests/App/Watch/WatchConfig.test.swift
+++ b/Tests/App/Watch/WatchConfig.test.swift
@@ -341,6 +341,36 @@ struct WatchDatabaseMirror_test {
         #expect(WatchDatabaseMirror.decodeForWatch(Data([0x00, 0x01, 0x02])) == nil)
     }
 
+    @Test func entityCategoryRoundTripsThroughMirror() throws {
+        let diagnostic = HAAppEntity(
+            id: "server1-sensor.uptime",
+            entityId: "sensor.uptime",
+            serverId: "server1",
+            domain: "sensor",
+            name: "Uptime",
+            icon: nil,
+            rawDeviceClass: nil,
+            entityCategory: 1
+        )
+        let ordinary = HAAppEntity(
+            id: "server1-light.kitchen",
+            entityId: "light.kitchen",
+            serverId: "server1",
+            domain: "light",
+            name: "Kitchen",
+            icon: nil,
+            rawDeviceClass: nil
+        )
+        let original = WatchDatabaseMirror(entities: [diagnostic, ordinary], areas: [], pipelines: [])
+
+        let data = try original.encodeForWatch()
+        let decoded = try #require(WatchDatabaseMirror.decodeForWatch(data))
+
+        #expect(decoded.entities == [diagnostic, ordinary])
+        #expect(decoded.entities?.first { $0.entityId == "sensor.uptime" }?.entityCategory == 1)
+        #expect(decoded.entities?.first { $0.entityId == "light.kitchen" }?.entityCategory == nil)
+    }
+
     @Test func partialMirrorRoundTripsNilTablesAsRetain() throws {
         // A delta payload: only areas carried, everything else omitted (nil = retain on the watch).
         let area = AppArea(


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The watch entity picker (add flow) no longer lists configuration and diagnostic entities, matching the CarPlay picker.

To keep this working offline, the entity category is now stored on `HAAppEntity` (copied from the entity registry when entities are saved) so it can be mirrored to the watch, which never receives the full registry.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — filtering only, no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Filtering activates once the phone re-syncs the database mirror with the new category data; until then nothing is filtered, so there is no regression.
