### PR TITLE
Entity picker: rename "Add all" to "Select all" and add "Remove all"

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -435,7 +435,6 @@
 "download_manager.downloading.title" = "Downloading";
 "download_manager.failed.title" = "Failed to download file, error: %@";
 "download_manager.finished.title" = "Download finished";
-"entity_picker.add_all" = "Add all";
 "entity_picker.add_selected" = "Add %lld";
 "entity_picker.filter.area.all.title" = "All areas";
 "entity_picker.filter.area.title" = "Area";
@@ -447,7 +446,9 @@
 "entity_picker.filter.server.title" = "Servers";
 "entity_picker.list.area.no_area.title" = "No area";
 "entity_picker.placeholder" = "Pick entity";
+"entity_picker.remove_all" = "Remove all";
 "entity_picker.search.placeholder" = "Entity name, ID, area name, device name...";
+"entity_picker.select_all" = "Select all";
 "error.client_certificate.flow_cancelled" = "Client Certificate Authentication required.\
 \
 This server requires a client certificate (mTLS) but the operation was cancelled.";

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -160,8 +160,13 @@ struct EntityPicker: View {
             Text(group.title.uppercased())
             if allowMultipleSelection {
                 Spacer()
-                Button(L10n.EntityPicker.addAll) {
-                    addAll(in: group)
+                let allSelected = allEntitiesSelected(in: group)
+                Button(allSelected ? L10n.EntityPicker.removeAll : L10n.EntityPicker.selectAll) {
+                    if allSelected {
+                        removeAll(in: group)
+                    } else {
+                        selectAll(in: group)
+                    }
                 }
                 .textCase(nil)
                 .font(DesignSystem.Font.footnote)
@@ -201,11 +206,21 @@ struct EntityPicker: View {
         }
     }
 
-    private func addAll(in group: EntityPickerGroup) {
+    private func allEntitiesSelected(in group: EntityPickerGroup) -> Bool {
+        let selectedIds = Set(selectedEntities.map(\.id))
+        return !group.entities.isEmpty && group.entities.allSatisfy { selectedIds.contains($0.id) }
+    }
+
+    private func selectAll(in group: EntityPickerGroup) {
         var existingIds = Set(selectedEntities.map(\.id))
         for entity in group.entities where existingIds.insert(entity.id).inserted {
             selectedEntities.append(entity)
         }
+    }
+
+    private func removeAll(in group: EntityPickerGroup) {
+        let groupIds = Set(group.entities.map(\.id))
+        selectedEntities.removeAll { groupIds.contains($0.id) }
     }
 
     private func confirmMultipleSelection() {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1621,14 +1621,16 @@ public enum L10n {
   }
 
   public enum EntityPicker {
-    /// Add all
-    public static var addAll: String { return L10n.tr("Localizable", "entity_picker.add_all") }
     /// Add %lld
     public static func addSelected(_ p1: Int) -> String {
       return L10n.tr("Localizable", "entity_picker.add_selected", p1)
     }
     /// Pick entity
     public static var placeholder: String { return L10n.tr("Localizable", "entity_picker.placeholder") }
+    /// Remove all
+    public static var removeAll: String { return L10n.tr("Localizable", "entity_picker.remove_all") }
+    /// Select all
+    public static var selectAll: String { return L10n.tr("Localizable", "entity_picker.select_all") }
     public enum Filter {
       public enum Area {
         /// Area


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
In the entity picker's multi-select mode, the section header button "Add all" is now "Select all". When every entity in a group is already selected, the button becomes "Remove all" and deselects the whole group. Both strings are localized.

## Screenshots

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01LtRnVWmgMFjLnYSVpdTc5t)_