### PR TITLE
Fix watch vacuum buttons triggering each other

### DIFF
--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumControlsView.swift
@@ -201,6 +201,10 @@ struct WatchVacuumControlsView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        // Explicit style, like the climate and cover controls: with the automatic one a `List` row
+        // holding several buttons becomes a single tap target, so start/pause would also stop the
+        // vacuum and send it back to its dock.
+        .buttonStyle(.bordered)
         .accessibilityLabel(Text(verbatim: accessibilityLabel ?? label ?? ""))
     }
 }


### PR DESCRIPTION


## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Tapping one button on the watch vacuum controls screen also ran the others — start/pause fired stop and return to dock as well.

Side-by-side buttons in a list row inherit the row as a single tap target unless they carry an explicit button style. Uses the same bordered style as the climate and cover controls.

The cover and lock screens had the same problem and were fixed in #5338; the vacuum screen was added around the same time and missed it.

## Screenshots

Not applicable — the buttons keep the same bordered look as the other control screens, they just get their own tap targets.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
Worth testing on a real watch.