### PR TITLE
Show OHF branding on first stand-by of a cold launch

### DIFF
--- a/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
+++ b/Sources/App/Container/LaunchSplash/LaunchSplashOverlayView.swift
@@ -13,12 +13,6 @@ struct LaunchSplashOverlayView: View {
         static let splashLogoSize = CGSize(width: 115, height: 115)
         /// Mirrors the storyboard's icon centerY constraint constant (logo sits above screen center).
         static let splashLogoCenterYOffset: CGFloat = -50
-        /// Mirrors the OHF logo constraints in `LaunchScreen.storyboard`.
-        static let ohfLogoSize = CGSize(width: 220, height: 25)
-        /// Mirrors the storyboard's OHF-logo-bottom-to-safe-area constraint.
-        static let ohfLogoBottomPadding: CGFloat = 32
-        /// Mirrors the "A PROJECT FROM THE" caption above the OHF logo in `LaunchScreen.storyboard`.
-        static let ohfCaptionFontSize: CGFloat = 13
         static let heroAnimation: SwiftUI.Animation = .spring(response: 0.5, dampingFraction: 0.85)
         /// How long the overlay holds before starting to fade out; the fade overlaps the tail of
         /// `heroAnimation`'s spring so the hand-off feels immediate.
@@ -48,17 +42,8 @@ struct LaunchSplashOverlayView: View {
                     .animation(Constants.heroAnimation, value: state.phase)
                 }
                 .ignoresSafeArea()
-                VStack(spacing: 0) {
-                    Text(verbatim: "A PROJECT FROM THE")
-                        .font(.system(size: Constants.ohfCaptionFontSize, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                    Image(.ohfInline)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: Constants.ohfLogoSize.width, height: Constants.ohfLogoSize.height)
-                }
-                .padding(.bottom, Constants.ohfLogoBottomPadding)
+                OHFBrandingFooter()
+                    .padding(.bottom, OHFBrandingFooter.bottomPadding)
             }
             .opacity(isFadingOut ? 0 : 1)
             .animation(Constants.fadeAnimation, value: isFadingOut)

--- a/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
+++ b/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// The "A PROJECT FROM THE" caption over the Open Home Foundation wordmark, as laid out at the bottom
+/// of `LaunchScreen.storyboard`. Shared by the launch splash overlay and the first stand-by screen of a
+/// cold launch so the branding stays put across the splash → stand-by hand-off.
+struct OHFBrandingFooter: View {
+    /// Mirrors the OHF logo constraints in `LaunchScreen.storyboard`.
+    static let logoSize = CGSize(width: 220, height: 25)
+    /// Mirrors the storyboard's OHF-logo-bottom-to-safe-area constraint.
+    static let bottomPadding: CGFloat = 32
+    /// Mirrors the "A PROJECT FROM THE" caption above the OHF logo in `LaunchScreen.storyboard`.
+    private static let captionFontSize: CGFloat = 13
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(verbatim: "A PROJECT FROM THE")
+                .font(.system(size: Self.captionFontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Image(.ohfInline)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Self.logoSize.width, height: Self.logoSize.height)
+        }
+    }
+}
+
+#Preview {
+    OHFBrandingFooter()
+}

--- a/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
+++ b/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
@@ -1,3 +1,4 @@
+import Shared
 import SwiftUI
 
 /// The "A PROJECT FROM THE" caption over the Open Home Foundation wordmark, as laid out at the bottom
