### PR TITLE
Add empty state and reload button to New List Sync screen

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1090,6 +1090,8 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "reminders_sync.add.duplicate_warning" = "These lists are already being synced.";
 "reminders_sync.add.lists_footer" = "The first sync links items that appear in both lists under the same title. Everything else is copied according to the sync direction. Completed items are not copied.";
 "reminders_sync.add.lists_header" = "Lists to sync";
+"reminders_sync.add.no_todo_lists.message" = "To sync with Apple Reminders, create a to-do list in Home Assistant first, then come back here.";
+"reminders_sync.add.no_todo_lists.title" = "No to-do lists";
 "reminders_sync.add.reminders_list" = "Apple Reminders list";
 "reminders_sync.add.server" = "Server";
 "reminders_sync.add.title" = "New List Sync";

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
@@ -76,6 +76,14 @@ struct RemindersSyncAddView: View {
                         dismiss()
                     }
                 }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.reloadServers()
+                    } label: {
+                        Image(systemSymbol: .arrowClockwise)
+                    }
+                    .accessibilityLabel(L10n.Settings.ConnectionSection.refreshServer)
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     if !viewModel.hasLoaded || viewModel.hasTodoLists {
                         Button(L10n.saveLabel) {
@@ -92,6 +100,11 @@ struct RemindersSyncAddView: View {
             }
             .task {
                 await viewModel.load()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .appDatabaseUpdaterDidFinishRoutine)) { _ in
+                // Re-read the entity cache so a list created in Home Assistant appears once its
+                // server's update finishes.
+                Task { await viewModel.load() }
             }
         }
     }

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
@@ -7,48 +7,65 @@ struct RemindersSyncAddView: View {
 
     var body: some View {
         NavigationView {
-            Form {
-                if viewModel.servers.count > 1 {
-                    Section {
-                        Picker(L10n.RemindersSync.Add.server, selection: $viewModel.selectedServerId) {
-                            ForEach(viewModel.servers, id: \.identifier.rawValue) { server in
-                                Text(server.info.name).tag(String?.some(server.identifier.rawValue))
+            Group {
+                if viewModel.hasLoaded, !viewModel.hasTodoLists {
+                    VStack(spacing: DesignSystem.Spaces.two) {
+                        Image(systemSymbol: .checklist)
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text(L10n.RemindersSync.Add.NoTodoLists.title)
+                            .font(.headline)
+                        Text(L10n.RemindersSync.Add.NoTodoLists.message)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(DesignSystem.Spaces.four)
+                } else {
+                    Form {
+                        if viewModel.servers.count > 1 {
+                            Section {
+                                Picker(L10n.RemindersSync.Add.server, selection: $viewModel.selectedServerId) {
+                                    ForEach(viewModel.servers, id: \.identifier.rawValue) { server in
+                                        Text(server.info.name).tag(String?.some(server.identifier.rawValue))
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                Section(
-                    header: Text(L10n.RemindersSync.Add.listsHeader),
-                    footer: Text(L10n.RemindersSync.Add.listsFooter)
-                ) {
-                    Picker(L10n.RemindersSync.Add.remindersList, selection: $viewModel.selectedReminderListId) {
-                        ForEach(viewModel.reminderLists, id: \.calendarIdentifier) { list in
-                            Text(list.title).tag(String?.some(list.calendarIdentifier))
+                        Section(
+                            header: Text(L10n.RemindersSync.Add.listsHeader),
+                            footer: Text(L10n.RemindersSync.Add.listsFooter)
+                        ) {
+                            Picker(L10n.RemindersSync.Add.remindersList, selection: $viewModel.selectedReminderListId) {
+                                ForEach(viewModel.reminderLists, id: \.calendarIdentifier) { list in
+                                    Text(list.title).tag(String?.some(list.calendarIdentifier))
+                                }
+                            }
+                            Picker(L10n.RemindersSync.Add.todoList, selection: $viewModel.selectedTodoEntityId) {
+                                ForEach(viewModel.todoEntities, id: \.entityId) { entity in
+                                    Text(entity.name).tag(String?.some(entity.entityId))
+                                }
+                            }
+                        }
+                        Section(
+                            header: Text(L10n.RemindersSync.Add.direction),
+                            footer: VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
+                                Text(directionFooter)
+                                if viewModel.isDuplicate {
+                                    Text(L10n.RemindersSync.Add.duplicateWarning)
+                                        .foregroundStyle(.red)
+                                }
+                            }
+                        ) {
+                            Picker(L10n.RemindersSync.Add.direction, selection: $viewModel.direction) {
+                                ForEach(RemindersSyncDirection.allCases) { direction in
+                                    Text(direction.localizedTitle).tag(direction)
+                                }
+                            }
+                            .pickerStyle(.inline)
+                            .labelsHidden()
                         }
                     }
-                    Picker(L10n.RemindersSync.Add.todoList, selection: $viewModel.selectedTodoEntityId) {
-                        ForEach(viewModel.todoEntities, id: \.entityId) { entity in
-                            Text(entity.name).tag(String?.some(entity.entityId))
-                        }
-                    }
-                }
-                Section(
-                    header: Text(L10n.RemindersSync.Add.direction),
-                    footer: VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
-                        Text(directionFooter)
-                        if viewModel.isDuplicate {
-                            Text(L10n.RemindersSync.Add.duplicateWarning)
-                                .foregroundStyle(.red)
-                        }
-                    }
-                ) {
-                    Picker(L10n.RemindersSync.Add.direction, selection: $viewModel.direction) {
-                        ForEach(RemindersSyncDirection.allCases) { direction in
-                            Text(direction.localizedTitle).tag(direction)
-                        }
-                    }
-                    .pickerStyle(.inline)
-                    .labelsHidden()
                 }
             }
             .navigationTitle(L10n.RemindersSync.Add.title)
@@ -60,12 +77,14 @@ struct RemindersSyncAddView: View {
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(L10n.saveLabel) {
-                        if viewModel.save() {
-                            dismiss()
+                    if !viewModel.hasLoaded || viewModel.hasTodoLists {
+                        Button(L10n.saveLabel) {
+                            if viewModel.save() {
+                                dismiss()
+                            }
                         }
+                        .disabled(!viewModel.canSave)
                     }
-                    .disabled(!viewModel.canSave)
                 }
             }
             .onChange(of: viewModel.selectedServerId) { _ in

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddView.swift
@@ -21,6 +21,7 @@ struct RemindersSyncAddView: View {
                             .multilineTextAlignment(.center)
                     }
                     .padding(DesignSystem.Spaces.four)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     Form {
                         if viewModel.servers.count > 1 {

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
@@ -10,6 +10,7 @@ final class RemindersSyncAddViewModel: ObservableObject {
     @Published var direction: RemindersSyncDirection = .bothWays
     @Published private(set) var todoEntitiesByServer: [(Server, [HAAppEntity])] = []
     @Published private(set) var reminderLists: [EKCalendar] = []
+    @Published private(set) var hasLoaded = false
 
     private var existingConfigs: [RemindersSyncConfig] = []
 
@@ -20,6 +21,12 @@ final class RemindersSyncAddViewModel: ObservableObject {
     var todoEntities: [HAAppEntity] {
         todoEntitiesByServer
             .first(where: { $0.0.identifier.rawValue == selectedServerId })?.1 ?? []
+    }
+
+    /// Whether any server has a todo list to sync with (servers without lists are filtered out
+    /// of `todoEntitiesByServer` on load).
+    var hasTodoLists: Bool {
+        !todoEntitiesByServer.isEmpty
     }
 
     /// The exact same list pairing already exists.
@@ -57,6 +64,7 @@ final class RemindersSyncAddViewModel: ObservableObject {
         if selectedReminderListId == nil {
             selectedReminderListId = reminderLists.first?.calendarIdentifier
         }
+        hasLoaded = true
     }
 
     func selectedServerChanged() {

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
@@ -55,11 +55,23 @@ final class RemindersSyncAddViewModel: ObservableObject {
         }
         reminderLists = RemindersSyncManager.shared.reminderLists()
 
+        // A reload can invalidate earlier selections (e.g. the selected server's last todo list
+        // was deleted): clear anything that no longer exists before filling in defaults.
+        if selectedServerId != nil, !servers.contains(where: { $0.identifier.rawValue == selectedServerId }) {
+            selectedServerId = nil
+        }
         if selectedServerId == nil {
             selectedServerId = servers.first?.identifier.rawValue
         }
+        if selectedTodoEntityId != nil, !todoEntities.contains(where: { $0.entityId == selectedTodoEntityId }) {
+            selectedTodoEntityId = nil
+        }
         if selectedTodoEntityId == nil {
             selectedTodoEntityId = todoEntities.first?.entityId
+        }
+        if selectedReminderListId != nil,
+           !reminderLists.contains(where: { $0.calendarIdentifier == selectedReminderListId }) {
+            selectedReminderListId = nil
         }
         if selectedReminderListId == nil {
             selectedReminderListId = reminderLists.first?.calendarIdentifier

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
@@ -67,6 +67,14 @@ final class RemindersSyncAddViewModel: ObservableObject {
         hasLoaded = true
     }
 
+    /// Triggers a full app database update for every server, so newly created to-do lists show
+    /// up. Progress and completion are reported through the updater's toasts.
+    func reloadServers() {
+        for server in Current.servers.all {
+            server.refreshAppDatabase(forceUpdate: true, showProgress: true)
+        }
+    }
+
     func selectedServerChanged() {
         // Entities belong to one server; reset the selection when it no longer matches.
         if !todoEntities.contains(where: { $0.entityId == selectedTodoEntityId }) {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3717,6 +3717,12 @@ public enum L10n {
         /// Home Assistant is the source of truth. Its items and changes overwrite the Apple Reminders list. Items that only exist in Reminders are left alone.
         public static var toReminders: String { return L10n.tr("Localizable", "reminders_sync.add.direction_footer.to_reminders") }
       }
+      public enum NoTodoLists {
+        /// To sync with Apple Reminders, create a to-do list in Home Assistant first, then come back here.
+        public static var message: String { return L10n.tr("Localizable", "reminders_sync.add.no_todo_lists.message") }
+        /// No to-do lists
+        public static var title: String { return L10n.tr("Localizable", "reminders_sync.add.no_todo_lists.title") }
+      }
     }
     public enum Conflict {
       /// Home Assistant


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The New List Sync screen always showed the Home Assistant to-do list picker, even when the user's server(s) have no todo entities, leaving an empty picker with no guidance.

Now, when no server has a to-do list, the form is replaced with a message asking the user to create a to-do list in Home Assistant first, and the Save button is hidden. A reload button in the toolbar triggers a forced app database update for all servers (progress and completion reported through the existing updater toasts), and the screen re-reads the entity cache as each server finishes, so a newly created list appears without leaving the screen.

## Screenshots
Not included, developed without a build environment. The empty state is a centered icon/title/message stack using design system tokens and system semantic colors, so it adapts to light and dark mode.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The reload button reuses the existing "Update server information" flow and localized strings; only the empty-state title and message are new strings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G32DeFHUCN5Mo6SD8HbUpZ)_