### PR TITLE
Fix Reminders sync failing on lists without description/due date support

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
@@ -62,6 +62,25 @@ struct RemindersSyncItemSnapshot: Equatable {
         }
     }
 
+    /// A copy without the fields the todo list can't store, so both sides compare equal on
+    /// fields that can never sync (`nil` features, from a failed state fetch, trims nothing).
+    /// A timed due is downgraded to its date part when the list only supports date-only dues.
+    func trimmed(to features: TodoListEntityFeature?) -> RemindersSyncItemSnapshot {
+        guard let features else { return self }
+        var copy = self
+        if !features.contains(.setDescriptionOnItem) {
+            copy.notes = nil
+        }
+        if let due {
+            if hasDueTime, !features.contains(.setDueDatetimeOnItem) {
+                copy.due = features.contains(.setDueDateOnItem) ? String(due.prefix(10)) : nil
+            } else if !hasDueTime, !features.contains(.setDueDateOnItem) {
+                copy.due = nil
+            }
+        }
+        return copy
+    }
+
     /// The due date as `EKReminder.dueDateComponents`.
     var dueComponents: DateComponents? {
         guard let due else { return nil }

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -270,10 +270,11 @@ final class RemindersSyncManager: ObservableObject {
 
         var details: [String] = []
         do {
+            let features = await todoListFeatures(server: server, entityId: config.todoEntityId)
             let todoItems = try await fetchTodoItems(api: api, listId: config.todoEntityId)
             let reminders = await fetchReminders(in: calendar)
             let todoSnapshots = Dictionary(
-                todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0)) },
+                todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0).trimmed(to: features)) },
                 uniquingKeysWith: { first, _ in first }
             )
             let remindersById = Dictionary(
@@ -284,10 +285,18 @@ final class RemindersSyncManager: ObservableObject {
             let configId = config.id
             let links = await Self.databaseAccess { RemindersSyncItemLink.links(configId: configId) }
                 .map(RemindersSyncPlanner.LinkState.init(link:))
+                .map { link in
+                    RemindersSyncPlanner.LinkState(
+                        todoItemUid: link.todoItemUid,
+                        reminderId: link.reminderId,
+                        snapshot: link.snapshot.trimmed(to: features)
+                    )
+                }
             details = try await applyPlan(
                 config: config,
                 api: api,
                 calendar: calendar,
+                features: features,
                 todoSnapshots: todoSnapshots,
                 remindersById: remindersById,
                 links: links
@@ -314,11 +323,14 @@ final class RemindersSyncManager: ObservableObject {
         config: RemindersSyncConfig,
         api: HomeAssistantAPI,
         calendar: EKCalendar,
+        features: TodoListEntityFeature?,
         todoSnapshots: [String: RemindersSyncItemSnapshot],
         remindersById: [String: EKReminder],
         links: [RemindersSyncPlanner.LinkState]
     ) async throws -> [String] {
-        let reminderSnapshots = remindersById.mapValues(RemindersSyncItemSnapshot.init(reminder:))
+        let reminderSnapshots = remindersById.mapValues {
+            RemindersSyncItemSnapshot(reminder: $0).trimmed(to: features)
+        }
         let operations = RemindersSyncPlanner.plan(
             direction: config.direction,
             conflictResolution: RemindersSyncSettings.current.conflictResolution,
@@ -338,6 +350,7 @@ final class RemindersSyncManager: ObservableObject {
                     operation,
                     config: config,
                     calendar: calendar,
+                    features: features,
                     todoSnapshots: todoSnapshots,
                     remindersById: remindersById
                 )
@@ -435,6 +448,7 @@ final class RemindersSyncManager: ObservableObject {
         _ operation: RemindersSyncOperation,
         config: RemindersSyncConfig,
         calendar: EKCalendar,
+        features: TodoListEntityFeature?,
         todoSnapshots: [String: RemindersSyncItemSnapshot],
         remindersById: [String: EKReminder]
     ) async throws -> Bool {
@@ -443,7 +457,7 @@ final class RemindersSyncManager: ObservableObject {
             guard let snapshot = todoSnapshots[todoItemUid] else { return false }
             let reminder = EKReminder(eventStore: eventStore)
             reminder.calendar = calendar
-            apply(snapshot, to: reminder)
+            apply(snapshot, to: reminder, features: features)
             try eventStore.save(reminder, commit: false)
             await saveLink(
                 config: config,
@@ -455,7 +469,7 @@ final class RemindersSyncManager: ObservableObject {
         case let .updateReminder(todoItemUid, reminderId):
             guard let snapshot = todoSnapshots[todoItemUid],
                   let reminder = remindersById[reminderId] else { return false }
-            apply(snapshot, to: reminder)
+            apply(snapshot, to: reminder, features: features)
             try eventStore.save(reminder, commit: false)
             await saveLink(config: config, todoItemUid: todoItemUid, reminderId: reminderId, snapshot: snapshot)
             return true
@@ -565,11 +579,29 @@ final class RemindersSyncManager: ObservableObject {
         }
     }
 
-    private func apply(_ snapshot: RemindersSyncItemSnapshot, to reminder: EKReminder) {
+    /// The todo entity's `supported_features` bitmask; nil when the state fetch fails, in which
+    /// case callers assume every field is supported.
+    private func todoListFeatures(server: Server, entityId: String) async -> TodoListEntityFeature? {
+        let attributes = await ControlEntityProvider(domains: [.todo]).attributes(server: server, entityId: entityId)
+        guard let rawValue = attributes?["supported_features"] as? Int else { return nil }
+        return TodoListEntityFeature(rawValue: rawValue)
+    }
+
+    private func apply(
+        _ snapshot: RemindersSyncItemSnapshot,
+        to reminder: EKReminder,
+        features: TodoListEntityFeature?
+    ) {
         reminder.title = snapshot.title
-        reminder.notes = snapshot.notes
         reminder.isCompleted = snapshot.isCompleted
-        reminder.dueDateComponents = snapshot.dueComponents
+        // Fields the list can't store are owned by the reminder side: never overwrite them with
+        // the todo side's (necessarily empty or less precise) value.
+        if features?.contains(.setDescriptionOnItem) ?? true {
+            reminder.notes = snapshot.notes
+        }
+        if RemindersSyncItemSnapshot(reminder: reminder).trimmed(to: features).due != snapshot.due {
+            reminder.dueDateComponents = snapshot.dueComponents
+        }
     }
 
     private func saveLink(

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -583,7 +583,8 @@ final class RemindersSyncManager: ObservableObject {
     /// case callers assume every field is supported.
     private func todoListFeatures(server: Server, entityId: String) async -> TodoListEntityFeature? {
         let attributes = await ControlEntityProvider(domains: [.todo]).attributes(server: server, entityId: entityId)
-        guard let rawValue = attributes?["supported_features"] as? Int else { return nil }
+        // NSNumber, not Int: the bitmask arrives as a JSON number whose bridged type isn't guaranteed.
+        guard let rawValue = (attributes?["supported_features"] as? NSNumber)?.intValue else { return nil }
         return TodoListEntityFeature(rawValue: rawValue)
     }
 
@@ -600,7 +601,17 @@ final class RemindersSyncManager: ObservableObject {
             reminder.notes = snapshot.notes
         }
         if RemindersSyncItemSnapshot(reminder: reminder).trimmed(to: features).due != snapshot.due {
-            reminder.dueDateComponents = snapshot.dueComponents
+            var newDue = snapshot.dueComponents
+            // A date-only value from a list that can't store times is a storage limitation, not
+            // the user removing the time: keep the reminder's local time on the changed date.
+            if let features, !features.contains(.setDueDatetimeOnItem),
+               newDue != nil, newDue?.hour == nil,
+               let existing = reminder.dueDateComponents, existing.hour != nil {
+                newDue?.hour = existing.hour
+                newDue?.minute = existing.minute
+                newDue?.second = existing.second
+            }
+            reminder.dueDateComponents = newDue
         }
     }
 

--- a/Sources/App/Utilities/RemindersSync/TodoListEntityFeature.swift
+++ b/Sources/App/Utilities/RemindersSync/TodoListEntityFeature.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Mirror of Home Assistant's `TodoListEntityFeature` bitmask, read from a todo entity's
+/// `supported_features` attribute. Todo lists only support a subset of the optional item fields
+/// (e.g. the Shopping List integration has no descriptions or due dates), and the todo services
+/// fail when they receive a field the entity can't store.
+struct TodoListEntityFeature: OptionSet {
+    let rawValue: Int
+
+    static let createItem = TodoListEntityFeature(rawValue: 1)
+    static let deleteItem = TodoListEntityFeature(rawValue: 2)
+    static let updateItem = TodoListEntityFeature(rawValue: 4)
+    static let moveItem = TodoListEntityFeature(rawValue: 8)
+    static let setDueDateOnItem = TodoListEntityFeature(rawValue: 16)
+    static let setDueDatetimeOnItem = TodoListEntityFeature(rawValue: 32)
+    static let setDescriptionOnItem = TodoListEntityFeature(rawValue: 64)
+}

--- a/Tests/App/Utilities/RemindersSync/RemindersSyncItemSnapshotTests.swift
+++ b/Tests/App/Utilities/RemindersSync/RemindersSyncItemSnapshotTests.swift
@@ -130,6 +130,85 @@ struct RemindersSyncItemSnapshotTests {
         #expect(RemindersSyncItemSnapshot.normalizedNotes(" note \n") == "note")
     }
 
+    // MARK: - Trimming to the list's supported features
+
+    @Test func testTrimmedWithNilFeaturesKeepsEverything() {
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: "3x",
+            due: "2026-07-17"
+        )
+        #expect(snapshot.trimmed(to: nil) == snapshot)
+    }
+
+    @Test func testTrimmedRemovesNotesWhenDescriptionsUnsupported() {
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: "3x",
+            due: nil
+        )
+        let trimmed = snapshot.trimmed(to: [.createItem, .updateItem, .deleteItem])
+        #expect(trimmed.notes == nil)
+        #expect(trimmed.title == "Buy milk")
+    }
+
+    @Test func testTrimmedKeepsNotesWhenDescriptionsSupported() {
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: "3x",
+            due: nil
+        )
+        #expect(snapshot.trimmed(to: [.setDescriptionOnItem]).notes == "3x")
+    }
+
+    @Test func testTrimmedRemovesAllDayDueWhenDueDatesUnsupported() {
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: nil,
+            due: "2026-07-17"
+        )
+        #expect(snapshot.trimmed(to: [.setDescriptionOnItem]).due == nil)
+    }
+
+    @Test func testTrimmedDowngradesTimedDueToDateWhenOnlyDatesSupported() {
+        let due = RemindersSyncItemSnapshot.canonicalDueString(from: Date(timeIntervalSince1970: 1_784_000_000))
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: nil,
+            due: due
+        )
+        let trimmed = snapshot.trimmed(to: [.setDueDateOnItem])
+        #expect(trimmed.due == String(due.prefix(10)))
+        #expect(!trimmed.hasDueTime)
+    }
+
+    @Test func testTrimmedRemovesTimedDueWhenDueDatesUnsupported() {
+        let due = RemindersSyncItemSnapshot.canonicalDueString(from: Date(timeIntervalSince1970: 1_784_000_000))
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: nil,
+            due: due
+        )
+        #expect(snapshot.trimmed(to: []).due == nil)
+    }
+
+    @Test func testTrimmedKeepsTimedDueWhenDatetimesSupported() {
+        let due = RemindersSyncItemSnapshot.canonicalDueString(from: Date(timeIntervalSince1970: 1_784_000_000))
+        let snapshot = RemindersSyncItemSnapshot(
+            title: "Buy milk",
+            isCompleted: false,
+            notes: nil,
+            due: due
+        )
+        #expect(snapshot.trimmed(to: [.setDueDatetimeOnItem]).due == due)
+    }
+
     // MARK: - Comparing sides
 
     @Test func testSnapshotsFromBothSidesCompareEqualWhenContentMatches() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Reminders sync sent every item field (description, due date) to the todo services unconditionally. Todo lists that don't support those fields (e.g. Shopping List) reject the call, so the sync failed permanently on the first reminder that had a note.

The sync now reads the todo entity's `supported_features` and trims unsupported fields from both sides before planning: they are never sent to the server, never compared, and never overwrite the reminder's local values.

## Screenshots
Not applicable, no UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Fields a list can't store stay owned by the Reminders side and are left untouched there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G32DeFHUCN5Mo6SD8HbUpZ)_