### PR TITLE
Fix Apple Watch home items not responding to taps

### DIFF
--- a/Sources/Shared/Watch/WatchConfig.swift
+++ b/Sources/Shared/Watch/WatchConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord {
+public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord, Equatable {
     public static var watchConfigId: String { "watch-config" }
     public var id = WatchConfig.watchConfigId
     public var assist: Assist = .init(showAssist: true)

--- a/Sources/Shared/Watch/WatchConfig.swift
+++ b/Sources/Shared/Watch/WatchConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord, Equatable {
+public struct WatchConfig: WatchCodable, FetchableRecord, PersistableRecord {
     public static var watchConfigId: String { "watch-config" }
     public var id = WatchConfig.watchConfigId
     public var assist: Assist = .init(showAssist: true)

--- a/Sources/WatchApp/Home/CircularGlassOrLegacyBackground.swift
+++ b/Sources/WatchApp/Home/CircularGlassOrLegacyBackground.swift
@@ -32,32 +32,41 @@ extension View {
     /// Full-width glass row style for the watch home items on watchOS 26: a rounded rectangle (not a
     /// capsule) spanning the row with no horizontal margin. Falls back to a rounded, optionally-tinted
     /// row background on older versions. Apply to the item's `Button`.
+    ///
+    /// The plain button style is applied on every version (like `watchHomeItemGridStyle` does): the row
+    /// draws its own background, and the plain style keeps the tap handled by SwiftUI's own press
+    /// gesture rather than the platform's default list-button treatment.
     @ViewBuilder
     func watchHomeItemRowStyle(tint: Color?) -> some View {
-        modify { view in
-            if #available(watchOS 26.0, *) {
-                view
-                    .buttonStyle(.plain)
-                    .glassEffect(
-                        .regular.tint(tint).interactive(),
-                        in: RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.two, style: .continuous)
-                    )
-                    .contentShape(RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.two, style: .continuous))
-                    .listRowBackground(Color.clear)
-                    .listRowInsets(EdgeInsets(
-                        top: DesignSystem.Spaces.micro,
-                        leading: .zero,
-                        bottom: DesignSystem.Spaces.micro,
-                        trailing: .zero
-                    ))
-            } else {
-                view
-                    .listRowBackground(
-                        (tint ?? Color.gray.opacity(0.3))
-                            .cornerRadius(DesignSystem.CornerRadius.two)
-                    )
+        buttonStyle(.plain)
+            .modify { view in
+                if #available(watchOS 26.0, *) {
+                    view
+                        .glassEffect(
+                            .regular.tint(tint).interactive(),
+                            in: RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.two, style: .continuous)
+                        )
+                        .contentShape(
+                            RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.two, style: .continuous)
+                        )
+                        .listRowBackground(Color.clear)
+                        .listRowInsets(EdgeInsets(
+                            top: DesignSystem.Spaces.micro,
+                            leading: .zero,
+                            bottom: DesignSystem.Spaces.micro,
+                            trailing: .zero
+                        ))
+                } else {
+                    view
+                        .contentShape(
+                            RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.two, style: .continuous)
+                        )
+                        .listRowBackground(
+                            (tint ?? Color.gray.opacity(0.3))
+                                .cornerRadius(DesignSystem.CornerRadius.two)
+                        )
+                }
             }
-        }
     }
 
     @ViewBuilder

