### PR TITLE
Fix kiosk mode "Hide status bar" having no effect

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewChromeState.swift
+++ b/Sources/App/Frontend/WebView/WebViewChromeState.swift
@@ -2,8 +2,9 @@ import Combine
 import Shared
 
 /// Observes the settings that drive system-chrome hiding (full-screen, kiosk hide-status-bar) so
-/// `HomeAssistantView` can hide the status bar / home indicator in SwiftUI rather than via UIKit overrides
-/// on `WebViewController`.
+/// `HomeAssistantView` can hide the status bar / home indicator in SwiftUI. `WebViewController` mirrors
+/// `resolveStatusBarHidden()` in its `prefersStatusBarHidden` override: SwiftUI defers status-bar
+/// appearance to the embedded web view controller, so the UIKit override is what actually takes effect.
 @MainActor
 final class WebViewChromeState: ObservableObject {
     @Published private(set) var statusBarHidden: Bool
@@ -31,7 +32,7 @@ final class WebViewChromeState: ObservableObject {
         homeIndicatorHidden = Current.settingsStore.fullScreen
     }
 
-    private static func resolveStatusBarHidden() -> Bool {
+    static func resolveStatusBarHidden() -> Bool {
         Current.settingsStore.fullScreen
             || (Current.kioskSettings.enabled && Current.kioskSettings.hideStatusBar)
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Settings.swift
@@ -52,6 +52,7 @@ extension WebViewController {
 
         if reason == .settingChange {
             setNeedsUpdateOfHomeIndicatorAutoHidden()
+            setNeedsStatusBarAppearanceUpdate()
             // The web view is always edge-to-edge (see `setupWebViewConstraints`); only the SwiftUI-themed
             // status-bar strip reacts to setting changes.
             updateThemedStatusBar()

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
@@ -95,6 +95,12 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
         underlyingPreferredStatusBarStyle
     }
 
+    /// SwiftUI defers status-bar appearance to this embedded controller (`preferredStatusBarStyle` above
+    /// works the same way), so `HomeAssistantView`'s `.statusBarHidden` alone has no effect.
+    override var prefersStatusBarHidden: Bool {
+        WebViewChromeState.resolveStatusBarHidden()
+    }
+
     #if targetEnvironment(macCatalyst)
     override var canBecomeFirstResponder: Bool {
         true
@@ -355,6 +361,16 @@ extension WebViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateFrontendKioskMode()
+            }
+            .store(in: &kioskCancellables)
+
+        Current.kiosk.settingsPublisher
+            .map { $0.enabled && $0.hideStatusBar }
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.setNeedsStatusBarAppearanceUpdate()
             }
             .store(in: &kioskCancellables)
 

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -1,3 +1,4 @@
+import GRDB
 @testable import HomeAssistant
 @testable import Shared
 import UIKit
@@ -344,6 +345,45 @@ final class WebViewControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(restored, URL(string: "http://homeassistant.local:8123/"))
+    }
+
+    /// SwiftUI defers status-bar appearance to the embedded controller, so the UIKit override must
+    /// resolve the kiosk hide-status-bar and full-screen settings itself.
+    func testPrefersStatusBarHiddenTracksKioskAndFullScreenSettings() throws {
+        let previousDatabase = Current.database
+        let previousKiosk = Current.kiosk
+        let previousFullScreen = Current.settingsStore.fullScreen
+        defer {
+            Current.database = previousDatabase
+            Current.kiosk = previousKiosk
+            Current.settingsStore.fullScreen = previousFullScreen
+        }
+
+        let database = try DatabaseQueue()
+        try KioskSettingsTable().createIfNeeded(database: database)
+        Current.database = { database }
+        Current.settingsStore.fullScreen = false
+
+        func setKiosk(enabled: Bool, hideStatusBar: Bool) throws {
+            try database.write { db in
+                try KioskSettings(enabled: enabled, hideStatusBar: hideStatusBar).insert(db, onConflict: .replace)
+            }
+            Current.kiosk = KioskModeManager()
+        }
+
+        let sut = makeSUT()
+
+        try setKiosk(enabled: true, hideStatusBar: true)
+        XCTAssertTrue(sut.prefersStatusBarHidden)
+
+        try setKiosk(enabled: true, hideStatusBar: false)
+        XCTAssertFalse(sut.prefersStatusBarHidden)
+
+        try setKiosk(enabled: false, hideStatusBar: true)
+        XCTAssertFalse(sut.prefersStatusBarHidden)
+
+        Current.settingsStore.fullScreen = true
+        XCTAssertTrue(sut.prefersStatusBarHidden)
     }
 
     private func makeSUT(server: Server = .fake()) -> WebViewController {


### PR DESCRIPTION


## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The kiosk mode "Hide status bar" toggle (and the full-screen setting) stopped hiding the status bar in 2026.8.0. Status-bar hiding relied only on the `.statusBarHidden` modifier in `HomeAssistantView`, but SwiftUI defers status-bar appearance to the embedded `WebViewController`, whose default `prefersStatusBarHidden` (`false`) always won.

This restores the `prefersStatusBarHidden` override on `WebViewController`, backed by the same `WebViewChromeState` resolution the SwiftUI path uses, and invalidates status-bar appearance when the kiosk hide-status-bar state or web-view-related settings change. Includes a regression test.

Fixes #5318

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behavior change beyond restoring the pre-2026.8.0 status-bar hiding.