### PR TITLE
Only show delete confirmation when editing CarPlay items without run confirmation

### DIFF
--- a/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemFlow.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayAddItemFlow.swift
@@ -221,9 +221,10 @@ final class CarPlayAddItemFlow {
     }
 
     private func presentConfirmation(server: Server, entity: HAAppEntity) {
-        // Control-screen domains (climate) never execute on tap — they open their own screen — so
-        // asking whether running should require confirmation doesn't apply. Add the item directly.
-        if Domain(rawValue: entity.domain)?.hasControlScreen == true {
+        // Control-screen domains (climate) never execute on tap — they open their own screen — and
+        // built-in-confirmation domains (lock) always confirm regardless of the setting, so asking
+        // whether running should require confirmation doesn't apply. Add the item directly.
+        if let domain = Domain(rawValue: entity.domain), domain.hasControlScreen || domain.hasBuiltInConfirmation {
             commit(server: server, entity: entity, requiresConfirmation: false, dismissPresented: false)
             return
         }

--- a/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayEditItemFlow.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayEditItemFlow.swift
@@ -92,13 +92,20 @@ final class CarPlayEditItemFlow {
         interfaceController?.presentTemplate(actionSheet, animated: true, completion: nil)
     }
 
-    /// Whether tapping this item runs an action that a confirmation prompt can guard. Folders
-    /// don't execute anything, and control-screen domains (climate) open their own screen instead
-    /// of executing, so the require-confirmation question doesn't apply to either.
+    /// Whether the per-item "require confirmation" setting has any effect when tapping this item.
+    /// Folders and assist items don't execute a guarded action, control-screen domains (climate)
+    /// open their own screen, and built-in-confirmation domains (lock) always confirm — so the
+    /// require-confirmation question doesn't apply to any of them.
     private func supportsRunConfirmation(_ item: MagicItem) -> Bool {
-        if item.type == .folder { return false }
-        if item.type == .entity, item.domain?.hasControlScreen == true { return false }
-        return true
+        switch item.type {
+        case .folder, .assistPipeline, .assistPrompt:
+            return false
+        case .entity:
+            guard let domain = item.domain else { return true }
+            return !domain.hasControlScreen && !domain.hasBuiltInConfirmation
+        case .script, .scene, .unsupported:
+            return true
+        }
     }
 
     private func delete(item: MagicItem) {

--- a/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayEditItemFlow.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/AddItem/CarPlayEditItemFlow.swift
@@ -80,10 +80,9 @@ final class CarPlayEditItemFlow {
             self?.interfaceController?.dismissTemplate(animated: true, completion: nil)
         }
 
-        // Folders don't execute anything, so a run confirmation doesn't apply to them.
-        let actions: [CPAlertAction] = item.type == .folder
-            ? [deleteAction, cancelAction]
-            : [deleteAction, requireConfirmationAction, noConfirmationAction, cancelAction]
+        let actions: [CPAlertAction] = supportsRunConfirmation(item)
+            ? [deleteAction, requireConfirmationAction, noConfirmationAction, cancelAction]
+            : [deleteAction, cancelAction]
 
         let actionSheet = CPActionSheetTemplate(
             title: title,
@@ -91,6 +90,15 @@ final class CarPlayEditItemFlow {
             actions: actions
         )
         interfaceController?.presentTemplate(actionSheet, animated: true, completion: nil)
+    }
+
+    /// Whether tapping this item runs an action that a confirmation prompt can guard. Folders
+    /// don't execute anything, and control-screen domains (climate) open their own screen instead
+    /// of executing, so the require-confirmation question doesn't apply to either.
+    private func supportsRunConfirmation(_ item: MagicItem) -> Bool {
+        if item.type == .folder { return false }
+        if item.type == .entity, item.domain?.hasControlScreen == true { return false }
+        return true
     }
 
     private func delete(item: MagicItem) {

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -542,6 +542,12 @@ public enum Domain: String, CaseIterable {
         Domain.controlScreenDomains.contains(self)
     }
 
+    /// Whether tapping this domain's entities always presents the domain's own confirmation
+    /// (e.g. lock), so the per-item "require confirmation" setting has no effect.
+    public var hasBuiltInConfirmation: Bool {
+        Domain.builtInConfirmationDomains.contains(self)
+    }
+
     /// Whether the entity icon changes with state/device class (e.g. cover open vs closed),
     /// so list UIs (CarPlay, watch) should render the live entity icon over a saved one.
     public var hasStateDependentIcon: Bool {
@@ -627,6 +633,12 @@ public extension Domain {
     /// frontend's more-info dialog offers.
     static let controlScreenDomains: [Domain] = [
         .climate,
+    ]
+
+    /// Domains that always show their own confirmation when tapped (state-aware lock handling),
+    /// making the per-item "require confirmation" customization irrelevant.
+    static let builtInConfirmationDomains: [Domain] = [
+        .lock,
     ]
 
     /// Everything the user can put on the watch home screen: the runnable domains, the display-only

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -374,6 +374,20 @@ struct DomainFeatureSupportTests {
         }
     }
 
+    @Test func builtInConfirmationMembership() {
+        let expected: Set<Domain> = [.lock]
+        #expect(
+            Set(Domain.builtInConfirmationDomains) == expected,
+            "Domain.builtInConfirmationDomains membership changed"
+        )
+        for domain in Domain.allCases {
+            #expect(
+                domain.hasBuiltInConfirmation == expected.contains(domain),
+                "hasBuiltInConfirmation mismatch for Domain.\(domain)"
+            )
+        }
+    }
+
     @Test func controlScreenDomainsAreNeitherRunnableNorDisplayOnly() {
         // A control-screen domain's tap opens its own screen; an action or the sensor details
         // screen competing for the same tap would be ambiguous.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
When editing Quick Access items from CarPlay itself, tapping an entity whose domain doesn't support run confirmation (control-screen domains such as climate) now only offers Delete and Cancel, instead of also asking whether running should require confirmation. This matches the add-item flow, which already skips the confirmation question for these domains, and the logic is generic via `Domain.hasControlScreen` so future control-screen domains behave the same.

## Screenshots
Not applicable (CarPlay action sheet change).

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_016i4hs4kK8jandJaC5cyCMf)_