### PR TITLE
Fix watch lock and cover buttons triggering each other

### DIFF
--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsView.swift
@@ -139,6 +139,9 @@ struct WatchCoverControlsView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        // Explicit style, like the climate controls: with the automatic one a `List` row holding
+        // several buttons becomes a single tap target, so tapping open would also stop the cover.
+        .buttonStyle(.bordered)
     }
 
     private var positionBinding: Binding<Double> {

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsView.swift
@@ -123,6 +123,9 @@ struct WatchLockControlsView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        // Explicit style, like the climate controls: with the automatic one a `List` row holding
+        // several buttons becomes a single tap target, so tapping lock would also unlock.
+        .buttonStyle(.bordered)
     }
 }
 


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On the cover controls screen, tapping open also ran stop and tapping stop also ran open. The lock screen had the same problem between lock and unlock.

Both screens place their action buttons side by side in a single `List` row using the automatic button style, which makes the whole row a single tap target and runs every button in it. Giving the buttons an explicit bordered style — the same thing the climate controls already do for their side-by-side buttons — gives each button its own tap target.

Checked the rest of the watch app: every other row with more than one button (home rows, folder header, settings, pickers, climate) already sets an explicit style, so these two screens were the only ones affected.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — watch-only, the buttons keep the same look as the climate controls.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZfr312N7zZ2Hbxz4mneZR)_