--- a/Sources/WatchApp/Home/WatchFolderContentView.swift
+++ b/Sources/WatchApp/Home/WatchFolderContentView.swift
@@ -70,15 +70,11 @@ struct WatchFolderContentView: View {
     }
 
     private var listItems: some View {
+        // No long-press-to-edit here: a gesture on the row swallows the tap of the `Button` it is built
+        // from on watchOS before 26, which left every item unresponsive. Edit mode is entered from the
+        // header's pencil button instead.
         ForEach(Array((folder?.items ?? []).enumerated()), id: \.element.serverUniqueId) { index, item in
             rowContent(for: item, at: index)
-                .modify { view in
-                    if isEditing {
-                        view
-                    } else {
-                        view.onLongPressGesture { enterEditMode() }
-                    }
-                }
         }
         .onMove(perform: isEditing ? moveItems : nil)
         .onDelete(perform: isEditing ? deleteItems : nil)

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -386,15 +386,11 @@ struct WatchHomeView: View {
 
     @ViewBuilder
     private var mainContent: some View {
+        // No long-press-to-edit here: a gesture on the row swallows the tap of the `Button` it is built
+        // from on watchOS before 26, which left every item unresponsive. Edit mode is entered from the
+        // footer's edit button instead.
         ForEach(Array(viewModel.watchConfig.items.enumerated()), id: \.offset) { index, item in
             rowContent(for: item, at: index)
-                .modify { view in
-                    if isEditing {
-                        view
-                    } else {
-                        view.onLongPressGesture { enterEditMode() }
-                    }
-                }
         }
         .onMove(perform: isEditing ? moveItems : nil)
         .onDelete(perform: isEditing ? deleteItems : nil)

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -698,9 +698,17 @@ final class WatchHomeViewModel: ObservableObject {
 
     @MainActor
     private func updateConfig(config: WatchConfig, magicItemsInfo: [MagicItem.Info]) {
+        // `configVersion` drives an `.id()` on the home list, which discards every row — including a
+        // row that is currently showing its run-confirmation dialog. Cache loads run on every sync
+        // (twice each: once for the cached config, once when the item info resolves), so re-issuing the
+        // id unconditionally would dismiss the dialog under the user's finger while a sync completes.
+        // Only unchanged data may keep the current id.
+        let contentChanged = config != watchConfig || magicItemsInfo != self.magicItemsInfo
         watchConfig = config
         self.magicItemsInfo = magicItemsInfo
-        configVersion = UUID()
+        if contentChanged {
+            configVersion = UUID()
+        }
 
         if config.assist.showAssist,
            config.assist.serverId != nil,

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -698,12 +698,7 @@ final class WatchHomeViewModel: ObservableObject {
 
     @MainActor
     private func updateConfig(config: WatchConfig, magicItemsInfo: [MagicItem.Info]) {
-        // `configVersion` drives an `.id()` on the home list, which discards every row — including a
-        // row that is currently showing its run-confirmation dialog. Cache loads run on every sync
-        // (twice each: once for the cached config, once when the item info resolves), so re-issuing the
-        // id unconditionally would dismiss the dialog under the user's finger while a sync completes.
-        // Only unchanged data may keep the current id.
-        let contentChanged = config != watchConfig || magicItemsInfo != self.magicItemsInfo
+        let contentChanged = rendersDifferentContent(config: config, magicItemsInfo: magicItemsInfo)
         watchConfig = config
         self.magicItemsInfo = magicItemsInfo
         if contentChanged {
@@ -717,6 +712,27 @@ final class WatchHomeViewModel: ObservableObject {
         } else {
             showAssist = false
         }
+    }
+
+    /// Whether a freshly loaded config renders anything different from what's on screen.
+    ///
+    /// `configVersion` drives an `.id()` on the home list, which discards every row — including a row
+    /// currently showing its run-confirmation dialog. Cache loads run on every sync (twice each: once
+    /// for the cached config, once when the item info resolves), so re-issuing the id unconditionally
+    /// dismissed that dialog under the user's finger while a sync completed. Only identical content may
+    /// keep the current id.
+    ///
+    /// Items are compared through `contentHash`, not `==`: `MagicItem`'s equality is identity-based
+    /// (id/server/type), so a renamed item, a recolored one or an edited folder child would otherwise
+    /// read as unchanged — and the rows, whose view models capture the item when they're created,
+    /// would keep rendering the old values.
+    @MainActor
+    private func rendersDifferentContent(config: WatchConfig, magicItemsInfo: [MagicItem.Info]) -> Bool {
+        config.items.map(\.contentHash) != watchConfig.items.map(\.contentHash)
+            || config.assist != watchConfig.assist
+            || config.resolvedLayout != watchConfig.resolvedLayout
+            || config.resolvedHideAreas != watchConfig.resolvedHideAreas
+            || magicItemsInfo != self.magicItemsInfo
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On watchOS below 26, tapping an item on the watch home screen did nothing: scripts, scenes, automations, buttons and entities were all unresponsive, while the header buttons kept working.

The home and folder lists attached a long press gesture to every row to enter edit mode, and that gesture swallowed the tap of the button the row is built from. The long press is removed; edit mode is still entered from the home footer's edit button and the folder header's pencil.

Two related changes on the same path:

- The plain button style is now applied to the home row style on every watchOS version, like the grid style already did, and the pre-26 branch gets the same explicit full row content shape as the watchOS 26 one.
- `configVersion` is only re-issued when the config or the resolved item info actually changed. It drives an `.id()` on the list, so every cache load (two per sync) discarded all rows, dismissing a row's run confirmation dialog while a sync completed underneath it. Items are compared through `contentHash`, since `MagicItem` equality is identity-based.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change, the fix is in the row's tap handling.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Reported through TestFlight feedback on watchOS 10. The behaviour is not reproducible on watchOS 26, where the row also carries the plain button style and interactive glass.
