### PR TITLE
Complication editor: remove redundant server picker and add icon color picker

### DIFF
--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
@@ -232,6 +232,7 @@ struct WatchComplicationBuilderEditView: View {
             selectedColor: iconColorBinding,
             style: .row(title: L10n.Watch.Complications.Slot.icon)
         )
+        staticColorPicker(L10n.Watch.Complications.Builder.iconColor, selection: iconColorBinding)
         if viewModel.config.kind == .customTemplate, viewModel.useTemplateColor {
             colorTemplateField(\.customIconColorTemplate, title: L10n.Watch.Complications.Builder.iconColor)
         }
@@ -313,10 +314,12 @@ struct WatchComplicationBuilderEditView: View {
                 Text(L10n.Watch.Complications.Builder.source)
             }
 
-            // Step 2: the server. The first one is pre-selected in the view model, and with a single
-            // server the picker is omitted entirely — the flow skips straight to the entity/template
-            // step.
-            if viewModel.selectedSource != nil, viewModel.servers.count > 1 {
+            // Step 2: the server — template flow only, since templates render against a server but
+            // have no entity picker. The entity flow needs no separate picker: the entity picker
+            // carries its own server filter, and the picked entity decides the server. The first
+            // server is pre-selected in the view model, and with a single server the picker is
+            // omitted entirely.
+            if viewModel.selectedSource == .customTemplate, viewModel.servers.count > 1 {
                 Section {
                     Picker(selection: serverBinding) {
                         ForEach(viewModel.servers, id: \.identifier.rawValue) { server in

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditView.swift
@@ -198,6 +198,14 @@ struct WatchComplicationBuilderEditView: View {
         appearanceOptions
     }
 
+    /// Whether template colors currently drive the complication. Only the template kind renders
+    /// color templates, so this — not `useTemplateColor` alone — gates the template fields and the
+    /// static pickers' disabled state: switching the source back to entity re-enables the static
+    /// colors even while the template fields keep their content for a later switch back.
+    private var templateColorsActive: Bool {
+        viewModel.config.kind == .customTemplate && viewModel.useTemplateColor
+    }
+
     /// The complication's colors, shown inline with the value element (its own icon color lives with
     /// the icon in the display-name row). Always visible — no opt-in — so the colors are discoverable
     /// without hunting for a toggle. The gauge/progress color only applies when a gauge is shown; the
@@ -213,12 +221,12 @@ struct WatchComplicationBuilderEditView: View {
         }
         if familyHasProgressBar, viewModel.config.showsGauge(for: currentFamily) {
             staticColorPicker(gaugeColorTitle, selection: tintBinding)
-            if viewModel.useTemplateColor {
+            if templateColorsActive {
                 colorTemplateField(\.customGaugeColorTemplate, title: gaugeColorTitle)
             }
         }
         staticColorPicker(L10n.Watch.Complications.Builder.textColor, selection: textColorBinding)
-        if viewModel.useTemplateColor {
+        if templateColorsActive {
             colorTemplateField(\.customTextColorTemplate, title: L10n.Watch.Complications.Builder.textColor)
         }
     }
@@ -233,7 +241,7 @@ struct WatchComplicationBuilderEditView: View {
             style: .row(title: L10n.Watch.Complications.Slot.icon)
         )
         staticColorPicker(L10n.Watch.Complications.Builder.iconColor, selection: iconColorBinding)
-        if viewModel.config.kind == .customTemplate, viewModel.useTemplateColor {
+        if templateColorsActive {
             colorTemplateField(\.customIconColorTemplate, title: L10n.Watch.Complications.Builder.iconColor)
         }
     }
@@ -584,8 +592,8 @@ struct WatchComplicationBuilderEditView: View {
     /// A static color picker that reads as disabled while template colors drive the complication.
     private func staticColorPicker(_ title: String, selection: Binding<Color>) -> some View {
         ColorPicker(title, selection: selection, supportsOpacity: false)
-            .disabled(viewModel.useTemplateColor)
-            .opacity(viewModel.useTemplateColor ? 0.4 : 1)
+            .disabled(templateColorsActive)
+            .opacity(templateColorsActive ? 0.4 : 1)
     }
 
     /// A color template row: shows the evaluated color (or the template source) and opens the full

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationBuilderEditViewModel.swift
@@ -110,7 +110,12 @@ final class WatchComplicationBuilderEditViewModel: ObservableObject {
             return
         }
         entitySubtitle = entity.contextualSubtitle
-        guard entity.entityId != config.entityId else { return }
+        // The same entity id on a different server is a different entity.
+        guard entity.entityId != config.entityId || entity.serverId != config.serverId else { return }
+        // The entity picker carries its own server filter, so the picked entity decides the server
+        // (the editor shows no separate server picker for the entity flow). Set it before the
+        // precision lookup below, which resolves against the config's server.
+        config.serverId = entity.serverId
         config.entityId = entity.entityId
         config.entityDisplayName = entity.name
         // A new entity's value source no longer applies to the old attributes.

--- a/Tests/App/Watch/WatchComplicationBuilderEditViewModel.test.swift
+++ b/Tests/App/Watch/WatchComplicationBuilderEditViewModel.test.swift
@@ -90,6 +90,22 @@ struct WatchComplicationBuilderEditViewModelTests {
         }
     }
 
+    @Test func pickingEntityFromAnotherServerAdoptsItsServer() throws {
+        try withBuilderTestWorld(serverIds: ["server-1", "server-2"]) { _ in
+            // The entity flow has no separate server picker: the entity picker's own server filter
+            // decides, so a picked entity carries its server into the config.
+            let viewModel = WatchComplicationBuilderEditViewModel(existing: nil)
+            viewModel.selectSource(.entity)
+            #expect(viewModel.config.serverId == "server-1")
+
+            viewModel.selectedEntity = Self.batteryEntity(serverId: "server-2")
+            viewModel.applySelectedEntity()
+
+            #expect(viewModel.config.serverId == "server-2")
+            #expect(viewModel.config.entityId == "sensor.battery")
+        }
+    }
+
     @Test func reselectingSameServerKeepsEntity() throws {
         try withBuilderTestWorld { _ in
             let viewModel = WatchComplicationBuilderEditViewModel(existing: nil)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Two more fixes in the watch complication editor:

- The separate server picker is removed for the entity flow: the entity picker already has a server filter inside, so the picked entity now decides the config's server. The picker is kept for the template flow, which renders against a server but has no entity picker.
- The icon color picker is now shown inside the Icon section, next to the icon selector (disabled while template colors drive the complication, matching the gauge/text color pickers).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01JMR4bLJyZzY9CmY2JguSKn)_