### PR TITLE
Respect display precision in watch and CarPlay entity states

### DIFF
--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationViewModel.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationViewModel.swift
@@ -180,6 +180,8 @@ final class WatchConfigurationViewModel: ObservableObject {
                 }
                 try watchConfig.insert(db, onConflict: .replace)
             }
+            // Newly added home entities need their registry rows (display precision) on the watch.
+            WatchMirrorPushCoordinator.schedule(reason: .watchConfigChanged)
             return true
         } catch {
             Current.Log.error("Failed to save new Watch config, error: \(error.localizedDescription)")

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -193,7 +193,7 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
     /// Returns a context-aware state description based on entity domain and device class
     private func getContextualStateDescription() -> String {
         if let domain = Domain(entityId: entity.entityId) {
-            return domain.contextualStateDescription(for: entity)
+            return domain.contextualStateDescription(for: entity, serverId: serverId)
         }
 
         let baseState = entity.localizedState.leadingCapitalized

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -270,6 +270,7 @@ public enum WatchMirrorPushCoordinator {
         case databaseUpdated
         case complicationChanged
         case serversChanged
+        case watchConfigChanged
 
         /// Human-readable text used in logs and client events.
         public var logDescription: String {
@@ -277,6 +278,7 @@ public enum WatchMirrorPushCoordinator {
             case .databaseUpdated: return "database updated"
             case .complicationChanged: return "complication changed"
             case .serversChanged: return "servers changed"
+            case .watchConfigChanged: return "watch config changed"
             }
         }
     }

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -133,9 +133,12 @@ public enum Domain: String, CaseIterable {
     ///   precision from the local registry (same as widgets); non-numeric states and entities
     ///   without a registry row pass through unchanged.
     public func contextualStateDescription(for entity: HAEntity, serverId: String? = nil) -> String {
-        var baseState = entity.localizedState.leadingCapitalized
-        if let serverId {
-            baseState = StatePrecision.adjustPrecision(
+        let baseState = entity.localizedState.leadingCapitalized
+        // The registry lookup is only worth its synchronous database read on the paths that render
+        // the state value itself — enum states (on/off, locked, …) never need it.
+        func adjustedBaseState() -> String {
+            guard let serverId else { return baseState }
+            return StatePrecision.adjustPrecision(
                 serverId: serverId,
                 entityId: entity.entityId,
                 stateValue: baseState
@@ -144,11 +147,11 @@ public enum Domain: String, CaseIterable {
 
         // Add unit of measurement if available
         if let unitOfMeasurement = entity.attributes.dictionary["unit_of_measurement"] {
-            return "\(baseState) \(unitOfMeasurement)"
+            return "\(adjustedBaseState()) \(unitOfMeasurement)"
         }
 
         guard let state = Domain.State(rawValue: entity.state) else {
-            return baseState
+            return adjustedBaseState()
         }
 
         return stateForDeviceClass(entity.deviceClass, state: state)

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -129,8 +129,18 @@ public enum Domain: String, CaseIterable {
         return states
     }
 
-    public func contextualStateDescription(for entity: HAEntity) -> String {
-        let baseState = entity.localizedState.leadingCapitalized
+    /// - Parameter serverId: when provided, numeric states are formatted with the entity's display
+    ///   precision from the local registry (same as widgets); non-numeric states and entities
+    ///   without a registry row pass through unchanged.
+    public func contextualStateDescription(for entity: HAEntity, serverId: String? = nil) -> String {
+        var baseState = entity.localizedState.leadingCapitalized
+        if let serverId {
+            baseState = StatePrecision.adjustPrecision(
+                serverId: serverId,
+                entityId: entity.entityId,
+                stateValue: baseState
+            )
+        }
 
         // Add unit of measurement if available
         if let unitOfMeasurement = entity.attributes.dictionary["unit_of_measurement"] {

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -37,9 +37,11 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// existing complications off the watch.
     public var complications: [WatchComplication]?
     public var complicationConfigs: [WatchComplicationConfig]?
-    /// Registry rows for the entities used by complications, so the watch can format values with the
-    /// right display precision without carrying the whole registry.
-    public var complicationEntities: [EntityRegistryListForDisplay.Entity]
+    /// Registry rows for the entities the watch renders — complication entities plus the home-screen
+    /// (magic item) entities — so the watch can format values with the right display precision
+    /// without carrying the whole registry. Encoded under the pre-rename `complicationEntities` key
+    /// so payloads stay compatible across builds.
+    public var registryEntities: [EntityRegistryListForDisplay.Entity]
     /// The phone's servers (`ServerManager.restorableState()` encoding), so every sync — the chunked
     /// pull and the proactive background push — also refreshes the watch's servers *in addition to*
     /// the on-demand `serversConfigSync` interactive exchange (which additionally carries the mTLS
@@ -53,7 +55,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         pipelines: [AssistPipelines]?,
         complications: [WatchComplication]? = nil,
         complicationConfigs: [WatchComplicationConfig]? = nil,
-        complicationEntities: [EntityRegistryListForDisplay.Entity] = [],
+        registryEntities: [EntityRegistryListForDisplay.Entity] = [],
         servers: Data? = nil
     ) {
         self.entities = entities
@@ -61,12 +63,13 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.pipelines = pipelines
         self.complications = complications
         self.complicationConfigs = complicationConfigs
-        self.complicationEntities = complicationEntities
+        self.registryEntities = registryEntities
         self.servers = servers
     }
 
     private enum CodingKeys: String, CodingKey {
-        case entities, areas, pipelines, complications, complicationConfigs, complicationEntities, servers
+        case entities, areas, pipelines, complications, complicationConfigs, servers
+        case registryEntities = "complicationEntities"
     }
 
     // Decode the complication fields defensively: they were added after the mirror shipped, so a payload
@@ -88,9 +91,9 @@ public struct WatchDatabaseMirror: WatchCodable {
             [WatchComplicationConfig].self,
             forKey: .complicationConfigs
         )).flatMap { $0 }
-        self.complicationEntities = (try? container.decodeIfPresent(
+        self.registryEntities = (try? container.decodeIfPresent(
             [EntityRegistryListForDisplay.Entity].self,
-            forKey: .complicationEntities
+            forKey: .registryEntities
         )).flatMap { $0 } ?? []
         self.servers = (try? container.decodeIfPresent(Data.self, forKey: .servers)).flatMap { $0 }
     }
@@ -107,17 +110,28 @@ public struct WatchDatabaseMirror: WatchCodable {
         // phone has none — only a successful read is authoritative.
         let complications = try? WatchComplication.all()
         let configs = try? WatchComplicationConfig.all()
-        // Precision lives in the entity registry; fetch just the entries the complications need.
-        let entitiesByServer = Dictionary(grouping: (configs ?? []).compactMap { config -> (String, String)? in
-            config.entityId.map { (config.serverId, $0) }
-        }, by: { $0.0 })
+        // Precision lives in the entity registry; fetch just the entries the watch renders — the
+        // complication entities plus the home-screen (magic item) entities.
+        var entityIdsByServer: [String: Set<String>] = [:]
+        for config in configs ?? [] {
+            if let entityId = config.entityId {
+                entityIdsByServer[config.serverId, default: []].insert(entityId)
+            }
+        }
+        let homeItems = ((try? WatchConfig.config())?.items ?? []).filter { $0.type == .entity }
+        for item in homeItems {
+            entityIdsByServer[item.serverId, default: []].insert(item.id)
+        }
         var registry: [EntityRegistryListForDisplay.Entity] = []
-        for (serverId, pairs) in entitiesByServer {
+        for (serverId, entityIds) in entityIdsByServer {
             registry += (try? EntityRegistryListForDisplay.Entity.entries(
                 serverId: serverId,
-                entityIds: pairs.map(\.1)
+                entityIds: Array(entityIds)
             )) ?? []
         }
+        // Deterministic order keeps the encoded payload — and therefore the delta-sync digests —
+        // stable across snapshots of unchanged data.
+        registry.sort { ($0.serverId, $0.entityId) < ($1.serverId, $1.entityId) }
         // Resolved outside the GRDB read: servers live in their own store, not the database.
         let servers = Current.servers.restorableState()
 
@@ -133,15 +147,15 @@ public struct WatchDatabaseMirror: WatchCodable {
                 pipelines: pipelines,
                 complications: complications,
                 complicationConfigs: configs,
-                complicationEntities: registry,
+                registryEntities: registry,
                 servers: servers
             )
         }
     }
 
     /// Overwrite the local GRDB reference tables with this snapshot (called on the watch). The watch
-    /// only ever holds mirrored rows in these tables, so a full replace is correct. Complication
-    /// registry rows are upserted (not wiped) so they don't disturb other registry data.
+    /// only ever holds mirrored rows in these tables, so a full replace is correct. Registry rows
+    /// are upserted (not wiped) so they don't disturb other registry data.
     public func apply() throws {
         try Current.database().write { db in
             try applyReferenceTables(in: db)
@@ -191,7 +205,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         // The registry is keyed on (serverId, entityId) with no stable primary key, so a plain
         // save() re-inserts on the next sync and violates that unique index (SQLite error 19).
         // Replace on conflict to upsert just these rows without wiping the rest of the registry.
-        for entity in complicationEntities {
+        for entity in registryEntities {
             try entity.insert(db, onConflict: .replace)
         }
     }
@@ -218,7 +232,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         if let complications, let complicationConfigs,
            let complicationsData = try? encoder.encode(complications),
            let configsData = try? encoder.encode(complicationConfigs),
-           let entitiesData = try? encoder.encode(complicationEntities) {
+           let entitiesData = try? encoder.encode(registryEntities) {
             digests["complications"] = Self.digest(of: [complicationsData, configsData, entitiesData])
         }
         if let servers {
@@ -252,7 +266,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         if matches("complications") {
             copy.complications = nil
             copy.complicationConfigs = nil
-            copy.complicationEntities = []
+            copy.registryEntities = []
         }
         if matches("servers") { copy.servers = nil }
         return copy

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -104,6 +104,20 @@ public struct WatchDatabaseMirror: WatchCodable {
         Set(Domain.watchAddable.map(\.rawValue))
     }
 
+    /// All `.entity` items the watch home screen renders, including those nested inside folders.
+    private static func entityItems(in items: [MagicItem]) -> [MagicItem] {
+        items.flatMap { item -> [MagicItem] in
+            switch item.type {
+            case .entity:
+                return [item]
+            case .folder:
+                return entityItems(in: item.items ?? [])
+            default:
+                return []
+            }
+        }
+    }
+
     /// Read the current reference tables from the local GRDB (called on the phone).
     public static func snapshot() throws -> WatchDatabaseMirror {
         // A read failure sends `nil` (not `[]`) so the watch retains its rows rather than being told the
@@ -118,8 +132,7 @@ public struct WatchDatabaseMirror: WatchCodable {
                 entityIdsByServer[config.serverId, default: []].insert(entityId)
             }
         }
-        let homeItems = ((try? WatchConfig.config())?.items ?? []).filter { $0.type == .entity }
-        for item in homeItems {
+        for item in entityItems(in: (try? WatchConfig.config())?.items ?? []) {
             entityIdsByServer[item.serverId, default: []].insert(item.id)
         }
         var registry: [EntityRegistryListForDisplay.Entity] = []

--- a/Sources/Shared/Watch/WatchEntityDetails.swift
+++ b/Sources/Shared/Watch/WatchEntityDetails.swift
@@ -43,11 +43,14 @@ public struct WatchEntityDetails: Equatable {
         "supported_features",
     ]
 
-    public init(entity: HAEntity) {
+    /// - Parameter serverId: forwarded to the state formatter so numeric states honor the entity's
+    ///   display precision when the registry row is mirrored locally.
+    public init(entity: HAEntity, serverId: String? = nil) {
         let domain = Domain(rawValue: entity.domain)
         self.entityId = entity.entityId
         self.name = entity.attributes.friendlyName ?? entity.entityId
-        self.state = domain?.contextualStateDescription(for: entity) ?? entity.state.leadingCapitalized
+        self.state = domain?.contextualStateDescription(for: entity, serverId: serverId)
+            ?? entity.state.leadingCapitalized
         // Read from the raw attribute rather than the `DeviceClass` enum, so a device class this app
         // doesn't know about is still shown instead of dropped (the key itself is hidden below).
         self.deviceClass = (entity.attributes.dictionary["device_class"] as? String)

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -522,6 +522,8 @@ final class WatchCommunicatorService {
                 try config.insert(db, onConflict: .replace)
             }
             notifyWatchConfig(message: message, watchConfig: config)
+            // Entities added from the watch need their registry rows (display precision) mirrored back.
+            WatchMirrorPushCoordinator.schedule(reason: .watchConfigChanged)
         } catch {
             Current.Log.error("Failed to persist watch config sent from watch, error: \(error.localizedDescription)")
             watchConfig(message: message)

--- a/Sources/WatchApp/Home/EntityDetails/WatchEntityDetailsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/WatchEntityDetailsViewModel.swift
@@ -25,7 +25,7 @@ final class WatchEntityDetailsViewModel: ObservableObject {
         self.item = item
         self.itemInfo = itemInfo
         self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
-        self.details = initialEntity.map(WatchEntityDetails.init(entity:))
+        self.details = initialEntity.map { WatchEntityDetails(entity: $0, serverId: item.serverId) }
     }
 
     /// The name the user configured for the item, falling back to the entity's own name.
@@ -48,7 +48,7 @@ final class WatchEntityDetailsViewModel: ObservableObject {
         poller.start { [weak self] snapshot in
             guard let self else { return }
             if let entity = snapshot.entity {
-                details = WatchEntityDetails(entity: entity)
+                details = WatchEntityDetails(entity: entity, serverId: item.serverId)
             }
             isStale = snapshot.isStale
         }

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -91,7 +91,7 @@ final class WatchMagicViewRowViewModel: ObservableObject {
 
     var stateText: String? {
         guard let liveEntity, let domain = item.domain else { return nil }
-        return domain.contextualStateDescription(for: liveEntity)
+        return domain.contextualStateDescription(for: liveEntity, serverId: item.serverId)
     }
 
     /// Mirrors CarPlay: dynamic domains render the live state-driven icon and color unless the

--- a/Tests/Shared/Watch/WatchComplicationSync.test.swift
+++ b/Tests/Shared/Watch/WatchComplicationSync.test.swift
@@ -23,11 +23,12 @@ struct WatchComplicationSyncTests {
     @Test("Mirror push reasons expose stable raw values and descriptions")
     func reasons() {
         #expect(Set(WatchMirrorPushCoordinator.Reason.allCases.map(\.rawValue)) == [
-            "databaseUpdated", "complicationChanged", "serversChanged",
+            "databaseUpdated", "complicationChanged", "serversChanged", "watchConfigChanged",
         ])
         #expect(WatchMirrorPushCoordinator.Reason.databaseUpdated.logDescription == "database updated")
         #expect(WatchMirrorPushCoordinator.Reason.complicationChanged.logDescription == "complication changed")
         #expect(WatchMirrorPushCoordinator.Reason.serversChanged.logDescription == "servers changed")
+        #expect(WatchMirrorPushCoordinator.Reason.watchConfigChanged.logDescription == "watch config changed")
     }
     #endif
 
@@ -98,5 +99,23 @@ struct WatchComplicationSyncTests {
         let authDecoded = try WatchDatabaseMirror.decodeForWatchThrowing(authoritative.encodeForWatch())
         #expect(authDecoded.complications == [])
         #expect(authDecoded.complicationConfigs == [])
+    }
+
+    @Test("Registry entities round-trip under the legacy complicationEntities wire key")
+    func registryEntitiesWireKey() throws {
+        let mirror = WatchDatabaseMirror(
+            entities: [],
+            areas: [],
+            pipelines: [],
+            registryEntities: [.init(serverId: "s1", entityId: "sensor.power", decimalPlaces: 1)]
+        )
+        let encoded = try mirror.encodeForWatch()
+
+        let decoded = try WatchDatabaseMirror.decodeForWatchThrowing(encoded)
+        #expect(decoded.registryEntities.map(\.entityId) == ["sensor.power"])
+        #expect(decoded.registryEntities.first?.decimalPlaces == 1)
+
+        let plist = try PropertyListSerialization.propertyList(from: encoded, format: nil) as? [String: Any]
+        #expect(plist?["complicationEntities"] != nil)
     }
 }

--- a/Tests/Shared/Watch/WatchEntityStateFetcher.test.swift
+++ b/Tests/Shared/Watch/WatchEntityStateFetcher.test.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 @testable import Shared
 import Testing
 
@@ -50,6 +51,35 @@ struct WatchEntityStateFetcherTests {
         ))
 
         #expect(Domain.cover.contextualStateDescription(for: entity) == "57 %")
+    }
+
+    @Test func parsedStateHonorsDisplayPrecisionWhenServerIdProvided() throws {
+        let database = try DatabaseQueue(path: ":memory:")
+        for table in DatabaseQueue.tables() {
+            try table.createIfNeeded(database: database)
+        }
+        let previousDatabase = Current.database
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        try database.write { db in
+            try EntityRegistryListForDisplay.Entity(
+                serverId: "server-1",
+                entityId: "sensor.power",
+                decimalPlaces: 0
+            ).insert(db)
+        }
+
+        let entity = try WatchEntityStateFetcher.entity(from: responseData(
+            entityId: "sensor.power",
+            state: "57.85",
+            attributes: #"{"unit_of_measurement": "W"}"#
+        ))
+
+        #expect(Domain.sensor.contextualStateDescription(for: entity, serverId: "server-1") == "58 W")
+        // Without a server id (or a registry row) the raw state passes through.
+        #expect(Domain.sensor.contextualStateDescription(for: entity) == "57.85 W")
+        #expect(Domain.sensor.contextualStateDescription(for: entity, serverId: "other-server") == "57.85 W")
     }
 
     @Test func invalidPayloadThrows() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Numeric entity states shown on the watch (home rows and the entity details screen) ignored the display precision configured in Home Assistant, showing raw values like `57.34999` instead of `57.3`. Widgets already handle this via `StatePrecision` and the mirrored entity registry, so this reuses that approach:

- `Domain.contextualStateDescription` now accepts an optional `serverId` and rounds numeric states with `StatePrecision.adjustPrecision`; watch rows, watch entity details, and CarPlay list items pass it.
- The watch database mirror now carries registry rows (decimal places) for home-screen entities in addition to complication entities, and a mirror push is scheduled when the watch config is saved (from the phone or the watch) so precision data reaches the watch promptly.

## Screenshots
Not applicable — value formatting only (e.g. `57.34999 %` → `57.3 %`), no layout changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No documentation change needed: this makes the watch/CarPlay match the precision already documented and applied elsewhere in the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zCLzSFkhXUs9HwKWwtuJU)_