### PR TITLE
Reduce launch loading times

### DIFF
--- a/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
+++ b/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
@@ -20,8 +20,9 @@ struct LaunchSplashOverlayView: View {
         /// Mirrors the "A PROJECT FROM THE" caption above the OHF logo in `LaunchScreen.storyboard`.
         static let ohfCaptionFontSize: CGFloat = 13
         static let heroAnimation: SwiftUI.Animation = .spring(response: 0.5, dampingFraction: 0.85)
-        /// Kept in sync with `heroAnimation` — how long the overlay holds before starting to fade out.
-        static let heroDuration: Duration = .seconds(1)
+        /// How long the overlay holds before starting to fade out; the fade overlaps the tail of
+        /// `heroAnimation`'s spring so the hand-off feels immediate.
+        static let heroDuration: Duration = .milliseconds(200)
         static let fadeAnimation: SwiftUI.Animation = .easeOut(duration: 0.25)
         static let fadeDuration: Duration = .milliseconds(250)
         /// If no screen ever reports a logo (kiosk mode, unexpected flows), never block the app for

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -10,7 +10,7 @@ final class HomeAssistantViewModel: ObservableObject {
             if Current.isCatalyst {
                 .seconds(0.8)
             } else {
-                .seconds(1.8)
+                .seconds(1.2)
             }
         }()
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Speeds up cold launch by reducing two fixed delays:

- Standby loader minimum on-screen time on iOS: 1.8s → 1.2s (Catalyst stays at 0.8s).
- Launch splash hero hold before fading out: 1s → 200ms.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Timing-only change, no visual differences.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The splash fade now overlaps the tail of the hero spring animation; the fade masks the remaining logo movement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6L25ZqnP4B7zYebpDM1Xz)_