### PR TITLE
Add areas browsing to Apple Watch home

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2067,6 +2067,8 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.configuration.folder_name.title" = "Folder Name";
 "watch.configuration.header.subtitle" = "Customize the items, folders and layout shown on your Apple Watch.";
 "watch.configuration.header.title" = "Apple Watch";
+"watch.configuration.hide_areas.footer" = "Areas let you browse and control compatible entities on your Apple Watch without adding them as items.";
+"watch.configuration.hide_areas.title" = "Hide areas in home";
 "watch.configuration.items.title" = "Items";
 "watch.configuration.layout.footer" = "Grid layout only displays icons.";
 "watch.configuration.layout.title" = "Layout";
@@ -2140,6 +2142,8 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.entity_details.stale" = "Couldn't refresh from the server. This value may be out of date.";
 "watch.fan_controls.power" = "Power";
 "watch.fan_controls.speed" = "Speed";
+"watch.home.areas.empty" = "There are no compatible entities in this area.";
+"watch.home.areas.title" = "Areas";
 "watch.home.cancel_and_use_cache.title" = "Cancel and use cache";
 "watch.home.loading.skip.title" = "Skip";
 "watch.home.run.confirmation.title" = "Are you sure you want to run \"%@\"?";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2143,6 +2143,8 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.fan_controls.power" = "Power";
 "watch.fan_controls.speed" = "Speed";
 "watch.home.areas.empty" = "There are no compatible entities in this area.";
+"watch.home.areas.section.controls.title" = "Controls";
+"watch.home.areas.section.sensors.title" = "Sensors";
 "watch.home.areas.title" = "Areas";
 "watch.home.cancel_and_use_cache.title" = "Cancel and use cache";
 "watch.home.loading.skip.title" = "Skip";

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -44,6 +44,7 @@ struct WatchConfigurationView: View {
                 isLoaded = true
             }
             layoutSection
+            areasSection
             itemsSection
             assistSection
             resetView
@@ -116,6 +117,19 @@ struct WatchConfigurationView: View {
             }
         } footer: {
             Text(verbatim: L10n.Watch.Configuration.Layout.footer)
+        }
+    }
+
+    private var areasSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { viewModel.watchConfig.resolvedHideAreas },
+                set: { viewModel.watchConfig.hideAreas = $0 }
+            )) {
+                Text(verbatim: L10n.Watch.Configuration.HideAreas.title)
+            }
+        } footer: {
+            Text(verbatim: L10n.Watch.Configuration.HideAreas.footer)
         }
     }
 
@@ -289,6 +303,7 @@ extension WatchConfigurationView: SettingsScreenSearchable {
             SettingsSearchEntry(L10n.Watch.Configuration.AddItem.title),
             SettingsSearchEntry(L10n.Watch.Configuration.AddFolder.title),
             SettingsSearchEntry(L10n.Watch.Configuration.ShowAssist.title),
+            SettingsSearchEntry(L10n.Watch.Configuration.HideAreas.title),
             SettingsSearchEntry(L10n.Watch.Labels.SelectedPipeline.title),
         ]
     }

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -59,6 +59,7 @@ public enum DatabaseTables {
         case assist
         case items
         case layout
+        case hideAreas
         case lastModified
     }
 

--- a/Sources/Shared/Database/Tables/WatchConfigTable.swift
+++ b/Sources/Shared/Database/Tables/WatchConfigTable.swift
@@ -17,6 +17,7 @@ final class WatchConfigTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.WatchConfig.assist.rawValue, .jsonText).notNull()
                     t.column(DatabaseTables.WatchConfig.items.rawValue, .jsonText).notNull()
                     t.column(DatabaseTables.WatchConfig.layout.rawValue, .text)
