### PR TITLE
Send user back to Home Assistant root when activating a server

### DIFF
--- a/Sources/App/Container/AppContainerCoordinator.swift
+++ b/Sources/App/Container/AppContainerCoordinator.swift
@@ -103,6 +103,17 @@ final class AppContainerCoordinator: AppCoordinator {
         return promise
     }
 
+    func activate(server: Server) {
+        if let current = frontend, current.server.identifier == server.identifier {
+            // Already showing this server, so `open(server:)` would be a no-op: send the frontend back to
+            // the root instead, so activating the server again recovers a user stuck on a broken screen.
+            current.navigateToRoot()
+        } else {
+            // Switching servers rebuilds the web view, which lands on the server root on its own.
+            open(server: server)
+        }
+    }
+
     func selectServer(prompt: String?, includeSettings: Bool, completion: @escaping (Server) -> Void) {
         pendingServerSelection = completion
         // The picker is a sheet on the container, so anything already presented (Settings, What's New, …)

--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -73,7 +73,7 @@ final class WebViewGestureHandler {
     private func showServersList() {
         Current.sceneManager.appCoordinator.done { coordinator in
             coordinator.selectServer(prompt: nil, includeSettings: true) { server in
-                coordinator.open(server: server)
+                coordinator.activate(server: server)
             }
         }
     }
@@ -153,6 +153,8 @@ final class WebViewGestureHandler {
 
         let nextServer = servers[nextIndex]
 
+        // Not `activate(server:)`: cycling servers with a gesture bypasses the server picker, so it
+        // switches in place without sending the user back to the Home Assistant root.
         Current.sceneManager.appCoordinator.done { coordinator in
             coordinator.open(server: nextServer)
         }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -287,7 +287,7 @@ final class HomeAssistantViewModel: ObservableObject {
 
     func selectServer(_ server: Server) {
         Current.sceneManager.appCoordinator.done { coordinator in
-            coordinator.open(server: server)
+            coordinator.activate(server: server)
         }
     }
 }

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -370,7 +370,7 @@ extension MacWebViewTitleBar {
                     state: server.identifier == selectedIdentifier ? .on : .off
                 ) { _ in
                     Current.sceneManager.appCoordinator.done { coordinator in
-                        coordinator.open(server: server)
+                        coordinator.activate(server: server)
                     }
                 }
             }

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -369,8 +369,10 @@ extension MacWebViewTitleBar {
                     title: server.info.name,
                     state: server.identifier == selectedIdentifier ? .on : .off
                 ) { _ in
+                    // Not `activate(server:)`: like the server-cycling gestures, the toolbar menu
+                    // switches in place without sending the user back to the Home Assistant root.
                     Current.sceneManager.appCoordinator.done { coordinator in
-                        coordinator.activate(server: server)
+                        coordinator.open(server: server)
                     }
                 }
             }

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -672,7 +672,7 @@ struct HomeAssistantStandByView: View {
 
     private func selectServer(_ server: Server) {
         Current.sceneManager.appCoordinator.done { coordinator in
-            coordinator.open(server: server)
+            coordinator.activate(server: server)
         }
     }
 

--- a/Sources/App/Frontend/WebView/Views/ServerPickerView.swift
+++ b/Sources/App/Frontend/WebView/Views/ServerPickerView.swift
@@ -52,7 +52,7 @@ struct ServerPickerView: View {
                 onSelect(server)
             } else {
                 Current.sceneManager.appCoordinator.done { coordinator in
-                    coordinator.open(server: server)
+                    coordinator.activate(server: server)
                 }
             }
         }

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -316,7 +316,7 @@ struct WebViewEmptyStateView: View {
             serverSelectionAction(server)
         } else {
             Current.sceneManager.appCoordinator.done { coordinator in
-                coordinator.open(server: server)
+                coordinator.activate(server: server)
             }
         }
     }

--- a/Sources/App/Frontend/WebView/WebFrontend.swift
+++ b/Sources/App/Frontend/WebView/WebFrontend.swift
@@ -17,6 +17,7 @@ protocol WebFrontend: AnyObject {
     func show(alert: ServerAlert)
     func open(inline url: URL, avoidUnnecessaryReload: Bool)
     func openPanel(_ url: URL)
+    func navigateToRoot()
     func dismissOverlayController(animated: Bool, completion: (() -> Void)?)
     func presentOverlayController(controller: UIViewController, animated: Bool)
 }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