@@ -13,7 +14,7 @@ struct OHFBrandingFooter: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Text(verbatim: "A PROJECT FROM THE")
+            Text(L10n.OhfBranding.caption)
                 .font(.system(size: Self.captionFontSize, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -138,7 +138,9 @@ struct HomeAssistantStandByView: View {
     }
 
     private var showsOHFBrandingFooter: Bool {
-        !showsEmptyState && !showsCleanCacheButton
+        // Mirrors the clean-cache button's render condition, so the footer only yields the bottom
+        // space when that button actually appears.
+        !showsEmptyState && !(showsCleanCacheButton && onCleanCacheAndReload != nil)
     }
 
     private func content(safeAreaInsets: EdgeInsets) -> some View {

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -42,6 +42,9 @@ struct HomeAssistantStandByView: View {
     @State private var showsServerPill = false
     @State private var showsAnimatedLogo: Bool
     @State private var networkType: NetworkType = Current.connectivity.simpleNetworkType()
+    // Shared across every stand-by instance: the OHF footer continues the launch splash's copy on the
+    // first stand-by of a cold launch only, and the flag flips for good when that stand-by disappears.
+    @ObservedObject private var ohfBranding = StandByOHFBrandingState.shared
 
     private var showsEmptyState: Bool { emptyState != nil }
     private var standByContentOpacity: Double { hasAppeared ? 1.0 : 0.0 }
@@ -112,6 +115,30 @@ struct HomeAssistantStandByView: View {
         GeometryReader { proxy in
             content(safeAreaInsets: proxy.safeAreaInsets)
         }
+        .overlay(alignment: .bottom) {
+            ohfBrandingFooter
+        }
+        .onDisappear(perform: ohfBranding.markStandByDismissed)
+    }
+
+    /// Kept at full opacity from the first frame (not tied to the content fade-in) so the launch
+    /// splash's identical footer crossfades into this one with no dip; hidden via opacity whenever
+    /// bottom-anchored content (empty-state buttons, clean-cache button) needs the space.
+    @ViewBuilder
+    private var ohfBrandingFooter: some View {
+        if ohfBranding.showsBranding {
+            OHFBrandingFooter()
+                .padding(.bottom, OHFBrandingFooter.bottomPadding)
+                .opacity(showsOHFBrandingFooter ? 1 : 0)
+                .animation(DesignSystem.Animation.default, value: showsOHFBrandingFooter)
+                .allowsHitTesting(false)
+                // Decorative, matching the launch splash's copy.
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var showsOHFBrandingFooter: Bool {
+        !showsEmptyState && !showsCleanCacheButton
     }
 
     private func content(safeAreaInsets: EdgeInsets) -> some View {

--- a/Sources/App/Frontend/WebView/Views/StandByOHFBrandingState.swift
+++ b/Sources/App/Frontend/WebView/Views/StandByOHFBrandingState.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Keeps the OHF branding footer on the stand-by screen limited to the first stand-by of a cold launch:
+/// the footer continues where the launch splash's copy left off, and once that first stand-by is
+/// dismissed it never returns for the rest of the app session (reconnects, reloads, server switches).
+@MainActor
+final class StandByOHFBrandingState: ObservableObject {
+    static let shared = StandByOHFBrandingState()
+
+    @Published private(set) var showsBranding = true
+
+    /// Called when a stand-by screen disappears; terminal for the rest of the app session.
+    func markStandByDismissed() {
+        showsBranding = false
+    }
+}

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -933,6 +933,7 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "notifications_configurator.settings.footer" = "Identifier must contain only letters and underscores and be uppercase. It must be globally unique to the app.";
 "notifications_configurator.settings.footer.id_set" = "Identifier can not be changed after creation. You must delete and recreate the action to change the identifier.";
 "notifications_configurator.settings.header" = "Settings";
+"ohf_branding.caption" = "A PROJECT FROM THE";
 "ok_label" = "OK";
 "onboarding.client_certificate.description" = "This server requires a client certificate (mTLS) for authentication. Please import your certificate file (.p12 or .pfx).";
 "onboarding.client_certificate.error.file_access" = "Unable to access the selected file";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -3229,6 +3229,11 @@ public enum L10n {
     }
   }
 
+  public enum OhfBranding {
+    /// A PROJECT FROM THE
+    public static var caption: String { return L10n.tr("Localizable", "ohf_branding.caption") }
+  }
+
   public enum Onboarding {
     public enum ClientCertificate {
       /// This server requires a client certificate (mTLS) for authentication. Please import your certificate file (.p12 or .pfx).


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The stand-by screen now shows the OHF branding footer ("A PROJECT FROM THE" + Open Home Foundation wordmark) at the same position as the launch splash, but only on the first stand-by of a cold launch. Once that stand-by is dismissed, the footer never returns for the rest of the app session (reconnects, reloads, server switches).

- Extracted the splash's footer into a shared `OHFBrandingFooter` view so both screens stay pixel-identical, making the splash → stand-by hand-off a seamless crossfade.
- Added `StandByOHFBrandingState`, a session-wide flag that flips when the first stand-by disappears.
- The footer hides while bottom-anchored content (empty-state buttons, clean-cache button) needs the space, and is excluded from accessibility like the splash's copy.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The footer matches the existing launch screen/splash layout exactly (same asset, font, and position).

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01R6L25ZqnP4B7zYebpDM1Xz)_