### PR TITLE
Add Apple Watch cover and fan controls with split-tap rows

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2091,6 +2091,10 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.configurator.sections.icon.header" = "Icon";
 "watch.configurator.sections.ring.footer" = "The ring showing progress surrounding the text.";
 "watch.configurator.sections.ring.header" = "Ring";
+"watch.cover_controls.close" = "Close";
+"watch.cover_controls.open" = "Open";
+"watch.cover_controls.position" = "Position";
+"watch.cover_controls.stop" = "Stop";
 "watch.debug.complication_refresh.finished.failed_line" = "%1$@ failed in %2$@: %3$@";
 "watch.debug.complication_refresh.finished.kept_previous_line" = "%1$@ failed in %2$@ (%3$@) — still showing %4$@";
 "watch.debug.complication_refresh.finished.summary" = "%1$li succeeded, %2$li failed in %3$@";
@@ -2108,6 +2112,8 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.entity_details.last_updated" = "Updated";
 "watch.entity_details.loading" = "Reading current state…";
 "watch.entity_details.stale" = "Couldn't refresh from the server. This value may be out of date.";
+"watch.fan_controls.power" = "Power";
+"watch.fan_controls.speed" = "Speed";
 "watch.home.cancel_and_use_cache.title" = "Cancel and use cache";
 "watch.home.loading.skip.title" = "Skip";
 "watch.home.run.confirmation.title" = "Are you sure you want to run \"%@\"?";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2300,6 +2300,9 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.light_controls.color" = "Color";
 "watch.light_controls.power" = "Power";
 "watch.light_controls.temperature" = "Temperature";
+"watch.lock_controls.lock" = "Lock";
+"watch.lock_controls.open" = "Open";
+"watch.lock_controls.unlock" = "Unlock";
 "watch.placeholder_complication_name" = "Placeholder";
 "watch.settings.auto" = "Auto";
 "watch.settings.client_certificate.available_on_watch" = "Available on this Watch";

--- a/Sources/Shared/Domain/CoverCapabilities.swift
+++ b/Sources/Shared/Domain/CoverCapabilities.swift
@@ -1,0 +1,47 @@
+import Foundation
+import HAKit
+
+/// What a cover entity can do beyond toggling, parsed from its state attributes.
+///
+/// Home Assistant advertises cover capabilities through the `supported_features` bitmask. The
+/// watch uses this to decide whether a cover row opens the controls screen (position slider,
+/// open/stop/close) or just toggles.
+public struct CoverCapabilities: Equatable {
+    /// `supported_features` bits, as defined by Home Assistant's cover entity model.
+    public enum Feature: Int {
+        case open = 1
+        case close = 2
+        case setPosition = 4
+        case stop = 8
+    }
+
+    public let supportsOpen: Bool
+    public let supportsClose: Bool
+    public let supportsStop: Bool
+    public let supportsSetPosition: Bool
+    /// Current position as 0 (closed) – 100 (open); nil when the cover doesn't report one.
+    public let currentPosition: Double?
+
+    /// Whether the cover offers anything beyond toggling. Stop counts: halting a moving cover
+    /// midway is impossible from a plain toggle row.
+    public var hasAdjustableControls: Bool {
+        supportsSetPosition || supportsStop
+    }
+
+    public init(entity: HAEntity) {
+        self.init(attributes: entity.attributes.dictionary)
+    }
+
+    public init(attributes: [String: Any]) {
+        let features = (attributes["supported_features"] as? Int) ?? 0
+        self.supportsOpen = features & Feature.open.rawValue != 0
+        self.supportsClose = features & Feature.close.rawValue != 0
+        self.supportsStop = features & Feature.stop.rawValue != 0
+        self.supportsSetPosition = features & Feature.setPosition.rawValue != 0
+        if let position = attributes["current_position"] as? NSNumber {
+            self.currentPosition = position.doubleValue
+        } else {
+            self.currentPosition = nil
+        }
+    }
+}

--- a/Sources/Shared/Domain/FanCapabilities.swift
+++ b/Sources/Shared/Domain/FanCapabilities.swift
@@ -1,0 +1,44 @@
+import Foundation
+import HAKit
+
+/// What a fan entity can do beyond toggling, parsed from its state attributes.
+///
+/// Home Assistant advertises fan capabilities through the `supported_features` bitmask. The
+/// watch uses this to decide whether a fan row opens the controls screen (speed slider) or just
+/// toggles.
+public struct FanCapabilities: Equatable {
+    /// `supported_features` bits, as defined by Home Assistant's fan entity model.
+    public enum Feature: Int {
+        case setSpeed = 1
+    }
+
+    public let supportsSpeedPercentage: Bool
+    /// Current speed as 0–100; nil when off or not reported.
+    public let speedPercentage: Double?
+    /// The fan's speed granularity — e.g. 25 for a fan with four speeds. Defaults to 1.
+    public let percentageStep: Double
+
+    /// Whether the fan offers anything beyond toggling.
+    public var hasAdjustableControls: Bool {
+        supportsSpeedPercentage
+    }
+
+    public init(entity: HAEntity) {
+        self.init(attributes: entity.attributes.dictionary)
+    }
+
+    public init(attributes: [String: Any]) {
+        let features = (attributes["supported_features"] as? Int) ?? 0
+        self.supportsSpeedPercentage = features & Feature.setSpeed.rawValue != 0
+        if let percentage = attributes["percentage"] as? NSNumber {
+            self.speedPercentage = percentage.doubleValue
+        } else {
+            self.speedPercentage = nil
+        }
+        if let step = attributes["percentage_step"] as? NSNumber, step.doubleValue > 0 {
+            self.percentageStep = step.doubleValue
+        } else {
+            self.percentageStep = 1
+        }
+    }
+}

--- a/Sources/Shared/Domain/FanCapabilities.swift
+++ b/Sources/Shared/Domain/FanCapabilities.swift
@@ -13,7 +13,8 @@ public struct FanCapabilities: Equatable {
     }
 
     public let supportsSpeedPercentage: Bool
-    /// Current speed as 0–100; nil when off or not reported.
+    /// Current speed as 0–100; nil when the attribute isn't reported (fans typically drop it
+    /// while off).
     public let speedPercentage: Double?
     /// The fan's speed granularity — e.g. 25 for a fan with four speeds. Defaults to 1.
     public let percentageStep: Double

