### PR TITLE
Fix legacy watch complications rendering blank on the watch face

### DIFF
--- a/Sources/Shared/API/Models/LegacyComplicationRender.swift
+++ b/Sources/Shared/API/Models/LegacyComplicationRender.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// A legacy (ClockKit-era) `WatchComplication` resolved into the slots the modern WidgetKit renderer
+/// draws: a title line, a value line, trailing bottom text, plus the gauge and icon.
+///
+/// The legacy model stores a free-form blob of per-template text areas, and ClockKit laid each
+/// template out its own way. WidgetKit's four accessory families have one shared layout instead, so
+/// the areas have to collapse onto it: they are read in the order the template declares them (which
+/// is the order they appeared on the face), a row's second column folds onto the first, and the
+/// result maps title → value → bottom text.
+///
+/// This is deliberately pure and lives in `Shared` — the watch turns it into a complication snapshot,
+/// but the mapping itself is testable without a watch.
+public struct LegacyComplicationRender: Equatable {
+    /// The top line: the first text area, when the template has more than one.
+    public let title: String
+    /// The main content: the second text area, or the only one when that's all there is.
+    public let value: String
+    /// Everything past the second area (the columns and table templates), joined.
+    public let bottomText: String
+    /// Every area joined onto one line, for the single-line inline family.
+    public let inlineText: String
+    /// Hex color for `value`, or nil to use the face's default.
+    public let textColor: String?
+    /// Hex color for `bottomText`, or nil to fall back to `textColor`.
+    public let bottomTextColor: String?
+    /// Gauge/ring fill (0...1), or nil when the template has neither.
+    public let fraction: Double?
+    /// Hex tint for the gauge/ring.
+    public let tint: String?
+    /// Raw `WatchComplicationConfig.GaugeStyle`, or nil when there is no gauge.
+    public let gaugeStyle: String?
+    /// Material Design icon name, possibly in its server-side form (e.g. "mdi:home").
+    public let iconName: String?
+    /// Hex color for the icon.
+    public let iconColor: String?
+
+    public init(complication: WatchComplication) {
+        let data = complication.Data
+        let icon = data["icon"] as? [String: String]
+        self.iconName = icon?["icon"]
+        self.iconColor = icon?["icon_color"]
+
+        let lines = Self.lines(from: complication)
+        // Fall back to the complication's own name only when it has nothing else to show, so an
+        // image-only template (e.g. "Simple Image") stays image-only.
+        let resolved: [(text: String, color: String?)] = lines.isEmpty && iconName == nil
+            ? [(complication.displayName, nil)]
+            : lines
+
+        self.title = resolved.count > 1 ? resolved[0].text : ""
+        self.value = resolved.count > 1 ? resolved[1].text : (resolved.first?.text ?? "")
+        self.bottomText = resolved.dropFirst(2).map(\.text).joined(separator: " ")
+        // Inline draws no icon, so an image-only template has nothing of the user's left to show
+        // there and would otherwise render as the app's own name.
+        let joined = resolved.map(\.text).joined(separator: " ")
+        self.inlineText = joined.isEmpty ? complication.displayName : joined
+
+        // ClockKit only ever painted the picked colors on the full-color "graphic" families; it tinted
+        // every other family itself. Honoring them everywhere would repaint complications that have
+        // always rendered in the watch face's own tint.
+        func graphicOnly(_ color: String?) -> String? {
+            switch complication.Family {
+            case .graphicBezel, .graphicCircular, .graphicCorner, .graphicRectangular: return color
+            default: return nil
+            }
+        }
+        self.textColor = graphicOnly(resolved.count > 1 ? resolved[1].color : resolved.first?.color)
+        self.bottomTextColor = graphicOnly(resolved.dropFirst(2).first?.color)
+
+        self.fraction = Self.fraction(from: data)
+        self.tint = Self.tint(from: data)
+        self.gaugeStyle = Self.gaugeStyle(from: data)
+    }
+
+    /// The template's text areas in declaration order, each resolved to its server-rendered value
+    /// (falling back to the configured text, which is what a non-template area stores) and paired
+    /// with the color picked for it. Empty areas drop out, and a row's second column folds onto the
+    /// first so the columns and table templates keep reading as rows.
+    ///
+    /// Walking `Template.textAreas` is what lets the areas no fixed key list mentioned — Outer, Inner,
+    /// Leading, Trailing, Bottom and the third table row — render at all.
+    private static func lines(from complication: WatchComplication) -> [(text: String, color: String?)] {
+        let configured = complication.Data["textAreas"] as? [String: [String: Any]] ?? [:]
+        let rendered = renderedTextAreas(from: complication.Data)
+
+        var lines: [(text: String, color: String?)] = []
+        var lastArea: ComplicationTextAreas?
+        for area in complication.Template.textAreas {
+            let raw = configured[area.slug] ?? [:]
+            let text = rendered[area.slug] ?? (raw["text"] as? String ?? "")
+            guard !text.isEmpty else { continue }
+
+            // Only fold a second column onto the line its own first column just emitted: when that
+            // first column is empty it drops out above, and the second column would otherwise land on
+            // the previous row's line.
+            if let firstColumn = area.firstColumnOfSameRow, firstColumn == lastArea,
+               let previous = lines.popLast() {
+                lines.append((previous.text + "  " + text, previous.color))
+            } else {
+                lines.append((text, raw["color"] as? String))
+            }
+            lastArea = area
+        }
+        return lines
+    }
+
+    private static func renderedTextAreas(from data: [String: Any]) -> [String: String] {
+        guard let rendered = data["rendered"] as? [String: Any] else { return [:] }
+
+        return rendered.reduce(into: [String: String]()) { result, item in
+            guard item.key.hasPrefix("textArea,") else { return }
+
+            let key = String(item.key.dropFirst("textArea,".count))
+            result[key] = String(describing: item.value)
+        }
+    }
+
+    private static func fraction(from data: [String: Any]) -> Double? {
+        if let rendered = data["rendered"] as? [String: Any] {
+            if let ringValue = rendered["ring"].flatMap(percentileNumber(from:)) {
+                return ringValue
+            } else if let gaugeValue = rendered["gauge"].flatMap(percentileNumber(from:)) {
+                return gaugeValue
+            }
+        }
+
+        if let ring = data["ring"] as? [String: String],
+           let value = ring["ring_value"].flatMap(percentileNumber(from:)) {
+            return value
+        }
+
+        if let gauge = data["gauge"] as? [String: String], let value = gauge["gauge"].flatMap(percentileNumber(from:)) {
+            return value
+        }
+
+        return nil
+    }
+
+    private static func percentileNumber(from value: Any) -> Double? {
+        WatchComplication.percentileNumber(from: value).map(Double.init)
+    }
+
+    private static func tint(from data: [String: Any]) -> String? {
+        if let ring = data["ring"] as? [String: String], let color = ring["ring_color"] {
+            return color
+        }
+
+        if let gauge = data["gauge"] as? [String: String], let color = gauge["gauge_color"] {
+            return color
+        }
+
+        return nil
+    }
+
+    /// ClockKit's "closed" ring/gauge is the modern capacity ring, everything else the open arc. Ring
+    /// wins over gauge, matching `fraction`.
+    private static func gaugeStyle(from data: [String: Any]) -> String? {
+        let type = (data["ring"] as? [String: String])?["ring_type"]
+            ?? (data["gauge"] as? [String: String])?["gauge_type"]
+        guard let type else { return nil }
+        return type.lowercased() == "closed"
+            ? WatchComplicationConfig.GaugeStyle.capacity.rawValue
+            : WatchComplicationConfig.GaugeStyle.open.rawValue
+    }
+}

