### PR TITLE
Add Apple Watch light controls with split-tap row behavior

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2289,6 +2289,9 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.labels.no_config_add" = "With your iPhone nearby, you can add compatible entities to your Apple Watch using the button below, or from your companion app settings on iPhone.";
 "watch.labels.no_config_add_plus" = "With your iPhone nearby, you can add compatible entities to your Apple Watch using the '+' button, or from your companion app settings on iPhone.";
 "watch.labels.selected_pipeline.title" = "Pipeline";
+"watch.light_controls.brightness" = "Brightness";
+"watch.light_controls.power" = "Power";
+"watch.light_controls.temperature" = "Temperature";
 "watch.placeholder_complication_name" = "Placeholder";
 "watch.settings.auto" = "Auto";
 "watch.settings.client_certificate.available_on_watch" = "Available on this Watch";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2290,6 +2290,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.labels.no_config_add_plus" = "With your iPhone nearby, you can add compatible entities to your Apple Watch using the '+' button, or from your companion app settings on iPhone.";
 "watch.labels.selected_pipeline.title" = "Pipeline";
 "watch.light_controls.brightness" = "Brightness";
+"watch.light_controls.color" = "Color";
 "watch.light_controls.power" = "Power";
 "watch.light_controls.temperature" = "Temperature";
 "watch.placeholder_complication_name" = "Placeholder";

--- a/Sources/Shared/Domain/LightCapabilities.swift
+++ b/Sources/Shared/Domain/LightCapabilities.swift
@@ -1,0 +1,86 @@
+import Foundation
+import HAKit
+
+/// What a light entity can do beyond turning on and off, parsed from its state attributes.
+///
+/// Home Assistant advertises light capabilities through `supported_color_modes`: every mode other
+/// than `onoff` implies the light can dim, and `color_temp` additionally means its white
+/// temperature is tunable. List UIs (the watch) use this to decide whether tapping a light opens
+/// its controls screen or just toggles it.
+public struct LightCapabilities: Equatable {
+    /// A value of `supported_color_modes`, as defined by Home Assistant's light entity model.
+    public enum ColorMode: String {
+        case onoff
+        case brightness
+        case colorTemp = "color_temp"
+        case hs
+        case xy
+        case rgb
+        case rgbw
+        case rgbww
+        case white
+
+        /// Every mode except plain on/off supports brightness.
+        public var supportsBrightness: Bool {
+            self != .onoff
+        }
+    }
+
+    /// Home Assistant's own defaults for lights that don't report a kelvin range
+    /// (min_mireds 153 / max_mireds 500, rounded to friendly values).
+    public static let defaultMinColorTempKelvin: Double = 2000
+    public static let defaultMaxColorTempKelvin: Double = 6500
+
+    public let supportsBrightness: Bool
+    public let supportsColorTemp: Bool
+    /// Current brightness as 0–100, derived from the 0–255 `brightness` attribute. Nil when the
+    /// light is off (Home Assistant drops the attribute) or doesn't dim.
+    public let brightnessPercentage: Double?
+    /// Current color temperature in kelvin; nil when the light is off or not in color temp mode.
+    public let colorTempKelvin: Double?
+    public let minColorTempKelvin: Double
+    public let maxColorTempKelvin: Double
+
+    /// Whether the light offers anything to control beyond toggling — the gate for showing a
+    /// dedicated controls screen instead of treating a tap as a toggle.
+    public var hasAdjustableControls: Bool {
+        supportsBrightness || supportsColorTemp
+    }
+
+    public init(entity: HAEntity) {
+        self.init(attributes: entity.attributes.dictionary)
+    }
+
+    public init(attributes: [String: Any]) {
+        let modes = (attributes["supported_color_modes"] as? [String] ?? [])
+            .compactMap(ColorMode.init(rawValue:))
+
+        if modes.isEmpty {
+            // Very old servers (pre-2021) don't report color modes; the presence of a brightness
+            // value is the only remaining hint that the light can dim.
+            self.supportsBrightness = attributes["brightness"] != nil
+            self.supportsColorTemp = attributes["color_temp_kelvin"] != nil
+        } else {
+            self.supportsBrightness = modes.contains { $0.supportsBrightness }
+            self.supportsColorTemp = modes.contains(.colorTemp)
+        }
+
+        if supportsBrightness, let brightness = Self.double(from: attributes["brightness"]) {
+            self.brightnessPercentage = (brightness / 255 * 100).rounded()
+        } else {
+            self.brightnessPercentage = nil
+        }
+        self.colorTempKelvin = Self.double(from: attributes["color_temp_kelvin"])
+        self.minColorTempKelvin = Self.double(from: attributes["min_color_temp_kelvin"])
+            ?? Self.defaultMinColorTempKelvin
+        self.maxColorTempKelvin = Self.double(from: attributes["max_color_temp_kelvin"])
+            ?? Self.defaultMaxColorTempKelvin
+    }
+
+    private static func double(from value: Any?) -> Double? {
+        if let number = value as? NSNumber {
+            return number.doubleValue
+        }
+        return value as? Double
+    }
+}

--- a/Sources/Shared/Domain/LightCapabilities.swift
+++ b/Sources/Shared/Domain/LightCapabilities.swift
@@ -24,6 +24,11 @@ public struct LightCapabilities: Equatable {
         public var supportsBrightness: Bool {
             self != .onoff
         }
+
+        /// Modes that can render an arbitrary color (not just white temperature).
+        public var supportsColor: Bool {
+            [.hs, .xy, .rgb, .rgbw, .rgbww].contains(self)
+        }
     }
 
     /// Home Assistant's own defaults for lights that don't report a kelvin range