+                    t.column(DatabaseTables.WatchConfig.hideAreas.rawValue, .boolean)
                     t.column(DatabaseTables.WatchConfig.lastModified.rawValue, .double)
                 }
             }

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -647,6 +647,34 @@ public extension Domain {
     /// the watch can execute with a single tap.
     static let watchAddable: [Domain] = watchSupported + watchDisplayOnly + controlScreenDomains
 
+    /// Display order of the watch area screens' controllable entities, most commonly used domains
+    /// first (same spirit as `commonlyUsedWidgetSupported`, extended to every watch-runnable
+    /// domain). Domains not listed sort last.
+    static let watchAreaControlsOrder: [Domain] = [
+        .light,
+        .switch,
+        .lock,
+        .cover,
+        .climate,
+        .fan,
+        .scene,
+        .script,
+        .humidifier,
+        .valve,
+        .inputBoolean,
+        .button,
+        .inputButton,
+        .automation,
+    ]
+
+    /// Sort index into `watchAreaControlsOrder`; unknown or unlisted domains go last.
+    static func watchAreaControlsSortIndex(for domain: Domain?) -> Int {
+        guard let domain, let index = watchAreaControlsOrder.firstIndex(of: domain) else {
+            return watchAreaControlsOrder.count
+        }
+        return index
+    }
+
     static let commonlyUsedWidgetSupported: [Domain] = [
         .light,
         .switch,

--- a/Sources/Shared/Environment/AppArea+Queries.swift
+++ b/Sources/Shared/Environment/AppArea+Queries.swift
@@ -12,6 +12,14 @@ public extension AppArea {
         }
     }
 
+    /// Fetch all areas across every server, each server's areas in display order
+    static func fetchAllAreas() throws -> [AppArea] {
+        try Current.database().read { db in
+            try AppArea.fetchAll(db)
+        }
+        .sorted(by: sortForDisplay(_:_:))
+    }
+
     /// Fetch a specific area by ID
     static func fetchArea(id: String) throws -> AppArea? {
         try Current.database().read { db in

--- a/Sources/Shared/HAAppEntity.swift
+++ b/Sources/Shared/HAAppEntity.swift
@@ -52,6 +52,19 @@ public extension HAAppEntity {
         })
     }
 
+    /// Entity ids the watch area screens can render for a server: watch-addable domains, without
+    /// config/diagnostic entities. Used to drop areas that would show an empty screen.
+    static func watchAreaEntityIds(serverId: String) throws -> Set<String> {
+        let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+        let entities = try Current.database().read { db in
+            try HAAppEntity
+                .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
+                .fetchAll(db)
+        }
+        let compatible = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+        return Set(compatible.map(\.entityId))
+    }
+
     static func entity(id: String, serverId: String) -> HAAppEntity? {
         do {
             return try Current.database().read { db in

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6750,6 +6750,12 @@ public enum L10n {
         /// Apple Watch
         public static var title: String { return L10n.tr("Localizable", "watch.configuration.header.title") }
       }
+      public enum HideAreas {
+        /// Areas let you browse and control compatible entities on your Apple Watch without adding them as items.
+        public static var footer: String { return L10n.tr("Localizable", "watch.configuration.hide_areas.footer") }
+        /// Hide areas in home
+        public static var title: String { return L10n.tr("Localizable", "watch.configuration.hide_areas.title") }
+      }
       public enum Items {
         /// Items
         public static var title: String { return L10n.tr("Localizable", "watch.configuration.items.title") }
@@ -7010,6 +7016,12 @@ public enum L10n {
       public static var speed: String { return L10n.tr("Localizable", "watch.fan_controls.speed") }
     }
     public enum Home {
+      public enum Areas {
+        /// There are no compatible entities in this area.
+        public static var empty: String { return L10n.tr("Localizable", "watch.home.areas.empty") }
+        /// Areas
+        public static var title: String { return L10n.tr("Localizable", "watch.home.areas.title") }
+      }
       public enum CancelAndUseCache {
         /// Cancel and use cache
         public static var title: String { return L10n.tr("Localizable", "watch.home.cancel_and_use_cache.title") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7021,6 +7021,16 @@ public enum L10n {
         public static var empty: String { return L10n.tr("Localizable", "watch.home.areas.empty") }
         /// Areas
         public static var title: String { return L10n.tr("Localizable", "watch.home.areas.title") }
+        public enum Section {
+          public enum Controls {
+            /// Controls
+            public static var title: String { return L10n.tr("Localizable", "watch.home.areas.section.controls.title") }
+          }
+          public enum Sensors {
+            /// Sensors
+            public static var title: String { return L10n.tr("Localizable", "watch.home.areas.section.sensors.title") }
+          }
+        }
       }
       public enum CancelAndUseCache {
         /// Cancel and use cache

--- a/Sources/Shared/Watch/WatchConfig.swift
+++ b/Sources/Shared/Watch/WatchConfig.swift
@@ -7,6 +7,9 @@ public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord {
     public var assist: Assist = .init(showAssist: true)
     public var items: [MagicItem] = []
     public var layout: WatchLayout?
+    /// Whether the watch home screen hides the automatic area rows. Optional so rows/payloads created
+    /// before this column existed decode as `nil` (areas shown).
+    public var hideAreas: Bool?
     /// Epoch (seconds) of the last edit, on either the iPhone or the watch. Used for last-writer /
     /// conflict resolution when the watch is configured offline. Optional so rows created before this
     /// column existed decode as `nil`.
@@ -17,17 +20,23 @@ public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord {
         assist: Assist = Assist(showAssist: true),
         items: [MagicItem] = [],
         layout: WatchLayout? = nil,
+        hideAreas: Bool? = nil,
         lastModified: Double? = nil
     ) {
         self.id = id
         self.assist = assist
         self.items = items
         self.layout = layout
+        self.hideAreas = hideAreas
         self.lastModified = lastModified
     }
 
     public var resolvedLayout: WatchLayout {
         layout ?? .list
+    }
+
+    public var resolvedHideAreas: Bool {
+        hideAreas ?? false
     }
 
     /// Stamp `lastModified` with the current time. Call whenever the config is edited before saving.

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -149,9 +149,17 @@ public struct WatchDatabaseMirror: WatchCodable {
         let servers = Current.servers.restorableState()
 
         return try Current.database().read { db in
+            // The watch never receives the full registry, so it can't filter hidden entities
+            // itself — exclude them here, matching the iPhone entity picker.
+            let hiddenKeys = try Set(
+                EntityRegistryListForDisplay.Entity.fetchAll(db)
+                    .filter(\.isHidden)
+                    .map { ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId) }
+            )
             let entities = try HAAppEntity
                 .filter(mirroredDomains.contains(Column(DatabaseTables.AppEntity.domain.rawValue)))
                 .fetchAll(db)
+                .filter { !hiddenKeys.contains(ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId)) }
             let areas = try AppArea.fetchAll(db)
             let pipelines = try AssistPipelines.fetchAll(db)
             return WatchDatabaseMirror(

--- a/Sources/Shared/Watch/WatchHomeAreasMode.swift
+++ b/Sources/Shared/Watch/WatchHomeAreasMode.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// How the watch home screen presents the automatic area rows, so users can browse and control
+/// entities by area without configuring items first.
+public enum WatchHomeAreasMode: Equatable {
+    /// No area rows: the user hid them, or no area contains a watch-compatible entity.
+    case hidden
+    /// Few enough areas on a single server to list each one directly on the home screen.
+    case inline([AppArea])
+    /// A single "Areas" row that drills into the server picker (multiple servers) or the area list.
+    case grouped(serverIds: [String])
+
+    /// Above this many areas the home screen collapses them into the single grouped row.
+    public static var maxInlineAreas: Int { 5 }
+
+    /// Decides the presentation from the mirrored data. Areas without any watch-compatible entity
+    /// are dropped — their screen would always be empty.
+    public static func compute(
+        areas: [AppArea],
+        watchEntityIdsByServer: [String: Set<String>],
+        hideAreas: Bool
+    ) -> WatchHomeAreasMode {
+        guard !hideAreas else { return .hidden }
+        let populatedAreas = areas.filter { area in
+            guard let entityIds = watchEntityIdsByServer[area.serverId] else { return false }
+            return !area.entities.isDisjoint(with: entityIds)
+        }
+        guard !populatedAreas.isEmpty else { return .hidden }
+        // Ordered by first appearance so the picker follows the areas' display order.
+        var serverIds: [String] = []
+        for area in populatedAreas where !serverIds.contains(area.serverId) {
+            serverIds.append(area.serverId)
+        }
+        if serverIds.count == 1, populatedAreas.count <= maxInlineAreas {
+            return .inline(populatedAreas)
+        }
+        return .grouped(serverIds: serverIds)
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesView.swift
@@ -1,0 +1,76 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// The watch-compatible entities of one area, pushed by `WatchAreaRow` through the home screen's
+/// `NavigationStack`. Rows are the same `WatchMagicViewRow` the home screen uses, so entities can
+/// be controlled exactly as if they were configured items. The navigation bar stays hidden — the
+/// custom header provides the back button, matching `WatchFolderContentView`.
+struct WatchAreaEntitiesView: View {
+    @StateObject private var viewModel: WatchAreaEntitiesViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(areaId: String, serverId: String) {
+        self._viewModel = .init(wrappedValue: .init(areaId: areaId, serverId: serverId))
+    }
+
+    var body: some View {
+        List {
+            header
+            if let entries = viewModel.entries {
+                if entries.isEmpty {
+                    Text(verbatim: L10n.Watch.Home.Areas.empty)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .listRowBackground(Color.clear)
+                } else {
+                    ForEach(entries) { entry in
+                        WatchMagicViewRow(item: entry.item, itemInfo: entry.info)
+                    }
+                }
+            } else {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+            }
+        }
+        .ignoresSafeArea([.all], edges: .top)
+        .navigationTitle("")
+        .navigationBarBackButtonHidden(true)
+        .modify { view in
+            if #available(watchOS 11.0, *) {
+                view.toolbarVisibility(.hidden, for: .navigationBar)
+            } else {
+                view.toolbar(.hidden, for: .navigationBar)
+            }
+        }
+        .onAppear {
+            viewModel.load()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemSymbol: .chevronLeft)
+            }
+            .buttonStyle(.plain)
+            .circularGlassOrLegacyBackground()
+            Text(viewModel.areaName ?? L10n.Watch.Home.Areas.title)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .listRowBackground(Color.clear)
+        .padding(.top, DesignSystem.Spaces.one)
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return NavigationStack {
+        WatchAreaEntitiesView(areaId: "living_room", serverId: "1")
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesView.swift
@@ -17,15 +17,30 @@ struct WatchAreaEntitiesView: View {
     var body: some View {
         List {
             header
-            if let entries = viewModel.entries {
-                if entries.isEmpty {
+            if let content = viewModel.content {
+                if content.isEmpty {
                     Text(verbatim: L10n.Watch.Home.Areas.empty)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .listRowBackground(Color.clear)
                 } else {
-                    ForEach(entries) { entry in
-                        WatchMagicViewRow(item: entry.item, itemInfo: entry.info)
+                    if !content.controls.isEmpty {
+                        Section {
+                            ForEach(content.controls) { entry in
+                                WatchMagicViewRow(item: entry.item, itemInfo: entry.info)
+                            }
+                        } header: {
+                            Text(verbatim: L10n.Watch.Home.Areas.Section.Controls.title)
+                        }
+                    }
+                    if !content.sensors.isEmpty {
+                        Section {
+                            ForEach(content.sensors) { entry in
+                                WatchMagicViewRow(item: entry.item, itemInfo: entry.info)
+                            }
+                        } header: {
+                            Text(verbatim: L10n.Watch.Home.Areas.Section.Sensors.title)
+                        }
                     }
                 }
             } else {

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -10,10 +10,19 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
         var id: String { item.serverUniqueId }
     }
 
+    /// The area's entities split into the sections the screen renders: controllable entities
+    /// first, display-only sensors after.
+    struct Content {
+        let controls: [Entry]
+        let sensors: [Entry]
+
+        var isEmpty: Bool { controls.isEmpty && sensors.isEmpty }
+    }
+
     @Published private(set) var areaName: String?
     /// `nil` until the first load finishes (spinner); empty afterwards means the area has no
     /// watch-compatible entities.
-    @Published private(set) var entries: [Entry]?
+    @Published private(set) var content: Content?
 
     let areaId: String
     let serverId: String
@@ -32,14 +41,14 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
     func load() {
         // `onAppear` fires again when the user navigates back from a pushed controls screen;
         // a finished load is kept, matching the add flow.
-        guard entries == nil, !isLoading else { return }
+        guard content == nil, !isLoading else { return }
         isLoading = true
         let areaId = areaId
         let serverId = serverId
         Self.loadQueue.async { [weak self] in
             guard let area = try? AppArea.fetchArea(areaId: areaId, serverId: serverId) else {
                 DispatchQueue.main.async { [weak self] in
-                    self?.entries = []
+                    self?.content = Content(controls: [], sensors: [])
                     self?.isLoading = false
                 }
                 return
@@ -59,9 +68,14 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
                         guard let info = provider.getInfo(for: item) else { return nil }
                         return Entry(item: item, info: info)
                     }
+                // Controllable entities come first; display-only sensors get their own section.
+                let content = Content(
+                    controls: entries.filter { !$0.item.isWatchDisplayOnly },
+                    sensors: entries.filter(\.item.isWatchDisplayOnly)
+                )
                 DispatchQueue.main.async { [weak self] in
                     self?.areaName = area.name
-                    self?.entries = entries
+                    self?.content = content
                     self?.isLoading = false
                 }
             }

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -68,9 +68,19 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
                         guard let info = provider.getInfo(for: item) else { return nil }
                         return Entry(item: item, info: info)
                     }
-                // Controllable entities come first; display-only sensors get their own section.
+                // Controllable entities come first, ordered by most commonly used domain (then
+                // name — `entries` is name-sorted, but Swift's sort isn't guaranteed stable);
+                // display-only sensors get their own section.
+                let controls = entries
+                    .filter { !$0.item.isWatchDisplayOnly }
+                    .sorted { lhs, rhs in
+                        let lhsIndex = Domain.watchAreaControlsSortIndex(for: lhs.item.domain)
+                        let rhsIndex = Domain.watchAreaControlsSortIndex(for: rhs.item.domain)
+                        if lhsIndex != rhsIndex { return lhsIndex < rhsIndex }
+                        return lhs.info.name.localizedCaseInsensitiveCompare(rhs.info.name) == .orderedAscending
+                    }
                 let content = Content(
-                    controls: entries.filter { !$0.item.isWatchDisplayOnly },
+                    controls: controls,
                     sensors: entries.filter(\.item.isWatchDisplayOnly)
                 )
                 DispatchQueue.main.async { [weak self] in

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -37,13 +37,19 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
         let areaId = areaId
         let serverId = serverId
         Self.loadQueue.async { [weak self] in
-            let area = (try? AppArea.fetchArea(areaId: areaId, serverId: serverId)) ?? nil
+            guard let area = try? AppArea.fetchArea(areaId: areaId, serverId: serverId) else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.entries = []
+                    self?.isLoading = false
+                }
+                return
+            }
             let provider = Current.magicItemProvider()
             provider.loadInformation { entitiesPerServer in
                 let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
                 let entries: [Entry] = (entitiesPerServer[serverId] ?? [])
                     .filter { entity in
-                        area?.entities.contains(entity.entityId) == true
+                        area.entities.contains(entity.entityId)
                             && allowedDomains.contains(entity.domain)
                             && entity.entityCategory == nil
                     }
@@ -54,7 +60,7 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
                         return Entry(item: item, info: info)
                     }
                 DispatchQueue.main.async { [weak self] in
-                    self?.areaName = area?.name
+                    self?.areaName = area.name
                     self?.entries = entries
                     self?.isLoading = false
                 }

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Shared
+
+final class WatchAreaEntitiesViewModel: ObservableObject {
+    /// An area entity rendered as a home-style row: the on-the-fly item plus its resolved info.
+    struct Entry: Identifiable {
+        let item: MagicItem
+        let info: MagicItem.Info
+
+        var id: String { item.serverUniqueId }
+    }
+
+    @Published private(set) var areaName: String?
+    /// `nil` until the first load finishes (spinner); empty afterwards means the area has no
+    /// watch-compatible entities.
+    @Published private(set) var entries: [Entry]?
+
+    let areaId: String
+    let serverId: String
+
+    /// Serial queue for the candidate build — `loadInformation` and the info lookups are synchronous
+    /// database work that would freeze the UI on the main thread (same reasoning as the add flow's
+    /// `availableItemsQueue`).
+    private static let loadQueue = DispatchQueue(label: "watch-area-entities", qos: .userInitiated)
+    private var isLoading = false
+
+    init(areaId: String, serverId: String) {
+        self.areaId = areaId
+        self.serverId = serverId
+    }
+
+    func load() {
+        // `onAppear` fires again when the user navigates back from a pushed controls screen;
+        // a finished load is kept, matching the add flow.
+        guard entries == nil, !isLoading else { return }
+        isLoading = true
+        let areaId = areaId
+        let serverId = serverId
+        Self.loadQueue.async { [weak self] in
+            let area = (try? AppArea.fetchArea(areaId: areaId, serverId: serverId)) ?? nil
+            let provider = Current.magicItemProvider()
+            provider.loadInformation { entitiesPerServer in
+                let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+                let entries: [Entry] = (entitiesPerServer[serverId] ?? [])
+                    .filter { entity in
+                        area?.entities.contains(entity.entityId) == true
+                            && allowedDomains.contains(entity.domain)
+                            && entity.entityCategory == nil
+                    }
+                    .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                    .compactMap { entity in
+                        let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
+                        guard let info = provider.getInfo(for: item) else { return nil }
+                        return Entry(item: item, info: info)
+                    }
+                DispatchQueue.main.async { [weak self] in
+                    self?.areaName = area?.name
+                    self?.entries = entries
+                    self?.isLoading = false
+                }
+            }
+        }
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreaRow.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaRow.swift
@@ -1,0 +1,74 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// A single area on the home screen or the per-server area list; tapping pushes the area's
+/// entities through the home stack's `watchNavigate` action.
+struct WatchAreaRow: View {
+    let area: AppArea
+    @Environment(\.watchNavigate) private var navigate
+
+    var body: some View {
+        Button {
+            navigate(.areaEntities(areaId: area.areaId, serverId: area.serverId))
+        } label: {
+            WatchHomeItemLabel(
+                name: area.name,
+                textColor: .white,
+                icon: {
+                    VStack {
+                        Image(uiImage: icon.image(
+                            ofSize: .init(width: 24, height: 24),
+                            color: .white
+                        ))
+                        .padding()
+                    }
+                    .watchRowIconContainer(color: .white)
+                },
+                accessory: {
+                    Image(systemSymbol: .chevronRight)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .watchHomeItemRowStyle(tint: nil)
+    }
+
+    private var icon: MaterialDesignIcons {
+        if let iconName = area.icon {
+            // The frontend's default icon for areas without a custom one.
+            return MaterialDesignIcons(serversideValueNamed: iconName, fallback: .textureBoxIcon)
+        }
+        return .textureBoxIcon
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return List {
+        WatchAreaRow(area: .init(
+            id: "1-living_room",
+            serverId: "1",
+            areaId: "living_room",
+            name: "Living Room",
+            aliases: [],
+            picture: nil,
+            icon: "mdi:sofa",
+            sortOrder: nil,
+            entities: ["light.living_room"]
+        ))
+        WatchAreaRow(area: .init(
+            id: "1-kitchen",
+            serverId: "1",
+            areaId: "kitchen",
+            name: "Kitchen",
+            aliases: [],
+            picture: nil,
+            icon: nil,
+            sortOrder: nil,
+            entities: ["light.kitchen"]
+        ))
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreasGroupRow.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasGroupRow.swift
@@ -2,17 +2,18 @@ import SFSafeSymbols
 import Shared
 import SwiftUI
 
-/// A single area on the home screen or the per-server area list; tapping pushes the area's
-/// entities through the home stack's `watchNavigate` action. Renders as an icon-only tile in
+/// The single grouped "Areas" entry on the home screen, shown when there are too many areas (or
+/// multiple servers) to list them inline. Tapping pushes the destination the view model resolved:
+/// the server picker, or straight to the only server's area list. Renders as an icon-only tile in
 /// the grid layout, matching `WatchFolderRow`.
-struct WatchAreaRow: View {
-    let area: AppArea
+struct WatchAreasGroupRow: View {
+    let destination: WatchHomeNavigation
     var layout: WatchLayout = .list
     @Environment(\.watchNavigate) private var navigate
 
     var body: some View {
         Button {
-            navigate(.areaEntities(areaId: area.areaId, serverId: area.serverId))
+            navigate(destination)
         } label: {
             label
         }
@@ -30,20 +31,20 @@ struct WatchAreaRow: View {
     @ViewBuilder
     private var label: some View {
         if layout == .grid {
-            Image(uiImage: icon.image(
+            Image(uiImage: MaterialDesignIcons.textureBoxIcon.image(
                 ofSize: .init(width: 28, height: 28),
                 color: .white
             ))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
-            .accessibilityLabel(Text(area.name))
+            .accessibilityLabel(Text(L10n.Watch.Home.Areas.title))
         } else {
             WatchHomeItemLabel(
-                name: area.name,
+                name: L10n.Watch.Home.Areas.title,
                 textColor: .white,
                 icon: {
                     VStack {
-                        Image(uiImage: icon.image(
+                        Image(uiImage: MaterialDesignIcons.textureBoxIcon.image(
                             ofSize: .init(width: 24, height: 24),
                             color: .white
                         ))
@@ -59,40 +60,19 @@ struct WatchAreaRow: View {
             )
         }
     }
-
-    private var icon: MaterialDesignIcons {
-        if let iconName = area.icon {
-            // The frontend's default icon for areas without a custom one.
-            return MaterialDesignIcons(serversideValueNamed: iconName, fallback: .textureBoxIcon)
-        }
-        return .textureBoxIcon
-    }
 }
 
 #Preview {
     MaterialDesignIcons.register()
     return List {
-        WatchAreaRow(area: .init(
-            id: "1-living_room",
-            serverId: "1",
-            areaId: "living_room",
-            name: "Living Room",
-            aliases: [],
-            picture: nil,
-            icon: "mdi:sofa",
-            sortOrder: nil,
-            entities: ["light.living_room"]
-        ))
-        WatchAreaRow(area: .init(
-            id: "1-kitchen",
-            serverId: "1",
-            areaId: "kitchen",
-            name: "Kitchen",
-            aliases: [],
-            picture: nil,
-            icon: nil,
-            sortOrder: nil,
-            entities: ["light.kitchen"]
-        ))
+        WatchAreasGroupRow(destination: .areasList(serverId: "1"))
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 60), spacing: DesignSystem.Spaces.one)],
+            spacing: DesignSystem.Spaces.one
+        ) {
+            WatchAreasGroupRow(destination: .areasList(serverId: "1"), layout: .grid)
+        }
+        .listRowBackground(Color.clear)
+        .listRowInsets(EdgeInsets())
     }
 }

--- a/Sources/WatchApp/Home/Areas/WatchAreasListView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasListView.swift
@@ -1,0 +1,67 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// One server's areas, pushed by the grouped areas row (directly, or through the server picker
+/// when multiple servers have areas). The navigation bar stays hidden — the custom header provides
+/// the back button, matching `WatchFolderContentView`.
+struct WatchAreasListView: View {
+    let serverId: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var areas: [AppArea] = []
+
+    var body: some View {
+        List {
+            header
+            ForEach(areas, id: \.id) { area in
+                WatchAreaRow(area: area)
+            }
+        }
+        .ignoresSafeArea([.all], edges: .top)
+        .navigationTitle("")
+        .navigationBarBackButtonHidden(true)
+        .modify { view in
+            if #available(watchOS 11.0, *) {
+                view.toolbarVisibility(.hidden, for: .navigationBar)
+            } else {
+                view.toolbar(.hidden, for: .navigationBar)
+            }
+        }
+        .onAppear {
+            areas = (try? AppArea.fetchAreas(for: serverId)) ?? []
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemSymbol: .chevronLeft)
+            }
+            .buttonStyle(.plain)
+            .circularGlassOrLegacyBackground()
+            Text(verbatim: title)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .listRowBackground(Color.clear)
+        .padding(.top, DesignSystem.Spaces.one)
+    }
+
+    /// The server name only helps when the config spans multiple servers; otherwise "Areas".
+    private var title: String {
+        guard Current.servers.all.count > 1,
+              let server = Current.servers.server(forServerIdentifier: serverId) else {
+            return L10n.Watch.Home.Areas.title
+        }
+        return server.info.name
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return NavigationStack {
+        WatchAreasListView(serverId: "1")
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreasListView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasListView.swift
@@ -3,12 +3,17 @@ import Shared
 import SwiftUI
 
 /// One server's areas, pushed by the grouped areas row (directly, or through the server picker
-/// when multiple servers have areas). The navigation bar stays hidden — the custom header provides
-/// the back button, matching `WatchFolderContentView`.
+/// when multiple servers have areas). Areas without watch-compatible entities are dropped, the
+/// same rule the home screen applies. The navigation bar stays hidden — the custom header
+/// provides the back button, matching `WatchFolderContentView`.
 struct WatchAreasListView: View {
     let serverId: String
     @Environment(\.dismiss) private var dismiss
     @State private var areas: [AppArea] = []
+
+    /// Serial queue for the area load — the fetches are synchronous database reads that would
+    /// block the main thread.
+    private static let loadQueue = DispatchQueue(label: "watch-areas-list", qos: .userInitiated)
 
     var body: some View {
         List {
@@ -28,7 +33,19 @@ struct WatchAreasListView: View {
             }
         }
         .onAppear {
-            areas = (try? AppArea.fetchAreas(for: serverId)) ?? []
+            loadAreas()
+        }
+    }
+
+    private func loadAreas() {
+        let serverId = serverId
+        Self.loadQueue.async {
+            let allAreas = (try? AppArea.fetchAreas(for: serverId)) ?? []
+            let entityIds = (try? HAAppEntity.watchAreaEntityIds(serverId: serverId)) ?? []
+            let populatedAreas = allAreas.filter { !$0.entities.isDisjoint(with: entityIds) }
+            DispatchQueue.main.async {
+                areas = populatedAreas
+            }
         }
     }
 

--- a/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
@@ -2,12 +2,14 @@ import SFSafeSymbols
 import Shared
 import SwiftUI
 
-/// The server chooser of the grouped areas row, shown only when more than one server has areas.
-/// Each row pushes that server's area list through the home stack's `watchNavigate` action.
+/// The server chooser of the grouped areas row, shown only when more than one server has areas
+/// with watch-compatible entities — the ids come from `WatchHomeAreasMode.grouped(serverIds:)`,
+/// so servers whose areas the home screen dropped never appear here. Each row pushes that
+/// server's area list through the home stack's `watchNavigate` action.
 struct WatchAreasServerPickerView: View {
+    let serverIds: [String]
     @Environment(\.dismiss) private var dismiss
     @Environment(\.watchNavigate) private var navigate
-    @State private var servers: [Server] = []
 
     var body: some View {
         List {
@@ -37,9 +39,10 @@ struct WatchAreasServerPickerView: View {
                 view.toolbar(.hidden, for: .navigationBar)
             }
         }
-        .onAppear {
-            loadServers()
-        }
+    }
+
+    private var servers: [Server] {
+        serverIds.compactMap { Current.servers.server(forServerIdentifier: $0) }
     }
 
     private var header: some View {
@@ -58,17 +61,11 @@ struct WatchAreasServerPickerView: View {
         .listRowBackground(Color.clear)
         .padding(.top, DesignSystem.Spaces.one)
     }
-
-    /// Only servers that actually have areas — a server without them would push an empty list.
-    private func loadServers() {
-        let serverIdsWithAreas = Set(((try? AppArea.fetchAllAreas()) ?? []).map(\.serverId))
-        servers = Current.servers.all.filter { serverIdsWithAreas.contains($0.identifier.rawValue) }
-    }
 }
 
 #Preview {
     MaterialDesignIcons.register()
     return NavigationStack {
-        WatchAreasServerPickerView()
+        WatchAreasServerPickerView(serverIds: ["1", "2"])
     }
 }

--- a/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
@@ -1,0 +1,74 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// The server chooser of the grouped areas row, shown only when more than one server has areas.
+/// Each row pushes that server's area list through the home stack's `watchNavigate` action.
+struct WatchAreasServerPickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.watchNavigate) private var navigate
+    @State private var servers: [Server] = []
+
+    var body: some View {
+        List {
+            header
+            ForEach(servers, id: \.identifier.rawValue) { server in
+                Button {
+                    navigate(.areasList(serverId: server.identifier.rawValue))
+                } label: {
+                    HStack {
+                        Text(verbatim: server.info.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(systemSymbol: .chevronRight)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .watchItemRowStyle()
+            }
+        }
+        .ignoresSafeArea([.all], edges: .top)
+        .navigationTitle("")
+        .navigationBarBackButtonHidden(true)
+        .modify { view in
+            if #available(watchOS 11.0, *) {
+                view.toolbarVisibility(.hidden, for: .navigationBar)
+            } else {
+                view.toolbar(.hidden, for: .navigationBar)
+            }
+        }
+        .onAppear {
+            loadServers()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemSymbol: .chevronLeft)
+            }
+            .buttonStyle(.plain)
+            .circularGlassOrLegacyBackground()
+            Text(verbatim: L10n.Watch.Home.Areas.title)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .listRowBackground(Color.clear)
+        .padding(.top, DesignSystem.Spaces.one)
+    }
+
+    /// Only servers that actually have areas — a server without them would push an empty list.
+    private func loadServers() {
+        let serverIdsWithAreas = Set(((try? AppArea.fetchAllAreas()) ?? []).map(\.serverId))
+        servers = Current.servers.all.filter { serverIdsWithAreas.contains($0.identifier.rawValue) }
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return NavigationStack {
+        WatchAreasServerPickerView()
+    }
+}

--- a/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreasServerPickerView.swift
@@ -1,71 +1,35 @@
-import SFSafeSymbols
 import Shared
 import SwiftUI
 
 /// The server chooser of the grouped areas row, shown only when more than one server has areas
 /// with watch-compatible entities — the ids come from `WatchHomeAreasMode.grouped(serverIds:)`,
-/// so servers whose areas the home screen dropped never appear here. Each row pushes that
+/// so servers whose areas the home screen dropped never appear here. Plain rows and a system
+/// navigation title, matching the entity picker (add) flow's server list. Each row pushes that
 /// server's area list through the home stack's `watchNavigate` action.
 struct WatchAreasServerPickerView: View {
     let serverIds: [String]
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.watchNavigate) private var navigate
 
     var body: some View {
         List {
-            header
             ForEach(servers, id: \.identifier.rawValue) { server in
                 Button {
                     navigate(.areasList(serverId: server.identifier.rawValue))
                 } label: {
-                    HStack {
-                        Text(verbatim: server.info.name)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Image(systemSymbol: .chevronRight)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
+                    Text(verbatim: server.info.name)
                 }
-                .watchItemRowStyle()
             }
         }
-        .ignoresSafeArea([.all], edges: .top)
-        .navigationTitle("")
-        .navigationBarBackButtonHidden(true)
-        .modify { view in
-            if #available(watchOS 11.0, *) {
-                view.toolbarVisibility(.hidden, for: .navigationBar)
-            } else {
-                view.toolbar(.hidden, for: .navigationBar)
-            }
-        }
+        .navigationTitle(Text(verbatim: L10n.Watch.Config.Assist.selectServer))
     }
 
     private var servers: [Server] {
         serverIds.compactMap { Current.servers.server(forServerIdentifier: $0) }
     }
-
-    private var header: some View {
-        HStack {
-            Button {
-                dismiss()
-            } label: {
-                Image(systemSymbol: .chevronLeft)
-            }
-            .buttonStyle(.plain)
-            .circularGlassOrLegacyBackground()
-            Text(verbatim: L10n.Watch.Home.Areas.title)
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .listRowBackground(Color.clear)
-        .padding(.top, DesignSystem.Spaces.one)
-    }
 }
 
 #Preview {
-    MaterialDesignIcons.register()
-    return NavigationStack {
+    NavigationStack {
         WatchAreasServerPickerView(serverIds: ["1", "2"])
     }
 }

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -19,8 +19,9 @@ enum WatchHomeNavigation: Hashable {
     /// The controls screen (target temperature, HVAC/fan/swing/preset modes, humidity) of a
     /// climate entity.
     case climateControls(MagicItem)
-    /// The server chooser of the grouped areas row (multiple servers with areas).
-    case areasServerPicker
+    /// The server chooser of the grouped areas row, limited to the servers whose areas contain
+    /// watch-compatible entities.
+    case areasServerPicker(serverIds: [String])
     /// One server's areas, pushed by the grouped areas row.
     case areasList(serverId: String)
     /// The watch-compatible entities of one area.

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -19,4 +19,10 @@ enum WatchHomeNavigation: Hashable {
     /// The controls screen (target temperature, HVAC/fan/swing/preset modes, humidity) of a
     /// climate entity.
     case climateControls(MagicItem)
+    /// The server chooser of the grouped areas row (multiple servers with areas).
+    case areasServerPicker
+    /// One server's areas, pushed by the grouped areas row.
+    case areasList(serverId: String)
+    /// The watch-compatible entities of one area.
+    case areaEntities(areaId: String, serverId: String)
 }

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -69,8 +69,8 @@ struct WatchHomeView: View {
                         WatchLockControlsView(item: item, itemInfo: viewModel.info(for: item))
                     case let .climateControls(item):
                         WatchClimateControlView(item: item, itemInfo: viewModel.info(for: item))
-                    case .areasServerPicker:
-                        WatchAreasServerPickerView()
+                    case let .areasServerPicker(serverIds):
+                        WatchAreasServerPickerView(serverIds: serverIds)
                     case let .areasList(serverId):
                         WatchAreasListView(serverId: serverId)
                     case let .areaEntities(areaId, serverId):
@@ -327,44 +327,45 @@ struct WatchHomeView: View {
     }
 
     /// The automatic area rows: each area directly when there are few on a single server, or one
-    /// grouped "Areas" row that drills into the server picker / area list.
+    /// grouped "Areas" row that drills into the server picker / area list. In the grid layout the
+    /// areas render as icon-only tiles so the home screen stays a single visual style.
     @ViewBuilder
     private var areasContent: some View {
         switch viewModel.areasMode {
         case .hidden:
             EmptyView()
         case let .inline(areas):
-            ForEach(areas, id: \.id) { area in
-                WatchAreaRow(area: area)
+            if viewModel.watchConfig.resolvedLayout == .grid {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 60), spacing: DesignSystem.Spaces.one)],
+                    spacing: DesignSystem.Spaces.one
+                ) {
+                    ForEach(areas, id: \.id) { area in
+                        WatchAreaRow(area: area, layout: .grid)
+                    }
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets())
+            } else {
+                ForEach(areas, id: \.id) { area in
+                    WatchAreaRow(area: area)
+                }
             }
         case .grouped:
-            Button {
-                if let destination = viewModel.groupedAreasDestination() {
-                    navigationPath.append(destination)
-                }
-            } label: {
-                WatchHomeItemLabel(
-                    name: L10n.Watch.Home.Areas.title,
-                    textColor: .white,
-                    icon: {
-                        VStack {
-                            Image(uiImage: MaterialDesignIcons.textureBoxIcon.image(
-                                ofSize: .init(width: 24, height: 24),
-                                color: .white
-                            ))
-                            .padding()
-                        }
-                        .watchRowIconContainer(color: .white)
-                    },
-                    accessory: {
-                        Image(systemSymbol: .chevronRight)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
+            if let destination = viewModel.groupedAreasDestination() {
+                if viewModel.watchConfig.resolvedLayout == .grid {
+                    LazyVGrid(
+                        columns: [GridItem(.adaptive(minimum: 60), spacing: DesignSystem.Spaces.one)],
+                        spacing: DesignSystem.Spaces.one
+                    ) {
+                        WatchAreasGroupRow(destination: destination, layout: .grid)
                     }
-                )
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets())
+                } else {
+                    WatchAreasGroupRow(destination: destination)
+                }
             }
-            .frame(maxWidth: .infinity)
-            .watchHomeItemRowStyle(tint: nil)
         }
     }
 

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -69,6 +69,12 @@ struct WatchHomeView: View {
                         WatchLockControlsView(item: item, itemInfo: viewModel.info(for: item))
                     case let .climateControls(item):
                         WatchClimateControlView(item: item, itemInfo: viewModel.info(for: item))
+                    case .areasServerPicker:
+                        WatchAreasServerPickerView()
+                    case let .areasList(serverId):
+                        WatchAreasListView(serverId: serverId)
+                    case let .areaEntities(areaId, serverId):
+                        WatchAreaEntitiesView(areaId: areaId, serverId: serverId)
                     }
                 }
         }
@@ -240,6 +246,9 @@ struct WatchHomeView: View {
                 onAdd: { activeSheet = .add }
             )
             listContent
+            if !isEditing {
+                areasContent
+            }
             if !isEditing, viewModel.showAssist {
                 addRow
             }
@@ -315,6 +324,48 @@ struct WatchHomeView: View {
         }
         .listRowBackground(Color.clear)
         .listRowInsets(EdgeInsets())
+    }
+
+    /// The automatic area rows: each area directly when there are few on a single server, or one
+    /// grouped "Areas" row that drills into the server picker / area list.
+    @ViewBuilder
+    private var areasContent: some View {
+        switch viewModel.areasMode {
+        case .hidden:
+            EmptyView()
+        case let .inline(areas):
+            ForEach(areas, id: \.id) { area in
+                WatchAreaRow(area: area)
+            }
+        case .grouped:
+            Button {
+                if let destination = viewModel.groupedAreasDestination() {
+                    navigationPath.append(destination)
+                }
+            } label: {
+                WatchHomeItemLabel(
+                    name: L10n.Watch.Home.Areas.title,
+                    textColor: .white,
+                    icon: {
+                        VStack {
+                            Image(uiImage: MaterialDesignIcons.textureBoxIcon.image(
+                                ofSize: .init(width: 24, height: 24),
+                                color: .white
+                            ))
+                            .padding()
+                        }
+                        .watchRowIconContainer(color: .white)
+                    },
+                    accessory: {
+                        Image(systemSymbol: .chevronRight)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                )
+            }
+            .frame(maxWidth: .infinity)
+            .watchHomeItemRowStyle(tint: nil)
+        }
     }
 
     private var addRow: some View {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -27,6 +27,9 @@ final class WatchHomeViewModel: ObservableObject {
 
     @Published var watchConfig: WatchConfig = .init()
     @Published var magicItemsInfo: [MagicItem.Info] = []
+    /// How the home screen presents the automatic area rows; recomputed on every cache load so it
+    /// follows config edits and mirror syncs.
+    @Published private(set) var areasMode: WatchHomeAreasMode = .hidden
     /// Whether the database actually holds a config row. False until the first successful cache
     /// read of a synced config — used to auto-retry the sync when the database is truly empty,
     /// without re-syncing for a config that legitimately has no items.
@@ -619,7 +622,7 @@ final class WatchHomeViewModel: ObservableObject {
         updateConfig(config: config, magicItemsInfo: magicItemsInfo)
 
         let provider = Current.magicItemProvider()
-        provider.loadInformation { [weak self] _ in
+        provider.loadInformation { [weak self] entitiesPerServer in
             DispatchQueue.main.async {
                 guard let self else { return }
                 var infos: [MagicItem.Info] = []
@@ -632,10 +635,38 @@ final class WatchHomeViewModel: ObservableObject {
                     }
                 }
                 self.updateConfig(config: config, magicItemsInfo: infos)
+                self.updateAreasMode(config: config, entitiesPerServer: entitiesPerServer)
                 self.resetError()
                 self.finishCacheLoad()
             }
         }
+    }
+
+    /// Recompute the automatic area rows from the mirrored areas and the entities the provider just
+    /// loaded, filtered to what the home screen can actually render.
+    @MainActor
+    private func updateAreasMode(config: WatchConfig, entitiesPerServer: [String: [HAAppEntity]]) {
+        let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+        let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
+            Set(entities
+                .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+                .map(\.entityId))
+        }
+        areasMode = WatchHomeAreasMode.compute(
+            areas: (try? AppArea.fetchAllAreas()) ?? [],
+            watchEntityIdsByServer: watchEntityIdsByServer,
+            hideAreas: config.resolvedHideAreas
+        )
+    }
+
+    /// Where the grouped "Areas" row goes: straight to the single server's areas, or through the
+    /// server picker when several servers have them.
+    func groupedAreasDestination() -> WatchHomeNavigation? {
+        guard case let .grouped(serverIds) = areasMode else { return nil }
+        if serverIds.count == 1, let serverId = serverIds.first {
+            return .areasList(serverId: serverId)
+        }
+        return .areasServerPicker
     }
 
     /// Re-evaluates whether any server lacks a usable URL, feeding the settings gear's yellow

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -648,9 +648,8 @@ final class WatchHomeViewModel: ObservableObject {
     private func updateAreasMode(config: WatchConfig, entitiesPerServer: [String: [HAAppEntity]]) {
         let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
         let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
-            Set(entities
-                .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
-                .map(\.entityId))
+            let watchEntities = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+            return Set(watchEntities.map(\.entityId))
         }
         areasMode = WatchHomeAreasMode.compute(
             areas: (try? AppArea.fetchAllAreas()) ?? [],

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -642,20 +642,29 @@ final class WatchHomeViewModel: ObservableObject {
         }
     }
 
+    /// Serial queue for the areas-mode computation — the area fetch is a synchronous database read
+    /// that must stay off the main thread.
+    private static let areasModeQueue = DispatchQueue(label: "watch-areas-mode", qos: .userInitiated)
+
     /// Recompute the automatic area rows from the mirrored areas and the entities the provider just
-    /// loaded, filtered to what the home screen can actually render.
-    @MainActor
+    /// loaded, filtered to what the home screen can actually render. Runs off-main and publishes
+    /// the result back on the main queue.
     private func updateAreasMode(config: WatchConfig, entitiesPerServer: [String: [HAAppEntity]]) {
-        let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
-        let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
-            let watchEntities = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
-            return Set(watchEntities.map(\.entityId))
+        Self.areasModeQueue.async { [weak self] in
+            let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+            let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
+                let watchEntities = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+                return Set(watchEntities.map(\.entityId))
+            }
+            let mode = WatchHomeAreasMode.compute(
+                areas: (try? AppArea.fetchAllAreas()) ?? [],
+                watchEntityIdsByServer: watchEntityIdsByServer,
+                hideAreas: config.resolvedHideAreas
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.areasMode = mode
+            }
         }
-        areasMode = WatchHomeAreasMode.compute(
-            areas: (try? AppArea.fetchAllAreas()) ?? [],
-            watchEntityIdsByServer: watchEntityIdsByServer,
-            hideAreas: config.resolvedHideAreas
-        )
     }
 
     /// Where the grouped "Areas" row goes: straight to the single server's areas, or through the
@@ -665,7 +674,7 @@ final class WatchHomeViewModel: ObservableObject {
         if serverIds.count == 1, let serverId = serverIds.first {
             return .areasList(serverId: serverId)
         }
-        return .areasServerPicker
+        return .areasServerPicker(serverIds: serverIds)
     }
 
     /// Re-evaluates whether any server lacks a usable URL, feeding the settings gear's yellow

--- a/Tests/Shared/Watch/WatchAreaControlsOrder.test.swift
+++ b/Tests/Shared/Watch/WatchAreaControlsOrder.test.swift
@@ -1,0 +1,30 @@
+@testable import Shared
+import Testing
+
+struct WatchAreaControlsOrderTests {
+    @Test func mostCommonDomainsSortFirst() {
+        let lightIndex = Domain.watchAreaControlsSortIndex(for: .light)
+        let switchIndex = Domain.watchAreaControlsSortIndex(for: .switch)
+        let lockIndex = Domain.watchAreaControlsSortIndex(for: .lock)
+        let automationIndex = Domain.watchAreaControlsSortIndex(for: .automation)
+
+        #expect(lightIndex < switchIndex)
+        #expect(switchIndex < lockIndex)
+        #expect(lockIndex < automationIndex)
+    }
+
+    @Test func unknownDomainSortsLast() {
+        let unlistedIndex = Domain.watchAreaControlsSortIndex(for: .sensor)
+        let nilIndex = Domain.watchAreaControlsSortIndex(for: nil)
+        let listedMaxIndex = Domain.watchAreaControlsSortIndex(for: .automation)
+
+        #expect(unlistedIndex == Domain.watchAreaControlsOrder.count)
+        #expect(nilIndex == Domain.watchAreaControlsOrder.count)
+        #expect(listedMaxIndex < unlistedIndex)
+    }
+
+    @Test func everyRunnableWatchDomainIsListed() {
+        let runnable = Set(Domain.watchSupported + Domain.controlScreenDomains)
+        #expect(Set(Domain.watchAreaControlsOrder) == runnable)
+    }
+}

--- a/Tests/Shared/Watch/WatchHomeAreasMode.test.swift
+++ b/Tests/Shared/Watch/WatchHomeAreasMode.test.swift
@@ -1,0 +1,109 @@
+@testable import Shared
+import Testing
+
+struct WatchHomeAreasModeTests {
+    private func makeArea(
+        areaId: String,
+        serverId: String = "server1",
+        entities: Set<String> = ["light.one"]
+    ) -> AppArea {
+        AppArea(
+            id: "\(serverId)-\(areaId)",
+            serverId: serverId,
+            areaId: areaId,
+            name: areaId.capitalized,
+            aliases: [],
+            picture: nil,
+            icon: nil,
+            sortOrder: nil,
+            entities: entities
+        )
+    }
+
+    @Test func hiddenWhenUserHidAreas() {
+        let mode = WatchHomeAreasMode.compute(
+            areas: [makeArea(areaId: "kitchen")],
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: true
+        )
+        #expect(mode == .hidden)
+    }
+
+    @Test func hiddenWhenThereAreNoAreas() {
+        let mode = WatchHomeAreasMode.compute(
+            areas: [],
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: false
+        )
+        #expect(mode == .hidden)
+    }
+
+    @Test func hiddenWhenNoAreaContainsWatchEntities() {
+        let mode = WatchHomeAreasMode.compute(
+            areas: [makeArea(areaId: "kitchen", entities: ["camera.front"])],
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: false
+        )
+        #expect(mode == .hidden)
+    }
+
+    @Test func inlineForFewAreasOnSingleServer() {
+        let areas = (1 ... 5).map { makeArea(areaId: "area\($0)") }
+        let mode = WatchHomeAreasMode.compute(
+            areas: areas,
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: false
+        )
+        #expect(mode == .inline(areas))
+    }
+
+    @Test func inlineDropsAreasWithoutWatchEntities() {
+        let populated = makeArea(areaId: "kitchen")
+        let empty = makeArea(areaId: "garage", entities: ["camera.garage"])
+        let mode = WatchHomeAreasMode.compute(
+            areas: [populated, empty],
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: false
+        )
+        #expect(mode == .inline([populated]))
+    }
+
+    @Test func groupedWhenMoreAreasThanInlineLimit() {
+        let areas = (1 ... 6).map { makeArea(areaId: "area\($0)") }
+        let mode = WatchHomeAreasMode.compute(
+            areas: areas,
+            watchEntityIdsByServer: ["server1": ["light.one"]],
+            hideAreas: false
+        )
+        #expect(mode == .grouped(serverIds: ["server1"]))
+    }
+
+    @Test func groupedWhenAreasSpanMultipleServers() {
+        let mode = WatchHomeAreasMode.compute(
+            areas: [
+                makeArea(areaId: "kitchen", serverId: "server1"),
+                makeArea(areaId: "office", serverId: "server2"),
+            ],
+            watchEntityIdsByServer: [
+                "server1": ["light.one"],
+                "server2": ["light.one"],
+            ],
+            hideAreas: false
+        )
+        #expect(mode == .grouped(serverIds: ["server1", "server2"]))
+    }
+
+    @Test func groupedIgnoresServersWithoutWatchEntities() {
+        let areas = (1 ... 6).map { makeArea(areaId: "area\($0)", serverId: "server1") }
+            + [makeArea(areaId: "office", serverId: "server2", entities: ["camera.office"])]
+        let mode = WatchHomeAreasMode.compute(
+            areas: areas,
+            watchEntityIdsByServer: [
+                "server1": ["light.one"],
+                "server2": ["light.two"],
+            ],
+            hideAreas: false
+        )
+        #expect(mode == .grouped(serverIds: ["server1"]))
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Show areas as items on the Apple Watch home screen, so users can browse and control compatible entities by area even before configuring any watch items. Up to 5 areas on a single server appear directly in the home list; with more than 5 areas or multiple servers they collapse into a single "Areas" item that navigates to a server picker (when more than one server has areas) and then per-server area lists. Area entities are rendered with the same rows as configured items, so they can be controlled the same way. Also adds a "Hide areas in home" toggle to the Apple Watch configuration screen on iPhone.

## Screenshots

N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes

Areas were already mirrored to the watch database, so no sync protocol changes were needed. The new `hideAreas` config field is optional for backwards compatibility with existing configs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb9JYfTcBgHBDG8dkc3RaD)_