### PR TITLE
Stop re-sending access tokens the server has rejected

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42EEEFE42E2792B20080E973 /* Service.test.swift */; };
 		42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */; };
 		42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */; };
+		42F1C0133140B00011AABB13 /* TokenManagerAccessTokenRejection.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */; };
 		42F1C0323140B00011AACC02 /* ConnectivityWrapper.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */; };
 		42F384052FB49C9500390AFC /* DebugSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 42F384042FB49C9500390AFC /* DebugSwift */; };
 		42FA000000000000000C0002 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 42FA000000000000000C0001 /* WebRTC */; };
@@ -669,6 +670,7 @@
 		42EEEFE42E2792B20080E973 /* Service.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.test.swift; sourceTree = "<group>"; };
 		42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAssistantAPIIdentity.test.swift; sourceTree = "<group>"; };
 		42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAPITokenFetchFailure.test.swift; sourceTree = "<group>"; };
+		42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerAccessTokenRejection.test.swift; sourceTree = "<group>"; };
 		42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityWrapper.test.swift; sourceTree = "<group>"; };
 		42F1DA732B4FF9F8002729BC /* MaterialDesignIcons+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MaterialDesignIcons+CarPlay.swift"; sourceTree = "<group>"; };
 		42FF5E962E22E5C100BDF5EF /* TodoListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListItem.swift; sourceTree = "<group>"; };
@@ -2611,6 +2613,7 @@
 				1130A5772751BDD900640E38 /* ServerManager.test.swift */,
 				42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */,
 				42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */,
+				42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */,
 				11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */,
 				42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */,
 				480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */,
@@ -4080,6 +4083,7 @@
 				1130A5782751BDD900640E38 /* ServerManager.test.swift in Sources */,
 				42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */,
 				42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */,