@@ -33,6 +38,8 @@ public struct LightCapabilities: Equatable {
 
     public let supportsBrightness: Bool
     public let supportsColorTemp: Bool
+    /// Whether the light can render arbitrary colors (hs/xy/rgb modes) — e.g. Hue color bulbs.
+    public let supportsColor: Bool
     /// Current brightness as 0–100, derived from the 0–255 `brightness` attribute. Nil when the
     /// light is off (Home Assistant drops the attribute) or doesn't dim.
     public let brightnessPercentage: Double?
@@ -44,7 +51,7 @@ public struct LightCapabilities: Equatable {
     /// Whether the light offers anything to control beyond toggling — the gate for showing a
     /// dedicated controls screen instead of treating a tap as a toggle.
     public var hasAdjustableControls: Bool {
-        supportsBrightness || supportsColorTemp
+        supportsBrightness || supportsColorTemp || supportsColor
     }
 
     public init(entity: HAEntity) {
@@ -56,13 +63,15 @@ public struct LightCapabilities: Equatable {
             .compactMap(ColorMode.init(rawValue:))
 
         if modes.isEmpty {
-            // Very old servers (pre-2021) don't report color modes; the presence of a brightness
-            // value is the only remaining hint that the light can dim.
+            // Very old servers (pre-2021) don't report color modes; the presence of the value
+            // attributes is the only remaining hint of what the light can do.
             self.supportsBrightness = attributes["brightness"] != nil
             self.supportsColorTemp = attributes["color_temp_kelvin"] != nil
+            self.supportsColor = attributes["hs_color"] != nil
         } else {
             self.supportsBrightness = modes.contains { $0.supportsBrightness }
             self.supportsColorTemp = modes.contains(.colorTemp)
+            self.supportsColor = modes.contains { $0.supportsColor }
         }
 
         if supportsBrightness, let brightness = Self.double(from: attributes["brightness"]) {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7479,6 +7479,8 @@ public enum L10n {
     public enum LightControls {
       /// Brightness
       public static var brightness: String { return L10n.tr("Localizable", "watch.light_controls.brightness") }
+      /// Color
+      public static var color: String { return L10n.tr("Localizable", "watch.light_controls.color") }
       /// Power
       public static var power: String { return L10n.tr("Localizable", "watch.light_controls.power") }
       /// Temperature

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7476,6 +7476,14 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "watch.labels.selected_pipeline.title") }
       }
     }
+    public enum LightControls {
+      /// Brightness
+      public static var brightness: String { return L10n.tr("Localizable", "watch.light_controls.brightness") }
+      /// Power
+      public static var power: String { return L10n.tr("Localizable", "watch.light_controls.power") }
+      /// Temperature
+      public static var temperature: String { return L10n.tr("Localizable", "watch.light_controls.temperature") }
+    }
     public enum Settings {
       /// Auto
       public static var auto: String { return L10n.tr("Localizable", "watch.settings.auto") }

--- a/Sources/Shared/Watch/WatchServiceCallSender.swift
+++ b/Sources/Shared/Watch/WatchServiceCallSender.swift
@@ -16,6 +16,11 @@ public enum WatchServiceCallSender {
     }
 
     #if os(watchOS)
+    /// How long to wait for a bearer token before failing — `TokenManager` caches the in-flight
+    /// refresh promise, so a refresh that never resolves would otherwise swallow every call
+    /// silently, with `completion` never invoked (same reasoning as `MagicItem.executeViaREST`).
+    private static var tokenDeadline: TimeInterval { 10 }
+
     /// Calls `completion` on the main queue with whether the server accepted the call.
     public static func send(
         domain: Domain,
@@ -46,47 +51,98 @@ public enum WatchServiceCallSender {
             return
         }
         let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
-        tokenManager.bearerToken.done { token, _ in
-            let url = baseURL
-                .appendingPathComponent("api")
-                .appendingPathComponent("services")
-                .appendingPathComponent(domain.rawValue)
-                .appendingPathComponent(service.rawValue)
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            // Bounded so a dead route fails visibly instead of hanging the controls for 60s.
-            request.timeoutInterval = 10
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
-            request.httpBody = body
-            let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
-            let task = session.dataTask(with: request) { [session] _, response, error in
-                // The session strongly retains its delegate until invalidated; do it once the task ends.
-                defer { session.finishTasksAndInvalidate() }
-                if let error {
-                    Current.Log.error(
-                        "REST \(domain.rawValue).\(service.rawValue) for \(entityId) failed: " +
-                            error.localizedDescription
-                    )
-                    finish(false)
-                    return
-                }
-                guard let http = response as? HTTPURLResponse,
-                      (200 ..< 300).contains(http.statusCode) else {
-                    finish(false)
-                    return
-                }
-                finish(true)
-            }
-            task.resume()
-        }.catch { error in
-            Current.Log.error(
-                "Token unavailable sending \(domain.rawValue).\(service.rawValue) from watch: " +
-                    error.localizedDescription
-            )
-            finish(false)
+
+        let lock = NSLock()
+        var settled = false
+        // First caller wins; the loser is discarded so `completion` runs exactly once. A late
+        // token still lands in the shared cache for the next call.
+        func settleOnce(_ body: () -> Void) {
+            lock.lock()
+            let shouldRun = !settled
+            settled = true
+            lock.unlock()
+            if shouldRun { body() }
         }
+
+        // Deadline so a stuck token refresh fails the call instead of silencing it. Main queue on
+        // purpose — it is the one queue proven to stay serviced on watch hardware (see
+        // `MagicItem.executeViaREST`).
+        DispatchQueue.main.asyncAfter(deadline: .now() + tokenDeadline) {
+            settleOnce {
+                Current.Log.error(
+                    "Token deadline elapsed sending \(domain.rawValue).\(service.rawValue) from watch"
+                )
+                finish(false)
+            }
+        }
+
+        tokenManager.bearerToken.done { token, _ in
+            settleOnce {
+                sendRequest(
+                    baseURL: baseURL,
+                    domain: domain,
+                    service: service,
+                    entityId: entityId,
+                    body: body,
+                    token: token,
+                    server: server,
+                    finish: finish
+                )
+            }
+        }.catch { error in
+            settleOnce {
+                Current.Log.error(
+                    "Token unavailable sending \(domain.rawValue).\(service.rawValue) from watch: " +
+                        error.localizedDescription
+                )
+                finish(false)
+            }
+        }
+    }
+
+    private static func sendRequest(
+        baseURL: URL,
+        domain: Domain,
+        service: Service,
+        entityId: String,
+        body: Data,
+        token: String,
+        server: Server,
+        finish: @escaping (Bool) -> Void
+    ) {
+        let url = baseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("services")
+            .appendingPathComponent(domain.rawValue)
+            .appendingPathComponent(service.rawValue)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        // Bounded so a dead route fails visibly instead of hanging the controls for 60s.
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
+        request.httpBody = body
+        let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+        let task = session.dataTask(with: request) { [session] _, response, error in
+            // The session strongly retains its delegate until invalidated; do it once the task ends.
+            defer { session.finishTasksAndInvalidate() }
+            if let error {
+                Current.Log.error(
+                    "REST \(domain.rawValue).\(service.rawValue) for \(entityId) failed: " +
+                        error.localizedDescription
+                )
+                finish(false)
+                return
+            }
+            guard let http = response as? HTTPURLResponse,
+                  (200 ..< 300).contains(http.statusCode) else {
+                finish(false)
+                return
+            }
+            finish(true)
+        }
+        task.resume()
     }
     #endif
 }

--- a/Sources/Shared/Watch/WatchServiceCallSender.swift
+++ b/Sources/Shared/Watch/WatchServiceCallSender.swift
@@ -1,0 +1,92 @@
+import Foundation
+import PromiseKit
+
+/// Sends a Home Assistant service call over the REST API from the watch.
+///
+/// The watch can't hold a WebSocket connection (see `MagicItem.execute`), so screens that control
+/// an entity directly — like the light controls screen — post to
+/// `/api/services/{domain}/{service}` the same way magic item execution does. Unlike that path,
+/// callers here own their UI feedback, so failures just report `false`.
+public enum WatchServiceCallSender {
+    /// The request body for a service call targeting one entity. Split out so it can be unit tested.
+    public static func payload(entityId: String, data: [String: Any]) -> [String: Any] {
+        var body = data
+        body["entity_id"] = entityId
+        return body
+    }
+
+    #if os(watchOS)
+    /// Calls `completion` on the main queue with whether the server accepted the call.
+    public static func send(
+        domain: Domain,
+        service: Service,
+        entityId: String,
+        data: [String: Any] = [:],
+        server: Server,
+        completion: @escaping (Bool) -> Void
+    ) {
+        let finish: (Bool) -> Void = { success in
+            DispatchQueue.main.async { completion(success) }
+        }
+        // Synchronous URL evaluation on purpose — see `MagicItem.executeViaREST`.
+        guard let baseURL = server.activeURLUsingLastKnownNetworkState() else {
+            Current.Log.error("No active URL sending \(domain.rawValue).\(service.rawValue) from watch")
+            finish(false)
+            return
+        }
+        let body: Data
+        do {
+            body = try JSONSerialization.data(
+                withJSONObject: payload(entityId: entityId, data: data),
+                options: []
+            )
+        } catch {
+            Current.Log.error("Failed encoding \(domain.rawValue).\(service.rawValue) payload: \(error)")
+            finish(false)
+            return
+        }
+        let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+        tokenManager.bearerToken.done { token, _ in
+            let url = baseURL
+                .appendingPathComponent("api")
+                .appendingPathComponent("services")
+                .appendingPathComponent(domain.rawValue)
+                .appendingPathComponent(service.rawValue)
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            // Bounded so a dead route fails visibly instead of hanging the controls for 60s.
+            request.timeoutInterval = 10
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
+            request.httpBody = body
+            let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
+            let task = session.dataTask(with: request) { [session] _, response, error in
+                // The session strongly retains its delegate until invalidated; do it once the task ends.
+                defer { session.finishTasksAndInvalidate() }
+                if let error {
+                    Current.Log.error(
+                        "REST \(domain.rawValue).\(service.rawValue) for \(entityId) failed: " +
+                            error.localizedDescription
+                    )
+                    finish(false)
+                    return
+                }
+                guard let http = response as? HTTPURLResponse,
+                      (200 ..< 300).contains(http.statusCode) else {
+                    finish(false)
+                    return
+                }
+                finish(true)
+            }
+            task.resume()
+        }.catch { error in
+            Current.Log.error(
+                "Token unavailable sending \(domain.rawValue).\(service.rawValue) from watch: " +
+                    error.localizedDescription
+            )
+            finish(false)
+        }
+    }
+    #endif
+}

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchGradientSlider.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchGradientSlider.swift
@@ -1,0 +1,99 @@
+import Shared
+import SwiftUI
+
+/// A horizontal gradient track with a draggable knob — the light controls' stand-in for a
+/// color-picker-style slider. watchOS renders `Slider` as -/+ buttons and has no `ColorPicker`,
+/// so level controls that are inherently visual (brightness, color temperature) draw their own
+/// track: the gradient shows what the ends mean, the knob shows where the light currently sits,
+/// and tapping or dragging anywhere on the track picks a value.
+struct WatchGradientSlider: View {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    /// Leading-to-trailing track colors, e.g. dark → bright or warm → cool.
+    let gradient: [Color]
+
+    private static let trackHeight: CGFloat = 30
+    private static let knobDiameter: CGFloat = 24
+    /// Breathing room so the knob never overflows the capsule's rounded ends.
+    private static let knobInset: CGFloat = 3
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(LinearGradient(colors: gradient, startPoint: .leading, endPoint: .trailing))
+                Circle()
+                    .fill(.white)
+                    .overlay {
+                        Circle().strokeBorder(Color.black.opacity(0.2), lineWidth: 1)
+                    }
+                    .frame(width: Self.knobDiameter, height: Self.knobDiameter)
+                    .shadow(color: .black.opacity(0.4), radius: 2)
+                    .offset(x: knobOffset(trackWidth: proxy.size.width))
+            }
+            .contentShape(Rectangle())
+            // Minimum distance zero so a plain tap on the track also picks that position.
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { gesture in
+                        value = pickedValue(atX: gesture.location.x, trackWidth: proxy.size.width)
+                    }
+            )
+        }
+        .frame(height: Self.trackHeight)
+    }
+
+    /// Where the knob travels: between the insets, over the width left after its own diameter.
+    private func travelWidth(trackWidth: CGFloat) -> CGFloat {
+        max(trackWidth - Self.knobDiameter - Self.knobInset * 2, 1)
+    }
+
+    private func knobOffset(trackWidth: CGFloat) -> CGFloat {
+        let span = range.upperBound - range.lowerBound
+        let fraction = span > 0 ? (value - range.lowerBound) / span : 0
+        return Self.knobInset + travelWidth(trackWidth: trackWidth) * min(max(fraction, 0), 1)
+    }
+
+    private func pickedValue(atX x: CGFloat, trackWidth: CGFloat) -> Double {
+        let position = x - Self.knobInset - Self.knobDiameter / 2
+        let fraction = min(max(position / travelWidth(trackWidth: trackWidth), 0), 1)
+        return range.lowerBound + (range.upperBound - range.lowerBound) * fraction
+    }
+}
+
+#Preview {
+    struct PreviewContainer: View {
+        @State private var brightness: Double = 60
+        @State private var kelvin: Double = 3200
+
+        var body: some View {
+            List {
+                Section {
+                    WatchGradientSlider(
+                        value: $brightness,
+                        range: 0 ... 100,
+                        gradient: [Color(uiColor: .init(hex: "#1A1A1A")), .white]
+                    )
+                    .listRowBackground(Color.clear)
+                } header: {
+                    Text(verbatim: "Brightness \(Int(brightness))%")
+                }
+                Section {
+                    WatchGradientSlider(
+                        value: $kelvin,
+                        range: 2000 ... 6500,
+                        gradient: [
+                            Color(uiColor: .init(hex: "#FFA757")),
+                            .white,
+                            Color(uiColor: .init(hex: "#BFDDFF")),
+                        ]
+                    )
+                    .listRowBackground(Color.clear)
+                } header: {
+                    Text(verbatim: "Temperature \(Int(kelvin)) K")
+                }
+            }
+        }
+    }
+    return PreviewContainer()
+}

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -10,9 +10,8 @@ import SwiftUI
 struct WatchLightControlsView: View {
     @StateObject private var viewModel: WatchLightControlsViewModel
 
-    /// The view model is built inside `StateObject`'s autoclosure so a `NavigationLink` can hold
-    /// this view without instantiating a poller per row render — creation is deferred until the
-    /// screen is actually pushed.
+    /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
+    /// is deferred until the screen is actually pushed.
     init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
         self._viewModel = .init(
             wrappedValue: WatchLightControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -3,47 +3,41 @@ import SFSafeSymbols
 import Shared
 import SwiftUI
 
-/// Controls screen a light row opens when tapped: power, brightness and — when the light supports
-/// it — color temperature. Lights without any of these capabilities never get here; their row
-/// toggles directly.
+/// Controls screen a light row pushes when its body is tapped: power, brightness and — when the
+/// light supports it — color temperature. Lights without any of these capabilities never get
+/// here; their row toggles directly. Pushed (not presented modally) to honor the row's chevron,
+/// so it relies on the home screen's `NavigationStack` for the bar and back button.
 struct WatchLightControlsView: View {
     @StateObject private var viewModel: WatchLightControlsViewModel
-    @Environment(\.dismiss) private var dismiss
 
-    init(viewModel: WatchLightControlsViewModel) {
-        self._viewModel = .init(wrappedValue: viewModel)
+    /// The view model is built inside `StateObject`'s autoclosure so a `NavigationLink` can hold
+    /// this view without instantiating a poller per row render — creation is deferred until the
+    /// screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self._viewModel = .init(
+            wrappedValue: WatchLightControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)
+        )
     }
 
     var body: some View {
-        NavigationView {
-            List {
-                header
-                if viewModel.isStale {
-                    staleWarning
-                }
-                Section {
-                    Toggle(isOn: powerBinding) {
-                        Text(verbatim: L10n.Watch.LightControls.power)
-                    }
-                }
-                if viewModel.capabilities?.supportsBrightness == true {
-                    brightnessSection
-                }
-                if viewModel.capabilities?.supportsColorTemp == true {
-                    colorTempSection
+        List {
+            header
+            if viewModel.isStale {
+                staleWarning
+            }
+            Section {
+                Toggle(isOn: powerBinding) {
+                    Text(verbatim: L10n.Watch.LightControls.power)
                 }
             }
-            .navigationTitle(Text(verbatim: viewModel.name))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemSymbol: .xmark)
-                    }
-                }
+            if viewModel.capabilities?.supportsBrightness == true {
+                brightnessSection
+            }
+            if viewModel.capabilities?.supportsColorTemp == true {
+                colorTempSection
             }
         }
+        .navigationTitle(Text(verbatim: viewModel.name))
         .onAppear {
             viewModel.startStateUpdates()
         }
@@ -169,5 +163,8 @@ struct WatchLightControlsView: View {
         ],
         context: .init(id: "", userId: "", parentId: "")
     )
-    return WatchLightControlsView(viewModel: .init(item: item, itemInfo: info, initialEntity: entity))
+    // In the app this screen is pushed by a row inside the home's NavigationStack.
+    return NavigationStack {
+        WatchLightControlsView(item: item, itemInfo: info, initialEntity: entity)
+    }
 }

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -36,6 +36,9 @@ struct WatchLightControlsView: View {
             if viewModel.capabilities?.supportsBrightness == true {
                 brightnessSection
             }
+            if viewModel.capabilities?.supportsColor == true {
+                colorSection
+            }
             if viewModel.capabilities?.supportsColorTemp == true {
                 colorTempSection
             }
@@ -104,6 +107,40 @@ struct WatchLightControlsView: View {
             .listRowBackground(Color.clear)
         } header: {
             Text(verbatim: L10n.Watch.LightControls.brightness)
+        }
+    }
+
+    /// Vivid hues covering the color wheel — the watch-sized stand-in for the frontend's full
+    /// color wheel. Tapping a swatch sends it as `rgb_color`.
+    private static let colorPalette: [String] = [
+        "#FF0000", "#FF7F00", "#FFBF00", "#FFFF00",
+        "#7FFF00", "#00FF00", "#00FFBF", "#00FFFF",
+        "#007FFF", "#0000FF", "#7F00FF", "#FF00FF",
+    ]
+
+    private var colorSection: some View {
+        Section {
+            LazyVGrid(
+                columns: Array(
+                    repeating: GridItem(.flexible(), spacing: DesignSystem.Spaces.one),
+                    count: 4
+                ),
+                spacing: DesignSystem.Spaces.one
+            ) {
+                ForEach(Self.colorPalette, id: \.self) { hex in
+                    Button {
+                        viewModel.setColor(hex: hex)
+                    } label: {
+                        Circle()
+                            .fill(Color(uiColor: .init(hex: hex)))
+                            .frame(width: 32, height: 32)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listRowBackground(Color.clear)
+        } header: {
+            Text(verbatim: L10n.Watch.LightControls.color)
         }
     }
 

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -86,7 +86,11 @@ struct WatchLightControlsView: View {
     private var brightnessSection: some View {
         Section {
             VStack(spacing: DesignSystem.Spaces.half) {
-                Slider(value: brightnessBinding, in: 0 ... 100, step: 10)
+                WatchGradientSlider(
+                    value: brightnessBinding,
+                    range: 0 ... 100,
+                    gradient: [Color(uiColor: .init(hex: "#1A1A1A")), .white]
+                )
                 Text(verbatim: "\(Int(viewModel.brightnessPercentage))%")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -100,7 +104,16 @@ struct WatchLightControlsView: View {
     private var colorTempSection: some View {
         Section {
             VStack(spacing: DesignSystem.Spaces.half) {
-                Slider(value: colorTempBinding, in: viewModel.colorTempRange, step: 100)
+                // Warm-to-cool, matching how Home Assistant's frontend paints the same control.
+                WatchGradientSlider(
+                    value: colorTempBinding,
+                    range: viewModel.colorTempRange,
+                    gradient: [
+                        Color(uiColor: .init(hex: "#FFA757")),
+                        .white,
+                        Color(uiColor: .init(hex: "#BFDDFF")),
+                    ]
+                )
                 Text(verbatim: "\(Int(viewModel.colorTempKelvin)) K")
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -1,0 +1,160 @@
+import HAKit
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Controls screen a light row opens when tapped: power, brightness and — when the light supports
+/// it — color temperature. Lights without any of these capabilities never get here; their row
+/// toggles directly.
+struct WatchLightControlsView: View {
+    @StateObject private var viewModel: WatchLightControlsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(viewModel: WatchLightControlsViewModel) {
+        self._viewModel = .init(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                header
+                if viewModel.isStale {
+                    staleWarning
+                }
+                Section {
+                    Toggle(isOn: powerBinding) {
+                        Text(verbatim: L10n.Watch.LightControls.power)
+                    }
+                }
+                if viewModel.capabilities?.supportsBrightness == true {
+                    brightnessSection
+                }
+                if viewModel.capabilities?.supportsColorTemp == true {
+                    colorTempSection
+                }
+            }
+            .navigationTitle(Text(verbatim: viewModel.name))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemSymbol: .xmark)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.startStateUpdates()
+        }
+        .onDisappear {
+            viewModel.stopStateUpdates()
+        }
+    }
+
+    private var header: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(uiImage: viewModel.icon.image(
+                    ofSize: .init(width: 24, height: 24),
+                    color: viewModel.iconColor
+                ))
+                .watchRowIconContainer(color: viewModel.iconColor)
+                if let stateText = viewModel.stateText {
+                    Text(verbatim: stateText)
+                        .font(.title3.bold())
+                        .multilineTextAlignment(.center)
+                        .minimumScaleFactor(0.6)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var staleWarning: some View {
+        Label {
+            Text(verbatim: L10n.Watch.EntityDetails.stale)
+                .font(.caption2)
+        } icon: {
+            Image(systemSymbol: .exclamationmarkCircleFill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.black, .orange)
+        }
+    }
+
+    private var brightnessSection: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Slider(value: brightnessBinding, in: 0 ... 100, step: 10)
+                Text(verbatim: "\(Int(viewModel.brightnessPercentage))%")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .listRowBackground(Color.clear)
+        } header: {
+            Text(verbatim: L10n.Watch.LightControls.brightness)
+        }
+    }
+
+    private var colorTempSection: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Slider(value: colorTempBinding, in: viewModel.colorTempRange, step: 100)
+                Text(verbatim: "\(Int(viewModel.colorTempKelvin)) K")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .listRowBackground(Color.clear)
+        } header: {
+            Text(verbatim: L10n.Watch.LightControls.temperature)
+        }
+    }
+
+    private var powerBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isOn },
+            set: { viewModel.setPower($0) }
+        )
+    }
+
+    private var brightnessBinding: Binding<Double> {
+        Binding(
+            get: { viewModel.brightnessPercentage },
+            set: { viewModel.setBrightness($0) }
+        )
+    }
+
+    private var colorTempBinding: Binding<Double> {
+        Binding(
+            get: { viewModel.colorTempKelvin },
+            set: { viewModel.setColorTemp($0) }
+        )
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "light.living_room", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-light.living_room",
+        name: "Living room",
+        iconName: "mdi:lightbulb"
+    )
+    let entity = try? HAEntity(
+        entityId: "light.living_room",
+        state: "on",
+        lastChanged: Date(timeIntervalSinceNow: -600),
+        lastUpdated: Date(timeIntervalSinceNow: -60),
+        attributes: [
+            "friendly_name": "Living room",
+            "supported_color_modes": ["color_temp", "xy"],
+            "brightness": 128,
+            "color_temp_kelvin": 3200,
+            "min_color_temp_kelvin": 2000,
+            "max_color_temp_kelvin": 6500,
+        ],
+        context: .init(id: "", userId: "", parentId: "")
+    )
+    return WatchLightControlsView(viewModel: .init(item: item, itemInfo: info, initialEntity: entity))
+}

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsView.swift
@@ -25,9 +25,13 @@ struct WatchLightControlsView: View {
             if viewModel.isStale {
                 staleWarning
             }
-            Section {
-                Toggle(isOn: powerBinding) {
-                    Text(verbatim: L10n.Watch.LightControls.power)
+            // No controls until the first snapshot: a toggle rendered before the state is known
+            // would show "off" for a light that may well be on.
+            if viewModel.entity != nil {
+                Section {
+                    Toggle(isOn: powerBinding) {
+                        Text(verbatim: L10n.Watch.LightControls.power)
+                    }
                 }
             }
             if viewModel.capabilities?.supportsBrightness == true {
@@ -59,6 +63,15 @@ struct WatchLightControlsView: View {
                         .font(.title3.bold())
                         .multilineTextAlignment(.center)
                         .minimumScaleFactor(0.6)
+                } else {
+                    // Pushed before the first state fetch answers — the controls appear as soon
+                    // as the entity's capabilities are known.
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text(verbatim: L10n.Watch.EntityDetails.loading)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -120,6 +120,21 @@ final class WatchLightControlsViewModel: ObservableObject {
         brightnessDebounce = debouncedSend(data: ["brightness_pct": Int(percentage)])
     }
 
+    /// Discrete swatch taps need no debounce. `light.turn_on` with a color also turns the light
+    /// on, like the frontend.
+    func setColor(hex: String) {
+        isOn = true
+        holdOffPolling()
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        UIColor(hex: hex).getRed(&red, &green, &blue, &alpha)
+        send(service: .turnOn, data: [
+            "rgb_color": [Int(red * 255), Int(green * 255), Int(blue * 255)],
+        ])
+    }
+
     /// Called for every slider tick; the actual service call waits until the value settles.
     /// `light.turn_on` with a color temperature also turns the light on, like the frontend.
     func setColorTemp(_ kelvin: Double) {

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -129,7 +129,7 @@ final class WatchLightControlsViewModel: ObservableObject {
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
-        UIColor(hex: hex).getRed(&red, &green, &blue, &alpha)
+        UIColor(hex: hex).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         send(service: .turnOn, data: [
             "rgb_color": [Int(red * 255), Int(green * 255), Int(blue * 255)],
         ])

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -1,0 +1,205 @@
+import Foundation
+import HAKit
+import Shared
+import UIKit
+import WatchKit
+
+/// Backs the light controls screen: power toggle, brightness and color temperature.
+///
+/// State stays fresh through the same REST polling the home rows use (`WatchEntityStatePoller`);
+/// commands go out as `light.turn_on` / `light.turn_off` REST calls (`WatchServiceCallSender`).
+/// Slider changes are debounced so dragging doesn't flood the server, and poll snapshots are held
+/// off briefly after the user touches a control so the just-set value doesn't snap back before the
+/// server reports it.
+final class WatchLightControlsViewModel: ObservableObject {
+    @Published private(set) var entity: HAEntity?
+    /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
+    /// presenting the values as current.
+    @Published private(set) var isStale = false
+    @Published private(set) var isOn = false
+    /// 0–100. Owned by the user while interacting (see `pollHoldoffUntil`), by polling otherwise.
+    @Published var brightnessPercentage: Double = 0
+    /// Kelvin, within `colorTempRange`.
+    @Published var colorTempKelvin: Double = LightCapabilities.defaultMinColorTempKelvin
+
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+
+    private let poller: WatchEntityStatePoller
+    private var brightnessDebounce: DispatchWorkItem?
+    private var colorTempDebounce: DispatchWorkItem?
+    /// While set and in the future, poll snapshots don't overwrite the user-facing control values —
+    /// the user just changed them and the server hasn't caught up yet.
+    private var pollHoldoffUntil: Date?
+
+    private static let sendDebounceInterval: TimeInterval = 0.4
+    private static let pollHoldoffInterval: TimeInterval = 3
+
+    /// - Parameter initialEntity: the row's last polled snapshot, so the screen opens with current
+    ///   values instead of waiting for its own first fetch.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self.item = item
+        self.itemInfo = itemInfo
+        self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
+        if let initialEntity {
+            apply(entity: initialEntity)
+        }
+    }
+
+    var name: String {
+        item.name(info: itemInfo)
+    }
+
+    var capabilities: LightCapabilities? {
+        entity.map(LightCapabilities.init(entity:))
+    }
+
+    var colorTempRange: ClosedRange<Double> {
+        let min = capabilities?.minColorTempKelvin ?? LightCapabilities.defaultMinColorTempKelvin
+        let max = capabilities?.maxColorTempKelvin ?? LightCapabilities.defaultMaxColorTempKelvin
+        guard min < max else {
+            return LightCapabilities.defaultMinColorTempKelvin ... LightCapabilities.defaultMaxColorTempKelvin
+        }
+        return min ... max
+    }
+
+    var stateText: String? {
+        guard let entity, let domain = item.domain else { return nil }
+        return domain.contextualStateDescription(for: entity)
+    }
+
+    /// Same live-icon rule as the home row: lights have a state-dependent icon, so render from the
+    /// entity unless the user explicitly picked a custom icon.
+    var icon: MaterialDesignIcons {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.getMDI()
+        }
+        return item.icon(info: itemInfo)
+    }
+
+    var iconColor: UIColor {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.carPlayIconColor() ?? .white
+        }
+        if let hex = itemInfo.customization?.iconColor {
+            return UIColor(hex: hex)
+        }
+        return .white
+    }
+
+    func startStateUpdates() {
+        poller.start { [weak self] snapshot in
+            guard let self else { return }
+            if let entity = snapshot.entity {
+                apply(entity: entity)
+            }
+            isStale = snapshot.isStale
+        }
+    }
+
+    func stopStateUpdates() {
+        poller.stop()
+    }
+
+    // MARK: - Commands
+
+    func setPower(_ on: Bool) {
+        guard on != isOn else { return }
+        isOn = on
+        holdOffPolling()
+        send(service: on ? .turnOn : .turnOff)
+    }
+
+    /// Called for every slider tick; the actual service call waits until the value settles.
+    func setBrightness(_ percentage: Double) {
+        brightnessPercentage = percentage
+        // Any brightness above zero turns the light on — mirror that immediately.
+        isOn = percentage > 0
+        holdOffPolling()
+        brightnessDebounce?.cancel()
+        brightnessDebounce = debouncedSend(data: ["brightness_pct": Int(percentage)])
+    }
+
+    /// Called for every slider tick; the actual service call waits until the value settles.
+    /// `light.turn_on` with a color temperature also turns the light on, like the frontend.
+    func setColorTemp(_ kelvin: Double) {
+        colorTempKelvin = kelvin
+        isOn = true
+        holdOffPolling()
+        colorTempDebounce?.cancel()
+        colorTempDebounce = debouncedSend(data: ["color_temp_kelvin": Int(kelvin)])
+    }
+
+    // MARK: - Private
+
+    private func apply(entity: HAEntity) {
+        self.entity = entity
+        // The user's in-flight adjustments own the controls until the server catches up.
+        guard pollHoldoffUntil.map({ Current.date() >= $0 }) ?? true else { return }
+        isOn = entity.state == Domain.State.on.rawValue
+        let capabilities = LightCapabilities(entity: entity)
+        if let percentage = capabilities.brightnessPercentage {
+            brightnessPercentage = percentage
+        } else if !isOn {
+            brightnessPercentage = 0
+        }
+        if let kelvin = capabilities.colorTempKelvin {
+            colorTempKelvin = kelvin.clamped(to: colorTempRange)
+        }
+    }
+
+    private func holdOffPolling() {
+        pollHoldoffUntil = Current.date().addingTimeInterval(Self.pollHoldoffInterval)
+    }
+
+    private func send(service: Service, data: [String: Any] = [:]) {
+        Self.sendCommand(entityId: item.id, serverId: item.serverId, service: service, data: data, poller: poller)
+    }
+
+    /// Slider debounces reference the command through this, capturing only values — so an
+    /// adjustment made right before dismissing the screen still reaches the server after the
+    /// view model is gone.
+    private func debouncedSend(data: [String: Any]) -> DispatchWorkItem {
+        let entityId = item.id
+        let serverId = item.serverId
+        let workItem = DispatchWorkItem { [weak poller] in
+            Self.sendCommand(entityId: entityId, serverId: serverId, service: .turnOn, data: data, poller: poller)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.sendDebounceInterval, execute: workItem)
+        return workItem
+    }
+
+    private static func sendCommand(
+        entityId: String,
+        serverId: String,
+        service: Service,
+        data: [String: Any],
+        poller: WatchEntityStatePoller?
+    ) {
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+            Current.Log.error("Server \(serverId) not synced to the watch for light controls")
+            WKInterfaceDevice.current().play(.failure)
+            return
+        }
+        WatchServiceCallSender.send(
+            domain: .light,
+            service: service,
+            entityId: entityId,
+            data: data,
+            server: server
+        ) { success in
+            if success {
+                // Reflect the executed command quickly instead of waiting a full poll interval.
+                poller?.refresh(after: 1)
+            } else {
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+}
+
+private extension Double {
+    func clamped(to range: ClosedRange<Double>) -> Double {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/WatchApp/Home/MagicItemRow/WatchFolderRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchFolderRow.swift
@@ -6,9 +6,12 @@ struct WatchFolderRow: View {
     let item: MagicItem
     let itemInfo: MagicItem.Info
     var layout: WatchLayout = .list
+    @Environment(\.watchNavigate) private var navigate
 
     var body: some View {
-        NavigationLink(value: WatchHomeNavigation.folder(item.id)) {
+        Button {
+            navigate(.folder(item.id))
+        } label: {
             label
         }
         .modify { view in

--- a/Sources/WatchApp/Home/MagicItemRow/WatchFolderRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchFolderRow.swift
@@ -6,12 +6,9 @@ struct WatchFolderRow: View {
     let item: MagicItem
     let itemInfo: MagicItem.Info
     var layout: WatchLayout = .list
-    let onTap: () -> Void
 
     var body: some View {
-        Button {
-            onTap()
-        } label: {
+        NavigationLink(value: WatchHomeNavigation.folder(item.id)) {
             label
         }
         .modify { view in
@@ -108,7 +105,7 @@ struct WatchFolderRow: View {
                 iconName: "mdi:folder",
                 customization: .init(iconColor: "#03A9F4")
             )
-        ) {}
+        )
     }
 }
 
@@ -134,7 +131,7 @@ struct WatchFolderRow: View {
                     customization: .init(iconColor: "#03A9F4")
                 ),
                 layout: .grid
-            ) {}
+            )
         }
         .listRowBackground(Color.clear)
         .listRowInsets(EdgeInsets())

--- a/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
@@ -4,30 +4,62 @@ import SwiftUI
 /// Shared layout for a watch home item row: a circular glass icon, a bold name with an optional
 /// subtitle, and an optional trailing accessory (e.g. a chevron for folders). Keeps `WatchMagicViewRow`
 /// and `WatchFolderRow` visually identical.
+///
+/// When both `onIconTap` and `onBodyTap` are set, the icon and the rest of the row become two
+/// sibling (plain) buttons — SwiftUI doesn't support nesting a button inside another, so a row
+/// with two actions must not additionally be wrapped in its own `Button`.
 struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
     let name: String
     let subtitle: String?
     let textColor: Color
     let icon: Icon
     let accessory: Accessory
+    let onIconTap: (() -> Void)?
+    let onBodyTap: (() -> Void)?
 
     init(
         name: String,
         subtitle: String? = nil,
         textColor: Color,
         @ViewBuilder icon: () -> Icon,
-        @ViewBuilder accessory: () -> Accessory = { EmptyView() }
+        @ViewBuilder accessory: () -> Accessory = { EmptyView() },
+        onIconTap: (() -> Void)? = nil,
+        onBodyTap: (() -> Void)? = nil
     ) {
         self.name = name
         self.subtitle = subtitle
         self.textColor = textColor
         self.icon = icon()
         self.accessory = accessory()
+        self.onIconTap = onIconTap
+        self.onBodyTap = onBodyTap
     }
 
     var body: some View {
         HStack(spacing: DesignSystem.Spaces.one) {
-            icon
+            if let onIconTap, let onBodyTap {
+                Button(action: onIconTap) {
+                    icon
+                }
+                .buttonStyle(.plain)
+                Button(action: onBodyTap) {
+                    bodyContent
+                }
+                .buttonStyle(.plain)
+            } else {
+                icon
+                bodyContent
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.leading, DesignSystem.Spaces.one)
+        .padding(.trailing, DesignSystem.Spaces.one)
+        .padding(.vertical, DesignSystem.Spaces.half)
+        .contentShape(Rectangle())
+    }
+
+    private var bodyContent: some View {
+        HStack(spacing: DesignSystem.Spaces.one) {
             VStack(alignment: .leading, spacing: .zero) {
                 Text(name)
                     .font(.body.bold())
@@ -45,10 +77,6 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
             .multilineTextAlignment(.leading)
             accessory
         }
-        .frame(maxWidth: .infinity)
-        .padding(.leading, DesignSystem.Spaces.one)
-        .padding(.trailing, DesignSystem.Spaces.one)
-        .padding(.vertical, DesignSystem.Spaces.half)
         .contentShape(Rectangle())
     }
 }

--- a/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
@@ -5,17 +5,34 @@ import SwiftUI
 /// subtitle, and an optional trailing accessory (e.g. a chevron for folders). Keeps `WatchMagicViewRow`
 /// and `WatchFolderRow` visually identical.
 ///
-/// When both `onIconTap` and `onBodyTap` are set, the icon and the rest of the row become two
-/// sibling (plain) buttons — SwiftUI doesn't support nesting a button inside another, so a row
-/// with two actions must not additionally be wrapped in its own `Button`.
-struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
+/// The split variant (`onIconTap` + `bodyDestination`) renders the icon as its own plain button
+/// and the rest of the row as a `NavigationLink` pushing the destination — two sibling tap
+/// targets, since SwiftUI doesn't support nesting a button inside another. A split row must not
+/// additionally be wrapped in its own `Button`, and needs a `NavigationStack` above it.
+struct WatchHomeItemLabel<Icon: View, Accessory: View, Destination: View>: View {
     let name: String
     let subtitle: String?
     let textColor: Color
     let icon: Icon
     let accessory: Accessory
     let onIconTap: (() -> Void)?
-    let onBodyTap: (() -> Void)?
+    let bodyDestination: Destination?
+
+    init(
+        name: String,
+        subtitle: String? = nil,
+        textColor: Color,
+        @ViewBuilder icon: () -> Icon,
+        @ViewBuilder accessory: () -> Accessory = { EmptyView() }
+    ) where Destination == EmptyView {
+        self.name = name
+        self.subtitle = subtitle
+        self.textColor = textColor
+        self.icon = icon()
+        self.accessory = accessory()
+        self.onIconTap = nil
+        self.bodyDestination = nil
+    }
 
     init(
         name: String,
@@ -23,8 +40,8 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
         textColor: Color,
         @ViewBuilder icon: () -> Icon,
         @ViewBuilder accessory: () -> Accessory = { EmptyView() },
-        onIconTap: (() -> Void)? = nil,
-        onBodyTap: (() -> Void)? = nil
+        onIconTap: @escaping () -> Void,
+        @ViewBuilder bodyDestination: () -> Destination
     ) {
         self.name = name
         self.subtitle = subtitle
@@ -32,17 +49,17 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
         self.icon = icon()
         self.accessory = accessory()
         self.onIconTap = onIconTap
-        self.onBodyTap = onBodyTap
+        self.bodyDestination = bodyDestination()
     }
 
     var body: some View {
         HStack(spacing: DesignSystem.Spaces.one) {
-            if let onIconTap, let onBodyTap {
+            if let onIconTap, let bodyDestination {
                 Button(action: onIconTap) {
                     icon
                 }
                 .buttonStyle(.plain)
-                Button(action: onBodyTap) {
+                NavigationLink(destination: bodyDestination) {
                     bodyContent
                 }
                 .buttonStyle(.plain)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
@@ -5,11 +5,11 @@ import SwiftUI
 /// subtitle, and an optional trailing accessory (e.g. a chevron for folders). Keeps `WatchMagicViewRow`
 /// and `WatchFolderRow` visually identical.
 ///
-/// The split variant (`onIconTap` + `bodyNavigationValue`) renders the icon as its own plain
-/// button and the rest of the row as a `NavigationLink(value:)` resolved by the home stack's
-/// `navigationDestination(for: WatchHomeNavigation.self)` registration — two sibling tap targets,
-/// since SwiftUI doesn't support nesting a button inside another. A split row must not
-/// additionally be wrapped in its own `Button`, and needs the home `NavigationStack` above it.
+/// The split variant (`onIconTap` + `onBodyTap`) renders the icon and the rest of the row as two
+/// sibling plain buttons — SwiftUI doesn't support nesting a button inside another, so a split
+/// row must not additionally be wrapped in its own `Button`. The body tap typically pushes a
+/// screen through the `watchNavigate` environment action (buttons, not `NavigationLink` — see
+/// `WatchNavigateAction`).
 struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
     let name: String
     let subtitle: String?
@@ -17,7 +17,7 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
     let icon: Icon
     let accessory: Accessory
     let onIconTap: (() -> Void)?
-    let bodyNavigationValue: WatchHomeNavigation?
+    let onBodyTap: (() -> Void)?
 
     init(
         name: String,
@@ -26,7 +26,7 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
         @ViewBuilder icon: () -> Icon,
         @ViewBuilder accessory: () -> Accessory = { EmptyView() },
         onIconTap: (() -> Void)? = nil,
-        bodyNavigationValue: WatchHomeNavigation? = nil
+        onBodyTap: (() -> Void)? = nil
     ) {
         self.name = name
         self.subtitle = subtitle
@@ -34,17 +34,17 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
         self.icon = icon()
         self.accessory = accessory()
         self.onIconTap = onIconTap
-        self.bodyNavigationValue = bodyNavigationValue
+        self.onBodyTap = onBodyTap
     }
 
     var body: some View {
         HStack(spacing: DesignSystem.Spaces.one) {
-            if let onIconTap, let bodyNavigationValue {
+            if let onIconTap, let onBodyTap {
                 Button(action: onIconTap) {
                     icon
                 }
                 .buttonStyle(.plain)
-                NavigationLink(value: bodyNavigationValue) {
+                Button(action: onBodyTap) {
                     bodyContent
                 }
                 .buttonStyle(.plain)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchHomeItemLabel.swift
@@ -5,34 +5,19 @@ import SwiftUI
 /// subtitle, and an optional trailing accessory (e.g. a chevron for folders). Keeps `WatchMagicViewRow`
 /// and `WatchFolderRow` visually identical.
 ///
-/// The split variant (`onIconTap` + `bodyDestination`) renders the icon as its own plain button
-/// and the rest of the row as a `NavigationLink` pushing the destination — two sibling tap
-/// targets, since SwiftUI doesn't support nesting a button inside another. A split row must not
-/// additionally be wrapped in its own `Button`, and needs a `NavigationStack` above it.
-struct WatchHomeItemLabel<Icon: View, Accessory: View, Destination: View>: View {
+/// The split variant (`onIconTap` + `bodyNavigationValue`) renders the icon as its own plain
+/// button and the rest of the row as a `NavigationLink(value:)` resolved by the home stack's
+/// `navigationDestination(for: WatchHomeNavigation.self)` registration — two sibling tap targets,
+/// since SwiftUI doesn't support nesting a button inside another. A split row must not
+/// additionally be wrapped in its own `Button`, and needs the home `NavigationStack` above it.
+struct WatchHomeItemLabel<Icon: View, Accessory: View>: View {
     let name: String
     let subtitle: String?
     let textColor: Color
     let icon: Icon
     let accessory: Accessory
     let onIconTap: (() -> Void)?
-    let bodyDestination: Destination?
-
-    init(
-        name: String,
-        subtitle: String? = nil,
-        textColor: Color,
-        @ViewBuilder icon: () -> Icon,
-        @ViewBuilder accessory: () -> Accessory = { EmptyView() }
-    ) where Destination == EmptyView {
-        self.name = name
-        self.subtitle = subtitle
-        self.textColor = textColor
-        self.icon = icon()
-        self.accessory = accessory()
-        self.onIconTap = nil
-        self.bodyDestination = nil
-    }
+    let bodyNavigationValue: WatchHomeNavigation?
 
     init(
         name: String,
@@ -40,8 +25,8 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View, Destination: View>: View 
         textColor: Color,
         @ViewBuilder icon: () -> Icon,
         @ViewBuilder accessory: () -> Accessory = { EmptyView() },
-        onIconTap: @escaping () -> Void,
-        @ViewBuilder bodyDestination: () -> Destination
+        onIconTap: (() -> Void)? = nil,
+        bodyNavigationValue: WatchHomeNavigation? = nil
     ) {
         self.name = name
         self.subtitle = subtitle
@@ -49,17 +34,17 @@ struct WatchHomeItemLabel<Icon: View, Accessory: View, Destination: View>: View 
         self.icon = icon()
         self.accessory = accessory()
         self.onIconTap = onIconTap
-        self.bodyDestination = bodyDestination()
+        self.bodyNavigationValue = bodyNavigationValue
     }
 
     var body: some View {
         HStack(spacing: DesignSystem.Spaces.one) {
-            if let onIconTap, let bodyDestination {
+            if let onIconTap, let bodyNavigationValue {
                 Button(action: onIconTap) {
                     icon
                 }
                 .buttonStyle(.plain)
-                NavigationLink(destination: bodyDestination) {
+                NavigationLink(value: bodyNavigationValue) {
                     bodyContent
                 }
                 .buttonStyle(.plain)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -129,8 +129,7 @@ struct WatchMagicViewRow: View {
 
     /// A capable light splits the row in two sibling tap targets: the icon keeps toggling while
     /// the row body pushes the controls screen — the chevron promises a push, so it must not be
-    /// presented modally. The entity snapshot is passed along so the pushed screen opens with
-    /// current values instead of waiting for its own first fetch.
+    /// presented modally. The push value resolves in `WatchHomeView`'s destination registration.
     private var splitLightLabel: some View {
         WatchHomeItemLabel(
             name: viewModel.item.name(info: viewModel.itemInfo),
@@ -144,13 +143,7 @@ struct WatchMagicViewRow: View {
                     .foregroundStyle(.secondary)
             },
             onIconTap: { viewModel.executeItem() },
-            bodyDestination: {
-                WatchLightControlsView(
-                    item: viewModel.item,
-                    itemInfo: viewModel.itemInfo,
-                    initialEntity: viewModel.liveEntity
-                )
-            }
+            bodyNavigationValue: .lightControls(viewModel.item)
         )
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct WatchMagicViewRow: View {
     @StateObject private var viewModel: WatchMagicViewRowViewModel
+    @Environment(\.watchNavigate) private var navigate
     private let subtitle: String?
     private let layout: WatchLayout
 
@@ -129,7 +130,7 @@ struct WatchMagicViewRow: View {
 
     /// A capable light splits the row in two sibling tap targets: the icon keeps toggling while
     /// the row body pushes the controls screen — the chevron promises a push, so it must not be
-    /// presented modally. The push value resolves in `WatchHomeView`'s destination registration.
+    /// presented modally. The pushed screen resolves in `WatchHomeView`'s destination registration.
     private var splitLightLabel: some View {
         WatchHomeItemLabel(
             name: viewModel.item.name(info: viewModel.itemInfo),
@@ -143,7 +144,7 @@ struct WatchMagicViewRow: View {
                     .foregroundStyle(.secondary)
             },
             onIconTap: { viewModel.executeItem() },
-            bodyNavigationValue: .lightControls(viewModel.item)
+            onBodyTap: { navigate(.lightControls(viewModel.item)) }
         )
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -14,16 +14,20 @@ struct WatchMagicViewRow: View {
     }
 
     var body: some View {
-        Button {
-            // A grid tile is just the icon, so it always toggles; a list row's body opens the
-            // light controls screen when the entity has any (the icon stays the toggle).
-            if layout == .grid {
-                viewModel.executeItem()
+        // The confirmation dialog and alerts hang off this per-row container (not a shared parent
+        // list): which button triggers them depends on the row variant below.
+        Group {
+            if layout == .list, viewModel.hasLightControls {
+                // Two sibling tap targets — the icon toggles, the body opens the controls
+                // screen. Not wrapped in a row `Button`: SwiftUI doesn't support nested buttons.
+                splitLightLabel
             } else {
-                viewModel.primaryRowAction()
+                Button {
+                    viewModel.executeItem()
+                } label: {
+                    label
+                }
             }
-        } label: {
-            label
         }
         .confirmationDialog(
             L10n.Watch.Home.Run.Confirmation.title(viewModel.item.name(info: viewModel.itemInfo)),
@@ -127,34 +131,29 @@ struct WatchMagicViewRow: View {
                 name: viewModel.item.name(info: viewModel.itemInfo),
                 subtitle: subtitleToDisplay,
                 textColor: textColor,
-                icon: { iconArea },
-                accessory: {
-                    // Same chevron as folder rows: the row body navigates somewhere.
-                    if viewModel.hasLightControls {
-                        Image(systemSymbol: .chevronRight)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) }
             )
         }
     }
 
-    /// A capable light splits the row in two tap targets: its icon keeps toggling while the row
-    /// body opens the controls screen — so the icon becomes its own (plain) button. Every other
-    /// row keeps a single target and the icon is just decoration.
-    @ViewBuilder
-    private var iconArea: some View {
-        if viewModel.hasLightControls {
-            Button {
-                viewModel.executeItem()
-            } label: {
-                iconToDisplay.animation(.bouncy, value: viewModel.state)
-            }
-            .buttonStyle(.plain)
-        } else {
-            iconToDisplay.animation(.bouncy, value: viewModel.state)
-        }
+    /// A capable light splits the row in two sibling tap targets: the icon keeps toggling while
+    /// the row body opens the controls screen. `WatchHomeItemLabel` renders each as its own plain
+    /// button when both actions are set.
+    private var splitLightLabel: some View {
+        WatchHomeItemLabel(
+            name: viewModel.item.name(info: viewModel.itemInfo),
+            subtitle: subtitleToDisplay,
+            textColor: textColor,
+            icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) },
+            accessory: {
+                // Same chevron as folder rows: the row body navigates somewhere.
+                Image(systemSymbol: .chevronRight)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            },
+            onIconTap: { viewModel.executeItem() },
+            onBodyTap: { viewModel.primaryRowAction() }
+        )
     }
 
     /// The one sheet this row presents; which flag it maps to depends on what the row is

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -93,19 +93,10 @@ struct WatchMagicViewRow: View {
                 onDismiss: { viewModel.errorMessage = nil }
             )
         }
-        // One sheet per row (stacking several is unreliable on older watchOS), covering the two
-        // mutually exclusive cases: a sensor's read-only details screen, or a capable light's
-        // controls screen (power/brightness/temperature).
-        .sheet(isPresented: detailsSheetBinding) {
-            if viewModel.isDisplayOnly {
-                WatchEntityDetailsView(viewModel: .init(item: viewModel.item, itemInfo: viewModel.itemInfo))
-            } else {
-                WatchLightControlsView(viewModel: .init(
-                    item: viewModel.item,
-                    itemInfo: viewModel.itemInfo,
-                    initialEntity: viewModel.liveEntity
-                ))
-            }
+        // Sensors run nothing when tapped: they open their own read-only details screen instead.
+        // (A capable light's controls screen is not a sheet — its row body pushes it.)
+        .sheet(isPresented: $viewModel.showDetails) {
+            WatchEntityDetailsView(viewModel: .init(item: viewModel.item, itemInfo: viewModel.itemInfo))
         }
         // Developer "Verbose item execution": a live log of the run, dismissed explicitly so the
         // steps stay readable after the execution finishes.
@@ -137,8 +128,9 @@ struct WatchMagicViewRow: View {
     }
 
     /// A capable light splits the row in two sibling tap targets: the icon keeps toggling while
-    /// the row body opens the controls screen. `WatchHomeItemLabel` renders each as its own plain
-    /// button when both actions are set.
+    /// the row body pushes the controls screen — the chevron promises a push, so it must not be
+    /// presented modally. The entity snapshot is passed along so the pushed screen opens with
+    /// current values instead of waiting for its own first fetch.
     private var splitLightLabel: some View {
         WatchHomeItemLabel(
             name: viewModel.item.name(info: viewModel.itemInfo),
@@ -152,14 +144,14 @@ struct WatchMagicViewRow: View {
                     .foregroundStyle(.secondary)
             },
             onIconTap: { viewModel.executeItem() },
-            onBodyTap: { viewModel.primaryRowAction() }
+            bodyDestination: {
+                WatchLightControlsView(
+                    item: viewModel.item,
+                    itemInfo: viewModel.itemInfo,
+                    initialEntity: viewModel.liveEntity
+                )
+            }
         )
-    }
-
-    /// The one sheet this row presents; which flag it maps to depends on what the row is
-    /// (sensor details vs. light controls) — the two can never apply to the same entity.
-    private var detailsSheetBinding: Binding<Bool> {
-        viewModel.isDisplayOnly ? $viewModel.showDetails : $viewModel.showLightControls
     }
 
     private var subtitleToDisplay: String? {

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -15,7 +15,13 @@ struct WatchMagicViewRow: View {
 
     var body: some View {
         Button {
-            viewModel.executeItem()
+            // A grid tile is just the icon, so it always toggles; a list row's body opens the
+            // light controls screen when the entity has any (the icon stays the toggle).
+            if layout == .grid {
+                viewModel.executeItem()
+            } else {
+                viewModel.primaryRowAction()
+            }
         } label: {
             label
         }
@@ -83,9 +89,19 @@ struct WatchMagicViewRow: View {
                 onDismiss: { viewModel.errorMessage = nil }
             )
         }
-        // Sensors run nothing when tapped: they open their own read-only details screen instead.
-        .sheet(isPresented: $viewModel.showDetails) {
-            WatchEntityDetailsView(viewModel: .init(item: viewModel.item, itemInfo: viewModel.itemInfo))
+        // One sheet per row (stacking several is unreliable on older watchOS), covering the two
+        // mutually exclusive cases: a sensor's read-only details screen, or a capable light's
+        // controls screen (power/brightness/temperature).
+        .sheet(isPresented: detailsSheetBinding) {
+            if viewModel.isDisplayOnly {
+                WatchEntityDetailsView(viewModel: .init(item: viewModel.item, itemInfo: viewModel.itemInfo))
+            } else {
+                WatchLightControlsView(viewModel: .init(
+                    item: viewModel.item,
+                    itemInfo: viewModel.itemInfo,
+                    initialEntity: viewModel.liveEntity
+                ))
+            }
         }
         // Developer "Verbose item execution": a live log of the run, dismissed explicitly so the
         // steps stay readable after the execution finishes.
@@ -111,9 +127,40 @@ struct WatchMagicViewRow: View {
                 name: viewModel.item.name(info: viewModel.itemInfo),
                 subtitle: subtitleToDisplay,
                 textColor: textColor,
-                icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) }
+                icon: { iconArea },
+                accessory: {
+                    // Same chevron as folder rows: the row body navigates somewhere.
+                    if viewModel.hasLightControls {
+                        Image(systemSymbol: .chevronRight)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
             )
         }
+    }
+
+    /// A capable light splits the row in two tap targets: its icon keeps toggling while the row
+    /// body opens the controls screen — so the icon becomes its own (plain) button. Every other
+    /// row keeps a single target and the icon is just decoration.
+    @ViewBuilder
+    private var iconArea: some View {
+        if viewModel.hasLightControls {
+            Button {
+                viewModel.executeItem()
+            } label: {
+                iconToDisplay.animation(.bouncy, value: viewModel.state)
+            }
+            .buttonStyle(.plain)
+        } else {
+            iconToDisplay.animation(.bouncy, value: viewModel.state)
+        }
+    }
+
+    /// The one sheet this row presents; which flag it maps to depends on what the row is
+    /// (sensor details vs. light controls) — the two can never apply to the same entity.
+    private var detailsSheetBinding: Binding<Bool> {
+        viewModel.isDisplayOnly ? $viewModel.showDetails : $viewModel.showLightControls
     }
 
     private var subtitleToDisplay: String? {
@@ -226,6 +273,10 @@ struct WatchMagicViewRow: View {
         WatchMagicViewRow(
             item: .init(id: "sensor.living_room_temperature", serverId: "1", type: .entity),
             itemInfo: .init(id: "1", name: "Living room temperature", iconName: "mdi:thermometer")
+        )
+        WatchMagicViewRow(
+            item: .init(id: "light.kitchen", serverId: "1", type: .entity),
+            itemInfo: .init(id: "1", name: "Kitchen light", iconName: "mdi:lightbulb")
         )
     }
     .background(Color.red)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -35,9 +35,6 @@ final class WatchMagicViewRowViewModel: ObservableObject {
     @Published var showUnsupportedAlert = false
     /// Drives the details screen for a display-only (sensor) item, which runs nothing when tapped.
     @Published var showDetails = false
-    /// Drives the controls screen (power/brightness/temperature) for a light row whose entity
-    /// reports adjustable capabilities.
-    @Published var showLightControls = false
     /// Latest entity snapshot from the poller; drives the state subtitle, the live icon, and the
     /// state-aware execution (lock).
     @Published private(set) var liveEntity: HAEntity?
@@ -79,17 +76,6 @@ final class WatchMagicViewRowViewModel: ObservableObject {
             showConfirmationDialog = true
         } else {
             executeItemAction()
-        }
-    }
-
-    /// What tapping the row body does. A light with adjustable capabilities opens its controls
-    /// screen (its icon stays the toggle); everything else — including a plain on/off light —
-    /// executes as before.
-    func primaryRowAction() {
-        if hasLightControls {
-            showLightControls = true
-        } else {
-            executeItem()
         }
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -35,6 +35,9 @@ final class WatchMagicViewRowViewModel: ObservableObject {
     @Published var showUnsupportedAlert = false
     /// Drives the details screen for a display-only (sensor) item, which runs nothing when tapped.
     @Published var showDetails = false
+    /// Drives the controls screen (power/brightness/temperature) for a light row whose entity
+    /// reports adjustable capabilities.
+    @Published var showLightControls = false
     /// Latest entity snapshot from the poller; drives the state subtitle, the live icon, and the
     /// state-aware execution (lock).
     @Published private(set) var liveEntity: HAEntity?
@@ -77,6 +80,25 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         } else {
             executeItemAction()
         }
+    }
+
+    /// What tapping the row body does. A light with adjustable capabilities opens its controls
+    /// screen (its icon stays the toggle); everything else — including a plain on/off light —
+    /// executes as before.
+    func primaryRowAction() {
+        if hasLightControls {
+            showLightControls = true
+        } else {
+            executeItem()
+        }
+    }
+
+    /// True once the polled state proves this light can do more than toggle (dim or tune its
+    /// color temperature). False until the first snapshot arrives, so a tap before then — or on a
+    /// plain on/off light — just toggles.
+    var hasLightControls: Bool {
+        guard item.type == .entity, item.domain == .light, let liveEntity else { return false }
+        return LightCapabilities(entity: liveEntity).hasAdjustableControls
     }
 
     // MARK: - Entity state

--- a/Sources/WatchApp/Home/WatchFolderContentView.swift
+++ b/Sources/WatchApp/Home/WatchFolderContentView.swift
@@ -2,10 +2,13 @@ import SFSafeSymbols
 import Shared
 import SwiftUI
 
+/// A folder's contents, pushed by `WatchFolderRow` through the home screen's `NavigationStack`.
+/// The navigation bar stays hidden — the custom header provides the back button (via `dismiss`),
+/// keeping the same look it had before folders were real pushes.
 struct WatchFolderContentView: View {
     let folderId: String
     @ObservedObject var viewModel: WatchHomeViewModel
-    let onBack: () -> Void
+    @Environment(\.dismiss) private var dismiss
 
     @State private var isEditing = false
     @State private var activeSheet: WatchHomeView.HomeSheet?
@@ -128,7 +131,7 @@ struct WatchFolderContentView: View {
                     withAnimation { isEditing = false }
                     viewModel.saveConfig()
                 }
-                onBack()
+                dismiss()
             } label: {
                 Image(systemSymbol: .chevronLeft)
             }

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -2,8 +2,8 @@ import Foundation
 import Shared
 
 /// Every screen the watch home hierarchy can push, registered once at the stack root
-/// (`WatchHomeView`) via `navigationDestination(for:)`. Rows navigate with
-/// `NavigationLink(value:)` — the standard `NavigationStack` pattern — so pushes work (and
+/// (`WatchHomeView`) via `navigationDestination(for:)`. Rows navigate by appending one of these
+/// to the stack's path through the `watchNavigate` environment action, so pushes work (and
 /// animate) identically from the home list, the grid, and inside folders.
 enum WatchHomeNavigation: Hashable {
     /// A folder's contents.

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Shared
+
+/// Every screen the watch home hierarchy can push, registered once at the stack root
+/// (`WatchHomeView`) via `navigationDestination(for:)`. Rows navigate with
+/// `NavigationLink(value:)` — the standard `NavigationStack` pattern — so pushes work (and
+/// animate) identically from the home list, the grid, and inside folders.
+enum WatchHomeNavigation: Hashable {
+    /// A folder's contents.
+    case folder(String)
+    /// The controls screen (power/brightness/temperature) of a capable light.
+    case lightControls(MagicItem)
+}

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -10,7 +10,6 @@ struct WatchHomeView: View {
     private let autoLoad: Bool
     @State private var showAssist = false
     @State private var showSettings = false
-    @State private var openFolderId: String?
     @State private var isEditing = false
     @State private var activeSheet: HomeSheet?
     @State private var iPhoneNotReachable = false
@@ -46,23 +45,20 @@ struct WatchHomeView: View {
     }
 
     var body: some View {
-        // The stack exists so rows can push detail screens (e.g. a light's controls). The home
-        // and folder screens hide the navigation bar themselves, so visually nothing changes
-        // at the root; only pushed screens show the system bar with a back button.
+        // Standard value-based navigation: every pushable screen (folders, a light's controls) is
+        // registered once here at the root, and rows push with `NavigationLink(value:)`. The home
+        // and folder screens hide the navigation bar themselves, so visually nothing changes at
+        // the root; only the light controls screen shows the system bar with a back button.
         NavigationStack {
-            Group {
-                if let folderId = openFolderId {
-                    WatchFolderContentView(folderId: folderId, viewModel: viewModel) {
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            openFolderId = nil
-                        }
+            content
+                .navigationDestination(for: WatchHomeNavigation.self) { destination in
+                    switch destination {
+                    case let .folder(folderId):
+                        WatchFolderContentView(folderId: folderId, viewModel: viewModel)
+                    case let .lightControls(item):
+                        WatchLightControlsView(item: item, itemInfo: viewModel.info(for: item))
                     }
-                    .transition(.move(edge: .trailing))
-                } else {
-                    content
-                        .transition(.move(edge: .leading))
                 }
-            }
         }
         ._statusBarHidden(true)
         .onReceive(NotificationCenter.default.publisher(for: AssistDefaultComplication.launchNotification)) { _ in
@@ -296,11 +292,7 @@ struct WatchHomeView: View {
         ) {
             ForEach(viewModel.watchConfig.items, id: \.serverUniqueId) { item in
                 if item.type == .folder {
-                    WatchFolderRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid) {
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            openFolderId = item.id
-                        }
-                    }
+                    WatchFolderRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 } else {
                     WatchMagicViewRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 }
@@ -356,11 +348,7 @@ struct WatchHomeView: View {
             }
             .watchConfigRowBackground()
         } else if item.type == .folder {
-            WatchFolderRow(item: item, itemInfo: viewModel.info(for: item)) {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    openFolderId = item.id
-                }
-            }
+            WatchFolderRow(item: item, itemInfo: viewModel.info(for: item))
         } else {
             WatchMagicViewRow(
                 item: item,

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -46,17 +46,22 @@ struct WatchHomeView: View {
     }
 
     var body: some View {
-        Group {
-            if let folderId = openFolderId {
-                WatchFolderContentView(folderId: folderId, viewModel: viewModel) {
-                    withAnimation(.easeInOut(duration: 0.25)) {
-                        openFolderId = nil
+        // The stack exists so rows can push detail screens (e.g. a light's controls). The home
+        // and folder screens hide the navigation bar themselves, so visually nothing changes
+        // at the root; only pushed screens show the system bar with a back button.
+        NavigationStack {
+            Group {
+                if let folderId = openFolderId {
+                    WatchFolderContentView(folderId: folderId, viewModel: viewModel) {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            openFolderId = nil
+                        }
                     }
+                    .transition(.move(edge: .trailing))
+                } else {
+                    content
+                        .transition(.move(edge: .leading))
                 }
-                .transition(.move(edge: .trailing))
-            } else {
-                content
-                    .transition(.move(edge: .leading))
             }
         }
         ._statusBarHidden(true)

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -11,6 +11,9 @@ struct WatchHomeView: View {
     @State private var showAssist = false
     @State private var showSettings = false
     @State private var isEditing = false
+    /// The stack's path. Rows push by appending through the `watchNavigate` environment action —
+    /// see `WatchNavigateAction` for why links aren't used.
+    @State private var navigationPath: [WatchHomeNavigation] = []
     @State private var activeSheet: HomeSheet?
     @State private var iPhoneNotReachable = false
     @State private var reachabilityToken: HAWatchConnectivity.ObservationToken?
@@ -45,11 +48,12 @@ struct WatchHomeView: View {
     }
 
     var body: some View {
-        // Standard value-based navigation: every pushable screen (folders, a light's controls) is
-        // registered once here at the root, and rows push with `NavigationLink(value:)`. The home
-        // and folder screens hide the navigation bar themselves, so visually nothing changes at
-        // the root; only the light controls screen shows the system bar with a back button.
-        NavigationStack {
+        // Standard path-driven navigation: every pushable screen (folders, a light's controls) is
+        // registered once here at the root, and rows push by appending to the path through the
+        // `watchNavigate` environment action. The home and folder screens hide the navigation bar
+        // themselves, so visually nothing changes at the root; only the light controls screen
+        // shows the system bar with a back button.
+        NavigationStack(path: $navigationPath) {
             content
                 .navigationDestination(for: WatchHomeNavigation.self) { destination in
                     switch destination {
@@ -60,6 +64,9 @@ struct WatchHomeView: View {
                     }
                 }
         }
+        .environment(\.watchNavigate, WatchNavigateAction { destination in
+            navigationPath.append(destination)
+        })
         ._statusBarHidden(true)
         .onReceive(NotificationCenter.default.publisher(for: AssistDefaultComplication.launchNotification)) { _ in
             showAssist = true

--- a/Sources/WatchApp/Home/WatchNavigateAction.swift
+++ b/Sources/WatchApp/Home/WatchNavigateAction.swift
@@ -1,0 +1,29 @@
+import Shared
+import SwiftUI
+
+/// Environment action rows use to push a `WatchHomeNavigation` screen.
+///
+/// Navigation is programmatic on purpose: `WatchHomeView` owns the stack's path and injects this
+/// action, and rows trigger it from plain `Button`s. `NavigationLink` resolves as inert inside the
+/// styled home rows on watchOS (taps do nothing), while buttons in the same rows work reliably —
+/// so buttons appending to the path are the dependable way to push.
+struct WatchNavigateAction {
+    let navigate: (WatchHomeNavigation) -> Void
+
+    func callAsFunction(_ destination: WatchHomeNavigation) {
+        navigate(destination)
+    }
+
+    fileprivate struct Key: EnvironmentKey {
+        static let defaultValue = WatchNavigateAction { destination in
+            Current.Log.error("watchNavigate used outside WatchHomeView's stack: \(destination)")
+        }
+    }
+}
+
+extension EnvironmentValues {
+    var watchNavigate: WatchNavigateAction {
+        get { self[WatchNavigateAction.Key.self] }
+        set { self[WatchNavigateAction.Key.self] = newValue }
+    }
+}

--- a/Tests/Shared/LightCapabilities.test.swift
+++ b/Tests/Shared/LightCapabilities.test.swift
@@ -14,11 +14,23 @@ struct LightCapabilitiesTests {
 
         #expect(capabilities.supportsBrightness)
         #expect(capabilities.supportsColorTemp)
+        #expect(capabilities.supportsColor)
         #expect(capabilities.hasAdjustableControls)
         #expect(capabilities.brightnessPercentage == 50)
         #expect(capabilities.colorTempKelvin == 3200)
         #expect(capabilities.minColorTempKelvin == 2202)
         #expect(capabilities.maxColorTempKelvin == 6535)
+    }
+
+    @Test func colorOnlyLightHasAdjustableControls() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["hs"],
+        ])
+
+        #expect(capabilities.supportsColor)
+        #expect(capabilities.supportsBrightness)
+        #expect(!capabilities.supportsColorTemp)
+        #expect(capabilities.hasAdjustableControls)
     }
 
     @Test func brightnessOnlyLightHasNoTemperature() {
@@ -29,6 +41,7 @@ struct LightCapabilitiesTests {
 
         #expect(capabilities.supportsBrightness)
         #expect(!capabilities.supportsColorTemp)
+        #expect(!capabilities.supportsColor)
         #expect(capabilities.hasAdjustableControls)
         #expect(capabilities.brightnessPercentage == 100)
     }

--- a/Tests/Shared/LightCapabilities.test.swift
+++ b/Tests/Shared/LightCapabilities.test.swift
@@ -1,0 +1,85 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct LightCapabilitiesTests {
+    @Test func colorTempLightSupportsBrightnessAndTemperature() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["color_temp", "xy"],
+            "brightness": 128,
+            "color_temp_kelvin": 3200,
+            "min_color_temp_kelvin": 2202,
+            "max_color_temp_kelvin": 6535,
+        ])
+
+        #expect(capabilities.supportsBrightness)
+        #expect(capabilities.supportsColorTemp)
+        #expect(capabilities.hasAdjustableControls)
+        #expect(capabilities.brightnessPercentage == 50)
+        #expect(capabilities.colorTempKelvin == 3200)
+        #expect(capabilities.minColorTempKelvin == 2202)
+        #expect(capabilities.maxColorTempKelvin == 6535)
+    }
+
+    @Test func brightnessOnlyLightHasNoTemperature() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["brightness"],
+            "brightness": 255,
+        ])
+
+        #expect(capabilities.supportsBrightness)
+        #expect(!capabilities.supportsColorTemp)
+        #expect(capabilities.hasAdjustableControls)
+        #expect(capabilities.brightnessPercentage == 100)
+    }
+
+    @Test func onOffLightHasNoAdjustableControls() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["onoff"],
+        ])
+
+        #expect(!capabilities.supportsBrightness)
+        #expect(!capabilities.supportsColorTemp)
+        #expect(!capabilities.hasAdjustableControls)
+        #expect(capabilities.brightnessPercentage == nil)
+    }
+
+    @Test func offLightKeepsCapabilitiesWithoutCurrentValues() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["color_temp"],
+        ])
+
+        #expect(capabilities.supportsBrightness)
+        #expect(capabilities.supportsColorTemp)
+        #expect(capabilities.brightnessPercentage == nil)
+        #expect(capabilities.colorTempKelvin == nil)
+    }
+
+    @Test func missingColorModesFallsBackToBrightnessAttribute() {
+        let capabilities = LightCapabilities(attributes: [
+            "brightness": 64,
+        ])
+
+        #expect(capabilities.supportsBrightness)
+        #expect(!capabilities.supportsColorTemp)
+        #expect(capabilities.brightnessPercentage == 25)
+    }
+
+    @Test func missingKelvinRangeUsesDefaults() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["color_temp"],
+        ])
+
+        #expect(capabilities.minColorTempKelvin == LightCapabilities.defaultMinColorTempKelvin)
+        #expect(capabilities.maxColorTempKelvin == LightCapabilities.defaultMaxColorTempKelvin)
+    }
+
+    @Test func unknownModesAreIgnored() {
+        let capabilities = LightCapabilities(attributes: [
+            "supported_color_modes": ["something_new", "onoff"],
+        ])
+
+        #expect(!capabilities.supportsBrightness)
+        #expect(!capabilities.hasAdjustableControls)
+    }
+}

--- a/Tests/Shared/Watch/WatchServiceCallSender.test.swift
+++ b/Tests/Shared/Watch/WatchServiceCallSender.test.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct WatchServiceCallSenderTests {
+    @Test func payloadMergesEntityIdIntoData() {
+        let payload = WatchServiceCallSender.payload(
+            entityId: "light.kitchen",
+            data: ["brightness_pct": 40]
+        )
+
+        #expect(payload["entity_id"] as? String == "light.kitchen")
+        #expect(payload["brightness_pct"] as? Int == 40)
+    }
+
+    @Test func payloadEntityIdWinsOverDataEntry() {
+        let payload = WatchServiceCallSender.payload(
+            entityId: "light.kitchen",
+            data: ["entity_id": "light.other"]
+        )
+
+        #expect(payload["entity_id"] as? String == "light.kitchen")
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
On the Apple Watch home screen, a light row now splits into two tap targets when the light supports brightness or color temperature: tapping the row icon toggles the light, and tapping the rest of the row opens a new screen with power, brightness, and color temperature controls. Lights that only support on/off keep toggling from anywhere on the row.

## Screenshots
N/A

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
