### PR TITLE
Show a loading indicator on watch lock actions

### DIFF
--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
@@ -27,11 +27,11 @@ struct WatchLockControlsView: View {
             }
             Section {
                 HStack(spacing: DesignSystem.Spaces.one) {
-                    actionButton(symbol: .lockFill, label: L10n.Watch.LockControls.lock) {
+                    actionButton(symbol: .lockFill, label: L10n.Watch.LockControls.lock, action: .lock) {
                         viewModel.lock()
                     }
                     .disabled(!viewModel.canLock)
-                    actionButton(symbol: .lockOpenFill, label: L10n.Watch.LockControls.unlock) {
+                    actionButton(symbol: .lockOpenFill, label: L10n.Watch.LockControls.unlock, action: .unlock) {
                         viewModel.unlock()
                     }
                     .disabled(!viewModel.canUnlock)
@@ -40,7 +40,7 @@ struct WatchLockControlsView: View {
             }
             if viewModel.supportsOpen {
                 Section {
-                    actionButton(symbol: .doorLeftHandOpen, label: L10n.Watch.LockControls.open) {
+                    actionButton(symbol: .doorLeftHandOpen, label: L10n.Watch.LockControls.open, action: .open) {
                         viewModel.open()
                     }
                     .disabled(!viewModel.canOpen)
@@ -95,11 +95,27 @@ struct WatchLockControlsView: View {
         }
     }
 
-    private func actionButton(symbol: SFSymbol, label: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+    private func actionButton(
+        symbol: SFSymbol,
+        label: String,
+        action: WatchLockControlsViewModel.Action,
+        onTap: @escaping () -> Void
+    ) -> some View {
+        Button(action: onTap) {
             VStack(spacing: DesignSystem.Spaces.half) {
-                Image(systemSymbol: symbol)
-                    .font(.body.weight(.semibold))
+                // A lock command can take seconds to reach the server, so the tapped button turns
+                // into a spinner until it answers. Fixed height so swapping the two doesn't
+                // resize the button.
+                Group {
+                    if viewModel.pendingAction == action {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                    } else {
+                        Image(systemSymbol: symbol)
+                            .font(.body.weight(.semibold))
+                    }
+                }
+                .frame(height: DesignSystem.Spaces.three)
                 Text(verbatim: label)
                     .font(.caption2)
                     .lineLimit(1)

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -11,10 +11,22 @@ import WatchKit
 /// can't lock a locked lock or unlock an unlocked one, and everything is disabled until the first
 /// state fetch answers (acting blind on a lock is worse than waiting a second).
 final class WatchLockControlsViewModel: ObservableObject {
+    /// One of the screen's three buttons, used to mark which command is currently in flight.
+    enum Action {
+        case lock
+        case unlock
+        case open
+    }
+
     @Published private(set) var entity: HAEntity?
     /// True when the state couldn't be refreshed recently — the screen shows a warning instead of
     /// presenting the state as current.
     @Published private(set) var isStale = false
+    /// The command waiting on the server, if any. The command travels over REST and can take a
+    /// while on a poor connection, so its button shows a spinner and every button stays disabled
+    /// until the server answers — both to signal the wait and to keep a second tap from queueing
+    /// another call.
+    @Published private(set) var pendingAction: Action?
 
     let item: MagicItem
     let itemInfo: MagicItem.Info
@@ -68,21 +80,21 @@ final class WatchLockControlsViewModel: ObservableObject {
     /// Locking is pointless when already locked (or on the way there), and impossible while the
     /// state is unknown.
     var canLock: Bool {
-        guard let state = knownState else { return false }
+        guard pendingAction == nil, let state = knownState else { return false }
         return ![.locked, .locking].contains(state)
     }
 
     /// Unlocking is pointless when already unlocked (or on the way there / open), and impossible
     /// while the state is unknown.
     var canUnlock: Bool {
-        guard let state = knownState else { return false }
+        guard pendingAction == nil, let state = knownState else { return false }
         return ![.unlocked, .unlocking, .open, .opening].contains(state)
     }
 
     /// Open (unlatch) works from any known state — e.g. a Nuki can unlatch a locked door —
     /// but never blind.
     var canOpen: Bool {
-        knownState != nil
+        pendingAction == nil && knownState != nil
     }
 
     func startStateUpdates() {
@@ -102,15 +114,15 @@ final class WatchLockControlsViewModel: ObservableObject {
     // MARK: - Commands
 
     func lock() {
-        send(service: .lock)
+        send(service: .lock, action: .lock)
     }
 
     func unlock() {
-        send(service: .unlock)
+        send(service: .unlock, action: .unlock)
     }
 
     func open() {
-        send(service: .open)
+        send(service: .open, action: .open)
     }
 
     // MARK: - Private
@@ -123,21 +135,30 @@ final class WatchLockControlsViewModel: ObservableObject {
         return state
     }
 
-    private func send(service: Service) {
+    /// Marks the action as pending for the whole round trip, so the screen can show the wait, and
+    /// clears it once the server answers — `WatchServiceCallSender` always calls back (it fails the
+    /// call on its own token and request deadlines), so the spinner can't outlive the request.
+    private func send(service: Service, action: Action) {
+        guard pendingAction == nil else { return }
         guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == item.serverId }) else {
             Current.Log.error("Server \(item.serverId) not synced to the watch for lock controls")
             WKInterfaceDevice.current().play(.failure)
             return
         }
+        pendingAction = action
+        // Same tap feedback the home rows give when an execution starts.
+        WKInterfaceDevice.current().play(.click)
         WatchServiceCallSender.send(
             domain: .lock,
             service: service,
             entityId: item.id,
             server: server
-        ) { [weak poller] success in
+        ) { [weak self] success in
+            // Called on the main queue by the sender.
+            self?.pendingAction = nil
             if success {
                 // Reflect the executed command quickly instead of waiting a full poll interval.
-                poller?.refresh(after: 1)
+                self?.poller.refresh(after: 1)
             } else {
                 WKInterfaceDevice.current().play(.failure)
             }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Lock, unlock and open on the watch lock screen send a REST service call that can take a while depending on connectivity, and until now nothing on screen showed that the tap was being handled.

The tapped button now turns into a spinner until the server answers, and all buttons stay disabled while a command is in flight so a second tap can't queue another call.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — watch-only change, the button icon is replaced by a spinner while the call is in flight.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZfr312N7zZ2Hbxz4mneZR)_