@@ -28,8 +28,10 @@ extension WebViewController {
     }
 
     func openServer(_ server: Server) {
+        // Not `activate(server:)`: like the server-cycling gestures, the status bar menu switches
+        // in place without sending the user back to the Home Assistant root.
         Current.sceneManager.appCoordinator.done { coordinator in
-            coordinator.activate(server: server)
+            coordinator.open(server: server)
         }
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
@@ -29,7 +29,7 @@ extension WebViewController {
 
     func openServer(_ server: Server) {
         Current.sceneManager.appCoordinator.done { coordinator in
-            coordinator.open(server: server)
+            coordinator.activate(server: server)
         }
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -241,6 +241,19 @@ extension WebViewController {
         }
     }
 
+    /// Sends the web view back to the frontend root — the kiosk dashboard when kiosk mode targets this
+    /// server, the server default otherwise. Always loads, even when already at the root, so activating
+    /// the server again recovers a web view stuck on a broken page.
+    func navigateToRoot() {
+        Task { [weak self] in
+            guard let self, let webviewURL = await server.webviewURL() else { return }
+            let target = await kioskDashboardURL(for: webviewURL) ?? webviewURL
+            Current.Log.info("navigating web view to root: \(target.path)")
+            loadViewIfNeeded()
+            load(request: URLRequest(url: target))
+        }
+    }
+
     func showNoActiveURLError() {
         // Load about:blank in webview to prevent any current connections
         load(request: URLRequest(url: URL(string: "about:blank")!))

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -245,7 +245,7 @@ extension WebViewController {
     /// server, the server default otherwise. Always loads, even when already at the root, so activating
     /// the server again recovers a web view stuck on a broken page.
     func navigateToRoot() {
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self, let webviewURL = await server.webviewURL() else { return }
             let target = await kioskDashboardURL(for: webviewURL) ?? webviewURL
             Current.Log.info("navigating web view to root: \(target.path)")

--- a/Sources/App/Scenes/SceneManager.swift
+++ b/Sources/App/Scenes/SceneManager.swift
@@ -46,6 +46,10 @@ protocol AppCoordinator: AnyObject {
     func showDownloadManager(_ viewModel: DownloadManagerViewModel)
     func showOnboardingPermissions(server: Server, steps: [OnboardingPermissionsNavigationViewModel.StepID])
     @discardableResult func open(server: Server) -> Guarantee<any WebFrontend>
+    /// Activates `server` in response to an explicit user action (server picker, server settings).
+    /// Unlike `open(server:)`, activating the already-active server is not a no-op: the frontend is sent
+    /// back to the Home Assistant root, so re-activating a server always recovers from a stuck screen.
+    func activate(server: Server)
     func selectServer(prompt: String?, includeSettings: Bool, completion: @escaping (Server) -> Void)
     func presentInvitation(url: URL?)
     func setup()

--- a/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
+++ b/Sources/App/Settings/Connection/ConnectionSettingsViewModel.swift
@@ -260,7 +260,7 @@ final class ConnectionSettingsViewModel: ObservableObject {
             }
         } else {
             Current.sceneManager.appCoordinator.done {
-                $0.open(server: self.server)
+                $0.activate(server: self.server)
             }
         }
     }

--- a/Tests/App/Container/AppContainerCoordinatorTests.swift
+++ b/Tests/App/Container/AppContainerCoordinatorTests.swift
@@ -80,6 +80,27 @@ final class AppContainerCoordinatorTests: XCTestCase {
         XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
     }
 
+    func testActivatingTheActiveServerSendsTheFrontendBackToTheRoot() {
+        var openedServer: Server?
+        coordinator.onOpenServer = { openedServer = $0 }
+
+        coordinator.activate(server: server)
+
+        XCTAssertEqual(frontend.navigateToRootCallCount, 1)
+        XCTAssertNil(openedServer)
+    }
+
+    func testActivatingAnotherServerOpensItWithoutNavigatingTheOutgoingFrontend() {
+        let otherServer = Server.fake()
+        var openedServer: Server?
+        coordinator.onOpenServer = { openedServer = $0 }
+
+        coordinator.activate(server: otherServer)
+
+        XCTAssertEqual(openedServer?.identifier, otherServer.identifier)
+        XCTAssertEqual(frontend.navigateToRootCallCount, 0)
+    }
+
     func testSelectingAServerClearsWhatIsAlreadyPresentedFirst() {
         AppSettingsPresenter.shared.isSheetPresented = true
         var settingsSheetWasClearedBeforePresenting: Bool?

--- a/Tests/App/WebView/Mocks/MockAppCoordinator.swift
+++ b/Tests/App/WebView/Mocks/MockAppCoordinator.swift
@@ -9,6 +9,7 @@ final class MockAppCoordinator: AppCoordinator {
     private(set) var showSettingsPushedOntoNavigationStack = false
     private(set) var showAssistSettingsCalled = false
     private(set) var dismissPresentedContentCallCount = 0
+    private(set) var activatedServers: [Server] = []
     var onShowSettings: (() -> Void)?
     var onShowAssistSettings: (() -> Void)?
 
@@ -34,6 +35,10 @@ final class MockAppCoordinator: AppCoordinator {
 
     func open(server: Server) -> Guarantee<any WebFrontend> {
         Guarantee<any WebFrontend> { _ in }
+    }
+
+    func activate(server: Server) {
+        activatedServers.append(server)
     }
 
     func selectServer(prompt: String?, includeSettings: Bool, completion: @escaping (Server) -> Void) {}

--- a/Tests/App/WebView/Mocks/MockWebFrontend.swift
+++ b/Tests/App/WebView/Mocks/MockWebFrontend.swift
@@ -9,6 +9,7 @@ final class MockWebFrontend: WebFrontend {
 
     private(set) var openedInlineURLs: [URL] = []
     private(set) var openedPanelURLs: [URL] = []
+    private(set) var navigateToRootCallCount = 0
     private(set) var dismissOverlayControllerCallCount = 0
     private(set) var presentedOverlayControllers: [UIViewController] = []
 
@@ -29,6 +30,10 @@ final class MockWebFrontend: WebFrontend {
     func openPanel(_ url: URL) {
         openedPanelURLs.append(url)
         onOpen?(url)
+    }
+
+    func navigateToRoot() {
+        navigateToRootCallCount += 1
     }
 
     func dismissOverlayController(animated: Bool, completion: (() -> Void)?) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Activating a server — from the server picker, the empty-state/standby pickers, or the server settings "Activate server" button — now always sends the web view back to the Home Assistant root, even when the selected server is already the active one. Re-activating the active server used to be a no-op, so a user stuck on a broken screen had no way to recover; now activating the server again always lands them home.

Surfaces that switch servers without going through the server picker are exempt and keep switching in place: the next/previous-server gestures and keyboard shortcuts, the Mac title bar and status bar server menus, and automatic switches (location-based server switching, kiosk return-to-default).

| Entry point | Sends to HA root? |
|---|---|
| Server picker menu (inline pill picker on empty-state and standby screens) | ✅ Yes |
| Server select sheet (list of servers with avatars) | ✅ Yes |
| Servers-list gesture/shortcut (opens the select sheet above) | ✅ Yes |
| Empty-state server menu on Mac (the on-page picker, not the toolbar) | ✅ Yes |
| Server settings → "Activate server" button | ✅ Yes |
| Next/previous-server swipe gestures and keyboard shortcuts | ❌ No |
| Mac title bar (toolbar) server menu | ❌ No |
| Mac status bar server menu | ❌ No |
| Location-based automatic server switching | ❌ No |
| Kiosk return-to-default | ❌ No (goes to the kiosk dashboard) |
| Deep links, notifications, app intents | ❌ No (navigate to their own target path) |

Notes on the table:
- Cross-server switches always rebuild the web view, which loads that server's default page — the exemption's practical meaning is that re-selecting the *current* server stays a no-op, with no forced reload.
- The "Yes" rows force navigation even when the selected server is already active — including a reload when already at the root — which is what makes them recovery paths. In kiosk mode, "root" for those rows means the configured kiosk dashboard.
- On Mac with "macOS native features only" enabled, the "Activate server" button keeps its existing behavior of opening the server in the browser.

## Screenshots
No visual changes; this only changes where the web view navigates on server activation.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