--- a/Sources/Shared/Domain/LockCapabilities.swift
+++ b/Sources/Shared/Domain/LockCapabilities.swift
@@ -1,0 +1,25 @@
+import Foundation
+import HAKit
+
+/// What a lock entity can do beyond lock/unlock, parsed from its state attributes.
+///
+/// Mirrors Home Assistant's frontend (`more-info-lock`): the open ("unlatch") action is
+/// advertised through the `supported_features` bitmask as `LockEntityFeature.OPEN` (bit 1).
+public struct LockCapabilities: Equatable {
+    /// `supported_features` bits, as defined by Home Assistant's lock entity model.
+    public enum Feature: Int {
+        case open = 1
+    }
+
+    /// Whether the lock supports `lock.open` — e.g. a latch the lock can pull open.
+    public let supportsOpen: Bool
+
+    public init(entity: HAEntity) {
+        self.init(attributes: entity.attributes.dictionary)
+    }
+
+    public init(attributes: [String: Any]) {
+        let features = (attributes["supported_features"] as? Int) ?? 0
+        self.supportsOpen = features & Feature.open.rawValue != 0
+    }
+}

--- a/Sources/Shared/Domain/Service.swift
+++ b/Sources/Shared/Domain/Service.swift
@@ -10,5 +10,8 @@ public enum Service: String, CaseIterable {
     case open = "open"
     case openCover = "open_cover"
     case closeCover = "close_cover"
+    case stopCover = "stop_cover"
+    case setCoverPosition = "set_cover_position"
+    case setPercentage = "set_percentage"
     case trigger = "trigger"
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7504,6 +7504,14 @@ public enum L10n {
       /// Temperature
       public static var temperature: String { return L10n.tr("Localizable", "watch.light_controls.temperature") }
     }
+    public enum LockControls {
+      /// Lock
+      public static var lock: String { return L10n.tr("Localizable", "watch.lock_controls.lock") }
+      /// Open
+      public static var open: String { return L10n.tr("Localizable", "watch.lock_controls.open") }
+      /// Unlock
+      public static var unlock: String { return L10n.tr("Localizable", "watch.lock_controls.unlock") }
+    }
     public enum Settings {
       /// Auto
       public static var auto: String { return L10n.tr("Localizable", "watch.settings.auto") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6846,6 +6846,16 @@ public enum L10n {
         }
       }
     }
+    public enum CoverControls {
+      /// Close
+      public static var close: String { return L10n.tr("Localizable", "watch.cover_controls.close") }
+      /// Open
+      public static var open: String { return L10n.tr("Localizable", "watch.cover_controls.open") }
+      /// Position
+      public static var position: String { return L10n.tr("Localizable", "watch.cover_controls.position") }
+      /// Stop
+      public static var stop: String { return L10n.tr("Localizable", "watch.cover_controls.stop") }
+    }
     public enum Debug {
       public enum ComplicationRefresh {
         public enum Finished {
@@ -6909,6 +6919,12 @@ public enum L10n {
       public static var loading: String { return L10n.tr("Localizable", "watch.entity_details.loading") }
       /// Couldn't refresh from the server. This value may be out of date.
       public static var stale: String { return L10n.tr("Localizable", "watch.entity_details.stale") }
+    }
+    public enum FanControls {
+      /// Power
+      public static var power: String { return L10n.tr("Localizable", "watch.fan_controls.power") }
+      /// Speed
+      public static var speed: String { return L10n.tr("Localizable", "watch.fan_controls.speed") }
     }
     public enum Home {
       public enum CancelAndUseCache {

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
@@ -1,0 +1,173 @@
+import HAKit
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Controls screen a cover row pushes when its body is tapped: a position slider (when the cover
+/// supports positioning) and open/stop/close buttons. Covers without position or stop support
+/// never get here; their row toggles directly. Pushed through the home screen's
+/// `NavigationStack`, like the light controls.
+struct WatchCoverControlsView: View {
+    @StateObject private var viewModel: WatchCoverControlsViewModel
+
+    /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
+    /// is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self._viewModel = .init(
+            wrappedValue: WatchCoverControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)
+        )
+    }
+
+    var body: some View {
+        List {
+            header
+            if viewModel.isStale {
+                staleWarning
+            }
+            if viewModel.capabilities?.supportsSetPosition == true {
+                positionSection
+            }
+            buttonsSection
+        }
+        .navigationTitle(Text(verbatim: viewModel.name))
+        .onAppear {
+            viewModel.startStateUpdates()
+        }
+        .onDisappear {
+            viewModel.stopStateUpdates()
+        }
+    }
+
+    private var header: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(uiImage: viewModel.icon.image(
+                    ofSize: .init(width: 24, height: 24),
+                    color: viewModel.iconColor
+                ))
+                .watchRowIconContainer(color: viewModel.iconColor)
+                if let stateText = viewModel.stateText {
+                    Text(verbatim: stateText)
+                        .font(.title3.bold())
+                        .multilineTextAlignment(.center)
+                        .minimumScaleFactor(0.6)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text(verbatim: L10n.Watch.EntityDetails.loading)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var staleWarning: some View {
+        Label {
+            Text(verbatim: L10n.Watch.EntityDetails.stale)
+                .font(.caption2)
+        } icon: {
+            Image(systemSymbol: .exclamationmarkCircleFill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.black, .orange)
+        }
+    }
+
+    private var positionSection: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                // Dark (closed) to light (open), matching the position scale.
+                WatchGradientSlider(
+                    value: positionBinding,
+                    range: 0 ... 100,
+                    gradient: [Color(uiColor: .init(hex: "#1A1A1A")), .white]
+                )
+                Text(verbatim: "\(Int(viewModel.position))%")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .listRowBackground(Color.clear)
+        } header: {
+            Text(verbatim: L10n.Watch.CoverControls.position)
+        }
+    }
+
+    /// Open/stop/close, shown only for the operations the cover reports. Stop is the reason a
+    /// toggle isn't enough: it's the only way to halt a cover midway.
+    @ViewBuilder
+    private var buttonsSection: some View {
+        // The screen only exists for capable covers, so at least one of these is always present.
+        let capabilities = viewModel.capabilities
+        Section {
+            HStack(spacing: DesignSystem.Spaces.one) {
+                if capabilities?.supportsOpen == true {
+                    coverButton(symbol: .arrowUp, label: L10n.Watch.CoverControls.open) {
+                        viewModel.open()
+                    }
+                }
+                if capabilities?.supportsStop == true {
+                    coverButton(symbol: .stopFill, label: L10n.Watch.CoverControls.stop) {
+                        viewModel.stop()
+                    }
+                }
+                if capabilities?.supportsClose == true {
+                    coverButton(symbol: .arrowDown, label: L10n.Watch.CoverControls.close) {
+                        viewModel.close()
+                    }
+                }
+            }
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private func coverButton(symbol: SFSymbol, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(systemSymbol: symbol)
+                    .font(.body.weight(.semibold))
+                Text(verbatim: label)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var positionBinding: Binding<Double> {
+        Binding(
+            get: { viewModel.position },
+            set: { viewModel.setPosition($0) }
+        )
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "cover.living_room_blind", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-cover.living_room_blind",
+        name: "Living room blind",
+        iconName: "mdi:blinds"
+    )
+    let entity = try? HAEntity(
+        entityId: "cover.living_room_blind",
+        state: "open",
+        lastChanged: Date(timeIntervalSinceNow: -600),
+        lastUpdated: Date(timeIntervalSinceNow: -60),
+        attributes: [
+            "friendly_name": "Living room blind",
+            "device_class": "blind",
+            "supported_features": 15,
+            "current_position": 60,
+        ],
+        context: .init(id: "", userId: "", parentId: "")
+    )
+    // In the app this screen is pushed by a row inside the home's NavigationStack.
+    return NavigationStack {
+        WatchCoverControlsView(item: item, itemInfo: info, initialEntity: entity)
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
@@ -24,10 +24,14 @@ struct WatchCoverControlsView: View {
             if viewModel.isStale {
                 staleWarning
             }
-            if viewModel.capabilities?.supportsSetPosition == true {
-                positionSection
+            // No controls until the first snapshot — capabilities are unknown, so the sections
+            // would render empty next to the loading header.
+            if viewModel.entity != nil {
+                if viewModel.capabilities?.supportsSetPosition == true {
+                    positionSection
+                }
+                buttonsSection
             }
-            buttonsSection
         }
         .navigationTitle(Text(verbatim: viewModel.name))
         .onAppear {

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -1,0 +1,173 @@
+import Foundation
+import HAKit
+import Shared
+import UIKit
+import WatchKit
+
+/// Backs the cover controls screen: position slider plus open/stop/close.
+///
+/// Mirrors `WatchLightControlsViewModel`: state stays fresh through the shared REST polling
+/// (`WatchEntityStatePoller`), commands go out as cover service REST calls
+/// (`WatchServiceCallSender`), slider changes are debounced, and poll snapshots are held off
+/// briefly after the user touches a control so the just-set value doesn't snap back.
+final class WatchCoverControlsViewModel: ObservableObject {
+    @Published private(set) var entity: HAEntity?
+    /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
+    /// presenting the values as current.
+    @Published private(set) var isStale = false
+    /// 0 (closed) – 100 (open). Owned by the user while interacting (see `pollHoldoffUntil`).
+    @Published var position: Double = 0
+
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+
+    private let poller: WatchEntityStatePoller
+    private var positionDebounce: DispatchWorkItem?
+    /// While set and in the future, poll snapshots don't overwrite the user-facing control values.
+    private var pollHoldoffUntil: Date?
+
+    private static let sendDebounceInterval: TimeInterval = 0.4
+    private static let pollHoldoffInterval: TimeInterval = 3
+
+    /// The view model is built inside `StateObject`'s autoclosure by its screen, so creation
+    /// (and its poller) is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self.item = item
+        self.itemInfo = itemInfo
+        self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
+        if let initialEntity {
+            apply(entity: initialEntity)
+        }
+    }
+
+    var name: String {
+        item.name(info: itemInfo)
+    }
+
+    var capabilities: CoverCapabilities? {
+        entity.map(CoverCapabilities.init(entity:))
+    }
+
+    var stateText: String? {
+        guard let entity, let domain = item.domain else { return nil }
+        return domain.contextualStateDescription(for: entity)
+    }
+
+    /// Same live-icon rule as the home row: covers have a state-dependent icon, so render from
+    /// the entity unless the user explicitly picked a custom icon.
+    var icon: MaterialDesignIcons {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.getMDI()
+        }
+        return item.icon(info: itemInfo)
+    }
+
+    var iconColor: UIColor {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.carPlayIconColor() ?? .white
+        }
+        if let hex = itemInfo.customization?.iconColor {
+            return UIColor(hex: hex)
+        }
+        return .white
+    }
+
+    func startStateUpdates() {
+        poller.start { [weak self] snapshot in
+            guard let self else { return }
+            if let entity = snapshot.entity {
+                apply(entity: entity)
+            }
+            isStale = snapshot.isStale
+        }
+    }
+
+    func stopStateUpdates() {
+        poller.stop()
+    }
+
+    // MARK: - Commands
+
+    func open() {
+        holdOffPolling()
+        send(service: .openCover)
+    }
+
+    func close() {
+        holdOffPolling()
+        send(service: .closeCover)
+    }
+
+    func stop() {
+        holdOffPolling()
+        send(service: .stopCover)
+    }
+
+    /// Called for every slider tick; the actual service call waits until the value settles.
+    func setPosition(_ value: Double) {
+        position = value
+        holdOffPolling()
+        positionDebounce?.cancel()
+        positionDebounce = debouncedSend(service: .setCoverPosition, data: ["position": Int(value)])
+    }
+
+    // MARK: - Private
+
+    private func apply(entity: HAEntity) {
+        self.entity = entity
+        // The user's in-flight adjustments own the controls until the server catches up.
+        guard pollHoldoffUntil.map({ Current.date() >= $0 }) ?? true else { return }
+        if let currentPosition = CoverCapabilities(entity: entity).currentPosition {
+            position = currentPosition
+        }
+    }
+
+    private func holdOffPolling() {
+        pollHoldoffUntil = Current.date().addingTimeInterval(Self.pollHoldoffInterval)
+    }
+
+    private func send(service: Service, data: [String: Any] = [:]) {
+        Self.sendCommand(entityId: item.id, serverId: item.serverId, service: service, data: data, poller: poller)
+    }
+
+    /// Slider debounces reference the command through this, capturing only values — so an
+    /// adjustment made right before leaving the screen still reaches the server after the view
+    /// model is gone.
+    private func debouncedSend(service: Service, data: [String: Any]) -> DispatchWorkItem {
+        let entityId = item.id
+        let serverId = item.serverId
+        let workItem = DispatchWorkItem { [weak poller] in
+            Self.sendCommand(entityId: entityId, serverId: serverId, service: service, data: data, poller: poller)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.sendDebounceInterval, execute: workItem)
+        return workItem
+    }
+
+    private static func sendCommand(
+        entityId: String,
+        serverId: String,
+        service: Service,
+        data: [String: Any],
+        poller: WatchEntityStatePoller?
+    ) {
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+            Current.Log.error("Server \(serverId) not synced to the watch for cover controls")
+            WKInterfaceDevice.current().play(.failure)
+            return
+        }
+        WatchServiceCallSender.send(
+            domain: .cover,
+            service: service,
+            entityId: entityId,
+            data: data,
+            server: server
+        ) { success in
+            if success {
+                // Reflect the executed command quickly instead of waiting a full poll interval.
+                poller?.refresh(after: 1)
+            } else {
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -108,7 +108,8 @@ final class WatchCoverControlsViewModel: ObservableObject {
         position = value
         holdOffPolling()
         positionDebounce?.cancel()
-        positionDebounce = debouncedSend(service: .setCoverPosition, data: ["position": Int(value)])
+        // Rounded, not truncated: a 59.999 from slider float math should send 60.
+        positionDebounce = debouncedSend(service: .setCoverPosition, data: ["position": Int(value.rounded())])
     }
 
     // MARK: - Private

--- a/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsView.swift
@@ -1,0 +1,149 @@
+import HAKit
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Controls screen a fan row pushes when its body is tapped: power and speed. Fans without speed
+/// support never get here; their row toggles directly. Pushed through the home screen's
+/// `NavigationStack`, like the light controls.
+struct WatchFanControlsView: View {
+    @StateObject private var viewModel: WatchFanControlsViewModel
+
+    /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
+    /// is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self._viewModel = .init(
+            wrappedValue: WatchFanControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)
+        )
+    }
+
+    var body: some View {
+        List {
+            header
+            if viewModel.isStale {
+                staleWarning
+            }
+            // No controls until the first snapshot: a toggle rendered before the state is known
+            // would show "off" for a fan that may well be on.
+            if viewModel.entity != nil {
+                Section {
+                    Toggle(isOn: powerBinding) {
+                        Text(verbatim: L10n.Watch.FanControls.power)
+                    }
+                }
+            }
+            if viewModel.capabilities?.supportsSpeedPercentage == true {
+                speedSection
+            }
+        }
+        .navigationTitle(Text(verbatim: viewModel.name))
+        .onAppear {
+            viewModel.startStateUpdates()
+        }
+        .onDisappear {
+            viewModel.stopStateUpdates()
+        }
+    }
+
+    private var header: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(uiImage: viewModel.icon.image(
+                    ofSize: .init(width: 24, height: 24),
+                    color: viewModel.iconColor
+                ))
+                .watchRowIconContainer(color: viewModel.iconColor)
+                if let stateText = viewModel.stateText {
+                    Text(verbatim: stateText)
+                        .font(.title3.bold())
+                        .multilineTextAlignment(.center)
+                        .minimumScaleFactor(0.6)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text(verbatim: L10n.Watch.EntityDetails.loading)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var staleWarning: some View {
+        Label {
+            Text(verbatim: L10n.Watch.EntityDetails.stale)
+                .font(.caption2)
+        } icon: {
+            Image(systemSymbol: .exclamationmarkCircleFill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.black, .orange)
+        }
+    }
+
+    private var speedSection: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                WatchGradientSlider(
+                    value: speedBinding,
+                    range: 0 ... 100,
+                    gradient: [Color(uiColor: .init(hex: "#1A1A1A")), .white]
+                )
+                Text(verbatim: "\(Int(viewModel.speedPercentage))%")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .listRowBackground(Color.clear)
+        } header: {
+            Text(verbatim: L10n.Watch.FanControls.speed)
+        }
+    }
+
+    private var powerBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.isOn },
+            set: { viewModel.setPower($0) }
+        )
+    }
+
+    /// Snaps to the fan's reported speed granularity — many fans only do e.g. 25/50/75/100.
+    private var speedBinding: Binding<Double> {
+        Binding(
+            get: { viewModel.speedPercentage },
+            set: { value in
+                let step = viewModel.speedStep
+                let snapped = (value / step).rounded() * step
+                viewModel.setSpeed(min(max(snapped, 0), 100))
+            }
+        )
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "fan.bedroom", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-fan.bedroom",
+        name: "Bedroom fan",
+        iconName: "mdi:fan"
+    )
+    let entity = try? HAEntity(
+        entityId: "fan.bedroom",
+        state: "on",
+        lastChanged: Date(timeIntervalSinceNow: -600),
+        lastUpdated: Date(timeIntervalSinceNow: -60),
+        attributes: [
+            "friendly_name": "Bedroom fan",
+            "supported_features": 1,
+            "percentage": 50,
+            "percentage_step": 25,
+        ],
+        context: .init(id: "", userId: "", parentId: "")
+    )
+    // In the app this screen is pushed by a row inside the home's NavigationStack.
+    return NavigationStack {
+        WatchFanControlsView(item: item, itemInfo: info, initialEntity: entity)
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsViewModel.swift
@@ -1,0 +1,168 @@
+import Foundation
+import HAKit
+import Shared
+import UIKit
+import WatchKit
+
+/// Backs the fan controls screen: power toggle and speed percentage.
+///
+/// Mirrors `WatchLightControlsViewModel`: state stays fresh through the shared REST polling
+/// (`WatchEntityStatePoller`), commands go out as fan service REST calls
+/// (`WatchServiceCallSender`), slider changes are debounced, and poll snapshots are held off
+/// briefly after the user touches a control so the just-set value doesn't snap back.
+final class WatchFanControlsViewModel: ObservableObject {
+    @Published private(set) var entity: HAEntity?
+    /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
+    /// presenting the values as current.
+    @Published private(set) var isStale = false
+    @Published private(set) var isOn = false
+    /// 0–100. Owned by the user while interacting (see `pollHoldoffUntil`), by polling otherwise.
+    @Published var speedPercentage: Double = 0
+
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+
+    private let poller: WatchEntityStatePoller
+    private var speedDebounce: DispatchWorkItem?
+    /// While set and in the future, poll snapshots don't overwrite the user-facing control values.
+    private var pollHoldoffUntil: Date?
+
+    private static let sendDebounceInterval: TimeInterval = 0.4
+    private static let pollHoldoffInterval: TimeInterval = 3
+
+    /// The view model is built inside `StateObject`'s autoclosure by its screen, so creation
+    /// (and its poller) is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self.item = item
+        self.itemInfo = itemInfo
+        self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
+        if let initialEntity {
+            apply(entity: initialEntity)
+        }
+    }
+
+    var name: String {
+        item.name(info: itemInfo)
+    }
+
+    var capabilities: FanCapabilities? {
+        entity.map(FanCapabilities.init(entity:))
+    }
+
+    /// The fan's speed granularity — many fans only do e.g. 25/50/75/100.
+    var speedStep: Double {
+        capabilities?.percentageStep ?? 1
+    }
+
+    var stateText: String? {
+        guard let entity, let domain = item.domain else { return nil }
+        return domain.contextualStateDescription(for: entity)
+    }
+
+    var icon: MaterialDesignIcons {
+        item.icon(info: itemInfo)
+    }
+
+    var iconColor: UIColor {
+        if let hex = itemInfo.customization?.iconColor {
+            return UIColor(hex: hex)
+        }
+        return .white
+    }
+
+    func startStateUpdates() {
+        poller.start { [weak self] snapshot in
+            guard let self else { return }
+            if let entity = snapshot.entity {
+                apply(entity: entity)
+            }
+            isStale = snapshot.isStale
+        }
+    }
+
+    func stopStateUpdates() {
+        poller.stop()
+    }
+
+    // MARK: - Commands
+
+    func setPower(_ on: Bool) {
+        guard on != isOn else { return }
+        isOn = on
+        holdOffPolling()
+        send(service: on ? .turnOn : .turnOff)
+    }
+
+    /// Called for every slider tick; the actual service call waits until the value settles.
+    /// `fan.set_percentage` with 0 turns the fan off, like the frontend.
+    func setSpeed(_ percentage: Double) {
+        speedPercentage = percentage
+        isOn = percentage > 0
+        holdOffPolling()
+        speedDebounce?.cancel()
+        speedDebounce = debouncedSend(service: .setPercentage, data: ["percentage": Int(percentage)])
+    }
+
+    // MARK: - Private
+
+    private func apply(entity: HAEntity) {
+        self.entity = entity
+        // The user's in-flight adjustments own the controls until the server catches up.
+        guard pollHoldoffUntil.map({ Current.date() >= $0 }) ?? true else { return }
+        isOn = entity.state == Domain.State.on.rawValue
+        if let percentage = FanCapabilities(entity: entity).speedPercentage {
+            speedPercentage = percentage
+        } else if !isOn {
+            speedPercentage = 0
+        }
+    }
+
+    private func holdOffPolling() {
+        pollHoldoffUntil = Current.date().addingTimeInterval(Self.pollHoldoffInterval)
+    }
+
+    private func send(service: Service, data: [String: Any] = [:]) {
+        Self.sendCommand(entityId: item.id, serverId: item.serverId, service: service, data: data, poller: poller)
+    }
+
+    /// Slider debounces reference the command through this, capturing only values — so an
+    /// adjustment made right before leaving the screen still reaches the server after the view
+    /// model is gone.
+    private func debouncedSend(service: Service, data: [String: Any]) -> DispatchWorkItem {
+        let entityId = item.id
+        let serverId = item.serverId
+        let workItem = DispatchWorkItem { [weak poller] in
+            Self.sendCommand(entityId: entityId, serverId: serverId, service: service, data: data, poller: poller)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.sendDebounceInterval, execute: workItem)
+        return workItem
+    }
+
+    private static func sendCommand(
+        entityId: String,
+        serverId: String,
+        service: Service,
+        data: [String: Any],
+        poller: WatchEntityStatePoller?
+    ) {
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+            Current.Log.error("Server \(serverId) not synced to the watch for fan controls")
+            WKInterfaceDevice.current().play(.failure)
+            return
+        }
+        WatchServiceCallSender.send(
+            domain: .fan,
+            service: service,
+            entityId: entityId,
+            data: data,
+            server: server
+        ) { success in
+            if success {
+                // Reflect the executed command quickly instead of waiting a full poll interval.
+                poller?.refresh(after: 1)
+            } else {
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Fan/WatchFanControlsViewModel.swift
@@ -100,7 +100,8 @@ final class WatchFanControlsViewModel: ObservableObject {
         isOn = percentage > 0
         holdOffPolling()
         speedDebounce?.cancel()
-        speedDebounce = debouncedSend(service: .setPercentage, data: ["percentage": Int(percentage)])
+        // Rounded, not truncated: a 24.999 from slider float math should send 25.
+        speedDebounce = debouncedSend(service: .setPercentage, data: ["percentage": Int(percentage.rounded())])
     }
 
     // MARK: - Private

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -117,7 +117,7 @@ final class WatchLightControlsViewModel: ObservableObject {
         isOn = percentage > 0
         holdOffPolling()
         brightnessDebounce?.cancel()
-        brightnessDebounce = debouncedSend(data: ["brightness_pct": Int(percentage)])
+        brightnessDebounce = debouncedSend(data: ["brightness_pct": Int(percentage.rounded())])
     }
 
     /// Discrete swatch taps need no debounce. `light.turn_on` with a color also turns the light
@@ -142,7 +142,7 @@ final class WatchLightControlsViewModel: ObservableObject {
         isOn = true
         holdOffPolling()
         colorTempDebounce?.cancel()
-        colorTempDebounce = debouncedSend(data: ["color_temp_kelvin": Int(kelvin)])
+        colorTempDebounce = debouncedSend(data: ["color_temp_kelvin": Int(kelvin.rounded())])
     }
 
     // MARK: - Private

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
@@ -1,0 +1,136 @@
+import HAKit
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// The screen every tap on a lock row opens — locks never toggle directly from the home screen.
+///
+/// A state-colored icon with the current state below it, a lock/unlock button pair, and — when
+/// the lock advertises the open (unlatch) feature, mirroring the frontend's `more-info-lock` —
+/// an open button. Buttons that can't act on the current state are disabled and greyed out.
+struct WatchLockControlsView: View {
+    @StateObject private var viewModel: WatchLockControlsViewModel
+
+    /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
+    /// is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self._viewModel = .init(
+            wrappedValue: WatchLockControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)
+        )
+    }
+
+    var body: some View {
+        List {
+            header
+            if viewModel.isStale {
+                staleWarning
+            }
+            Section {
+                HStack(spacing: DesignSystem.Spaces.one) {
+                    actionButton(symbol: .lockFill, label: L10n.Watch.LockControls.lock) {
+                        viewModel.lock()
+                    }
+                    .disabled(!viewModel.canLock)
+                    actionButton(symbol: .lockOpenFill, label: L10n.Watch.LockControls.unlock) {
+                        viewModel.unlock()
+                    }
+                    .disabled(!viewModel.canUnlock)
+                }
+                .listRowBackground(Color.clear)
+            }
+            if viewModel.supportsOpen {
+                Section {
+                    actionButton(symbol: .doorLeftHandOpen, label: L10n.Watch.LockControls.open) {
+                        viewModel.open()
+                    }
+                    .disabled(!viewModel.canOpen)
+                    .listRowBackground(Color.clear)
+                }
+            }
+        }
+        .navigationTitle(Text(verbatim: viewModel.name))
+        .onAppear {
+            viewModel.startStateUpdates()
+        }
+        .onDisappear {
+            viewModel.stopStateUpdates()
+        }
+    }
+
+    private var header: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(uiImage: viewModel.icon.image(
+                    ofSize: .init(width: 24, height: 24),
+                    color: viewModel.iconColor
+                ))
+                .watchRowIconContainer(color: viewModel.iconColor)
+                if let stateText = viewModel.stateText {
+                    Text(verbatim: stateText)
+                        .font(.title3.bold())
+                        .multilineTextAlignment(.center)
+                        .minimumScaleFactor(0.6)
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text(verbatim: L10n.Watch.EntityDetails.loading)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var staleWarning: some View {
+        Label {
+            Text(verbatim: L10n.Watch.EntityDetails.stale)
+                .font(.caption2)
+        } icon: {
+            Image(systemSymbol: .exclamationmarkCircleFill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.black, .orange)
+        }
+    }
+
+    private func actionButton(symbol: SFSymbol, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(systemSymbol: symbol)
+                    .font(.body.weight(.semibold))
+                Text(verbatim: label)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "lock.front_door", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-lock.front_door",
+        name: "Front door",
+        iconName: "mdi:lock"
+    )
+    let entity = try? HAEntity(
+        entityId: "lock.front_door",
+        state: "locked",
+        lastChanged: Date(timeIntervalSinceNow: -600),
+        lastUpdated: Date(timeIntervalSinceNow: -60),
+        attributes: [
+            "friendly_name": "Front door",
+            "supported_features": 1,
+        ],
+        context: .init(id: "", userId: "", parentId: "")
+    )
+    // In the app this screen is pushed by a row inside the home's NavigationStack.
+    return NavigationStack {
+        WatchLockControlsView(item: item, itemInfo: info, initialEntity: entity)
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -1,0 +1,146 @@
+import Foundation
+import HAKit
+import Shared
+import UIKit
+import WatchKit
+
+/// Backs the lock screen: state-colored icon, current state, and the lock/unlock/open actions.
+///
+/// Locks are security-sensitive, so their row never toggles directly — every tap lands here and
+/// the action is an explicit button press. Which buttons are enabled follows the live state: you
+/// can't lock a locked lock or unlock an unlocked one, and everything is disabled until the first
+/// state fetch answers (acting blind on a lock is worse than waiting a second).
+final class WatchLockControlsViewModel: ObservableObject {
+    @Published private(set) var entity: HAEntity?
+    /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
+    /// presenting the state as current.
+    @Published private(set) var isStale = false
+
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+
+    private let poller: WatchEntityStatePoller
+
+    /// The view model is built inside `StateObject`'s autoclosure by its screen, so creation
+    /// (and its poller) is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self.item = item
+        self.itemInfo = itemInfo
+        self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
+        self.entity = initialEntity
+    }
+
+    var name: String {
+        item.name(info: itemInfo)
+    }
+
+    var stateText: String? {
+        guard let entity, let domain = item.domain else { return nil }
+        return domain.contextualStateDescription(for: entity)
+    }
+
+    /// Same live-icon rule as the home row: locks have a state-dependent icon, so render from the
+    /// entity unless the user explicitly picked a custom icon. The color codes the state (locked
+    /// vs. unlocked vs. jammed) through the shared entity color provider.
+    var icon: MaterialDesignIcons {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.getMDI()
+        }
+        return item.icon(info: itemInfo)
+    }
+
+    var iconColor: UIColor {
+        if let entity, itemInfo.customization?.iconIsCustomized != true {
+            return entity.carPlayIconColor() ?? .white
+        }
+        if let hex = itemInfo.customization?.iconColor {
+            return UIColor(hex: hex)
+        }
+        return .white
+    }
+
+    /// Whether the lock advertises `lock.open` (unlatch) — mirrors the frontend's feature check.
+    var supportsOpen: Bool {
+        guard let entity else { return false }
+        return LockCapabilities(entity: entity).supportsOpen
+    }
+
+    /// Locking is pointless when already locked (or on the way there), and impossible while the
+    /// state is unknown.
+    var canLock: Bool {
+        guard let state = knownState else { return false }
+        return ![.locked, .locking].contains(state)
+    }
+
+    /// Unlocking is pointless when already unlocked (or on the way there / open), and impossible
+    /// while the state is unknown.
+    var canUnlock: Bool {
+        guard let state = knownState else { return false }
+        return ![.unlocked, .unlocking, .open, .opening].contains(state)
+    }
+
+    /// Open (unlatch) works from any known state — e.g. a Nuki can unlatch a locked door —
+    /// but never blind.
+    var canOpen: Bool {
+        knownState != nil
+    }
+
+    func startStateUpdates() {
+        poller.start { [weak self] snapshot in
+            guard let self else { return }
+            if let entity = snapshot.entity {
+                self.entity = entity
+            }
+            isStale = snapshot.isStale
+        }
+    }
+
+    func stopStateUpdates() {
+        poller.stop()
+    }
+
+    // MARK: - Commands
+
+    func lock() {
+        send(service: .lock)
+    }
+
+    func unlock() {
+        send(service: .unlock)
+    }
+
+    func open() {
+        send(service: .open)
+    }
+
+    // MARK: - Private
+
+    /// The current state, but only when it's an actionable one — unknown/unavailable answer nil
+    /// so every button disables.
+    private var knownState: Domain.State? {
+        guard let entity, let state = Domain.State(rawValue: entity.state) else { return nil }
+        if [.unknown, .unavailable].contains(state) { return nil }
+        return state
+    }
+
+    private func send(service: Service) {
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == item.serverId }) else {
+            Current.Log.error("Server \(item.serverId) not synced to the watch for lock controls")
+            WKInterfaceDevice.current().play(.failure)
+            return
+        }
+        WatchServiceCallSender.send(
+            domain: .lock,
+            service: service,
+            entityId: item.id,
+            server: server
+        ) { [weak poller] success in
+            if success {
+                // Reflect the executed command quickly instead of waiting a full poll interval.
+                poller?.refresh(after: 1)
+            } else {
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+}

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -18,7 +18,14 @@ struct WatchMagicViewRow: View {
         // The confirmation dialog and alerts hang off this per-row container (not a shared parent
         // list): which button triggers them depends on the row variant below.
         Group {
-            if layout == .list, let controlsDestination = viewModel.controlsDestination {
+            if let rowDestination = viewModel.wholeRowNavigationDestination {
+                // Locks: the whole row (icon included) opens the lock screen, in both layouts.
+                Button {
+                    navigate(rowDestination)
+                } label: {
+                    label
+                }
+            } else if layout == .list, let controlsDestination = viewModel.controlsDestination {
                 // Two sibling tap targets — the icon toggles, the body opens the controls
                 // screen. Not wrapped in a row `Button`: SwiftUI doesn't support nested buttons.
                 splitControlsLabel(destination: controlsDestination)
@@ -123,7 +130,15 @@ struct WatchMagicViewRow: View {
                 name: viewModel.item.name(info: viewModel.itemInfo),
                 subtitle: subtitleToDisplay,
                 textColor: textColor,
-                icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) }
+                icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) },
+                accessory: {
+                    // Rows that navigate as a whole (locks) show the same chevron as folders.
+                    if viewModel.wholeRowNavigationDestination != nil {
+                        Image(systemSymbol: .chevronRight)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
             )
         }
     }

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -18,10 +18,10 @@ struct WatchMagicViewRow: View {
         // The confirmation dialog and alerts hang off this per-row container (not a shared parent
         // list): which button triggers them depends on the row variant below.
         Group {
-            if layout == .list, viewModel.hasLightControls {
+            if layout == .list, let controlsDestination = viewModel.controlsDestination {
                 // Two sibling tap targets — the icon toggles, the body opens the controls
                 // screen. Not wrapped in a row `Button`: SwiftUI doesn't support nested buttons.
-                splitLightLabel
+                splitControlsLabel(destination: controlsDestination)
             } else {
                 Button {
                     viewModel.executeItem()
@@ -128,10 +128,11 @@ struct WatchMagicViewRow: View {
         }
     }
 
-    /// A capable light splits the row in two sibling tap targets: the icon keeps toggling while
-    /// the row body pushes the controls screen — the chevron promises a push, so it must not be
-    /// presented modally. The pushed screen resolves in `WatchHomeView`'s destination registration.
-    private var splitLightLabel: some View {
+    /// A capable entity (light, cover, fan) splits the row in two sibling tap targets: the icon
+    /// keeps toggling while the row body pushes its controls screen — the chevron promises a
+    /// push, so it must not be presented modally. The pushed screen resolves in `WatchHomeView`'s
+    /// destination registration.
+    private func splitControlsLabel(destination: WatchHomeNavigation) -> some View {
         WatchHomeItemLabel(
             name: viewModel.item.name(info: viewModel.itemInfo),
             subtitle: subtitleToDisplay,
@@ -144,7 +145,7 @@ struct WatchMagicViewRow: View {
                     .foregroundStyle(.secondary)
             },
             onIconTap: { viewModel.executeItem() },
-            onBodyTap: { navigate(.lightControls(viewModel.item)) }
+            onBodyTap: { navigate(destination) }
         )
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -79,6 +79,15 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         }
     }
 
+    /// The screen the entire row (icon included) opens. Locks never toggle from the home screen —
+    /// they're security-sensitive, so every tap lands on the lock screen where the action is an
+    /// explicit button press. Unlike `controlsDestination` this doesn't wait for the polled state:
+    /// the lock screen itself handles an unknown state by disabling its buttons.
+    var wholeRowNavigationDestination: WatchHomeNavigation? {
+        guard item.type == .entity, item.domain == .lock else { return nil }
+        return .lockControls(item)
+    }
+
     /// The controls screen this row's body pushes, once the polled state proves the entity can do
     /// more than toggle (dim a light, position a cover, set a fan's speed…). Nil until the first
     /// snapshot arrives — or for entities without adjustable capabilities — so a tap just toggles.

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -79,12 +79,21 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         }
     }
 
-    /// True once the polled state proves this light can do more than toggle (dim or tune its
-    /// color temperature). False until the first snapshot arrives, so a tap before then — or on a
-    /// plain on/off light — just toggles.
-    var hasLightControls: Bool {
-        guard item.type == .entity, item.domain == .light, let liveEntity else { return false }
-        return LightCapabilities(entity: liveEntity).hasAdjustableControls
+    /// The controls screen this row's body pushes, once the polled state proves the entity can do
+    /// more than toggle (dim a light, position a cover, set a fan's speed…). Nil until the first
+    /// snapshot arrives — or for entities without adjustable capabilities — so a tap just toggles.
+    var controlsDestination: WatchHomeNavigation? {
+        guard item.type == .entity, let liveEntity, let domain = item.domain else { return nil }
+        switch domain {
+        case .light:
+            return LightCapabilities(entity: liveEntity).hasAdjustableControls ? .lightControls(item) : nil
+        case .cover:
+            return CoverCapabilities(entity: liveEntity).hasAdjustableControls ? .coverControls(item) : nil
+        case .fan:
+            return FanCapabilities(entity: liveEntity).hasAdjustableControls ? .fanControls(item) : nil
+        default:
+            return nil
+        }
     }
 
     // MARK: - Entity state

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -8,6 +8,10 @@ import Shared
 enum WatchHomeNavigation: Hashable {
     /// A folder's contents.
     case folder(String)
-    /// The controls screen (power/brightness/temperature) of a capable light.
+    /// The controls screen (power/brightness/color/temperature) of a capable light.
     case lightControls(MagicItem)
+    /// The controls screen (position/open/stop/close) of a capable cover.
+    case coverControls(MagicItem)
+    /// The controls screen (power/speed) of a capable fan.
+    case fanControls(MagicItem)
 }

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -14,4 +14,6 @@ enum WatchHomeNavigation: Hashable {
     case coverControls(MagicItem)
     /// The controls screen (power/speed) of a capable fan.
     case fanControls(MagicItem)
+    /// The lock screen (lock/unlock/open). Every lock gets one — locks never toggle directly.
+    case lockControls(MagicItem)
 }

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -65,6 +65,8 @@ struct WatchHomeView: View {
                         WatchCoverControlsView(item: item, itemInfo: viewModel.info(for: item))
                     case let .fanControls(item):
                         WatchFanControlsView(item: item, itemInfo: viewModel.info(for: item))
+                    case let .lockControls(item):
+                        WatchLockControlsView(item: item, itemInfo: viewModel.info(for: item))
                     }
                 }
         }

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -61,6 +61,10 @@ struct WatchHomeView: View {
                         WatchFolderContentView(folderId: folderId, viewModel: viewModel)
                     case let .lightControls(item):
                         WatchLightControlsView(item: item, itemInfo: viewModel.info(for: item))
+                    case let .coverControls(item):
+                        WatchCoverControlsView(item: item, itemInfo: viewModel.info(for: item))
+                    case let .fanControls(item):
+                        WatchFanControlsView(item: item, itemInfo: viewModel.info(for: item))
                     }
                 }
         }

--- a/Tests/Shared/CoverCapabilities.test.swift
+++ b/Tests/Shared/CoverCapabilities.test.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct CoverCapabilitiesTests {
+    @Test func positionableCoverSupportsEverything() {
+        let capabilities = CoverCapabilities(attributes: [
+            "supported_features": 15,
+            "current_position": 60,
+        ])
+
+        #expect(capabilities.supportsOpen)
+        #expect(capabilities.supportsClose)
+        #expect(capabilities.supportsStop)
+        #expect(capabilities.supportsSetPosition)
+        #expect(capabilities.hasAdjustableControls)
+        #expect(capabilities.currentPosition == 60)
+    }
+
+    @Test func openCloseOnlyCoverHasNoAdjustableControls() {
+        let capabilities = CoverCapabilities(attributes: [
+            "supported_features": 3,
+        ])
+
+        #expect(capabilities.supportsOpen)
+        #expect(capabilities.supportsClose)
+        #expect(!capabilities.supportsStop)
+        #expect(!capabilities.supportsSetPosition)
+        #expect(!capabilities.hasAdjustableControls)
+        #expect(capabilities.currentPosition == nil)
+    }
+
+    @Test func stopWithoutPositionStillGetsControls() {
+        let capabilities = CoverCapabilities(attributes: [
+            "supported_features": 11,
+        ])
+
+        #expect(capabilities.supportsStop)
+        #expect(!capabilities.supportsSetPosition)
+        #expect(capabilities.hasAdjustableControls)
+    }
+
+    @Test func missingFeaturesMeansNoControls() {
+        let capabilities = CoverCapabilities(attributes: [:])
+
+        #expect(!capabilities.hasAdjustableControls)
+        #expect(!capabilities.supportsOpen)
+    }
+}

--- a/Tests/Shared/FanCapabilities.test.swift
+++ b/Tests/Shared/FanCapabilities.test.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct FanCapabilitiesTests {
+    @Test func speedFanSupportsPercentage() {
+        let capabilities = FanCapabilities(attributes: [
+            "supported_features": 1,
+            "percentage": 50,
+            "percentage_step": 25,
+        ])
+
+        #expect(capabilities.supportsSpeedPercentage)
+        #expect(capabilities.hasAdjustableControls)
+        #expect(capabilities.speedPercentage == 50)
+        #expect(capabilities.percentageStep == 25)
+    }
+
+    @Test func onOffFanHasNoAdjustableControls() {
+        let capabilities = FanCapabilities(attributes: [
+            "supported_features": 0,
+        ])
+
+        #expect(!capabilities.supportsSpeedPercentage)
+        #expect(!capabilities.hasAdjustableControls)
+        #expect(capabilities.speedPercentage == nil)
+    }
+
+    @Test func missingStepDefaultsToOne() {
+        let capabilities = FanCapabilities(attributes: [
+            "supported_features": 1,
+        ])
+
+        #expect(capabilities.percentageStep == 1)
+    }
+
+    @Test func zeroStepFallsBackToOne() {
+        let capabilities = FanCapabilities(attributes: [
+            "supported_features": 1,
+            "percentage_step": 0,
+        ])
+
+        #expect(capabilities.percentageStep == 1)
+    }
+}

--- a/Tests/Shared/LockCapabilities.test.swift
+++ b/Tests/Shared/LockCapabilities.test.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct LockCapabilitiesTests {
+    @Test func openFeatureBitEnablesOpen() {
+        let capabilities = LockCapabilities(attributes: [
+            "supported_features": 1,
+        ])
+
+        #expect(capabilities.supportsOpen)
+    }
+
+    @Test func missingFeaturesMeansNoOpen() {
+        #expect(!LockCapabilities(attributes: [:]).supportsOpen)
+        #expect(!LockCapabilities(attributes: ["supported_features": 0]).supportsOpen)
+    }
+}

--- a/Tests/Shared/Service.test.swift
+++ b/Tests/Shared/Service.test.swift
@@ -34,6 +34,18 @@ struct ServiceTests {
             Service(rawValue: "close_cover") == .closeCover,
             "Service(rawValue: 'close_cover') should initialize to .closeCover"
         )
+        #expect(
+            Service(rawValue: "stop_cover") == .stopCover,
+            "Service(rawValue: 'stop_cover') should initialize to .stopCover"
+        )
+        #expect(
+            Service(rawValue: "set_cover_position") == .setCoverPosition,
+            "Service(rawValue: 'set_cover_position') should initialize to .setCoverPosition"
+        )
+        #expect(
+            Service(rawValue: "set_percentage") == .setPercentage,
+            "Service(rawValue: 'set_percentage') should initialize to .setPercentage"
+        )
         #expect(Service(rawValue: "trigger") == .trigger, "Service(rawValue: 'trigger') should initialize to .trigger")
 
         // Test invalid raw value
@@ -41,8 +53,8 @@ struct ServiceTests {
 
         // Test case count
         #expect(
-            Service.allCases.count == 10,
-            "Service enum should have 10 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
+            Service.allCases.count == 13,
+            "Service enum should have 13 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
         )
     }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Extends the Apple Watch split-tap row behavior (introduced for lights in #5311) to covers and fans, and gives locks a dedicated screen. For covers and fans that support more than on/off, tapping the row icon toggles them and tapping the rest of the row pushes a controls screen: covers get a position slider plus open/stop/close buttons, fans get a power toggle and a speed slider that respects the fan's speed steps. Covers and fans without those capabilities keep toggling from anywhere on the row.

Locks never toggle directly anymore: any tap on a lock row opens a screen with a state-colored icon, the current state, lock/unlock buttons, and an open (unlatch) button when the lock advertises that feature — buttons that can't act on the current state are disabled.

## Screenshots
N/A

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
