### PR TITLE
Keep back/forward navigation on the active base URL

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
@@ -57,7 +57,8 @@ extension WebViewController: WebViewControllerProtocol {
     /// are likely unreachable on the current network. A same-base item navigates natively; a cross-base
     /// item is rebased onto the current base and loaded as a fresh request -- except the duplicated
     /// boundary entry for the page already showing, which is skipped so the navigation doesn't reduce to
-    /// a reload of the current page. `about:blank` entries (no-active-URL state) are skipped as well.
+    /// a reload of the current page. `about:blank` entries (no-active-URL state) are skipped as well,
+    /// and while `about:blank` itself is showing there is no base to navigate within, so nothing resolves.
     /// Returns `nil` when no candidate resolves to a different page. Non-private for tests.
     static func resolvedBackForwardNavigation(
         currentURL: URL?,
@@ -68,19 +69,42 @@ extension WebViewController: WebViewControllerProtocol {
             return candidateURLs.isEmpty ? nil : .navigate(index: 0)
         }
 
+        guard isWebURL(currentURL) else { return nil }
+
         for (index, candidateURL) in candidateURLs.enumerated() {
             if candidateURL.baseIsEqual(to: currentURL) {
                 return .navigate(index: index)
             }
             guard let rebased = rebased(candidateURL, onto: currentURL) else { continue }
-            // Both directions because HA appends /0 to lovelace paths on only one side.
-            let isCurrentPage = rebased.isEqualIgnoringQueryParams(to: currentURL)
-                || currentURL.isEqualIgnoringQueryParams(to: rebased)
-            if !isCurrentPage {
+            if !isSamePage(rebased, currentURL) {
                 return .load(rebased)
             }
         }
         return nil
+    }
+
+    /// Whether two same-base URLs identify the same frontend page, i.e. one is the duplicated boundary
+    /// entry for the other. Only differences the base switch itself introduces are ignored: the
+    /// `external_auth` parameter and HA's `/0` suffix on default lovelace paths. Any other path, query
+    /// or fragment difference is a distinct page that history navigation must still reach.
+    private static func isSamePage(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard lhs.path == rhs.path || lhs.path == rhs.path + "/0" || rhs.path == lhs.path + "/0" else {
+            return false
+        }
+        return queryItemsIgnoringExternalAuth(lhs) == queryItemsIgnoringExternalAuth(rhs)
+            && lhs.fragment == rhs.fragment
+    }
+
+    private static func queryItemsIgnoringExternalAuth(_ url: URL) -> [URLQueryItem] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.filter { $0.name != "external_auth" } ?? []
+        // Order-insensitive: the boundary load may append items in a different order than the original.
+        return items.sorted { ($0.name, $0.value ?? "") < ($1.name, $1.value ?? "") }
+    }
+
+    private static func isWebURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
     }
 
     /// `url` with its scheme/host/port/credentials replaced by `baseURL`'s, keeping path, query and
