### PR TITLE
Add vacuum controls to CarPlay and Apple Watch

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		13E4D63B90C14B0DA25F2827 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = C8FA7E5B23954D258050DD72 /* SFSafeSymbols */; };
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
 		42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */; };
+		42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
 		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -715,6 +716,7 @@
 		D0EEF300214D8EAB00D1D360 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		DA5459C05BEB77340680D8C6 /* Domain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.test.swift; sourceTree = "<group>"; };
 		42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimateControlState.test.swift; sourceTree = "<group>"; };
+		42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VacuumCapabilities.test.swift; sourceTree = "<group>"; };
 		FA11C0DE0000000000000100 /* BackgroundRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshManager.swift; sourceTree = "<group>"; };
 		FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+CarPlay.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2629,6 +2631,7 @@
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
 				42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */,
+				42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */,
 				42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */,
 				B90B4A989089C3375C55AF75 /* CallServiceResponse.test.swift */,
 				42EDBC3C3002FBE40051FC9B /* Watch */,
@@ -4080,6 +4083,7 @@
 				42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */,
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
 				42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */,
+				42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */,
 				42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */,
 				42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */,
 				42AB77022FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift in Sources */,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
 		42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */; };
 		42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */; };
+		42C11A0731AC500011AABB07 /* VacuumAreaMapping.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0631AC500011AABB06 /* VacuumAreaMapping.test.swift */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
 		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -717,6 +718,7 @@
 		DA5459C05BEB77340680D8C6 /* Domain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.test.swift; sourceTree = "<group>"; };
 		42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimateControlState.test.swift; sourceTree = "<group>"; };
 		42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VacuumCapabilities.test.swift; sourceTree = "<group>"; };
+		42C11A0631AC500011AABB06 /* VacuumAreaMapping.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VacuumAreaMapping.test.swift; sourceTree = "<group>"; };
 		FA11C0DE0000000000000100 /* BackgroundRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshManager.swift; sourceTree = "<group>"; };
 		FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+CarPlay.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2632,6 +2634,7 @@
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
 				42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */,
 				42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */,
+				42C11A0631AC500011AABB06 /* VacuumAreaMapping.test.swift */,
 				42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */,
 				B90B4A989089C3375C55AF75 /* CallServiceResponse.test.swift */,
 				42EDBC3C3002FBE40051FC9B /* Watch */,
@@ -4084,6 +4087,7 @@
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
 				42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */,
 				42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */,
+				42C11A0731AC500011AABB07 /* VacuumAreaMapping.test.swift in Sources */,
 				42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */,
 				42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */,
 				42AB77022FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift in Sources */,

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1926,6 +1926,10 @@ Importing replaces every category listed on this screen, including app settings.
 "url_handler.x_callback_url.error.templateMissing" = "A renderable template must be defined";
 "url_label" = "URL";
 "vacuum.control.battery_%@" = "Battery: %@";
+"vacuum.control.clean_areas.empty" = "No areas mapped. Map your vacuum's segments to areas in Home Assistant to clean by area.";
+"vacuum.control.clean_areas.order_%@" = "Cleaning order: %@";
+"vacuum.control.clean_areas.start_%@" = "Start cleaning (%@)";
+"vacuum.control.clean_areas.title" = "Clean areas";
 "vacuum.control.fan_speed.title" = "Fan speed";
 "vacuum.control.locate" = "Locate";
 "vacuum.control.pause" = "Pause";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1925,6 +1925,13 @@ Importing replaces every category listed on this screen, including app settings.
 "url_handler.x_callback_url.error.serviceMissing" = "service (e.g. homeassistant.turn_on) must be defined";
 "url_handler.x_callback_url.error.templateMissing" = "A renderable template must be defined";
 "url_label" = "URL";
+"vacuum.control.battery_%@" = "Battery: %@";
+"vacuum.control.fan_speed.title" = "Fan speed";
+"vacuum.control.locate" = "Locate";
+"vacuum.control.pause" = "Pause";
+"vacuum.control.return_to_base" = "Return to dock";
+"vacuum.control.start" = "Start";
+"vacuum.control.stop" = "Stop";
 "watch.assist.button.recording.title" = "Recording...";
 "watch.assist.button.send_request.title" = "Tap to send request";
 "watch.assist.lack_config.error.title" = "Please configure Assist using iOS companion App";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1927,6 +1927,7 @@ Importing replaces every category listed on this screen, including app settings.
 "url_label" = "URL";
 "vacuum.control.battery_%@" = "Battery: %@";
 "vacuum.control.clean_areas.empty" = "No areas mapped. Map your vacuum's segments to areas in Home Assistant to clean by area.";
+"vacuum.control.clean_areas.needs_phone" = "Your iPhone is out of reach, so the areas can't be loaded.";
 "vacuum.control.clean_areas.order_%@" = "Cleaning order: %@";
 "vacuum.control.clean_areas.start_%@" = "Start cleaning (%@)";
 "vacuum.control.clean_areas.title" = "Clean areas";