--- a/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
+++ b/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
@@ -1536,6 +1536,19 @@ public enum ComplicationTextAreas: String, CaseIterable {
         }
     }
 
+    /// For a row's second column, the first column of that same row — so a renderer can fold the two
+    /// onto one line the way ClockKit's columns and table templates laid them out side by side. nil
+    /// for every other area. Naming the counterpart rather than answering "am I a second column?"
+    /// lets the renderer check that the pair really is adjacent before merging them.
+    public var firstColumnOfSameRow: ComplicationTextAreas? {
+        switch self {
+        case .Row1Column2: return .Row1Column1
+        case .Row2Column2: return .Row2Column1
+        case .Row3Column2: return .Row3Column1
+        default: return nil
+        }
+    }
+
     public var slug: String {
         var cleanLocation = rawValue
         cleanLocation = cleanLocation.replacingOccurrences(of: " ", with: "")

--- a/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot+RenderModel.swift
+++ b/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot+RenderModel.swift
@@ -10,8 +10,9 @@ extension WatchWidgetComplicationSnapshot {
     /// `RectangularComplicationView.renderModel(_:)` — if the two drift, the in-app row stops being a
     /// faithful preview of the complication.
     ///
-    /// `nil` for legacy (server-rendered) complications, which carry no `perFamily` payload and have
-    /// no rectangular layout to reproduce.
+    /// `nil` for the built-in placeholder and Assist snapshots, which carry no `perFamily` payload and
+    /// have no rectangular layout to reproduce. Legacy (server-rendered) complications do carry one —
+    /// see `init(complication:)` — so they draw here through the same layout as everything else.
     var rectangularRenderModel: RectangularComplicationRenderModel? {
         guard let options = perFamily?[WatchComplicationConfig.Family.rectangular.rawValue] else {
             return nil

--- a/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot.swift
@@ -321,32 +321,56 @@ struct WatchWidgetComplicationSnapshot: Codable, Equatable {
         return (snapshot, isLive, failureReason)
     }
 
+    /// Adapts a legacy (ClockKit-era) complication into the modern snapshot shape.
+    ///
+    /// Legacy complications used to ship with no `perFamily` payload, which every on-face view reads
+    /// as "this is a built-in" and renders as the Home Assistant logo alone (circular and corner) or a
+    /// single unstyled line (rectangular) — silently dropping the user's text areas, gauge and ring.
+    /// Populating `perFamily` sends them through the same content views the modern configs use, so
+    /// they render their own content again.
     init(complication: WatchComplication) {
-        let textAreas = Self.textAreas(from: complication.Data)
-        let renderedTextAreas = Self.renderedTextAreas(from: complication.Data)
-        let preferredText = Self.firstText(
-            from: renderedTextAreas,
-            textAreas,
-            keys: ["Center", "InsideRing", "Line1", "Header", "Body1", "Row1Column1"]
+        let render = LegacyComplicationRender(complication: complication)
+        let iconData = Self.iconData(name: render.iconName, colorHex: render.iconColor)
+
+        let options = PerFamily(
+            fraction: render.fraction,
+            tint: render.tint,
+            showValue: !render.value.isEmpty,
+            showName: !render.title.isEmpty,
+            showIcon: iconData != nil,
+            gaugeStyle: render.gaugeStyle,
+            textColor: render.textColor,
+            bottomTextColor: render.bottomTextColor,
+            title: render.title,
+            value: render.value,
+            bottomText: render.bottomText,
+            showBottomText: !render.bottomText.isEmpty
         )
-        let secondaryText = Self.firstText(
-            from: renderedTextAreas,
-            textAreas,
-            keys: ["Line2", "Body2", "Row1Column2", "Row2Column1", "Row2Column2"]
-        )
-        let resolvedTitle = preferredText ?? complication.displayName
-        let resolvedFraction = Self.fraction(from: complication.Data)
+        // Inline is a single system-tinted line with no icon or gauge, and resolves that whole line
+        // from the title slot — so it gets every area joined together rather than just one of them.
+        var inlineOptions = options
+        inlineOptions.title = render.inlineText
+        inlineOptions.showName = !render.inlineText.isEmpty
 
         self.init(
             id: complication.identifier,
             family: complication.Family.rawValue,
-            title: resolvedTitle,
-            subtitle: secondaryText ?? complication.Template.style,
-            inlineText: [resolvedTitle, secondaryText].compactMap { $0 }.joined(separator: " "),
-            fraction: resolvedFraction,
-            tint: Self.tint(from: complication.Data),
-            iconData: Self.iconData(from: complication.Data),
-            perFamily: nil,
+            title: render.value.isEmpty ? complication.displayName : render.value,
+            // `subtitle` is this struct's pre-slot name field, so it carries the complication's name
+            // rather than one of its text areas — the slots below hold the rendered content.
+            subtitle: complication.displayName,
+            inlineText: render.inlineText,
+            fraction: render.fraction,
+            tint: render.tint,
+            iconData: iconData,
+            // Spelled out rather than aliased to `Family`: `WatchComplication.Family` is the legacy
+            // ClockKit family, and the two reading alike in one initializer invites a mix-up.
+            perFamily: [
+                WatchComplicationConfig.Family.circular.rawValue: options,
+                WatchComplicationConfig.Family.rectangular.rawValue: options,
+                WatchComplicationConfig.Family.corner.rawValue: options,
+                WatchComplicationConfig.Family.inline.rawValue: inlineOptions,
+            ],
             menuName: complication.displayName
         )
     }
@@ -379,82 +403,11 @@ struct WatchWidgetComplicationSnapshot: Codable, Equatable {
         )
     }
 
-    private static func textAreas(from data: [String: Any]) -> [String: String] {
-        guard let textAreas = data["textAreas"] as? [String: [String: Any]] else { return [:] }
+    /// Rasterizes a legacy complication's Material Design icon for the snapshot payload.
+    private static func iconData(name: String?, colorHex: String?) -> Data? {
+        guard let name else { return nil }
 
-        return textAreas.compactMapValues { $0["text"] as? String }
-    }
-
-    private static func renderedTextAreas(from data: [String: Any]) -> [String: String] {
-        guard let rendered = data["rendered"] as? [String: Any] else { return [:] }
-
-        return rendered.reduce(into: [String: String]()) { result, item in
-            guard item.key.hasPrefix("textArea,") else { return }
-
-            let key = String(item.key.dropFirst("textArea,".count))
-            result[key] = String(describing: item.value)
-        }
-    }
-
-    private static func firstText(
-        from renderedTextAreas: [String: String],
-        _ textAreas: [String: String],
-        keys: [String]
-    ) -> String? {
-        for key in keys {
-            if let rendered = renderedTextAreas[key], rendered.isEmpty == false {
-                return rendered
-            } else if let configured = textAreas[key], configured.isEmpty == false {
-                return configured
-            }
-        }
-
-        return nil
-    }
-
-    private static func fraction(from data: [String: Any]) -> Double? {
-        if let rendered = data["rendered"] as? [String: Any] {
-            if let ringValue = rendered["ring"].flatMap(percentileNumber(from:)) {
-                return ringValue
-            } else if let gaugeValue = rendered["gauge"].flatMap(percentileNumber(from:)) {
-                return gaugeValue
-            }
-        }
-
-        if let ring = data["ring"] as? [String: String],
-           let value = ring["ring_value"].flatMap(percentileNumber(from:)) {
-            return value
-        }
-
-        if let gauge = data["gauge"] as? [String: String], let value = gauge["gauge"].flatMap(percentileNumber(from:)) {
-            return value
-        }
-
-        return nil
-    }
-
-    private static func percentileNumber(from value: Any) -> Double? {
-        WatchComplication.percentileNumber(from: value).map(Double.init)
-    }
-
-    private static func tint(from data: [String: Any]) -> String? {
-        if let ring = data["ring"] as? [String: String], let color = ring["ring_color"] {
-            return color
-        }
-
-        if let gauge = data["gauge"] as? [String: String], let color = gauge["gauge_color"] {
-            return color
-        }
-
-        return nil
-    }
-
-    private static func iconData(from data: [String: Any]) -> Data? {
-        guard let icon = data["icon"] as? [String: String], let name = icon["icon"] else {
-            return nil
-        }
-
-        let color = icon["icon_color"].map { UIColor($0) } ?? AppConstants.tintColor
+        let color = colorHex.map { UIColor($0) } ?? AppConstants.tintColor
         // The stored name may be a server-side value (e.g. "mdi:music"); normalize before lookup so
         // image-based legacy complications (e.g. "Ring Image") actually resolve an icon.
         return MaterialDesignIcons(serversideValueNamed: name)

--- a/Sources/WatchWidgets/Complications/CircularComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CircularComplicationView.swift
@@ -4,7 +4,7 @@ import WidgetKit
 
 /// Circular complication: a gauge around the center content (icon / value / name) when a value exists
 /// — an open arc (optionally with min/max labels) or a full capacity ring — otherwise just the center
-/// content. Legacy/built-ins show the icon alone.
+/// content. Built-ins (Home Assistant / Assist) show the icon alone.
 ///
 /// The modern layout is rendered by the shared `CircularComplicationContentView` (in the
 /// HAWatchComplications package) so the in-app editor preview renders from the exact same code.
@@ -17,7 +17,7 @@ struct CircularComplicationView: View {
         if let complication, complication.perFamily != nil {
             CircularComplicationContentView(model: renderModel(complication))
         } else {
-            // Legacy/built-ins (Home Assistant / Assist): the icon alone fills the disc.
+            // Built-ins (Home Assistant / Assist): the icon alone fills the disc.
             ComplicationIconView(complication: complication)
                 .padding(WatchWidgetConstants.Layout.logoPadding)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchWidgets/WatchWidgetComplicationSnapshot.swift
@@ -7,7 +7,8 @@ struct WatchWidgetComplicationSnapshot: Codable {
     static let assistID = "default-assist"
 
     /// Per-widget-family rendering values, keyed by `WatchComplicationConfig.Family.rawValue`
-    /// ("circular"/"rectangular"/"inline"/"corner"). Absent for built-in/legacy complications.
+    /// ("circular"/"rectangular"/"inline"/"corner"). Absent only for the built-in placeholder and
+    /// Assist complications; legacy complications are adapted into this shape too.
     struct PerFamily: Codable {
         var fraction: Double?
         let tint: String?

--- a/Tests/Shared/Watch/LegacyComplicationRender.test.swift
+++ b/Tests/Shared/Watch/LegacyComplicationRender.test.swift
@@ -1,0 +1,269 @@
+import Foundation
+@testable import Shared
+import Testing
+
+/// Legacy (ClockKit-era) complications are rendered by the modern WidgetKit views now, which means
+/// their per-template text areas have to collapse onto the shared title / value / bottom-text layout.
+/// These pin that mapping down — regressions here show up as a blank or logo-only watch face.
+struct LegacyComplicationRenderTests {
+    private func complication(
+        family: ComplicationGroupMember,
+        template: ComplicationTemplate,
+        textAreas: [String: (text: String, color: String)] = [:],
+        rendered: [String: Any] = [:],
+        extra: [String: Any] = [:]
+    ) -> WatchComplication {
+        var complication = WatchComplication(family: family, template: template, name: "Rain")
+        var areas: [String: [String: Any]] = [:]
+        for (slug, area) in textAreas {
+            areas[slug] = ["text": area.text, "color": area.color]
+        }
+        var data: [String: Any] = extra
+        data["textAreas"] = areas
+        if !rendered.isEmpty {
+            data["rendered"] = rendered
+        }
+        complication.Data = data
+        return complication
+    }
+
+    // MARK: - Text areas
+
+    /// The Graphic Corner "Text Image" complication behind the long-standing rain-sparkline recipe:
+    /// an icon in the corner and a single Center text area riding the arc.
+    @Test func singleTextAreaBecomesTheValue() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerTextImage,
+            textAreas: ["Center": ("▁▂▃▄▅▆▇█", "#00FF00FF")],
+            extra: ["icon": ["icon": "weather-pouring", "icon_color": "#FFFFFFFF"]]
+        ))
+
+        #expect(render.value == "▁▂▃▄▅▆▇█")
+        #expect(render.title.isEmpty)
+        #expect(render.bottomText.isEmpty)
+        #expect(render.iconName == "weather-pouring")
+    }
+
+    @Test func firstAreaLabelsTheSecond() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicRectangular,
+            template: .GraphicRectangularStandardBody,
+            textAreas: [
+                "Header": ("Rain", "#FFFFFFFF"),
+                "Body1": ("▁▂▃", "#00FF00FF"),
+                "Body2": ("in 45m", "#FF0000FF"),
+            ]
+        ))
+
+        #expect(render.title == "Rain")
+        #expect(render.value == "▁▂▃")
+        #expect(render.bottomText == "in 45m")
+        #expect(render.inlineText == "Rain ▁▂▃ in 45m")
+    }
+
+    /// Areas are read in the template's own order, not in whatever order the blob happens to
+    /// enumerate — the templates put the label first for a reason.
+    @Test func areasFollowTemplateOrder() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerStackText,
+            textAreas: ["Inner": ("inner", "#FFFFFFFF"), "Outer": ("outer", "#FFFFFFFF")]
+        ))
+
+        // GraphicCornerStackText declares [.Outer, .Inner].
+        #expect(render.title == "outer")
+        #expect(render.value == "inner")
+    }
+
+    /// Outer / Inner / Leading / Trailing / Bottom and the third table row used to be unreachable:
+    /// the renderer looked up a fixed list of area names that never mentioned them.
+    @Test func areasOutsideTheOldKeyListRender() {
+        let areas: [(ComplicationTemplate, [String])] = [
+            (.GraphicCornerGaugeText, ["Outer", "Leading", "Trailing"]),
+            (.GraphicCornerStackText, ["Outer", "Inner"]),
+            (.GraphicCircularOpenGaugeSimpleText, ["Center", "Bottom"]),
+        ]
+        for (template, slugs) in areas {
+            let textAreas = Dictionary(uniqueKeysWithValues: slugs.map { ($0, (text: $0, color: "#FFFFFFFF")) })
+            let render = LegacyComplicationRender(complication: complication(
+                family: template.groupMember,
+                template: template,
+                textAreas: textAreas
+            ))
+            for slug in slugs {
+                #expect(render.inlineText.contains(slug), "\(template.rawValue) dropped \(slug)")
+            }
+        }
+    }
+
+    /// The columns and table templates laid two columns out side by side, so they stay one line each
+    /// rather than stacking into four.
+    @Test func columnPairsFoldOntoOneLine() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .modularLarge,
+            template: .ModularLargeColumns,
+            textAreas: [
+                "Row1Column1": ("Rain", "#FFFFFFFF"),
+                "Row1Column2": ("2mm", "#FFFFFFFF"),
+                "Row2Column1": ("Wind", "#FFFFFFFF"),
+                "Row2Column2": ("3km/h", "#FFFFFFFF"),
+            ]
+        ))
+
+        #expect(render.title == "Rain  2mm")
+        #expect(render.value == "Wind  3km/h")
+        #expect(render.bottomText.isEmpty)
+    }
+
+    /// An empty first column drops out, and its second column has to start its own line rather than
+    /// folding onto the row above it.
+    @Test func secondColumnDoesNotFoldOntoThePreviousRow() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .modularLarge,
+            template: .ModularLargeColumns,
+            textAreas: [
+                "Row1Column1": ("Rain", "#FFFFFFFF"),
+                "Row1Column2": ("2mm", "#FFFFFFFF"),
+                "Row2Column1": ("", "#FFFFFFFF"),
+                "Row2Column2": ("3km/h", "#FFFFFFFF"),
+            ]
+        ))
+
+        #expect(render.title == "Rain  2mm")
+        #expect(render.value == "3km/h")
+    }
+
+    @Test func emptyAreasAreSkipped() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicRectangular,
+            template: .GraphicRectangularStandardBody,
+            textAreas: [
+                "Header": ("Rain", "#FFFFFFFF"),
+                "Body1": ("", "#FFFFFFFF"),
+                "Body2": ("in 45m", "#FFFFFFFF"),
+            ]
+        ))
+
+        #expect(render.title == "Rain")
+        #expect(render.value == "in 45m")
+        #expect(render.bottomText.isEmpty)
+    }
+
+    /// A server-rendered template wins over the raw Jinja the area stores.
+    @Test func renderedTemplatesWinOverConfiguredText() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerTextImage,
+            textAreas: ["Center": ("{{ states('sensor.rain') }}", "#FFFFFFFF")],
+            rendered: ["textArea,Center": "▁▂▃"]
+        ))
+
+        #expect(render.value == "▁▂▃")
+    }
+
+    /// An image-only template has nothing to say, and must not start captioning itself with the
+    /// complication's name.
+    @Test func imageOnlyTemplateStaysImageOnly() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularImage,
+            extra: ["icon": ["icon": "home", "icon_color": "#FFFFFFFF"]]
+        ))
+
+        #expect(render.value.isEmpty)
+        #expect(render.title.isEmpty)
+        #expect(render.iconName == "home")
+        // Inline has no icon to fall back on, so it borrows the complication's name rather than
+        // rendering as the app itself.
+        #expect(render.inlineText == "Rain")
+    }
+
+    /// …but a complication with neither text nor image still needs something on the face.
+    @Test func emptyComplicationFallsBackToItsName() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularOpenGaugeSimpleText
+        ))
+
+        #expect(render.value == "Rain")
+    }
+
+    // MARK: - Gauge
+
+    @Test func ringWinsOverGaugeAndClosedMeansCapacity() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularClosedGaugeText,
+            textAreas: ["Center": ("42", "#FFFFFFFF")],
+            // Fractions that are exact in binary, so the Float→Double widening the percentile parser
+            // does can't turn an equality check into a rounding puzzle.
+            rendered: ["ring": "0.25", "gauge": "0.75"],
+            extra: [
+                "ring": ["ring_value": "{{ 0.25 }}", "ring_color": "#00FF00FF", "ring_type": "closed"],
+                "gauge": ["gauge": "{{ 0.75 }}", "gauge_color": "#FF0000FF", "gauge_type": "open"],
+            ]
+        ))
+
+        #expect(render.fraction == 0.25)
+        #expect(render.tint == "#00FF00FF")
+        #expect(render.gaugeStyle == WatchComplicationConfig.GaugeStyle.capacity.rawValue)
+    }
+
+    @Test func openGaugeMapsToTheOpenArc() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularOpenGaugeSimpleText,
+            textAreas: ["Center": ("42", "#FFFFFFFF")],
+            extra: ["gauge": ["gauge": "0.5", "gauge_color": "#FF0000FF", "gauge_type": "open"]]
+        ))
+
+        #expect(render.fraction == 0.5)
+        #expect(render.gaugeStyle == WatchComplicationConfig.GaugeStyle.open.rawValue)
+    }
+
+    @Test func noGaugeMeansNoFraction() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerTextImage,
+            textAreas: ["Center": ("hi", "#FFFFFFFF")]
+        ))
+
+        #expect(render.fraction == nil)
+        #expect(render.gaugeStyle == nil)
+    }
+
+    // MARK: - Colors
+
+    @Test func graphicFamiliesKeepTheirTextColors() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicRectangular,
+            template: .GraphicRectangularStandardBody,
+            textAreas: [
+                "Header": ("Rain", "#FFFFFFFF"),
+                "Body1": ("▁▂▃", "#00FF00FF"),
+                "Body2": ("in 45m", "#FF0000FF"),
+            ]
+        ))
+
+        #expect(render.textColor == "#00FF00FF")
+        #expect(render.bottomTextColor == "#FF0000FF")
+    }
+
+    /// ClockKit tinted the non-graphic families itself and ignored the picked color, so honoring it
+    /// now would repaint complications that have always rendered in the face's own tint.
+    @Test func nonGraphicFamiliesIgnoreTextColors() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .modularLarge,
+            template: .ModularLargeStandardBody,
+            textAreas: [
+                "Header": ("Rain", "#FFFFFFFF"),
+                "Body1": ("▁▂▃", "#00FF00FF"),
+                "Body2": ("in 45m", "#FF0000FF"),
+            ]
+        ))
+
+        #expect(render.textColor == nil)
+        #expect(render.bottomTextColor == nil)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Legacy (ClockKit-era) complications were sent to the widget with no `perFamily` payload. Every on-face view treats a missing `perFamily` as "this is a built-in", so they rendered as the Home Assistant logo alone (circular and corner) or a single unstyled line (rectangular), dropping the configured text areas, gauge and ring.

The adapter also read its text from a fixed list of area names that never mentioned Outer, Inner, Leading, Trailing, Bottom or the third table row, so those areas could not render at all, and Header always masked Body 1.

Legacy complications are now resolved into the same slots the modern renderer draws: areas are read in the order the template declares them, a row's second column folds onto the first, and the result maps title → value → bottom text, carrying the gauge, its style and the icon along. The mapping lives in `LegacyComplicationRender` in `Shared` so it is covered by the unit test scheme.

Text colors come back for the graphic families only. ClockKit tinted the other families itself and ignored the picked color, so honoring it everywhere would repaint complications that have always rendered in the face's own tint.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes

Reported by a user whose Graphic Corner "Text Image" complication (the unicode rain-sparkline recipe) showed only the logo after 2026.8.0.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pistzp9JrJAJ8MqriGYwBf)_