@@ -91,9 +115,7 @@ extension WebViewController: WebViewControllerProtocol {
     /// bare path, and without the parameter the frontend would use the browser login flow instead of
     /// the app's token bridge.
     private static func rebased(_ url: URL, onto baseURL: URL) -> URL? {
-        let webSchemes: Set<String> = ["http", "https"]
-        guard let scheme = url.scheme?.lowercased(), webSchemes.contains(scheme),
-              let baseScheme = baseURL.scheme?.lowercased(), webSchemes.contains(baseScheme),
+        guard isWebURL(url), isWebURL(baseURL),
               var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let baseComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             return nil

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ProtocolConformance.swift
@@ -5,19 +5,110 @@ import WebKit
 
 extension WebViewController: WebViewControllerProtocol {
     var canGoBack: Bool {
-        webView.canGoBack
+        Self.resolvedBackForwardNavigation(
+            currentURL: webView.url,
+            candidateURLs: webView.backForwardList.backList.reversed().map(\.url)
+        ) != nil
     }
 
     var canGoForward: Bool {
-        webView.canGoForward
+        Self.resolvedBackForwardNavigation(
+            currentURL: webView.url,
+            candidateURLs: webView.backForwardList.forwardList.map(\.url)
+        ) != nil
     }
 
     @objc func goBack() {
-        webView.goBack()
+        // Nearest-first: the immediate back item is last in `backList`.
+        performBackForwardNavigation(among: Array(webView.backForwardList.backList.reversed()))
     }
 
     @objc func goForward() {
-        webView.goForward()
+        performBackForwardNavigation(among: webView.backForwardList.forwardList)
+    }
+
+    private func performBackForwardNavigation(among items: [WKBackForwardListItem]) {
+        guard let resolution = Self.resolvedBackForwardNavigation(
+            currentURL: webView.url,
+            candidateURLs: items.map(\.url)
+        ) else { return }
+
+        switch resolution {
+        case let .navigate(index):
+            webView.go(to: items[index])
+        case let .load(url):
+            Current.Log.info("rebasing history navigation onto the active base URL: \(url.path)")
+            load(request: URLRequest(url: url))
+        }
+    }
+
+    enum BackForwardNavigationResolution: Equatable {
+        /// Navigate natively to the history item at this index of the nearest-first candidate list.
+        case navigate(index: Int)
+        /// The history item is on a different base; load its page rebuilt onto the current base instead.
+        case load(URL)
+    }
+
+    /// Resolves what back/forward should do so history navigation always stays on the current (active)
+    /// base URL. `candidateURLs` are the history item URLs on that side, ordered nearest-first.
+    ///
+    /// History can span base URLs after an internal/external switch: the current path is re-loaded onto
+    /// the newly active base (see `resolvedLoadURL`), leaving the old base's entries behind, and those
+    /// are likely unreachable on the current network. A same-base item navigates natively; a cross-base
+    /// item is rebased onto the current base and loaded as a fresh request -- except the duplicated
+    /// boundary entry for the page already showing, which is skipped so the navigation doesn't reduce to
+    /// a reload of the current page. `about:blank` entries (no-active-URL state) are skipped as well.
+    /// Returns `nil` when no candidate resolves to a different page. Non-private for tests.
+    static func resolvedBackForwardNavigation(
+        currentURL: URL?,
+        candidateURLs: [URL]
+    ) -> BackForwardNavigationResolution? {
+        guard let currentURL else {
+            // Nothing to compare against; preserve plain history navigation.
+            return candidateURLs.isEmpty ? nil : .navigate(index: 0)
+        }
+
+        for (index, candidateURL) in candidateURLs.enumerated() {
+            if candidateURL.baseIsEqual(to: currentURL) {
+                return .navigate(index: index)
+            }
+            guard let rebased = rebased(candidateURL, onto: currentURL) else { continue }
+            // Both directions because HA appends /0 to lovelace paths on only one side.
+            let isCurrentPage = rebased.isEqualIgnoringQueryParams(to: currentURL)
+                || currentURL.isEqualIgnoringQueryParams(to: rebased)
+            if !isCurrentPage {
+                return .load(rebased)
+            }
+        }
+        return nil
+    }
+
+    /// `url` with its scheme/host/port/credentials replaced by `baseURL`'s, keeping path, query and
+    /// fragment. `nil` when either side isn't a web URL (e.g. `about:blank`), which nothing can rebase.
+    ///
+    /// The result is loaded as a fresh document, so `external_auth=1` is ensured like `webviewURL()`
+    /// does for app-initiated loads: history entries created by the frontend's own routing may carry a
+    /// bare path, and without the parameter the frontend would use the browser login flow instead of
+    /// the app's token bridge.
+    private static func rebased(_ url: URL, onto baseURL: URL) -> URL? {
+        let webSchemes: Set<String> = ["http", "https"]
+        guard let scheme = url.scheme?.lowercased(), webSchemes.contains(scheme),
+              let baseScheme = baseURL.scheme?.lowercased(), webSchemes.contains(baseScheme),
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let baseComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.scheme = baseComponents.scheme
+        components.host = baseComponents.host
+        components.port = baseComponents.port
+        components.user = baseComponents.user
+        components.password = baseComponents.password
+        var queryItems = components.queryItems ?? []
+        if !queryItems.contains(where: { $0.name == "external_auth" }) {
+            queryItems.append(URLQueryItem(name: "external_auth", value: "1"))
+        }
+        components.queryItems = queryItems
+        return components.url
     }
 
     var overlayedController: UIViewController? {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -438,11 +438,50 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(resolution, .navigate(index: 1))
     }
 
+    func testBackForwardResolutionTreatsQueryDifferencesAsDistinctPages() throws {
+        // Only external_auth is ignored by duplicate detection; a cross-base entry that differs in any
+        // other query parameter is a distinct page that history navigation must still reach.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=2")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?start=1"))]
+        )
+
+        XCTAssertEqual(
+            resolution,
+            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1")))
+        )
+    }
+
+    func testBackForwardResolutionTreatsFragmentDifferencesAsDistinctPages() throws {
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/todo#list-a")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/todo#list-b"))]
+        )
+
+        XCTAssertEqual(
+            resolution,
+            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/todo?external_auth=1#list-b")))
+        )
+    }
+
     func testBackForwardResolutionReturnsNilWhileShowingAboutBlank() throws {
         // While the no-active-URL screen shows, no base exists to rebase history onto.
         let resolution = try WebViewController.resolvedBackForwardNavigation(
             currentURL: XCTUnwrap(URL(string: "about:blank")),
             candidateURLs: [XCTUnwrap(URL(string: "https://example.com/lovelace/0"))]
+        )
+
+        XCTAssertNil(resolution)
+    }
+
+    func testBackForwardResolutionReturnsNilWhileShowingAboutBlankWithAboutBlankHistory() throws {
+        // Two about:blank URLs compare as same-base; that must not surface as a navigable entry.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "about:blank")),
+            candidateURLs: [
+                XCTUnwrap(URL(string: "about:blank")),
+                XCTUnwrap(URL(string: "https://example.com/lovelace/0")),
+            ]
         )
 
         XCTAssertNil(resolution)

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -374,10 +374,8 @@ final class WebViewControllerTests: XCTestCase {
             candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?start=1#detail"))]
         )
 
-        XCTAssertEqual(
-            resolution,
-            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1#detail")))
-        )
+        let expected = try XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1#detail"))
+        XCTAssertEqual(resolution, .load(expected))
     }
 
     func testBackForwardResolutionDoesNotDuplicateExternalAuthWhenRebasing() throws {
@@ -386,10 +384,8 @@ final class WebViewControllerTests: XCTestCase {
             candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?external_auth=1"))]
         )
 
-        XCTAssertEqual(
-            resolution,
-            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?external_auth=1")))
-        )
+        let expected = try XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?external_auth=1"))
+        XCTAssertEqual(resolution, .load(expected))
     }
 
     func testBackForwardResolutionSkipsDuplicatedBoundaryEntryForCurrentPage() throws {
@@ -403,7 +399,8 @@ final class WebViewControllerTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(resolution, .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/config?external_auth=1"))))
+        let expected = try XCTUnwrap(URL(string: "https://example.ui.nabu.casa/config?external_auth=1"))
+        XCTAssertEqual(resolution, .load(expected))
     }
 
     func testBackForwardResolutionSkipsBoundaryEntryWithLovelaceZeroSuffix() throws {
@@ -446,10 +443,8 @@ final class WebViewControllerTests: XCTestCase {
             candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?start=1"))]
         )
 
-        XCTAssertEqual(
-            resolution,
-            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1")))
-        )
+        let expected = try XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1"))
+        XCTAssertEqual(resolution, .load(expected))
     }
 
     func testBackForwardResolutionTreatsFragmentDifferencesAsDistinctPages() throws {
@@ -458,10 +453,8 @@ final class WebViewControllerTests: XCTestCase {
             candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/todo#list-b"))]
         )
 
-        XCTAssertEqual(
-            resolution,
-            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/todo?external_auth=1#list-b")))
-        )
+        let expected = try XCTUnwrap(URL(string: "https://example.ui.nabu.casa/todo?external_auth=1#list-b"))
+        XCTAssertEqual(resolution, .load(expected))
     }
 
     func testBackForwardResolutionReturnsNilWhileShowingAboutBlank() throws {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -346,6 +346,118 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(restored, URL(string: "http://homeassistant.local:8123/"))
     }
 
+    func testBackForwardResolutionNavigatesNativelyWithinSameBase() throws {
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "http://homeassistant.local:8123/lovelace/0?external_auth=1")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history"))]
+        )
+
+        XCTAssertEqual(resolution, .navigate(index: 0))
+    }
+
+    func testBackForwardResolutionTreatsDefaultPortAsSameBase() throws {
+        // WKWebView may strip default ports from navigated URLs; that must not read as a base change.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.com/lovelace/0")),
+            candidateURLs: [XCTUnwrap(URL(string: "https://example.com:443/history"))]
+        )
+
+        XCTAssertEqual(resolution, .navigate(index: 0))
+    }
+
+    func testBackForwardResolutionRebasesCrossBaseItemOntoCurrentBase() throws {
+        // The internal entry left behind by an internal -> external switch is unreachable externally;
+        // its page is re-requested on the active base instead, keeping path, query and fragment. The
+        // fresh document load needs external_auth like any app-initiated load.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/lovelace/0")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?start=1#detail"))]
+        )
+
+        XCTAssertEqual(
+            resolution,
+            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?start=1&external_auth=1#detail")))
+        )
+    }
+
+    func testBackForwardResolutionDoesNotDuplicateExternalAuthWhenRebasing() throws {
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/lovelace/0")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/history?external_auth=1"))]
+        )
+
+        XCTAssertEqual(
+            resolution,
+            .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/history?external_auth=1")))
+        )
+    }
+
+    func testBackForwardResolutionSkipsDuplicatedBoundaryEntryForCurrentPage() throws {
+        // The base switch re-loads the current path onto the new base, so the nearest cross-base entry
+        // is the page already showing; back must go to the previous distinct page, not reload this one.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/lovelace/0?external_auth=1")),
+            candidateURLs: [
+                XCTUnwrap(URL(string: "http://homeassistant.local:8123/lovelace/0")),
+                XCTUnwrap(URL(string: "http://homeassistant.local:8123/config")),
+            ]
+        )
+
+        XCTAssertEqual(resolution, .load(XCTUnwrap(URL(string: "https://example.ui.nabu.casa/config?external_auth=1"))))
+    }
+
+    func testBackForwardResolutionSkipsBoundaryEntryWithLovelaceZeroSuffix() throws {
+        // HA appends /0 to the default lovelace path; that still counts as the same page.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/lovelace/0")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/lovelace"))]
+        )
+
+        XCTAssertNil(resolution)
+    }
+
+    func testBackForwardResolutionReturnsNilWhenOnlyDuplicateOfCurrentPageExists() throws {
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.ui.nabu.casa/lovelace/0")),
+            candidateURLs: [XCTUnwrap(URL(string: "http://homeassistant.local:8123/lovelace/0"))]
+        )
+
+        XCTAssertNil(resolution)
+    }
+
+    func testBackForwardResolutionSkipsAboutBlankEntries() throws {
+        // about:blank comes from the no-active-URL state and must never be rebased into "/blank".
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "https://example.com/lovelace/0")),
+            candidateURLs: [
+                XCTUnwrap(URL(string: "about:blank")),
+                XCTUnwrap(URL(string: "https://example.com/history")),
+            ]
+        )
+
+        XCTAssertEqual(resolution, .navigate(index: 1))
+    }
+
+    func testBackForwardResolutionReturnsNilWhileShowingAboutBlank() throws {
+        // While the no-active-URL screen shows, no base exists to rebase history onto.
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: XCTUnwrap(URL(string: "about:blank")),
+            candidateURLs: [XCTUnwrap(URL(string: "https://example.com/lovelace/0"))]
+        )
+
+        XCTAssertNil(resolution)
+    }
+
+    func testBackForwardResolutionWithoutCurrentURLPreservesPlainNavigation() throws {
+        let resolution = try WebViewController.resolvedBackForwardNavigation(
+            currentURL: nil,
+            candidateURLs: [XCTUnwrap(URL(string: "https://example.com/lovelace/0"))]
+        )
+
+        XCTAssertEqual(resolution, .navigate(index: 0))
+        XCTAssertNil(WebViewController.resolvedBackForwardNavigation(currentURL: nil, candidateURLs: []))
+    }
+
     private func makeSUT(server: Server = .fake()) -> WebViewController {
         let sut = WebViewController(server: server)
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
After switching between the internal and external URL, the web view history still contains entries from the previously active base URL. Going back or forward could load one of those, which is usually unreachable on the current network.

Back/forward now always stays on the active base URL: same-base history entries navigate normally, while entries from another base are reloaded with their path/query/fragment on the active base (ensuring `external_auth=1` for the fresh load). The duplicated entry created by the base switch and `about:blank` entries are skipped, so back goes to the previous distinct page instead of reloading the current one.

## Screenshots
Not applicable, no visual changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXipLujVUk7Jpdb2vkHHc4)_