### PR TITLE
Confirm open action on watch lock controls and add haptics

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2334,6 +2334,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.light_controls.temperature" = "Temperature";
 "watch.lock_controls.lock" = "Lock";
 "watch.lock_controls.open" = "Open";
+"watch.lock_controls.open_confirmation.title" = "Are you sure you want to open \"%@\"?";
 "watch.lock_controls.unlock" = "Unlock";
 "watch.placeholder_complication_name" = "Placeholder";
 "watch.settings.auto" = "Auto";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -7616,6 +7616,12 @@ public enum L10n {
       public static var `open`: String { return L10n.tr("Localizable", "watch.lock_controls.open") }
       /// Unlock
       public static var unlock: String { return L10n.tr("Localizable", "watch.lock_controls.unlock") }
+      public enum OpenConfirmation {
+        /// Are you sure you want to open "%@"?
+        public static func title(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "watch.lock_controls.open_confirmation.title", String(describing: p1))
+        }
+      }
     }
     public enum Settings {
       /// Auto

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
@@ -8,8 +8,12 @@ import SwiftUI
 /// A state-colored icon with the current state below it, a lock/unlock button pair, and — when
 /// the lock advertises the open (unlatch) feature, mirroring the frontend's `more-info-lock` —
 /// an open button. Buttons that can't act on the current state are disabled and greyed out.
+///
+/// Open (unlatch) physically releases the door rather than just changing a bolt's state, so it
+/// asks for confirmation first — a stray tap on a wrist shouldn't swing a door open.
 struct WatchLockControlsView: View {
     @StateObject private var viewModel: WatchLockControlsViewModel
+    @State private var showOpenConfirmation = false
 
     /// The view model is built inside `StateObject`'s autoclosure, so creation (and its poller)
     /// is deferred until the screen is actually pushed.
@@ -41,9 +45,25 @@ struct WatchLockControlsView: View {
             if viewModel.supportsOpen {
                 Section {
                     actionButton(symbol: .doorLeftHandOpen, label: L10n.Watch.LockControls.open) {
-                        viewModel.open()
+                        showOpenConfirmation = true
                     }
                     .disabled(!viewModel.canOpen)
+                    // Owned by the open button itself, so no other control can present it.
+                    .confirmationDialog(
+                        L10n.Watch.LockControls.OpenConfirmation.title(viewModel.name),
+                        isPresented: $showOpenConfirmation,
+                        titleVisibility: .visible,
+                        actions: {
+                            Button(role: .destructive) {
+                                viewModel.open()
+                            } label: {
+                                Text(verbatim: L10n.Watch.LockControls.open)
+                            }
+                            Button(role: .cancel) {} label: {
+                                Text(verbatim: L10n.cancelLabel)
+                            }
+                        }
+                    )
                     .listRowBackground(Color.clear)
                 }
             }

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -123,12 +123,16 @@ final class WatchLockControlsViewModel: ObservableObject {
         return state
     }
 
+    /// Every action answers on the wrist: a click when the command leaves, then success or failure
+    /// once the server replies. The screen's own state can take a poll interval to catch up, so
+    /// without haptics a lock command looks like it did nothing.
     private func send(service: Service) {
         guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == item.serverId }) else {
             Current.Log.error("Server \(item.serverId) not synced to the watch for lock controls")
             WKInterfaceDevice.current().play(.failure)
             return
         }
+        WKInterfaceDevice.current().play(.click)
         WatchServiceCallSender.send(
             domain: .lock,
             service: service,
@@ -136,6 +140,7 @@ final class WatchLockControlsViewModel: ObservableObject {
             server: server
         ) { [weak poller] success in
             if success {
+                WKInterfaceDevice.current().play(.success)
                 // Reflect the executed command quickly instead of waiting a full poll interval.
                 poller?.refresh(after: 1)
             } else {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The Apple Watch lock screen now asks for confirmation before sending the open (unlatch) action, since it physically releases the door instead of just moving a bolt. Lock and unlock stay one tap. The dialog is attached to the open button itself, so no other control can present it.

The open action also plays a success haptic when the server confirms it, alongside the existing click and failure feedback, so every action on the screen answers on the wrist.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Adds one new string, `watch.lock_controls.open_confirmation.title`. The confirm and cancel buttons reuse the existing `watch.lock_controls.open` and `cancel_label`.
