### PR TITLE
Make "Remember Last Page" opt-in by default

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		42BB4C382CD26490003E47FD /* HATypedRequest+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */; };
 		42BC36C5300683F700E5EE14 /* JinjaEntityReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */; };
 		42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */; };
+		42AB77022FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */; };
 		42C57CB02FFD4BD5002457D9 /* ObjectMapper in Frameworks */ = {isa = PBXBuildFile; productRef = 42C57CAF2FFD4BD5002457D9 /* ObjectMapper */; };
 		42C57CB22FFD4BE5002457D9 /* ObjectMapper in Frameworks */ = {isa = PBXBuildFile; productRef = 42C57CB12FFD4BE5002457D9 /* ObjectMapper */; };
 		42C5E5AB2F7C20EA004797B5 /* EntityColorAttributesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42145A652F7F4CC000891E04 /* EntityColorAttributesParser.swift */; };
@@ -645,6 +646,7 @@
 		42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HATypedRequest+App.swift"; sourceTree = "<group>"; };
 		42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaEntityReference.swift; sourceTree = "<group>"; };
 		42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayAssistDebugSettings.test.swift; sourceTree = "<group>"; };
+		42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreRestoreLastURL.test.swift; sourceTree = "<group>"; };
 		42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceClassProvider.swift; sourceTree = "<group>"; };
 		42D14C46301BAD2E0058088E /* RectangularComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangularComplicationSnapshot.test.swift; sourceTree = "<group>"; };
 		42D14C6D301BB6330058088E /* HomeAssistant-WatchAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "HomeAssistant-WatchAppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2621,6 +2623,7 @@
 				114CBAEA2839FC2500A9BAFF /* SecurityExceptions.test.swift */,
 				114CBAEC283AB92D00A9BAFF /* SecTrust+TestAdditions.swift */,
 				42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */,
+				42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */,
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
 				42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */,
@@ -4075,6 +4078,7 @@
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
 				42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */,
 				42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */,
+				42AB77022FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift in Sources */,
 				114CBAEB2839FC2500A9BAFF /* SecurityExceptions.test.swift in Sources */,
 				1130A5742751B29E00640E38 /* PerServerContainer.test.swift in Sources */,
 				116570802702D325003906A7 /* URLComponents+WidgetAuthenticity.test.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -488,6 +488,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func migrateIfNeeded() {
         resetLocalPush()
         resetShakeGesture()
+        migrateRestoreLastURL()
+    }
+
+    /// Remember Last Page becomes opt-in (disabled by default); installs that already
+    /// have a server configured keep the previous enabled-by-default behavior.
+    private func migrateRestoreLastURL() {
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(
+            hasExistingServers: !Current.servers.all.isEmpty
+        )
     }
 
     /// Shake gesture no longer opens debug by default; users who had it set to debug are reset once to none.

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -210,16 +210,41 @@ public class SettingsStore {
         }
     }
 
+    /// Reopens the last page visited in the frontend when the app launches.
+    /// Disabled by default (opt-in); toggled in Settings > Server Switching.
+    /// Installs that predate the opt-in default keep the old behavior via
+    /// `migrateRestoreLastURLToOptInIfNeeded`. Catalyst hides the toggle (macOS
+    /// owns state restoration there), so it keeps the enabled default.
     public var restoreLastURL: Bool {
         get {
             if let value = prefs.object(forKey: "restoreLastURL") as? NSNumber {
                 return value.boolValue
             } else {
-                return true
+                return Current.isCatalyst
             }
         }
         set {
             prefs.set(newValue, forKey: "restoreLastURL")
+        }
+    }
+
+    /// Remember Last Page used to be enabled by default; existing installs keep that
+    /// behavior by persisting the old default once, unless the user had explicitly
+    /// turned it off. Fresh installs get the new disabled default.
+    public func migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: Bool) {
+        guard !migratedRestoreLastURLOptIn else { return }
+        if hasExistingServers, prefs.object(forKey: "restoreLastURL") == nil {
+            restoreLastURL = true
+        }
+        migratedRestoreLastURLOptIn = true
+    }
+
+    private var migratedRestoreLastURLOptIn: Bool {
+        get {
+            prefs.bool(forKey: "migratedRestoreLastURLOptIn")
+        }
+        set {
+            prefs.set(newValue, forKey: "migratedRestoreLastURLOptIn")
         }
     }
 

--- a/Tests/Shared/SettingsStoreRestoreLastURL.test.swift
+++ b/Tests/Shared/SettingsStoreRestoreLastURL.test.swift
@@ -1,0 +1,58 @@
+@testable import Shared
+import XCTest
+
+final class SettingsStoreRestoreLastURLTests: XCTestCase {
+    private var originalIsCatalyst: Bool!
+
+    override func setUp() {
+        super.setUp()
+        originalIsCatalyst = Current.isCatalyst
+        Current.isCatalyst = false
+        removePersistedKeys()
+    }
+
+    override func tearDown() {
+        removePersistedKeys()
+        Current.isCatalyst = originalIsCatalyst
+        super.tearDown()
+    }
+
+    private func removePersistedKeys() {
+        Current.settingsStore.prefs.removeObject(forKey: "restoreLastURL")
+        Current.settingsStore.prefs.removeObject(forKey: "migratedRestoreLastURLOptIn")
+    }
+
+    func testDefaultsToDisabledOnFreshInstall() {
+        XCTAssertFalse(Current.settingsStore.restoreLastURL)
+    }
+
+    func testDefaultsToEnabledOnCatalyst() {
+        // Catalyst hides the toggle, so the enabled default is the only way restore works there
+        Current.isCatalyst = true
+        XCTAssertTrue(Current.settingsStore.restoreLastURL)
+    }
+
+    func testMigrationKeepsEnabledForExistingInstall() {
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: true)
+        XCTAssertTrue(Current.settingsStore.restoreLastURL)
+    }
+
+    func testMigrationRespectsExplicitOptOut() {
+        Current.settingsStore.restoreLastURL = false
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: true)
+        XCTAssertFalse(Current.settingsStore.restoreLastURL)
+    }
+
+    func testMigrationLeavesFreshInstallDisabled() {
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: false)
+        XCTAssertFalse(Current.settingsStore.restoreLastURL)
+    }
+
+    func testMigrationRunsOnlyOnce() {
+        // A fresh install adds its first server after the initial launch already ran the
+        // migration; the later launch must not flip the new opt-in default to enabled.
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: false)
+        Current.settingsStore.migrateRestoreLastURLToOptInIfNeeded(hasExistingServers: true)
+        XCTAssertFalse(Current.settingsStore.restoreLastURL)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Makes the "Remember Last Page" setting disabled by default, so restoring the last visited page is opt-in for new installs.

Existing users are not affected: a one-time migration keeps the setting enabled for installs that already have a server configured, unless the user had explicitly turned it off. Catalyst keeps the enabled default since the toggle is hidden there.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI changes — only the default value of the existing toggle changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Unit tests cover the new default, the migration, and the opt-out case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaymyP275UNBitqHaWtBep)_