### PR TITLE
Fix watch complication gauge ignoring edited min/max range

### DIFF
--- a/Sources/HAModels/Sources/WatchComplicationConfig.swift
+++ b/Sources/HAModels/Sources/WatchComplicationConfig.swift
@@ -307,17 +307,17 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         return gaugeMin != nil && gaugeMax != nil
     }
 
-    /// The resolved gauge range for this family, or nil when no gauge should be drawn.
+    /// The resolved gauge range for this family, or nil when no gauge should be drawn. Each bound
+    /// resolves independently (per-size override → base) because the editor's Minimum/Maximum fields
+    /// store only the bound the user edited — requiring both overrides would silently keep gauging
+    /// against the base range.
     public func gaugeRange(for family: Family) -> (min: Double, max: Double)? {
         guard showsGauge(for: family) else { return nil }
         let options = families?[family.rawValue]
-        if let minValue = options?.gaugeMin, let maxValue = options?.gaugeMax, maxValue > minValue {
-            return (minValue, maxValue)
-        }
-        if let minValue = gaugeMin, let maxValue = gaugeMax, maxValue > minValue {
-            return (minValue, maxValue)
-        }
-        return nil
+        guard let minValue = options?.gaugeMin ?? gaugeMin,
+              let maxValue = options?.gaugeMax ?? gaugeMax,
+              maxValue > minValue else { return nil }
+        return (minValue, maxValue)
     }
 
     public func gaugeAttribute(for family: Family) -> String? {

--- a/Tests/Shared/WatchComplicationConfigGaugeRange.test.swift
+++ b/Tests/Shared/WatchComplicationConfigGaugeRange.test.swift
@@ -1,0 +1,91 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct WatchComplicationConfigGaugeRangeTests {
+    private func config(
+        gaugeMin: Double? = nil,
+        gaugeMax: Double? = nil,
+        options: WatchComplicationConfig.FamilyOptions? = nil
+    ) -> WatchComplicationConfig {
+        WatchComplicationConfig(
+            serverId: "server-1",
+            gaugeMin: gaugeMin,
+            gaugeMax: gaugeMax,
+            families: options.map { [WatchComplicationConfig.Family.circular.rawValue: $0] }
+        )
+    }
+
+    @Test func baseRangeAppliesWithoutOverrides() {
+        let config = config(gaugeMin: 0, gaugeMax: 100)
+        let range = config.gaugeRange(for: .circular)
+        #expect(range?.min == 0)
+        #expect(range?.max == 100)
+    }
+
+    @Test func fullPerFamilyOverrideWins() {
+        let config = config(
+            gaugeMin: 0,
+            gaugeMax: 100,
+            options: .init(gaugeMin: 10, gaugeMax: 40)
+        )
+        let range = config.gaugeRange(for: .circular)
+        #expect(range?.min == 10)
+        #expect(range?.max == 40)
+    }
+
+    /// Feedback regression: editing only Maximum stores just that bound per-family; the resolved
+    /// range must combine it with the base Minimum instead of reverting to the base 0–100.
+    @Test func maxOnlyOverrideCombinesWithBaseMin() {
+        let config = config(
+            gaugeMin: 0,
+            gaugeMax: 100,
+            options: .init(gaugeMax: 40)
+        )
+        let range = config.gaugeRange(for: .circular)
+        #expect(range?.min == 0)
+        #expect(range?.max == 40)
+    }
+
+    @Test func minOnlyOverrideCombinesWithBaseMax() {
+        let config = config(
+            gaugeMin: 0,
+            gaugeMax: 100,
+            options: .init(gaugeMin: 20)
+        )
+        let range = config.gaugeRange(for: .circular)
+        #expect(range?.min == 20)
+        #expect(range?.max == 100)
+    }
+
+    @Test func overridesOnlyAffectTheirFamily() {
+        let config = config(
+            gaugeMin: 0,
+            gaugeMax: 100,
+            options: .init(gaugeMax: 40)
+        )
+        let range = config.gaugeRange(for: .rectangular)
+        #expect(range?.min == 0)
+        #expect(range?.max == 100)
+    }
+
+    @Test func invalidResolvedRangeHidesGauge() {
+        // Base 50–100 with a per-family max of 40 resolves to 50–40 — exactly what the editor's
+        // fields show — so no gauge rather than silently gauging against the base range.
+        var config = config(
+            gaugeMin: 50,
+            gaugeMax: 100,
+            options: .init(gaugeMax: 40)
+        )
+        // Keep the gauge toggled on so the range validity alone decides.
+        var options = config.options(for: .circular)
+        options.showGauge = true
+        config.setOptions(options, for: .circular)
+        #expect(config.gaugeRange(for: .circular) == nil)
+    }
+
+    @Test func noRangeMeansNoGauge() {
+        #expect(config().gaugeRange(for: .circular) == nil)
+        #expect(config(gaugeMin: 0).gaugeRange(for: .circular) == nil)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes the watch complication gauge not respecting an edited Minimum/Maximum range. The editor stores only the bound the user actually edited in the per-size options, but `gaugeRange(for:)` required both per-size bounds before using them — so setting just Maximum (e.g. 40 over the default 0–100) silently kept scaling the gauge against 0–100, leaving the dot at value/100 instead of value/max.

Each bound now resolves independently (per-size override → base), matching exactly what the editor's fields display. Added unit tests covering the regression and the surrounding range-resolution cases.

## Screenshots
Reported via in-app feedback: with Minimum 0 / Maximum 40 and a value of 31, the gauge dot sat at ~31% of the arc instead of ~77%. After the fix the dot position matches the configured range.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Bug fix only — no documentation change needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113HHev43XcDoaYEhhyeMeH)_