+				42F1C0133140B00011AABB13 /* TokenManagerAccessTokenRejection.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */,
 				1133F5F625F1DBF000AD776F /* CLLocation+Sanitize.test.swift in Sources */,

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
@@ -468,8 +468,20 @@ struct WatchComplicationLivePreview: View {
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
         defer { session.finishTasksAndInvalidate() }
         guard let (data, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let http = response as? HTTPURLResponse else {
+            return nil
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            // The server rejected a token the client still considered valid; invalidate it so the
+            // next fetch refreshes instead of re-sending it (which the server logs as invalid auth
+            // and eventually answers with an IP ban).
+            if http.statusCode == 401 {
+                let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+                tokenManager.handleAccessTokenRejected(token)
+            }
+            return nil
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let state = json["state"] as? String else {
             return nil
         }

--- a/Sources/HANetworking/Sources/TokenManager.swift
+++ b/Sources/HANetworking/Sources/TokenManager.swift
@@ -87,6 +87,26 @@ public final class TokenManager: @unchecked Sendable {
         }
     }
 
+    /// Call when the server answered a request with HTTP 401 for an access token this manager handed
+    /// out. The client-side expiration said the token was still valid, yet the server rejected it —
+    /// typically because its refresh token was revoked (device deleted from the HA profile) or the
+    /// server was restored from a backup. Without this, every poll re-sends the same rejected token,
+    /// which the server logs as invalid auth and eventually answers with an IP ban.
+    ///
+    /// Marking the stored token expired makes every future `bearerToken` refuse to hand it out and go
+    /// through a refresh instead: either the refresh mints a working token, or it fails with
+    /// 400...403 and the reauthentication-required flow kicks in — in both cases the rejected token is
+    /// never sent again.
+    public func handleAccessTokenRejected(_ rejectedToken: String) {
+        // A refresh may have already replaced the token by the time the 401 lands; only the
+        // currently stored token must be invalidated, never its fresh successor.
+        guard server.info.token.accessToken == rejectedToken else { return }
+        HANetworkingEnvironment.current.log.error(
+            "Server rejected access token \(rejectedToken.hash) before its expiration; forcing refresh"
+        )
+        server.update { $0.token.expiration = .distantPast }
+    }
+
     public func authDictionaryForWebView(forceRefresh: Bool) -> Promise<[String: Any]> {
         firstly { () -> Promise<(String, Date)> in
             if forceRefresh {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -812,6 +812,13 @@ public extension MagicItem {
                     Current.Log.error(
                         "REST execution of magic item \(self.id) returned \(http.statusCode): \(body ?? "<no body>")"
                     )
+                    // The server rejected a token the client still considered valid; invalidate it
+                    // so the next run refreshes instead of re-sending it — repeats get logged as
+                    // invalid auth server-side and eventually IP-ban the watch.
+                    if http.statusCode == 401 {
+                        let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+                        tokenManager.handleAccessTokenRejected(token)
+                    }
                     completion(false, WatchRESTExecutionError.httpStatus(http.statusCode, body: body))
                 }
             }

--- a/Sources/Shared/Watch/WatchEntityStateFetcher.swift
+++ b/Sources/Shared/Watch/WatchEntityStateFetcher.swift
@@ -46,6 +46,11 @@ public enum WatchEntityStateFetcher {
                 guard let data,
                       let http = response as? HTTPURLResponse,
                       (200 ..< 300).contains(http.statusCode) else {
+                    // The server rejected a token the client still considered valid; stop polling
+                    // with it, or every cycle logs invalid auth server-side until an IP ban.
+                    if (response as? HTTPURLResponse)?.statusCode == 401 {
+                        tokenManager.handleAccessTokenRejected(token)
+                    }
                     finish(nil)
                     return
                 }

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -853,8 +853,12 @@ private enum ComplicationStateFetcher {
         let attributes: [String: Any]
     }
 
+    private static func tokenManager(for server: Server) -> TokenManager {
+        Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+    }
+
     private static func bearerToken(for server: Server) async -> String? {
-        let tokenManager = Current.api(for: server)?.tokenManager ?? TokenManager(server: server)
+        let tokenManager = Self.tokenManager(for: server)
         return try? await withCheckedThrowingContinuation { continuation in
             tokenManager.bearerToken.done { token, _ in
                 continuation.resume(returning: token)
@@ -868,7 +872,14 @@ private enum ComplicationStateFetcher {
     /// invalidating the session afterwards as `MagicItem.sendRESTServiceCall` does. On failure the
     /// data is nil and `failure` says why (transport error, HTTP status), so diagnostics can show
     /// the actual cause instead of a generic "unavailable".
-    private static func data(for request: URLRequest, server: Server) async -> (data: Data?, failure: String?) {
+    /// `token` is the bearer already applied to `request`: when the server answers 401, that exact
+    /// token is reported rejected so the next fetch refreshes instead of re-sending it — otherwise
+    /// every refresh cycle logs invalid auth server-side until the watch's IP gets banned.
+    private static func data(
+        for request: URLRequest,
+        server: Server,
+        token: String
+    ) async -> (data: Data?, failure: String?) {
         let session = HomeAssistantAPI.makeCertificateAwareURLSession(server: server)
         defer { session.finishTasksAndInvalidate() }
         do {
@@ -879,6 +890,9 @@ private enum ComplicationStateFetcher {
             }
             guard (200 ..< 300).contains(http.statusCode) else {
                 Current.Log.error("[Complication] HTTP \(http.statusCode) for \(request.url?.absoluteString ?? "?")")
+                if http.statusCode == 401 {
+                    tokenManager(for: server).handleAccessTokenRejected(token)
+                }
                 return (nil, "HTTP \(http.statusCode)")
             }
             return (data, nil)
@@ -901,7 +915,7 @@ private enum ComplicationStateFetcher {
         var request = URLRequest(url: baseURL.appendingPathComponent("api/states/\(entityId)"))
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
-        let result = await data(for: request, server: server)
+        let result = await data(for: request, server: server, token: token)
         guard let data = result.data else {
             return (nil, result.failure)
         }
@@ -946,7 +960,7 @@ private enum ComplicationStateFetcher {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["template": template])
-        guard let data = await data(for: request, server: server).data else { return nil }
+        guard let data = await data(for: request, server: server, token: token).data else { return nil }
         return String(data: data, encoding: .utf8)
     }
 }

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -114,7 +114,8 @@ enum WatchWidgetLiveFetch {
             return "Failed: no valid access token for server(s) " + stored.keys.sorted().joined(separator: ", ")
         }
 
-        let (updates, details) = await fetchUpdates(targets: targets, usable: usable)
+        let (updates, details, rejectedServerIds) = await fetchUpdates(targets: targets, usable: usable)
+        if !rejectedServerIds.isEmpty { invalidateRejectedCredentials(rejectedServerIds, defaults: defaults) }
         if !updates.isEmpty { applyUpdates(updates, configs: configs) }
 
         let entityCount = targets.filter { $0.kind == .entity }.count
@@ -129,9 +130,10 @@ enum WatchWidgetLiveFetch {
     private static func fetchUpdates(
         targets: [WatchComplicationConfig],
         usable: [String: WatchWidgetServerCredential]
-    ) async -> (updates: [String: LiveValue], details: [String]) {
+    ) async -> (updates: [String: LiveValue], details: [String], rejectedServerIds: Set<String>) {
         var updates: [String: LiveValue] = [:] // config.id -> fresh value
         var details: [String] = []
+        var rejectedServerIds: Set<String> = []
         for config in targets {
             let label = config.entityId.map { "\(config.displayName) (\($0))" } ?? config.displayName
             guard config.kind == .entity else {
@@ -149,6 +151,9 @@ enum WatchWidgetLiveFetch {
             let started = Date()
             let result = await fetchValue(config: config, entityId: entityId, credential: credential)
             let elapsed = String(format: "%.1fs", Date().timeIntervalSince(started))
+            if result.unauthorized {
+                rejectedServerIds.insert(config.serverId)
+            }
             if let value = result.value {
                 updates[config.id] = value
                 details.append("\(label): updated to \(value.value) in \(elapsed)")
@@ -156,7 +161,31 @@ enum WatchWidgetLiveFetch {
                 details.append("\(label): failed in \(elapsed) — \(result.failure ?? "unknown reason")")
             }
         }
-        return (updates, details)
+        return (updates, details, rejectedServerIds)
+    }
+
+    /// The server answered 401 for these servers' tokens even though their client-side expiration
+    /// hadn't passed (revoked refresh token, server restored from backup, clock skew). Persist them
+    /// as expired so the next run mints a fresh token via the refresh token — or skips the server
+    /// entirely — instead of re-sending a token the server logs as invalid auth and, on repeats,
+    /// answers with an IP ban.
+    private static func invalidateRejectedCredentials(_ serverIds: Set<String>, defaults: UserDefaults?) {
+        let current = WatchWidgetServerCredential.read(from: defaults)
+        guard !current.isEmpty else { return }
+        let updated = current.map { credential -> WatchWidgetServerCredential in
+            guard serverIds.contains(credential.serverId) else { return credential }
+            return WatchWidgetServerCredential(
+                serverId: credential.serverId,
+                baseURL: credential.baseURL,
+                token: credential.token,
+                expiration: .distantPast,
+                refreshToken: credential.refreshToken,
+                clientID: credential.clientID,
+                clientCertLabel: credential.clientCertLabel,
+                trustExceptions: credential.trustExceptions
+            )
+        }
+        WatchWidgetServerCredential.write(updated, to: defaults)
     }
 
     /// A fresh formatted value plus the raw state and attributes, so slot formulas and gauge
@@ -261,12 +290,14 @@ enum WatchWidgetLiveFetch {
 
     /// Fetches the entity's live state. On failure the value is nil and `failure` says why
     /// (transport error, HTTP status, malformed body), so the developer notification can report the
-    /// actual cause instead of a generic "fetch failed".
+    /// actual cause instead of a generic "fetch failed". `unauthorized` flags an HTTP 401 — the
+    /// server rejected the token despite its client-side expiration — so the caller can retire the
+    /// credential instead of re-sending it.
     private static func fetchValue(
         config: WatchComplicationConfig,
         entityId: String,
         credential: WatchWidgetServerCredential
-    ) async -> (value: LiveValue?, failure: String?) {
+    ) async -> (value: LiveValue?, failure: String?, unauthorized: Bool) {
         var request = URLRequest(url: credential.baseURL.appendingPathComponent("api/states/\(entityId)"))
         request.setValue("Bearer \(credential.token)", forHTTPHeaderField: "Authorization")
 
@@ -276,15 +307,17 @@ enum WatchWidgetLiveFetch {
         let data: Data
         do {
             let (body, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else { return (nil, "no HTTP response") }
-            guard (200 ..< 300).contains(http.statusCode) else { return (nil, "HTTP \(http.statusCode)") }
+            guard let http = response as? HTTPURLResponse else { return (nil, "no HTTP response", false) }
+            guard (200 ..< 300).contains(http.statusCode) else {
+                return (nil, "HTTP \(http.statusCode)", http.statusCode == 401)
+            }
             data = body
         } catch {
-            return (nil, error.localizedDescription)
+            return (nil, error.localizedDescription, false)
         }
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let state = json["state"] as? String else {
-            return (nil, "unexpected response body")
+            return (nil, "unexpected response body", false)
         }
         let attributes = json["attributes"] as? [String: Any] ?? [:]
 
@@ -311,7 +344,8 @@ enum WatchWidgetLiveFetch {
                 state: state,
                 attributes: attributes
             ),
-            nil
+            nil,
+            false
         )
     }
 

--- a/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
+++ b/Sources/WatchWidgets/WatchWidgetLiveFetch.swift
@@ -148,6 +148,12 @@ enum WatchWidgetLiveFetch {
                 details.append("\(label): failed — no valid credential for its server")
                 continue
             }
+            // Once this run saw a 401 for the server, don't send its rejected token again for the
+            // remaining complications — each repeat is another invalid-auth hit toward an IP ban.
+            guard !rejectedServerIds.contains(config.serverId) else {
+                details.append("\(label): skipped — server rejected this run's token")
+                continue
+            }
             let started = Date()
             let result = await fetchValue(config: config, entityId: entityId, credential: credential)
             let elapsed = String(format: "%.1fs", Date().timeIntervalSince(started))

--- a/Tests/Shared/TokenManagerAccessTokenRejection.test.swift
+++ b/Tests/Shared/TokenManagerAccessTokenRejection.test.swift
@@ -1,0 +1,53 @@
+import Foundation
+@testable import Shared
+import XCTest
+
+class TokenManagerAccessTokenRejectionTests: XCTestCase {
+    /// A 401 for the currently stored token must expire it, so no later request re-sends a token the
+    /// server already rejected (repeats get logged as invalid auth and eventually IP-banned).
+    func testRejectingCurrentTokenExpiresIt() {
+        let server = Server.fake()
+        let tokenManager = TokenManager(server: server)
+
+        XCTAssertGreaterThan(server.info.token.expiration, Date())
+        tokenManager.handleAccessTokenRejected(server.info.token.accessToken)
+
+        XCTAssertEqual(server.info.token.expiration, .distantPast)
+    }
+
+    /// A 401 for a token that a concurrent refresh already replaced must not clobber the fresh
+    /// token's expiration.
+    func testRejectingSupersededTokenIsIgnored() {
+        let server = Server.fake()
+        let tokenManager = TokenManager(server: server)
+        let expiration = server.info.token.expiration
+
+        tokenManager.handleAccessTokenRejected("OlderTokenAlreadyReplaced")
+
+        XCTAssertEqual(server.info.token.expiration, expiration)
+    }
+
+    /// Once rejected, `bearerToken` must not hand the token out again — it must go through the
+    /// refresh path instead (which here fails fast for lack of a server, rather than fulfilling
+    /// with the rejected token).
+    func testBearerTokenDoesNotProvideRejectedToken() {
+        let server = Server.fake(update: { info in
+            info.connection.set(address: nil, for: .external)
+        })
+        let tokenManager = TokenManager(server: server)
+        let rejectedToken = server.info.token.accessToken
+        tokenManager.handleAccessTokenRejected(rejectedToken)
+
+        let settled = expectation(description: "bearerToken settled")
+        tokenManager.bearerToken.done { token, _ in
+            XCTAssertNotEqual(token, rejectedToken)
+            settled.fulfill()
+        }.catch { _ in
+            // Refresh failing (no reachable server in tests) is the acceptable outcome; what matters
+            // is that the rejected token was not fulfilled.
+            settled.fulfill()
+        }
+
+        wait(for: [settled], timeout: 5)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
When the server answers 401 for an access token that hasn't reached its client-side expiration (revoked refresh token, server restored from backup, clock skew), the app kept re-sending the same token on every watch complication refresh, entity poll, and magic-item run. The server logs each attempt as invalid authentication (`components/http/ban`) and repeats can end in an IP ban.

`TokenManager` now marks a 401-rejected token as expired, so the next request refreshes instead of re-sending it — either minting a working token or failing into the existing reauthentication flow. All plain-`URLSession` call sites report the 401 back, and the watch-widget self-fetch persists its credential as expired so its next run refreshes or skips. Includes unit tests.

## Screenshots
Not applicable — no user-facing UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Not applicable — behavior fix only; no documentation change needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbvExSfMZSUVCp7f5xULe1)_