--- a/Sources/CarPlay/Templates/Entities/CarPlayControlScreenFactory.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayControlScreenFactory.swift
@@ -1,0 +1,20 @@
+import CarPlay
+import Foundation
+import HAKit
+import Shared
+
+/// Builds the pushed control screen for an entity of a control-screen domain (see
+/// `Domain.controlScreenDomains`). Returns nil for domains without one, so callers can fall back
+/// to executing the tap instead.
+enum CarPlayControlScreenFactory {
+    static func template(entity: HAEntity, server: Server) -> (any CarPlayTemplateProvider)? {
+        switch Domain(entityId: entity.entityId) {
+        case .climate:
+            return CarPlayClimateControlTemplate(viewModel: .init(server: server, entity: entity))
+        case .vacuum:
+            return CarPlayVacuumControlTemplate(viewModel: .init(server: server, entity: entity))
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntitiesListTemplate.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntitiesListTemplate.swift
@@ -64,8 +64,8 @@ final class CarPlayEntitiesListTemplate: CarPlayTemplateProvider {
         }
     }
 
-    func displayClimateControl(entity: HAEntity, server: Server) {
-        let provider = CarPlayClimateControlTemplate(viewModel: .init(server: server, entity: entity))
+    func displayControlScreen(entity: HAEntity, server: Server) {
+        guard var provider = CarPlayControlScreenFactory.template(entity: entity, server: server) else { return }
         provider.interfaceController = interfaceController
         childTemplateProvider = provider
         interfaceController?.pushTemplate(provider.template, animated: true, completion: nil)

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntitiesListViewModel.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntitiesListViewModel.swift
@@ -194,7 +194,7 @@ final class CarPlayEntitiesListViewModel {
             completion()
         } else if let domain = Domain(rawValue: entity.domain), domain.hasControlScreen {
             // Domains without a single tap action (climate) push their own control screen.
-            templateProvider?.displayClimateControl(entity: entity, server: server)
+            templateProvider?.displayControlScreen(entity: entity, server: server)
             completion()
         } else {
             // For non-lock entities, use entity.onPress directly

--- a/Sources/CarPlay/Templates/Entities/Climate/CarPlayClimateControlViewModel.swift
+++ b/Sources/CarPlay/Templates/Entities/Climate/CarPlayClimateControlViewModel.swift
@@ -177,7 +177,7 @@ final class CarPlayClimateControlViewModel {
             Current.Log.error("No API available for CarPlay climate service call on \(entityId)")
             return
         }
-        connection.send(.callClimateService(service, entityId: entityId, data: data)).promise
+        connection.send(.callEntityService(domain: .climate, service, entityId: entityId, data: data)).promise
             .done { _ in
                 Current.Log.verbose("CarPlay climate \(service.rawValue) succeeded for \(self.entityId)")
             }

--- a/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlTemplate.swift
+++ b/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlTemplate.swift
@@ -18,6 +18,8 @@ final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
     private var statusItem: CPListItem?
     private var fanSpeedItem: CPListItem?
     private var capabilitySignature: [String] = []
+    /// The pushed area picker, kept so its rows can be refreshed in place as the selection changes.
+    private weak var areaSelectionTemplate: CPListTemplate?
 
     init(viewModel: CarPlayVacuumControlViewModel) {
         self.viewModel = viewModel
@@ -63,6 +65,7 @@ final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
             String(capabilities.supportsStop),
             String(capabilities.supportsReturnHome),
             String(capabilities.supportsLocate),
+            String(capabilities.supportsCleanArea),
             String(capabilities.supportsFanSpeed),
             capabilities.fanSpeedList.joined(separator: ","),
             // The primary command row (start vs pause) follows the cleaning state.
@@ -123,6 +126,20 @@ final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
         }
         sections.append(CPListSection(items: commandItems))
 
+        var selectionItems: [CPListItem] = []
+        if capabilities.supportsCleanArea {
+            let item = CPListItem(
+                text: L10n.Vacuum.Control.CleanAreas.title,
+                detailText: nil,
+                image: MaterialDesignIcons.textureBoxIcon.carPlayIcon()
+            )
+            item.accessoryType = .disclosureIndicator
+            item.handler = { [weak self] _, completion in
+                self?.presentAreaSelection()
+                completion()
+            }
+            selectionItems.append(item)
+        }
         if capabilities.supportsFanSpeed {
             let item = CPListItem(text: L10n.Vacuum.Control.FanSpeed.title, detailText: nil)
             item.accessoryType = .disclosureIndicator
@@ -131,7 +148,10 @@ final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
                 completion()
             }
             fanSpeedItem = item
-            sections.append(CPListSection(items: [item]))
+            selectionItems.append(item)
+        }
+        if !selectionItems.isEmpty {
+            sections.append(CPListSection(items: selectionItems))
         }
 
         applyDisplayedValues()
@@ -165,6 +185,68 @@ final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
             completion()
         }
         return item
+    }
+
+    /// Pushes the "clean areas" picker: the areas an administrator mapped to the vacuum's
+    /// segments, tapped in the order they should be cleaned (mirroring the frontend, which
+    /// numbers the selection), with a start row that sends `vacuum.clean_area` and pops.
+    private func presentAreaSelection() {
+        viewModel.clearAreaSelection()
+        let selectionTemplate = CPListTemplate(title: L10n.Vacuum.Control.CleanAreas.title, sections: [])
+        selectionTemplate.emptyViewSubtitleVariants = [L10n.CarPlay.State.Loading.title]
+        areaSelectionTemplate = selectionTemplate
+        interfaceController?.pushTemplate(selectionTemplate, animated: true, completion: nil)
+        viewModel.loadCleanableAreas { [weak self] in
+            self?.refreshAreaSelection()
+        }
+    }
+
+    /// Rebuilds the picker's rows so the tapped order (and the start row's count) stay current.
+    private func refreshAreaSelection() {
+        guard let areaSelectionTemplate else { return }
+
+        guard !viewModel.isLoadingAreas else { return }
+        guard !viewModel.cleanableAreas.isEmpty else {
+            // Nothing mapped: say so rather than leaving an empty list, and point at where the
+            // mapping is configured — which is the frontend, not this app.
+            areaSelectionTemplate.emptyViewSubtitleVariants = [L10n.Vacuum.Control.CleanAreas.empty]
+            areaSelectionTemplate.updateSections([])
+            return
+        }
+
+        let areaItems = viewModel.cleanableAreas.map { area in
+            let order = viewModel.selectionOrder(of: area.areaId)
+            let item = CPListItem(
+                text: area.name,
+                // The number is the cleaning order, matching the frontend's badge.
+                detailText: order.map { L10n.Vacuum.Control.CleanAreas.order("\($0)") },
+                image: order == nil
+                    ? MaterialDesignIcons.textureBoxIcon.carPlayIcon()
+                    : MaterialDesignIcons.checkIcon.carPlayIcon()
+            )
+            item.handler = { [weak self] _, completion in
+                self?.viewModel.toggleAreaSelection(area.areaId)
+                self?.refreshAreaSelection()
+                completion()
+            }
+            return item
+        }
+
+        var sections = [CPListSection(items: areaItems)]
+        if !viewModel.selectedAreaIds.isEmpty {
+            let startItem = CPListItem(
+                text: L10n.Vacuum.Control.CleanAreas.start("\(viewModel.selectedAreaIds.count)"),
+                detailText: nil,
+                image: MaterialDesignIcons.playIcon.carPlayIcon()
+            )
+            startItem.handler = { [weak self] _, completion in
+                self?.viewModel.startCleaningSelectedAreas()
+                self?.interfaceController?.popTemplate(animated: true, completion: nil)
+                completion()
+            }
+            sections.append(CPListSection(items: [startItem]))
+        }
+        areaSelectionTemplate.updateSections(sections)
     }
 
     /// Pushes a single-choice fan speed list; the current value carries a check icon, and

--- a/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlTemplate.swift
+++ b/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlTemplate.swift
@@ -1,0 +1,193 @@
+import CarPlay
+import Foundation
+import HAKit
+import Shared
+
+/// Pushed control screen for a vacuum entity: start/pause, stop, return to dock, locate and fan
+/// speed, each shown only when the entity supports the capability. Vacuums have no single tap
+/// action, so their rows navigate here instead of executing.
+final class CarPlayVacuumControlTemplate: CarPlayTemplateProvider {
+    var template: CPListTemplate
+    weak var interfaceController: CPInterfaceController?
+
+    private let viewModel: CarPlayVacuumControlViewModel
+
+    // Rows are cached and mutated in place: `updateSections` resets rotary-knob focus, so it only
+    // runs when the entity's capabilities (or the state-driven primary command) change, not on
+    // every value refresh.
+    private var statusItem: CPListItem?
+    private var fanSpeedItem: CPListItem?
+    private var capabilitySignature: [String] = []
+
+    init(viewModel: CarPlayVacuumControlViewModel) {
+        self.viewModel = viewModel
+        self.template = CPListTemplate(title: viewModel.entityName, sections: [])
+        template.emptyViewSubtitleVariants = [L10n.CarPlay.State.Loading.title]
+        viewModel.templateProvider = self
+        rebuildSections()
+    }
+
+    func templateWillDisappear(template: CPTemplate) {
+        if self.template == template {
+            /* no-op */
+        }
+    }
+
+    func templateWillAppear(template: CPTemplate) {
+        if self.template == template {
+            update()
+        }
+    }
+
+    func entitiesStateChange(serverId: String, entities: HACachedStates) {
+        viewModel.updateStates(serverId: serverId, entities: entities)
+    }
+
+    func update() {
+        refreshDisplayedValues()
+    }
+
+    func refreshDisplayedValues() {
+        guard currentCapabilitySignature() == capabilitySignature else {
+            rebuildSections()
+            return
+        }
+        applyDisplayedValues()
+    }
+
+    private func currentCapabilitySignature() -> [String] {
+        let capabilities = viewModel.capabilities
+        return [
+            String(capabilities.supportsStart),
+            String(capabilities.supportsPause),
+            String(capabilities.supportsStop),
+            String(capabilities.supportsReturnHome),
+            String(capabilities.supportsLocate),
+            String(capabilities.supportsFanSpeed),
+            capabilities.fanSpeedList.joined(separator: ","),
+            // The primary command row (start vs pause) follows the cleaning state.
+            String(viewModel.isCleaning),
+        ]
+    }
+
+    private func rebuildSections() {
+        let capabilities = viewModel.capabilities
+        capabilitySignature = currentCapabilitySignature()
+        var sections: [CPListSection] = []
+
+        statusItem = nil
+        fanSpeedItem = nil
+
+        let status = CPListItem(text: nil, detailText: nil)
+        statusItem = status
+
+        var commandItems: [CPListItem] = [status]
+        if viewModel.isCleaning, capabilities.supportsPause {
+            commandItems.append(commandItem(
+                text: L10n.Vacuum.Control.pause,
+                icon: .pauseIcon
+            ) { [weak self] in
+                self?.viewModel.pause()
+            })
+        } else if capabilities.supportsStart {
+            commandItems.append(commandItem(
+                text: L10n.Vacuum.Control.start,
+                icon: .playIcon
+            ) { [weak self] in
+                self?.viewModel.start()
+            })
+        }
+        if capabilities.supportsStop {
+            commandItems.append(commandItem(
+                text: L10n.Vacuum.Control.stop,
+                icon: .stopIcon
+            ) { [weak self] in
+                self?.viewModel.stop()
+            })
+        }
+        if capabilities.supportsReturnHome {
+            commandItems.append(commandItem(
+                text: L10n.Vacuum.Control.returnToBase,
+                icon: .homeImportOutlineIcon
+            ) { [weak self] in
+                self?.viewModel.returnToBase()
+            })
+        }
+        if capabilities.supportsLocate {
+            commandItems.append(commandItem(
+                text: L10n.Vacuum.Control.locate,
+                icon: .mapMarkerIcon
+            ) { [weak self] in
+                self?.viewModel.locate()
+            })
+        }
+        sections.append(CPListSection(items: commandItems))
+
+        if capabilities.supportsFanSpeed {
+            let item = CPListItem(text: L10n.Vacuum.Control.FanSpeed.title, detailText: nil)
+            item.accessoryType = .disclosureIndicator
+            item.handler = { [weak self] _, completion in
+                self?.presentFanSpeedSelection()
+                completion()
+            }
+            fanSpeedItem = item
+            sections.append(CPListSection(items: [item]))
+        }
+
+        applyDisplayedValues()
+        template.updateSections(sections)
+    }
+
+    private func applyDisplayedValues() {
+        let capabilities = viewModel.capabilities
+
+        if let statusItem {
+            statusItem.setText(viewModel.stateText)
+            statusItem.setDetailText(
+                capabilities.batteryLevel.map { L10n.Vacuum.Control.battery("\(Int($0))%") }
+            )
+            statusItem.setImage(MaterialDesignIcons.robotVacuumIcon.carPlayIcon())
+        }
+        if let fanSpeedItem {
+            fanSpeedItem.setDetailText(capabilities.fanSpeed.map(ClimateControlState.displayName(forMode:)))
+            fanSpeedItem.setImage(MaterialDesignIcons.fanIcon.carPlayIcon())
+        }
+    }
+
+    private func commandItem(
+        text: String,
+        icon: MaterialDesignIcons,
+        action: @escaping () -> Void
+    ) -> CPListItem {
+        let item = CPListItem(text: text, detailText: nil, image: icon.carPlayIcon())
+        item.handler = { _, completion in
+            action()
+            completion()
+        }
+        return item
+    }
+
+    /// Pushes a single-choice fan speed list; the current value carries a check icon, and
+    /// selecting pops straight back to the control screen.
+    private func presentFanSpeedSelection() {
+        let items = viewModel.capabilities.fanSpeedList.map { speed in
+            let isSelected = speed == viewModel.capabilities.fanSpeed
+            let item = CPListItem(
+                text: ClimateControlState.displayName(forMode: speed),
+                detailText: nil,
+                image: isSelected ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
+            )
+            item.handler = { [weak self] _, completion in
+                self?.viewModel.setFanSpeed(speed)
+                self?.interfaceController?.popTemplate(animated: true, completion: nil)
+                completion()
+            }
+            return item
+        }
+        let selectionTemplate = CPListTemplate(
+            title: L10n.Vacuum.Control.FanSpeed.title,
+            sections: [CPListSection(items: items)]
+        )
+        interfaceController?.pushTemplate(selectionTemplate, animated: true, completion: nil)
+    }
+}

--- a/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlViewModel.swift
+++ b/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlViewModel.swift
@@ -10,6 +10,17 @@ final class CarPlayVacuumControlViewModel {
     private(set) var entity: HAEntity
     weak var templateProvider: CarPlayVacuumControlTemplate?
 
+    /// Areas the vacuum has segments mapped to, resolved against the local area registry. Empty
+    /// until `loadCleanableAreas` answers — or when the user has mapped nothing, which the picker
+    /// surfaces as an empty state.
+    private(set) var cleanableAreas: [AppArea] = []
+    /// Whether the mapping fetch is still in flight, so the picker can say so rather than looking
+    /// like an empty mapping.
+    private(set) var isLoadingAreas = false
+    /// Area ids picked for the next `clean_area` call, in tap order — the service takes an ordered
+    /// list, and the frontend surfaces the same numbering.
+    private(set) var selectedAreaIds: [String] = []
+
     init(server: Server, entity: HAEntity) {
         self.server = server
         self.entityId = entity.entityId
@@ -61,6 +72,71 @@ final class CarPlayVacuumControlViewModel {
 
     func setFanSpeed(_ speed: String) {
         send(service: .setFanSpeed, data: ["fan_speed": speed])
+    }
+
+    // MARK: - Clean areas
+
+    /// Fetches the vacuum's area mapping and resolves it against the local area registry. The
+    /// mapping lives in the entity registry (WebSocket only) and changes rarely, so it is fetched
+    /// when the picker opens rather than kept in sync.
+    func loadCleanableAreas(completion: @escaping () -> Void) {
+        guard let connection = Current.api(for: server)?.connection else {
+            Current.Log.error("No API available to load vacuum area mapping for \(entityId)")
+            completion()
+            return
+        }
+        isLoadingAreas = true
+        connection.send(.vacuumAreaMapping(entityId: entityId)).promise
+            .done { [weak self] mapping in
+                guard let self else { return }
+                cleanableAreas = Self.resolveAreas(ids: mapping.areaIds, serverId: server.identifier.rawValue)
+            }
+            .catch { error in
+                Current.Log.error("Failed to load vacuum area mapping for \(self.entityId): \(error)")
+            }
+            .finally { [weak self] in
+                self?.isLoadingAreas = false
+                completion()
+            }
+    }
+
+    /// Maps registry area ids to the app's stored areas, dropping any the app doesn't know about
+    /// (a mapping can outlive an area deletion) and keeping the mapping's order.
+    private static func resolveAreas(ids: [String], serverId: String) -> [AppArea] {
+        guard !ids.isEmpty else { return [] }
+        let areas: [AppArea]
+        do {
+            areas = try AppArea.fetchAreas(for: serverId)
+        } catch {
+            Current.Log.error("Failed to fetch areas for CarPlay vacuum clean areas: \(error.localizedDescription)")
+            return []
+        }
+        let areasById = Dictionary(areas.map { ($0.areaId, $0) }, uniquingKeysWith: { first, _ in first })
+        return ids.compactMap { areasById[$0] }
+    }
+
+    /// Adds or removes an area from the pending selection, preserving tap order.
+    func toggleAreaSelection(_ areaId: String) {
+        if let index = selectedAreaIds.firstIndex(of: areaId) {
+            selectedAreaIds.remove(at: index)
+        } else {
+            selectedAreaIds.append(areaId)
+        }
+    }
+
+    /// 1-based position of an area in the pending selection, or nil when it isn't selected.
+    func selectionOrder(of areaId: String) -> Int? {
+        selectedAreaIds.firstIndex(of: areaId).map { $0 + 1 }
+    }
+
+    func clearAreaSelection() {
+        selectedAreaIds = []
+    }
+
+    func startCleaningSelectedAreas() {
+        guard !selectedAreaIds.isEmpty else { return }
+        send(service: .cleanArea, data: ["cleaning_area_id": selectedAreaIds])
+        clearAreaSelection()
     }
 
     // MARK: - Private

--- a/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlViewModel.swift
+++ b/Sources/CarPlay/Templates/Entities/Vacuum/CarPlayVacuumControlViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import HAKit
+import PromiseKit
+import Shared
+
+final class CarPlayVacuumControlViewModel {
+    let server: Server
+    let entityId: String
+    private(set) var entityName: String
+    private(set) var entity: HAEntity
+    weak var templateProvider: CarPlayVacuumControlTemplate?
+
+    init(server: Server, entity: HAEntity) {
+        self.server = server
+        self.entityId = entity.entityId
+        self.entityName = entity.attributes.friendlyName ?? entity.entityId
+        self.entity = entity
+    }
+
+    var capabilities: VacuumCapabilities {
+        VacuumCapabilities(entity: entity)
+    }
+
+    /// Whether the vacuum is actively cleaning, which flips the primary row to pause.
+    var isCleaning: Bool {
+        entity.state == "cleaning"
+    }
+
+    var stateText: String {
+        Domain.vacuum.contextualStateDescription(for: entity, serverId: server.identifier.rawValue)
+    }
+
+    func updateStates(serverId: String, entities: HACachedStates) {
+        guard serverId == server.identifier.rawValue, let updated = entities[entityId] else { return }
+        entity = updated
+        entityName = updated.attributes.friendlyName ?? updated.entityId
+        templateProvider?.refreshDisplayedValues()
+    }
+
+    // MARK: - Commands
+
+    func start() {
+        send(service: .start)
+    }
+
+    func pause() {
+        send(service: .pause)
+    }
+
+    func stop() {
+        send(service: .stop)
+    }
+
+    func returnToBase() {
+        send(service: .returnToBase)
+    }
+
+    func locate() {
+        send(service: .locate)
+    }
+
+    func setFanSpeed(_ speed: String) {
+        send(service: .setFanSpeed, data: ["fan_speed": speed])
+    }
+
+    // MARK: - Private
+
+    private func send(service: Service, data: [String: Any] = [:]) {
+        guard let connection = Current.api(for: server)?.connection else {
+            Current.Log.error("No API available for CarPlay vacuum service call on \(entityId)")
+            return
+        }
+        connection.send(.callEntityService(domain: .vacuum, service, entityId: entityId, data: data)).promise
+            .done { _ in
+                Current.Log.verbose("CarPlay vacuum \(service.rawValue) succeeded for \(self.entityId)")
+            }
+            .catch { [weak self] error in
+                guard let self else { return }
+                Current.Log.error("CarPlay vacuum \(service.rawValue) failed for \(entityId): \(error)")
+            }
+    }
+}

--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
@@ -54,9 +54,9 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
     private var activeAssistSession: AnyObject?
     private var addItemFlow: CarPlayAddItemFlow?
     private var editItemFlow: CarPlayEditItemFlow?
-    /// Control screen pushed for domains that have one (climate); fed with the per-server state
-    /// events this template receives and cleared when the list reappears (i.e. it was popped).
-    private var climateControlTemplate: CarPlayClimateControlTemplate?
+    /// Control screen pushed for domains that have one (climate, vacuum); fed with the per-server
+    /// state events this template receives and cleared when the list reappears (i.e. it was popped).
+    private var controlScreenTemplate: (any CarPlayTemplateProvider)?
 
     /// `folder` is provided when this template renders a folder promoted to its own tab
     /// (`CarPlayQuickAccessViewModel.Source.folder`); it supplies the tab's title and icon.
@@ -199,7 +199,7 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
         if template == self.template {
             /* no-op */
         }
-        climateControlTemplate?.templateWillDisappear(template: template)
+        controlScreenTemplate?.templateWillDisappear(template: template)
     }
 
     func templateWillAppear(template: CPTemplate) {
@@ -209,16 +209,16 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
             openFolderTemplates.removeAll()
             folderListItemsByKey.removeAll()
             folderFooterRows.removeAll()
-            climateControlTemplate = nil
+            controlScreenTemplate = nil
             update()
         }
-        climateControlTemplate?.templateWillAppear(template: template)
+        controlScreenTemplate?.templateWillAppear(template: template)
     }
 
     func entitiesStateChange(serverId: String, entities: HACachedStates) {
         let previousEntities = entitiesPerServer[serverId]
         entitiesPerServer[serverId] = entities
-        climateControlTemplate?.entitiesStateChange(serverId: serverId, entities: entities)
+        controlScreenTemplate?.entitiesStateChange(serverId: serverId, entities: entities)
         guard !currentItems.isEmpty else { return }
         guard hasRelevantEntityChange(serverId: serverId, previous: previousEntities, current: entities) else {
             return
@@ -717,7 +717,7 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
     ) {
         // Domains without a single tap action (climate) push their own control screen.
         if magicItem.type == .entity, Domain(entityId: magicItem.id)?.hasControlScreen == true {
-            presentClimateControl(magicItem: magicItem)
+            presentControlScreen(magicItem: magicItem)
             return
         }
 
@@ -743,20 +743,20 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
         }
     }
 
-    private func presentClimateControl(magicItem: MagicItem) {
+    private func presentControlScreen(magicItem: MagicItem) {
         guard let server = Current.servers.all.first(where: { server in
             server.identifier.rawValue == magicItem.serverId
         }) else {
-            Current.Log.error("Failed to get server for climate magic item id: \(magicItem.id)")
+            Current.Log.error("Failed to get server for control screen magic item id: \(magicItem.id)")
             return
         }
         guard let entity = resolvedEntity(for: magicItem) else {
-            Current.Log.error("Failed to resolve entity for climate magic item id: \(magicItem.id)")
+            Current.Log.error("Failed to resolve entity for control screen magic item id: \(magicItem.id)")
             return
         }
-        let provider = CarPlayClimateControlTemplate(viewModel: .init(server: server, entity: entity))
+        guard var provider = CarPlayControlScreenFactory.template(entity: entity, server: server) else { return }
         provider.interfaceController = interfaceController
-        climateControlTemplate = provider
+        controlScreenTemplate = provider
         interfaceController?.pushTemplate(provider.template, animated: true, completion: nil)
     }
 

--- a/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateMessages.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateMessages.swift
@@ -38,4 +38,10 @@ public enum InteractiveImmediateMessages: String, CaseIterable {
     /// user can supply a `.p12` + password for the given server. The phone can't foreground itself,
     /// so the screen appears the next time the user opens the iPhone app.
     case clientCertImportRequest
+    /// Watch → phone: ask which Home Assistant areas a vacuum can be told to clean, `{entityId,
+    /// serverId}`. The mapping lives in the entity registry, which Home Assistant only serves over
+    /// WebSocket — a transport the watch doesn't have — so the phone fetches it and replies with
+    /// `vacuumCleanableAreasResponse`. Only sent while the phone is immediately reachable; the
+    /// watch hides the option otherwise.
+    case vacuumCleanableAreas
 }

--- a/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
@@ -34,4 +34,8 @@ public enum InteractiveImmediateResponses: String, CaseIterable {
     case serversConfigSyncResponse
     /// Phone → watch: acknowledgement that the client-certificate import screen will be presented.
     case clientCertImportRequestResponse
+    /// Phone → watch: reply to `vacuumCleanableAreas`, carrying `{areas}` — the id and name of each
+    /// area the vacuum has segments mapped to, already resolved against the phone's area registry.
+    /// An empty list means the vacuum supports cleaning by area but nothing has been mapped yet.
+    case vacuumCleanableAreasResponse
 }

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -659,6 +659,7 @@ public extension Domain {
         .cover,
         .climate,
         .fan,
+        .vacuum,
         .scene,
         .script,
         .humidifier,

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -602,6 +602,7 @@ public extension Domain {
         .scene,
         .script,
         .switch,
+        .vacuum,
         .valve,
     ]
 
@@ -633,6 +634,7 @@ public extension Domain {
     /// frontend's more-info dialog offers.
     static let controlScreenDomains: [Domain] = [
         .climate,
+        .vacuum,
     ]
 
     /// Domains that always show their own confirmation when tapped (state-aware lock handling),

--- a/Sources/Shared/Domain/Service.swift
+++ b/Sources/Shared/Domain/Service.swift
@@ -21,4 +21,10 @@ public enum Service: String, CaseIterable {
     case setSwingHorizontalMode = "set_swing_horizontal_mode"
     case setPresetMode = "set_preset_mode"
     case setHumidity = "set_humidity"
+    case start = "start"
+    case pause = "pause"
+    case stop = "stop"
+    case returnToBase = "return_to_base"
+    case setFanSpeed = "set_fan_speed"
+    case locate = "locate"
 }

--- a/Sources/Shared/Domain/Service.swift
+++ b/Sources/Shared/Domain/Service.swift
@@ -27,4 +27,5 @@ public enum Service: String, CaseIterable {
     case returnToBase = "return_to_base"
     case setFanSpeed = "set_fan_speed"
     case locate = "locate"
+    case cleanArea = "clean_area"
 }

--- a/Sources/Shared/Domain/VacuumAreaMapping.swift
+++ b/Sources/Shared/Domain/VacuumAreaMapping.swift
@@ -27,6 +27,30 @@ public struct VacuumAreaMapping: HADataDecodable, Equatable {
         self.init(attributes: entry)
     }
 
+    /// An area a vacuum can be told to clean, resolved to something displayable.
+    ///
+    /// Crosses the WatchConnectivity wire as a plain dictionary: the watch can't read the entity
+    /// registry itself (it has no WebSocket), so the phone resolves the mapping's ids against its
+    /// area registry and relays these — see `InteractiveImmediateMessages.vacuumCleanableAreas`.
+    public struct Area: Equatable {
+        public let id: String
+        public let name: String
+
+        public init(id: String, name: String) {
+            self.id = id
+            self.name = name
+        }
+
+        public init?(wireFormat: [String: String]) {
+            guard let id = wireFormat["id"], let name = wireFormat["name"] else { return nil }
+            self.init(id: id, name: name)
+        }
+
+        public var wireFormat: [String: String] {
+            ["id": id, "name": name]
+        }
+    }
+
     /// Split from the `HAData` decode so the option digging can be unit tested without HAKit.
     public init(attributes: [String: Any]) {
         let options = attributes["options"] as? [String: Any]

--- a/Sources/Shared/Domain/VacuumAreaMapping.swift
+++ b/Sources/Shared/Domain/VacuumAreaMapping.swift
@@ -1,0 +1,39 @@
+import Foundation
+import HAKit
+
+/// The Home Assistant areas a vacuum can be told to clean, read from its entity registry entry.
+///
+/// A vacuum reports numbered *segments* (rooms as its own firmware knows them); an administrator
+/// maps those to Home Assistant areas in the frontend, which stores the result under the entity
+/// registry's `options.vacuum.area_mapping` (area id → segment ids). `vacuum.clean_area` then takes
+/// **area** ids, so this app only needs the mapping's keys: the set of areas the vacuum can clean.
+///
+/// Decoded from `config/entity_registry/get`, which is WebSocket-only — see
+/// `HATypedRequest.entityRegistryEntry(entityId:)`.
+public struct VacuumAreaMapping: HADataDecodable, Equatable {
+    /// Home Assistant area ids the vacuum has segments mapped to. Empty when the vacuum supports
+    /// cleaning by area but nothing has been mapped yet, which the UI surfaces as an empty state.
+    public let areaIds: [String]
+
+    public init(areaIds: [String]) {
+        self.areaIds = areaIds
+    }
+
+    public init(data: HAData) throws {
+        guard case let .dictionary(entry) = data else {
+            self.init(areaIds: [])
+            return
+        }
+        self.init(attributes: entry)
+    }
+
+    /// Split from the `HAData` decode so the option digging can be unit tested without HAKit.
+    public init(attributes: [String: Any]) {
+        let options = attributes["options"] as? [String: Any]
+        let vacuumOptions = options?["vacuum"] as? [String: Any]
+        let mapping = vacuumOptions?["area_mapping"] as? [String: Any]
+        // Sorted so the picker's order is stable across fetches; the frontend orders by floor,
+        // which needs data these surfaces don't carry.
+        self.areaIds = (mapping?.keys).map { Array($0).sorted() } ?? []
+    }
+}

--- a/Sources/Shared/Domain/VacuumAreaMapping.swift
+++ b/Sources/Shared/Domain/VacuumAreaMapping.swift
@@ -9,7 +9,7 @@ import HAKit
 /// **area** ids, so this app only needs the mapping's keys: the set of areas the vacuum can clean.
 ///
 /// Decoded from `config/entity_registry/get`, which is WebSocket-only — see
-/// `HATypedRequest.entityRegistryEntry(entityId:)`.
+/// `HATypedRequest.vacuumAreaMapping(entityId:)`.
 public struct VacuumAreaMapping: HADataDecodable, Equatable {
     /// Home Assistant area ids the vacuum has segments mapped to. Empty when the vacuum supports
     /// cleaning by area but nothing has been mapped yet, which the UI surfaces as an empty state.

--- a/Sources/Shared/Domain/VacuumCapabilities.swift
+++ b/Sources/Shared/Domain/VacuumCapabilities.swift
@@ -16,6 +16,7 @@ public struct VacuumCapabilities: Equatable {
         case battery = 64
         case locate = 512
         case start = 8192
+        case cleanArea = 16384
     }
 
     public let supportsStart: Bool
@@ -23,6 +24,10 @@ public struct VacuumCapabilities: Equatable {
     public let supportsStop: Bool
     public let supportsReturnHome: Bool
     public let supportsLocate: Bool
+    /// Whether the vacuum can be told to clean specific Home Assistant areas
+    /// (`vacuum.clean_area`). The areas themselves come from the entity registry — see
+    /// `VacuumAreaMapping`.
+    public let supportsCleanArea: Bool
     public let supportsFanSpeed: Bool
     /// The active fan speed; nil when the vacuum doesn't report one.
     public let fanSpeed: String?
@@ -45,6 +50,7 @@ public struct VacuumCapabilities: Equatable {
         self.supportsStop = supports(.stop)
         self.supportsReturnHome = supports(.returnHome)
         self.supportsLocate = supports(.locate)
+        self.supportsCleanArea = supports(.cleanArea)
         let fanSpeedList = attributes["fan_speed_list"] as? [String] ?? []
         self.supportsFanSpeed = supports(.fanSpeed) && !fanSpeedList.isEmpty
         self.fanSpeedList = fanSpeedList

--- a/Sources/Shared/Domain/VacuumCapabilities.swift
+++ b/Sources/Shared/Domain/VacuumCapabilities.swift
@@ -1,0 +1,58 @@
+import Foundation
+import HAKit
+
+/// What a vacuum entity can do, parsed from its state attributes.
+///
+/// Home Assistant advertises vacuum capabilities through the `supported_features` bitmask. The
+/// watch and CarPlay use this to decide which commands the vacuum's control screen offers —
+/// vacuums have no single tap action, so every capable command is an explicit button.
+public struct VacuumCapabilities: Equatable {
+    /// `supported_features` bits, as defined by Home Assistant's vacuum entity model.
+    public enum Feature: Int {
+        case pause = 4
+        case stop = 8
+        case returnHome = 16
+        case fanSpeed = 32
+        case battery = 64
+        case locate = 512
+        case start = 8192
+    }
+
+    public let supportsStart: Bool
+    public let supportsPause: Bool
+    public let supportsStop: Bool
+    public let supportsReturnHome: Bool
+    public let supportsLocate: Bool
+    public let supportsFanSpeed: Bool
+    /// The active fan speed; nil when the vacuum doesn't report one.
+    public let fanSpeed: String?
+    /// The selectable fan speeds; empty when the vacuum doesn't expose any.
+    public let fanSpeedList: [String]
+    /// 0–100; nil when the vacuum doesn't report battery (or the feature bit is unset).
+    public let batteryLevel: Double?
+
+    public init(entity: HAEntity) {
+        self.init(attributes: entity.attributes.dictionary)
+    }
+
+    public init(attributes: [String: Any]) {
+        let features = (attributes["supported_features"] as? Int) ?? 0
+        func supports(_ feature: Feature) -> Bool {
+            features & feature.rawValue != 0
+        }
+        self.supportsStart = supports(.start)
+        self.supportsPause = supports(.pause)
+        self.supportsStop = supports(.stop)
+        self.supportsReturnHome = supports(.returnHome)
+        self.supportsLocate = supports(.locate)
+        let fanSpeedList = attributes["fan_speed_list"] as? [String] ?? []
+        self.supportsFanSpeed = supports(.fanSpeed) && !fanSpeedList.isEmpty
+        self.fanSpeedList = fanSpeedList
+        self.fanSpeed = attributes["fan_speed"] as? String
+        if supports(.battery), let battery = attributes["battery_level"] as? NSNumber {
+            self.batteryLevel = battery.doubleValue
+        } else {
+            self.batteryLevel = nil
+        }
+    }
+}

--- a/Sources/Shared/HATypedRequest+App.swift
+++ b/Sources/Shared/HATypedRequest+App.swift
@@ -42,8 +42,10 @@ public extension HATypedRequest {
         ))
     }
 
-    /// Calls a climate domain service (e.g. `climate.set_temperature`) with the given service data.
-    static func callClimateService(
+    /// Calls a service on `domain` targeting one entity (e.g. `climate.set_temperature`,
+    /// `vacuum.start`) with the given service data.
+    static func callEntityService(
+        domain: Domain,
         _ service: Service,
         entityId: String,
         data: [String: Any] = [:]
@@ -53,7 +55,7 @@ public extension HATypedRequest {
         return HATypedRequest<HAResponseVoid>(request: .init(
             type: "call_service",
             data: [
-                "domain": Domain.climate.rawValue,
+                "domain": domain.rawValue,
                 "service": service.rawValue,
                 "service_data": serviceData,
             ]

--- a/Sources/Shared/HATypedRequest+App.swift
+++ b/Sources/Shared/HATypedRequest+App.swift
@@ -203,6 +203,15 @@ public extension HATypedRequest {
         ))
     }
 
+    /// The areas a vacuum has segments mapped to, read from its entity registry entry — the
+    /// display listing omits the per-domain `options` this lives in. WebSocket only.
+    static func vacuumAreaMapping(entityId: String) -> HATypedRequest<VacuumAreaMapping> {
+        HATypedRequest<VacuumAreaMapping>(request: .init(
+            type: .webSocket("config/entity_registry/get"),
+            data: ["entity_id": entityId]
+        ))
+    }
+
     static func usagePredictionCommonControl() -> HATypedRequest<HAUsagePredictionCommonControl> {
         HATypedRequest<HAUsagePredictionCommonControl>(request: .init(
             type: .webSocket("usage_prediction/common_control")

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6382,6 +6382,29 @@ public enum L10n {
     }
   }
 
+  public enum Vacuum {
+    public enum Control {
+      /// Battery: %@
+      public static func battery(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "vacuum.control.battery_%@", String(describing: p1))
+      }
+      /// Locate
+      public static var locate: String { return L10n.tr("Localizable", "vacuum.control.locate") }
+      /// Pause
+      public static var pause: String { return L10n.tr("Localizable", "vacuum.control.pause") }
+      /// Return to dock
+      public static var returnToBase: String { return L10n.tr("Localizable", "vacuum.control.return_to_base") }
+      /// Start
+      public static var start: String { return L10n.tr("Localizable", "vacuum.control.start") }
+      /// Stop
+      public static var stop: String { return L10n.tr("Localizable", "vacuum.control.stop") }
+      public enum FanSpeed {
+        /// Fan speed
+        public static var title: String { return L10n.tr("Localizable", "vacuum.control.fan_speed.title") }
+      }
+    }
+  }
+
   public enum Watch {
     /// Placeholder
     public static var placeholderComplicationName: String { return L10n.tr("Localizable", "watch.placeholder_complication_name") }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6390,6 +6390,20 @@ public enum L10n {
       }
       /// Locate
       public static var locate: String { return L10n.tr("Localizable", "vacuum.control.locate") }
+      public enum CleanAreas {
+        /// No areas mapped. Map your vacuum's segments to areas in Home Assistant to clean by area.
+        public static var empty: String { return L10n.tr("Localizable", "vacuum.control.clean_areas.empty") }
+        /// Clean areas
+        public static var title: String { return L10n.tr("Localizable", "vacuum.control.clean_areas.title") }
+        /// Cleaning order: %@
+        public static func order(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "vacuum.control.clean_areas.order_%@", String(describing: p1))
+        }
+        /// Start cleaning (%@)
+        public static func start(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "vacuum.control.clean_areas.start_%@", String(describing: p1))
+        }
+      }
       /// Pause
       public static var pause: String { return L10n.tr("Localizable", "vacuum.control.pause") }
       /// Return to dock

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6393,6 +6393,8 @@ public enum L10n {
       public enum CleanAreas {
         /// No areas mapped. Map your vacuum's segments to areas in Home Assistant to clean by area.
         public static var empty: String { return L10n.tr("Localizable", "vacuum.control.clean_areas.empty") }
+        /// Your iPhone is out of reach, so the areas can't be loaded.
+        public static var needsPhone: String { return L10n.tr("Localizable", "vacuum.control.clean_areas.needs_phone") }
         /// Clean areas
         public static var title: String { return L10n.tr("Localizable", "vacuum.control.clean_areas.title") }
         /// Cleaning order: %@

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -176,6 +176,8 @@ final class WatchCommunicatorService {
                     handleServersConfigSync(message: message)
                 case .clientCertImportRequest:
                     handleClientCertImportRequest(message: message)
+                case .vacuumCleanableAreas:
+                    handleVacuumCleanableAreas(message: message)
                 }
             }
     }
@@ -226,6 +228,43 @@ final class WatchCommunicatorService {
             identifier: InteractiveImmediateResponses.serversConfigSyncResponse.rawValue,
             content: content
         ))
+    }
+
+    /// Fetch a vacuum's cleanable areas on the watch's behalf. The mapping lives in the entity
+    /// registry (WebSocket only), so the watch — which reaches Home Assistant over REST — has to
+    /// ask the phone. The reply carries the areas already resolved to `{id, name}` pairs so the
+    /// watch renders them without needing the registry itself.
+    private func handleVacuumCleanableAreas(message: HAWatchConnectivity.InteractiveImmediateMessage) {
+        let reply: ([VacuumAreaMapping.Area]) -> Void = { areas in
+            message.reply(.init(
+                identifier: InteractiveImmediateResponses.vacuumCleanableAreasResponse.rawValue,
+                content: ["areas": areas.map(\.wireFormat)]
+            ))
+        }
+
+        guard let entityId = message.content["entityId"] as? String,
+              let serverId = message.content["serverId"] as? String,
+              let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }),
+              let connection = Current.api(for: server)?.connection else {
+            Current.Log.error("Watch asked for vacuum areas with no usable server/entity")
+            reply([])
+            return
+        }
+
+        connection.send(.vacuumAreaMapping(entityId: entityId)).promise
+            .done { mapping in
+                let areas = (try? AppArea.fetchAreas(for: serverId)) ?? []
+                let areasById = Dictionary(areas.map { ($0.areaId, $0) }, uniquingKeysWith: { first, _ in first })
+                // Drop ids the phone no longer knows (a mapping outlives a deleted area) and keep
+                // the mapping's order.
+                reply(mapping.areaIds.compactMap { areaId in
+                    areasById[areaId].map { VacuumAreaMapping.Area(id: $0.areaId, name: $0.name) }
+                })
+            }
+            .catch { error in
+                Current.Log.error("Failed to fetch vacuum area mapping for the watch: \(error)")
+                reply([])
+            }
     }
 
     // MARK: - mTLS client certificate transfer (phone → watch)

--- a/Sources/WatchApp/Home/EntityDetails/Climate/WatchClimateControlView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Climate/WatchClimateControlView.swift
@@ -158,7 +158,7 @@ struct WatchClimateControlView: View {
                     Section {
                         if control.supportsHvacModes {
                             NavigationLink {
-                                WatchClimateModeSelectionView(
+                                WatchModeSelectionView(
                                     title: L10n.Climate.Control.Mode.title,
                                     options: control.hvacModes,
                                     selected: control.hvacMode,
@@ -177,7 +177,7 @@ struct WatchClimateControlView: View {
                         }
                         if control.supportsFanMode {
                             NavigationLink {
-                                WatchClimateModeSelectionView(
+                                WatchModeSelectionView(
                                     title: L10n.Climate.Control.FanMode.title,
                                     options: control.fanModes,
                                     selected: control.fanMode,
@@ -199,7 +199,7 @@ struct WatchClimateControlView: View {
                         }
                         if control.supportsSwingMode {
                             NavigationLink {
-                                WatchClimateModeSelectionView(
+                                WatchModeSelectionView(
                                     title: L10n.Climate.Control.SwingMode.title,
                                     options: control.swingModes,
                                     selected: control.swingMode,
@@ -221,7 +221,7 @@ struct WatchClimateControlView: View {
                         }
                         if control.supportsSwingHorizontalMode {
                             NavigationLink {
-                                WatchClimateModeSelectionView(
+                                WatchModeSelectionView(
                                     title: L10n.Climate.Control.SwingHorizontalMode.title,
                                     options: control.swingHorizontalModes,
                                     selected: control.swingHorizontalMode,
@@ -243,7 +243,7 @@ struct WatchClimateControlView: View {
                         }
                         if control.supportsPresetMode {
                             NavigationLink {
-                                WatchClimateModeSelectionView(
+                                WatchModeSelectionView(
                                     title: L10n.Climate.Control.PresetMode.title,
                                     options: control.presetModes,
                                     selected: control.presetMode,

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumCleanAreasView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumCleanAreasView.swift
@@ -1,0 +1,105 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Area picker the vacuum controls screen navigates to: the areas an administrator mapped to the
+/// vacuum's segments, tapped in the order they should be cleaned (the frontend numbers the
+/// selection the same way), then started with `vacuum.clean_area`.
+///
+/// The area list comes from the paired iPhone — the mapping lives in the entity registry, which
+/// Home Assistant serves over WebSocket only, and the watch has no WebSocket. The controls screen
+/// only offers this when the phone is reachable, and this screen handles it going away mid-use.
+struct WatchVacuumCleanAreasView: View {
+    @ObservedObject var viewModel: WatchVacuumControlsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            if viewModel.isLoadingAreas {
+                loading
+            } else if viewModel.cleanableAreas.isEmpty {
+                empty
+            } else {
+                areas
+                startButton
+            }
+        }
+        .navigationTitle(Text(verbatim: L10n.Vacuum.Control.CleanAreas.title))
+        .onAppear {
+            viewModel.loadCleanableAreas()
+        }
+    }
+
+    private var loading: some View {
+        VStack(spacing: DesignSystem.Spaces.half) {
+            ProgressView()
+                .progressViewStyle(.circular)
+            Text(verbatim: L10n.Watch.EntityDetails.loading)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .listRowBackground(Color.clear)
+    }
+
+    private var empty: some View {
+        // Either nothing is mapped yet, or the phone stopped answering mid-flight. Both are
+        // resolved elsewhere (the frontend / bringing the phone closer), so just say so.
+        Text(
+            verbatim: viewModel.isPhoneReachable
+                ? L10n.Vacuum.Control.CleanAreas.empty
+                : L10n.Vacuum.Control.CleanAreas.needsPhone
+        )
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: .infinity)
+        .listRowBackground(Color.clear)
+    }
+
+    private var areas: some View {
+        ForEach(viewModel.cleanableAreas, id: \.id) { area in
+            Button {
+                viewModel.toggleAreaSelection(area.id)
+            } label: {
+                HStack {
+                    Text(verbatim: area.name)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let order = viewModel.selectionOrder(of: area.id) {
+                        // The number is the cleaning order, matching the frontend's badge.
+                        Text(verbatim: "\(order)")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.haPrimary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var startButton: some View {
+        Button {
+            viewModel.startCleaningSelectedAreas()
+            dismiss()
+        } label: {
+            Label {
+                Text(verbatim: L10n.Vacuum.Control.CleanAreas.start("\(viewModel.selectedAreaIds.count)"))
+            } icon: {
+                Image(systemSymbol: .playFill)
+            }
+        }
+        .disabled(viewModel.selectedAreaIds.isEmpty)
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "vacuum.downstairs", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-vacuum.downstairs",
+        name: "Downstairs vacuum",
+        iconName: "mdi:robot-vacuum"
+    )
+    return NavigationStack {
+        WatchVacuumCleanAreasView(viewModel: .init(item: item, itemInfo: info))
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
@@ -28,6 +28,11 @@ struct WatchVacuumControlsView: View {
             // would render empty next to the loading header.
             if viewModel.entity != nil {
                 buttonsSection
+                // Cleaning by area needs the phone to read the entity registry for us, so the
+                // option only appears while it's reachable.
+                if viewModel.capabilities?.supportsCleanArea == true, viewModel.isPhoneReachable {
+                    cleanAreasSection
+                }
                 if viewModel.capabilities?.supportsFanSpeed == true {
                     fanSpeedSection
                 }
@@ -117,6 +122,20 @@ struct WatchVacuumControlsView: View {
                 }
             }
             .listRowBackground(Color.clear)
+        }
+    }
+
+    private var cleanAreasSection: some View {
+        Section {
+            NavigationLink {
+                WatchVacuumCleanAreasView(viewModel: viewModel)
+            } label: {
+                Label {
+                    Text(verbatim: L10n.Vacuum.Control.CleanAreas.title)
+                } icon: {
+                    Image(systemSymbol: .squareGrid2x2)
+                }
+            }
         }
     }
 

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
@@ -1,0 +1,203 @@
+import HAKit
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Controls screen a vacuum row pushes when tapped: start/pause, stop and return to dock, plus —
+/// when the vacuum supports it — fan speed and locate. Vacuums have no single tap action, so
+/// every tap on their row lands here. Pushed through the home screen's `NavigationStack`, like
+/// the other entity controls.
+struct WatchVacuumControlsView: View {
+    @StateObject private var viewModel: WatchVacuumControlsViewModel
+
+    /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
+    /// is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self._viewModel = .init(
+            wrappedValue: WatchVacuumControlsViewModel(item: item, itemInfo: itemInfo, initialEntity: initialEntity)
+        )
+    }
+
+    var body: some View {
+        List {
+            header
+            if viewModel.isStale {
+                staleWarning
+            }
+            // No controls until the first snapshot — capabilities are unknown, so the sections
+            // would render empty next to the loading header.
+            if viewModel.entity != nil {
+                buttonsSection
+                if viewModel.capabilities?.supportsFanSpeed == true {
+                    fanSpeedSection
+                }
+                if viewModel.capabilities?.supportsLocate == true {
+                    locateSection
+                }
+            }
+        }
+        .navigationTitle(Text(verbatim: viewModel.name))
+        .onAppear {
+            viewModel.startStateUpdates()
+        }
+        .onDisappear {
+            viewModel.stopStateUpdates()
+        }
+    }
+
+    private var header: some View {
+        Section {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(uiImage: viewModel.icon.image(
+                    ofSize: .init(width: 24, height: 24),
+                    color: viewModel.iconColor
+                ))
+                .watchRowIconContainer(color: viewModel.iconColor)
+                if let stateText = viewModel.stateText {
+                    Text(verbatim: stateText)
+                        .font(.title3.bold())
+                        .multilineTextAlignment(.center)
+                        .minimumScaleFactor(0.6)
+                    if let battery = viewModel.capabilities?.batteryLevel {
+                        Text(verbatim: L10n.Vacuum.Control.battery("\(Int(battery))%"))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text(verbatim: L10n.Watch.EntityDetails.loading)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var staleWarning: some View {
+        Label {
+            Text(verbatim: L10n.Watch.EntityDetails.stale)
+                .font(.caption2)
+        } icon: {
+            Image(systemSymbol: .exclamationmarkCircleFill)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.black, .orange)
+        }
+    }
+
+    /// Start (or pause while cleaning), stop and return to dock, shown only for the operations
+    /// the vacuum reports.
+    @ViewBuilder
+    private var buttonsSection: some View {
+        // The screen exists for every vacuum, so render whatever subset the entity supports.
+        let capabilities = viewModel.capabilities
+        Section {
+            HStack(spacing: DesignSystem.Spaces.one) {
+                if viewModel.isCleaning, capabilities?.supportsPause == true {
+                    vacuumButton(symbol: .pauseFill, label: L10n.Vacuum.Control.pause) {
+                        viewModel.pause()
+                    }
+                } else if capabilities?.supportsStart == true {
+                    vacuumButton(symbol: .playFill, label: L10n.Vacuum.Control.start) {
+                        viewModel.start()
+                    }
+                }
+                if capabilities?.supportsStop == true {
+                    vacuumButton(symbol: .stopFill, label: L10n.Vacuum.Control.stop) {
+                        viewModel.stop()
+                    }
+                }
+                if capabilities?.supportsReturnHome == true {
+                    vacuumButton(symbol: .houseFill, label: L10n.Vacuum.Control.returnToBase) {
+                        viewModel.returnToBase()
+                    }
+                }
+            }
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var fanSpeedSection: some View {
+        Section {
+            NavigationLink {
+                WatchModeSelectionView(
+                    title: L10n.Vacuum.Control.FanSpeed.title,
+                    options: viewModel.capabilities?.fanSpeedList ?? [],
+                    selected: viewModel.capabilities?.fanSpeed,
+                    displayName: { ClimateControlState.displayName(forMode: $0) },
+                    onSelect: { viewModel.setFanSpeed($0) }
+                )
+            } label: {
+                HStack {
+                    Text(verbatim: L10n.Vacuum.Control.FanSpeed.title)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(
+                        verbatim: viewModel.capabilities?.fanSpeed
+                            .map(ClimateControlState.displayName(forMode:)) ?? ""
+                    )
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    private var locateSection: some View {
+        Section {
+            Button {
+                viewModel.locate()
+            } label: {
+                Label {
+                    Text(verbatim: L10n.Vacuum.Control.locate)
+                } icon: {
+                    Image(systemSymbol: .dotRadiowavesLeftAndRight)
+                }
+            }
+        }
+    }
+
+    private func vacuumButton(symbol: SFSymbol, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: DesignSystem.Spaces.half) {
+                Image(systemSymbol: symbol)
+                    .font(.body.weight(.semibold))
+                Text(verbatim: label)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    let item = MagicItem(id: "vacuum.downstairs", serverId: "1", type: .entity)
+    let info = MagicItem.Info(
+        id: "1-vacuum.downstairs",
+        name: "Downstairs vacuum",
+        iconName: "mdi:robot-vacuum"
+    )
+    let entity = try? HAEntity(
+        entityId: "vacuum.downstairs",
+        state: "cleaning",
+        lastChanged: Date(timeIntervalSinceNow: -600),
+        lastUpdated: Date(timeIntervalSinceNow: -60),
+        attributes: [
+            "friendly_name": "Downstairs vacuum",
+            "supported_features": 8828,
+            "battery_level": 80,
+            "fan_speed": "medium",
+            "fan_speed_list": ["quiet", "medium", "high", "max"],
+        ],
+        context: .init(id: "", userId: "", parentId: "")
+    )
+    // In the app this screen is pushed by a row inside the home's NavigationStack.
+    return NavigationStack {
+        WatchVacuumControlsView(item: item, itemInfo: info, initialEntity: entity)
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
@@ -116,7 +116,9 @@ struct WatchVacuumControlsView: View {
                     }
                 }
                 if capabilities?.supportsReturnHome == true {
-                    vacuumButton(symbol: .houseFill, label: L10n.Vacuum.Control.returnToBase) {
+                    // Icon only: "Return to dock" is far too long to sit under a third-width
+                    // button, and the house reads clearly on its own.
+                    vacuumButton(symbol: .houseFill, label: nil, accessibilityLabel: L10n.Vacuum.Control.returnToBase) {
                         viewModel.returnToBase()
                     }
                 }
@@ -178,18 +180,28 @@ struct WatchVacuumControlsView: View {
         }
     }
 
-    private func vacuumButton(symbol: SFSymbol, label: String, action: @escaping () -> Void) -> some View {
+    /// A `nil` label renders the icon alone — for commands whose name is too long to sit under a
+    /// third-width button; `accessibilityLabel` then carries the name for VoiceOver.
+    private func vacuumButton(
+        symbol: SFSymbol,
+        label: String?,
+        accessibilityLabel: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             VStack(spacing: DesignSystem.Spaces.half) {
                 Image(systemSymbol: symbol)
                     .font(.body.weight(.semibold))
-                Text(verbatim: label)
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.6)
+                if let label {
+                    Text(verbatim: label)
+                        .font(.caption2)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                }
             }
             .frame(maxWidth: .infinity)
         }
+        .accessibilityLabel(Text(verbatim: accessibilityLabel ?? label ?? ""))
     }
 }
 

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+import HAKit
+import Shared
+import UIKit
+import WatchKit
+
+/// Backs the vacuum controls screen: start/pause/stop/return to dock plus fan speed.
+///
+/// Mirrors `WatchCoverControlsViewModel`: state stays fresh through the shared REST polling
+/// (`WatchEntityStatePoller`) and commands go out as vacuum service REST calls
+/// (`WatchServiceCallSender`). There is nothing continuous to debounce — every control is an
+/// explicit button or a single-choice pick.
+final class WatchVacuumControlsViewModel: ObservableObject {
+    @Published private(set) var entity: HAEntity?
+    /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
+    /// presenting the values as current.
+    @Published private(set) var isStale = false
+
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+
+    private let poller: WatchEntityStatePoller
+
+    /// The view model is built inside `StateObject`'s autoclosure by its screen, so creation
+    /// (and its poller) is deferred until the screen is actually pushed.
+    init(item: MagicItem, itemInfo: MagicItem.Info, initialEntity: HAEntity? = nil) {
+        self.item = item
+        self.itemInfo = itemInfo
+        self.poller = WatchEntityStatePoller(entityId: item.id, serverId: item.serverId)
+        self.entity = initialEntity
+    }
+
+    var name: String {
+        item.name(info: itemInfo)
+    }
+
+    var capabilities: VacuumCapabilities? {
+        entity.map(VacuumCapabilities.init(entity:))
+    }
+
+    var stateText: String? {
+        guard let entity, let domain = item.domain else { return nil }
+        return domain.contextualStateDescription(for: entity)
+    }
+
+    /// Whether the vacuum is actively cleaning, which flips the primary button to pause.
+    var isCleaning: Bool {
+        entity?.state == "cleaning"
+    }
+
+    var icon: MaterialDesignIcons {
+        item.icon(info: itemInfo)
+    }
+
+    var iconColor: UIColor {
+        if let hex = itemInfo.customization?.iconColor {
+            return UIColor(hex: hex)
+        }
+        return .white
+    }
+
+    func startStateUpdates() {
+        poller.start { [weak self] snapshot in
+            guard let self else { return }
+            if let entity = snapshot.entity {
+                self.entity = entity
+            }
+            isStale = snapshot.isStale
+        }
+    }
+
+    func stopStateUpdates() {
+        poller.stop()
+    }
+
+    // MARK: - Commands
+
+    func start() {
+        send(service: .start)
+    }
+
+    func pause() {
+        send(service: .pause)
+    }
+
+    func stop() {
+        send(service: .stop)
+    }
+
+    func returnToBase() {
+        send(service: .returnToBase)
+    }
+
+    func locate() {
+        send(service: .locate)
+    }
+
+    func setFanSpeed(_ speed: String) {
+        send(service: .setFanSpeed, data: ["fan_speed": speed])
+    }
+
+    // MARK: - Private
+
+    private func send(service: Service, data: [String: Any] = [:]) {
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == item.serverId }) else {
+            Current.Log.error("Server \(item.serverId) not synced to the watch for vacuum controls")
+            WKInterfaceDevice.current().play(.failure)
+            return
+        }
+        WKInterfaceDevice.current().play(.click)
+        WatchServiceCallSender.send(
+            domain: .vacuum,
+            service: service,
+            entityId: item.id,
+            data: data,
+            server: server
+        ) { [weak poller] success in
+            if success {
+                // Reflect the executed command quickly instead of waiting a full poll interval.
+                poller?.refresh(after: 1)
+            } else {
+                WKInterfaceDevice.current().play(.failure)
+            }
+        }
+    }
+}

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
@@ -49,11 +49,8 @@ final class WatchVacuumControlsViewModel: ObservableObject {
         self.entity = initialEntity
     }
 
-    /// The entity's friendly name, preferred over the configured item name because this screen is
-    /// also reached from the area screens, where the entity isn't a configured home item and the
-    /// info lookup falls back to the raw entity id.
     var name: String {
-        entity?.attributes.friendlyName ?? item.name(info: itemInfo)
+        item.name(info: itemInfo)
     }
 
     var capabilities: VacuumCapabilities? {

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
@@ -15,11 +15,30 @@ final class WatchVacuumControlsViewModel: ObservableObject {
     /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
     /// presenting the values as current.
     @Published private(set) var isStale = false
+    /// Areas the vacuum can be told to clean, relayed by the phone (see `loadCleanableAreas`).
+    @Published private(set) var cleanableAreas: [VacuumAreaMapping.Area] = []
+    /// True while the phone is answering, so the picker can say so rather than looking empty.
+    @Published private(set) var isLoadingAreas = false
+    /// Area ids picked for the next `clean_area` call, in tap order — the service takes an ordered
+    /// list, and the frontend surfaces the same numbering.
+    @Published private(set) var selectedAreaIds: [String] = []
+    /// Whether the iPhone is close enough to answer right now. Cleaning by area needs it: the
+    /// areas come from the entity registry, which Home Assistant serves over WebSocket only — a
+    /// transport the watch doesn't have. Without the phone the option is hidden rather than shown
+    /// broken.
+    @Published private(set) var isPhoneReachable = false
 
     let item: MagicItem
     let itemInfo: MagicItem.Info
 
     private let poller: WatchEntityStatePoller
+    private var reachabilityObservation: HAWatchConnectivity.ObservationToken?
+
+    deinit {
+        if let reachabilityObservation {
+            Communicator.shared.reachability.unobserve(reachabilityObservation)
+        }
+    }
 
     /// The view model is built inside `StateObject`'s autoclosure by its screen, so creation
     /// (and its poller) is deferred until the screen is actually pushed.
@@ -67,10 +86,74 @@ final class WatchVacuumControlsViewModel: ObservableObject {
             }
             isStale = snapshot.isStale
         }
+        observeReachability()
     }
 
     func stopStateUpdates() {
         poller.stop()
+    }
+
+    /// Track the phone's reachability while the screen is open, so the clean-by-area option
+    /// appears and disappears with it instead of being decided once on appear.
+    private func observeReachability() {
+        isPhoneReachable = Communicator.shared.currentReachability == .immediatelyReachable
+        guard reachabilityObservation == nil else { return }
+        reachabilityObservation = Communicator.shared.reachability.observe { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.isPhoneReachable = Communicator.shared.currentReachability == .immediatelyReachable
+            }
+        }
+    }
+
+    // MARK: - Clean areas
+
+    /// Ask the phone which areas this vacuum can clean. The watch can't read the entity registry
+    /// itself, so the phone makes the WebSocket call and replies with resolved `{id, name}` pairs.
+    func loadCleanableAreas() {
+        guard Communicator.shared.currentReachability == .immediatelyReachable else {
+            Current.Log.info("[Watch] Skipping vacuum area fetch, iPhone not immediately reachable")
+            isPhoneReachable = false
+            return
+        }
+        isLoadingAreas = true
+        Communicator.shared.send(.init(
+            identifier: InteractiveImmediateMessages.vacuumCleanableAreas.rawValue,
+            content: ["entityId": item.id, "serverId": item.serverId],
+            reply: { [weak self] message in
+                let wireAreas = message.content["areas"] as? [[String: String]] ?? []
+                DispatchQueue.main.async {
+                    self?.cleanableAreas = wireAreas.compactMap(VacuumAreaMapping.Area.init(wireFormat:))
+                    self?.isLoadingAreas = false
+                }
+            }
+        ), errorHandler: { [weak self] error in
+            Current.Log.error("[Watch] Failed to request vacuum areas: \(error)")
+            DispatchQueue.main.async {
+                self?.isLoadingAreas = false
+            }
+        })
+    }
+
+    /// Adds or removes an area from the pending selection, preserving tap order.
+    func toggleAreaSelection(_ areaId: String) {
+        if let index = selectedAreaIds.firstIndex(of: areaId) {
+            selectedAreaIds.remove(at: index)
+        } else {
+            selectedAreaIds.append(areaId)
+        }
+    }
+
+    /// 1-based position of an area in the pending selection, or nil when it isn't selected.
+    func selectionOrder(of areaId: String) -> Int? {
+        selectedAreaIds.firstIndex(of: areaId).map { $0 + 1 }
+    }
+
+    /// The service call itself goes out over REST like every other watch command — only the area
+    /// list needed the phone.
+    func startCleaningSelectedAreas() {
+        guard !selectedAreaIds.isEmpty else { return }
+        send(service: .cleanArea, data: ["cleaning_area_id": selectedAreaIds])
+        selectedAreaIds = []
     }
 
     // MARK: - Commands

--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsViewModel.swift
@@ -49,8 +49,11 @@ final class WatchVacuumControlsViewModel: ObservableObject {
         self.entity = initialEntity
     }
 
+    /// The entity's friendly name, preferred over the configured item name because this screen is
+    /// also reached from the area screens, where the entity isn't a configured home item and the
+    /// info lookup falls back to the raw entity id.
     var name: String {
-        item.name(info: itemInfo)
+        entity?.attributes.friendlyName ?? item.name(info: itemInfo)
     }
 
     var capabilities: VacuumCapabilities? {

--- a/Sources/WatchApp/Home/EntityDetails/WatchModeSelectionView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/WatchModeSelectionView.swift
@@ -2,10 +2,10 @@ import SFSafeSymbols
 import Shared
 import SwiftUI
 
-/// Single-choice list the climate control screen navigates to for a mode attribute
-/// (HVAC/fan/swing/preset): the current value carries a checkmark, and selecting an option
-/// reports it back and pops.
-struct WatchClimateModeSelectionView: View {
+/// Single-choice list a control screen navigates to for a mode attribute (climate's
+/// HVAC/fan/swing/preset modes, a vacuum's fan speed): the current value carries a checkmark, and
+/// selecting an option reports it back and pops.
+struct WatchModeSelectionView: View {
     let title: String
     let options: [String]
     let selected: String?
@@ -38,7 +38,7 @@ struct WatchClimateModeSelectionView: View {
 
 #Preview {
     NavigationView {
-        WatchClimateModeSelectionView(
+        WatchModeSelectionView(
             title: "Mode",
             options: ["off", "heat", "cool", "heat_cool"],
             selected: "heat",

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -19,7 +19,7 @@ struct WatchMagicViewRow: View {
         // list): which button triggers them depends on the row variant below.
         Group {
             if let rowDestination = viewModel.wholeRowNavigationDestination {
-                // Locks and climate: the whole row (icon included) opens their screen, in both
+                // Locks, climate and vacuums: the whole row (icon included) opens their screen, in both
                 // layouts.
                 Button {
                     navigate(rowDestination)
@@ -133,7 +133,7 @@ struct WatchMagicViewRow: View {
                 textColor: textColor,
                 icon: { iconToDisplay.animation(.bouncy, value: viewModel.state) },
                 accessory: {
-                    // Rows that navigate as a whole (locks, climate) show the same chevron as
+                    // Rows that navigate as a whole (locks, climate, vacuums) show the same chevron as
                     // folders.
                     if viewModel.wholeRowNavigationDestination != nil {
                         Image(systemSymbol: .chevronRight)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -86,13 +86,16 @@ final class WatchMagicViewRowViewModel: ObservableObject {
     /// screens handle an unknown state themselves.
     var wholeRowNavigationDestination: WatchHomeNavigation? {
         guard item.type == .entity, let domain = item.domain else { return nil }
-        if domain == .lock {
+        switch domain {
+        case .lock:
             return .lockControls(item)
-        }
-        if domain.hasControlScreen {
+        case .climate:
             return .climateControls(item)
+        case .vacuum:
+            return .vacuumControls(item)
+        default:
+            return nil
         }
-        return nil
     }
 
     /// The controls screen this row's body pushes, once the polled state proves the entity can do

--- a/Sources/WatchApp/Home/WatchHomeNavigation.swift
+++ b/Sources/WatchApp/Home/WatchHomeNavigation.swift
@@ -19,6 +19,8 @@ enum WatchHomeNavigation: Hashable {
     /// The controls screen (target temperature, HVAC/fan/swing/preset modes, humidity) of a
     /// climate entity.
     case climateControls(MagicItem)
+    /// The controls screen (start/pause/stop/return to dock, fan speed) of a vacuum.
+    case vacuumControls(MagicItem)
     /// The server chooser of the grouped areas row, limited to the servers whose areas contain
     /// watch-compatible entities.
     case areasServerPicker(serverIds: [String])

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -69,6 +69,8 @@ struct WatchHomeView: View {
                         WatchLockControlsView(item: item, itemInfo: viewModel.info(for: item))
                     case let .climateControls(item):
                         WatchClimateControlView(item: item, itemInfo: viewModel.info(for: item))
+                    case let .vacuumControls(item):
+                        WatchVacuumControlsView(item: item, itemInfo: viewModel.info(for: item))
                     case let .areasServerPicker(serverIds):
                         WatchAreasServerPickerView(serverIds: serverIds)
                     case let .areasList(serverId):

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -27,6 +27,10 @@ final class WatchHomeViewModel: ObservableObject {
 
     @Published var watchConfig: WatchConfig = .init()
     @Published var magicItemsInfo: [MagicItem.Info] = []
+    /// Retained across cache loads so `info(for:)` can resolve entities that aren't configured home
+    /// items — the ones the area screens push. `Current.magicItemProvider()` hands back an empty
+    /// instance every call, so the loaded one has to be kept rather than rebuilt per lookup.
+    private let magicItemProvider = Current.magicItemProvider()
     /// How the home screen presents the automatic area rows; recomputed on every cache load so it
     /// follows config edits and mirror syncs.
     @Published private(set) var areasMode: WatchHomeAreasMode = .hidden
@@ -234,13 +238,16 @@ final class WatchHomeViewModel: ObservableObject {
     }
 
     func info(for magicItem: MagicItem) -> MagicItem.Info {
-        magicItemsInfo.first(where: {
-            $0.id == magicItem.serverUniqueId
-        }) ?? .init(
-            id: magicItem.id,
-            name: magicItem.id,
-            iconName: ""
-        )
+        if let configured = magicItemsInfo.first(where: { $0.id == magicItem.serverUniqueId }) {
+            return configured
+        }
+        // Not a configured home item — the area screens push entities the user never added, and
+        // their info lives in the mirrored entity database instead. Resolving it here keeps every
+        // pushed control screen titled with the entity's name rather than its id.
+        if let resolved = magicItemProvider.getInfo(for: magicItem) {
+            return resolved
+        }
+        return .init(id: magicItem.id, name: magicItem.id, iconName: "")
     }
 
     // MARK: - Offline-aware config reconciliation
@@ -621,7 +628,7 @@ final class WatchHomeViewModel: ObservableObject {
         // but the user should not see the empty state while cached rows already exist.
         updateConfig(config: config, magicItemsInfo: magicItemsInfo)
 
-        let provider = Current.magicItemProvider()
+        let provider = magicItemProvider
         provider.loadInformation { [weak self] entitiesPerServer in
             DispatchQueue.main.async {
                 guard let self else { return }

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -358,13 +358,13 @@ struct DomainFeatureSupportTests {
     @Test func carPlaySupportedMembership() {
         let expected: Set<Domain> = [
             .automation, .button, .climate, .cover, .fan, .humidifier, .inputBoolean, .inputButton,
-            .light, .lock, .scene, .script, .switch, .valve,
+            .light, .lock, .scene, .script, .switch, .vacuum, .valve,
         ]
         #expect(Set(Domain.carPlaySupported) == expected, "Domain.carPlaySupported membership changed")
     }
 
     @Test func controlScreenMembership() {
-        let expected: Set<Domain> = [.climate]
+        let expected: Set<Domain> = [.climate, .vacuum]
         #expect(Set(Domain.controlScreenDomains) == expected, "Domain.controlScreenDomains membership changed")
         for domain in Domain.allCases {
             #expect(

--- a/Tests/Shared/Service.test.swift
+++ b/Tests/Shared/Service.test.swift
@@ -54,6 +54,10 @@ struct ServiceTests {
             "Service.setFanSpeed raw value should be 'set_fan_speed'"
         )
         #expect(Service.locate.rawValue == "locate", "Service.locate raw value should be 'locate'")
+        #expect(
+            Service.cleanArea.rawValue == "clean_area",
+            "Service.cleanArea raw value should be 'clean_area'"
+        )
 
         // Test initialization from raw value
         #expect(Service(rawValue: "turn_on") == .turnOn, "Service(rawValue: 'turn_on') should initialize to .turnOn")
@@ -93,8 +97,8 @@ struct ServiceTests {
 
         // Test case count
         #expect(
-            Service.allCases.count == 26,
-            "Service enum should have 26 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
+            Service.allCases.count == 27,
+            "Service enum should have 27 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
         )
     }
 }

--- a/Tests/Shared/Service.test.swift
+++ b/Tests/Shared/Service.test.swift
@@ -42,6 +42,18 @@ struct ServiceTests {
             Service.setHumidity.rawValue == "set_humidity",
             "Service.setHumidity raw value should be 'set_humidity'"
         )
+        #expect(Service.start.rawValue == "start", "Service.start raw value should be 'start'")
+        #expect(Service.pause.rawValue == "pause", "Service.pause raw value should be 'pause'")
+        #expect(Service.stop.rawValue == "stop", "Service.stop raw value should be 'stop'")
+        #expect(
+            Service.returnToBase.rawValue == "return_to_base",
+            "Service.returnToBase raw value should be 'return_to_base'"
+        )
+        #expect(
+            Service.setFanSpeed.rawValue == "set_fan_speed",
+            "Service.setFanSpeed raw value should be 'set_fan_speed'"
+        )
+        #expect(Service.locate.rawValue == "locate", "Service.locate raw value should be 'locate'")
 
         // Test initialization from raw value
         #expect(Service(rawValue: "turn_on") == .turnOn, "Service(rawValue: 'turn_on') should initialize to .turnOn")
@@ -81,8 +93,8 @@ struct ServiceTests {
 
         // Test case count
         #expect(
-            Service.allCases.count == 20,
-            "Service enum should have 20 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
+            Service.allCases.count == 26,
+            "Service enum should have 26 cases, but has \(Service.allCases.count). Cases: \(Service.allCases.map(\.rawValue).joined(separator: ", "))"
         )
     }
 }

--- a/Tests/Shared/VacuumAreaMapping.test.swift
+++ b/Tests/Shared/VacuumAreaMapping.test.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct VacuumAreaMappingTests {
+    @Test func readsMappedAreaIdsFromRegistryOptions() {
+        // Shape of `config/entity_registry/get`: the mapping is area id → the vacuum's segment ids,
+        // and only the keys (the areas) matter to `vacuum.clean_area`.
+        let mapping = VacuumAreaMapping(attributes: [
+            "entity_id": "vacuum.downstairs",
+            "options": [
+                "vacuum": [
+                    "area_mapping": [
+                        "kitchen": ["16"],
+                        "living_room": ["17", "18"],
+                    ],
+                ],
+            ],
+        ])
+
+        #expect(mapping.areaIds == ["kitchen", "living_room"])
+    }
+
+    @Test func sortsAreaIdsForStableOrdering() {
+        let mapping = VacuumAreaMapping(attributes: [
+            "options": ["vacuum": ["area_mapping": [
+                "study": ["3"],
+                "bedroom": ["1"],
+                "hallway": ["2"],
+            ]]],
+        ])
+
+        #expect(mapping.areaIds == ["bedroom", "hallway", "study"])
+    }
+
+    @Test func missingOptionsYieldNoAreas() {
+        // A vacuum that advertises cleaning by area but has nothing mapped yet, and entries whose
+        // options carry other domains only — both must read as "no areas", not as a failure.
+        #expect(VacuumAreaMapping(attributes: [:]).areaIds.isEmpty)
+        #expect(VacuumAreaMapping(attributes: ["options": [:]]).areaIds.isEmpty)
+        #expect(VacuumAreaMapping(attributes: ["options": ["vacuum": [:]]]).areaIds.isEmpty)
+        #expect(VacuumAreaMapping(attributes: ["options": ["light": ["favorite_colors": []]]]).areaIds.isEmpty)
+    }
+
+    @Test func unexpectedMappingShapeIsIgnored() {
+        // Defensive: a payload whose mapping isn't a dictionary must not crash the picker.
+        #expect(VacuumAreaMapping(attributes: ["options": ["vacuum": ["area_mapping": "nope"]]]).areaIds.isEmpty)
+    }
+}

--- a/Tests/Shared/VacuumCapabilities.test.swift
+++ b/Tests/Shared/VacuumCapabilities.test.swift
@@ -1,0 +1,72 @@
+import Foundation
+@testable import Shared
+import Testing
+
+struct VacuumCapabilitiesTests {
+    @Test func fullFeaturedVacuumSupportsEverything() {
+        let capabilities = VacuumCapabilities(attributes: [
+            "supported_features": 8828,
+            "battery_level": 80,
+            "fan_speed": "medium",
+            "fan_speed_list": ["quiet", "medium", "high", "max"],
+        ])
+
+        #expect(capabilities.supportsStart)
+        #expect(capabilities.supportsPause)
+        #expect(capabilities.supportsStop)
+        #expect(capabilities.supportsReturnHome)
+        #expect(capabilities.supportsLocate)
+        #expect(capabilities.supportsFanSpeed)
+        #expect(capabilities.fanSpeed == "medium")
+        #expect(capabilities.fanSpeedList == ["quiet", "medium", "high", "max"])
+        #expect(capabilities.batteryLevel == 80)
+    }
+
+    @Test func featureBitsMatchCore() {
+        #expect(VacuumCapabilities.Feature.pause.rawValue == 4)
+        #expect(VacuumCapabilities.Feature.stop.rawValue == 8)
+        #expect(VacuumCapabilities.Feature.returnHome.rawValue == 16)
+        #expect(VacuumCapabilities.Feature.fanSpeed.rawValue == 32)
+        #expect(VacuumCapabilities.Feature.battery.rawValue == 64)
+        #expect(VacuumCapabilities.Feature.locate.rawValue == 512)
+        #expect(VacuumCapabilities.Feature.start.rawValue == 8192)
+    }
+
+    @Test func bareVacuumSupportsNothing() {
+        let capabilities = VacuumCapabilities(attributes: [:])
+
+        #expect(!capabilities.supportsStart)
+        #expect(!capabilities.supportsPause)
+        #expect(!capabilities.supportsStop)
+        #expect(!capabilities.supportsReturnHome)
+        #expect(!capabilities.supportsLocate)
+        #expect(!capabilities.supportsFanSpeed)
+        #expect(capabilities.fanSpeed == nil)
+        #expect(capabilities.fanSpeedList.isEmpty)
+        #expect(capabilities.batteryLevel == nil)
+    }
+
+    @Test func fanSpeedRequiresBitAndOptions() {
+        // Feature bit set but no speed list → the picker has nothing to offer.
+        let withoutOptions = VacuumCapabilities(attributes: [
+            "supported_features": 32,
+        ])
+        #expect(!withoutOptions.supportsFanSpeed)
+
+        // Speed list present but feature bit unset → the entity doesn't support the service.
+        let withoutBit = VacuumCapabilities(attributes: [
+            "supported_features": 0,
+            "fan_speed_list": ["low", "high"],
+        ])
+        #expect(!withoutBit.supportsFanSpeed)
+    }
+
+    @Test func batteryRequiresFeatureBit() {
+        // A reported battery_level without the feature bit isn't advertised as supported.
+        let capabilities = VacuumCapabilities(attributes: [
+            "supported_features": 0,
+            "battery_level": 55,
+        ])
+        #expect(capabilities.batteryLevel == nil)
+    }
+}

--- a/Tests/Shared/VacuumCapabilities.test.swift
+++ b/Tests/Shared/VacuumCapabilities.test.swift
@@ -34,6 +34,19 @@ struct VacuumCapabilitiesTests {
         #expect(VacuumCapabilities.Feature.cleanArea.rawValue == 16384)
     }
 
+    @Test func parsesFeaturesDeliveredAsNSNumber() {
+        // Both transports hand the attributes over as JSONSerialization output, where numbers are
+        // NSNumber. `as? Int` bridges those, and this pins that down: were it to stop holding, every
+        // capability would silently read as unsupported.
+        let capabilities = VacuumCapabilities(attributes: [
+            "supported_features": NSNumber(value: 25212),
+        ])
+
+        #expect(capabilities.supportsStart)
+        #expect(capabilities.supportsCleanArea)
+        #expect(capabilities.batteryLevel == nil, "no battery_level attribute was reported")
+    }
+
     @Test func bareVacuumSupportsNothing() {
         let capabilities = VacuumCapabilities(attributes: [:])
 

--- a/Tests/Shared/VacuumCapabilities.test.swift
+++ b/Tests/Shared/VacuumCapabilities.test.swift
@@ -5,7 +5,7 @@ import Testing
 struct VacuumCapabilitiesTests {
     @Test func fullFeaturedVacuumSupportsEverything() {
         let capabilities = VacuumCapabilities(attributes: [
-            "supported_features": 8828,
+            "supported_features": 25212,
             "battery_level": 80,
             "fan_speed": "medium",
             "fan_speed_list": ["quiet", "medium", "high", "max"],
@@ -16,6 +16,7 @@ struct VacuumCapabilitiesTests {
         #expect(capabilities.supportsStop)
         #expect(capabilities.supportsReturnHome)
         #expect(capabilities.supportsLocate)
+        #expect(capabilities.supportsCleanArea)
         #expect(capabilities.supportsFanSpeed)
         #expect(capabilities.fanSpeed == "medium")
         #expect(capabilities.fanSpeedList == ["quiet", "medium", "high", "max"])
@@ -30,6 +31,7 @@ struct VacuumCapabilitiesTests {
         #expect(VacuumCapabilities.Feature.battery.rawValue == 64)
         #expect(VacuumCapabilities.Feature.locate.rawValue == 512)
         #expect(VacuumCapabilities.Feature.start.rawValue == 8192)
+        #expect(VacuumCapabilities.Feature.cleanArea.rawValue == 16384)
     }
 
     @Test func bareVacuumSupportsNothing() {
@@ -40,6 +42,7 @@ struct VacuumCapabilitiesTests {
         #expect(!capabilities.supportsStop)
         #expect(!capabilities.supportsReturnHome)
         #expect(!capabilities.supportsLocate)
+        #expect(!capabilities.supportsCleanArea)
         #expect(!capabilities.supportsFanSpeed)
         #expect(capabilities.fanSpeed == nil)
         #expect(capabilities.fanSpeedList.isEmpty)


### PR DESCRIPTION


## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I&#39;ve reviewed and understood it before submitting and will respond without AI during review.

## Summary
Tapping a vacuum on CarPlay or the Apple Watch did nothing, since a vacuum has no single toggle action. Vacuums now join climate as a control-screen domain: the row opens a control screen showing only what the entity supports — start/pause, stop, return to dock, locate, fan speed and battery level.

It also supports cleaning specific areas, like the frontend&#39;s more-info dialog: for vacuums that report `CLEAN_AREA`, the areas an administrator mapped to the vacuum&#39;s segments can be picked in the order they should be cleaned, then started with `vacuum.clean_area`.

That mapping lives in the entity registry, which is only served over WebSocket. CarPlay reads it directly. The watch has no WebSocket, so it asks the paired iPhone over WatchConnectivity and the phone replies with the resolved areas; the option is only offered while the iPhone is reachable, and starting the clean still goes out over REST like every other watch command.

It also fixes a bug that isn&#39;t vacuum-specific: control screens opened from the watch area screens were titled with the raw entity id, because the home view model only knew the info of configured home items. It now falls back to the magic item provider, which knows every mirrored entity — so light, cover, fan, lock and climate screens get their names back too.

## Screenshots

Not available yet — this was developed without access to a simulator. Can be added on request.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
The CarPlay entity-list and Quick Access dispatch now goes through a small factory, so future control-screen domains plug in with one case. The watch relay needs a real device to verify. Snapshot tests for the new watch views still need reference images recorded on a Mac.