### PR TITLE
Format datetime sensor states instead of showing the raw ISO string

### DIFF
--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -139,6 +139,12 @@ public enum Domain: String, CaseIterable {
             return ClimateControlState(entity: entity).stateSummary
         }
 
+        // Datetime-backed entities report a raw UTC ISO 8601 string as their state; render it the
+        // way the frontend's automatic time format does rather than showing the machine format.
+        if let timestampDescription = timestampStateDescription(for: entity) {
+            return timestampDescription
+        }
+
         let baseState = entity.localizedState.leadingCapitalized
         // The registry lookup is only worth its synchronous database read on the paths that render
         // the state value itself — enum states (on/off, locked, …) never need it.
@@ -161,6 +167,21 @@ public enum Domain: String, CaseIterable {
         }
 
         return stateForDeviceClass(entity.deviceClass, state: state)
+    }
+
+    /// Renders the datetime device classes the way the frontend's automatic format does: timestamps
+    /// relative ("In 56 minutes"), dates absolute and localized. Nil for every other entity, and for
+    /// a datetime entity whose state isn't currently a date (`unavailable`, `unknown`) so those keep
+    /// their usual localized wording.
+    private func timestampStateDescription(for entity: HAEntity) -> String? {
+        switch entity.deviceClass {
+        case .timestamp:
+            return EntityTimestampFormatter.relativeDescription(for: entity.state)?.leadingCapitalized
+        case .date:
+            return EntityTimestampFormatter.dateDescription(for: entity.state)
+        default:
+            return nil
+        }
     }
 
     public func stateForDeviceClass(_ deviceClass: DeviceClass, state: Domain.State) -> String {
@@ -563,7 +584,7 @@ public enum Domain: String, CaseIterable {
     public func localizedState(for state: String) -> String {
         switch self {
         case .button, .inputButton, .scene:
-            if let relativeDate = isoDateToRelativeTimeString(state) {
+            if let relativeDate = EntityTimestampFormatter.relativeDescription(for: state) {
                 return relativeDate
             }
         default:
@@ -571,17 +592,6 @@ public enum Domain: String, CaseIterable {
         }
         return CoreStrings.getDomainStateLocalizedTitle(state: state) ?? FrontendStrings
             .getDefaultStateLocalizedTitle(state: state) ?? state
-    }
-
-    private func isoDateToRelativeTimeString(_ isoDateString: String) -> String? {
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        guard let date = dateFormatter.date(from: isoDateString) else {
-            return nil
-        }
-
-        let relativeFormatter = RelativeDateTimeFormatter()
-        return relativeFormatter.localizedString(for: date, relativeTo: Date())
     }
 }
 

--- a/Sources/Shared/Domain/EntityTimestampFormatter.swift
+++ b/Sources/Shared/Domain/EntityTimestampFormatter.swift
@@ -3,10 +3,14 @@ import Foundation
 /// Formats the ISO 8601 states Home Assistant reports for datetime-backed entities: `device_class:
 /// timestamp` / `device_class: date` sensors, and the last-triggered state of buttons and scenes.
 ///
-/// The server sends those states as machine-readable UTC (`2026-08-03T18:15:00+00:00`), so rendering
-/// them verbatim both leaks an unreadable format into the UI and reads as the wrong timezone. This
-/// mirrors the frontend's automatic time format instead — a localized relative description in the
-/// device's own timezone, the same "In 56 minutes" a tile card shows.
+/// Timestamp states are an absolute instant carrying whatever offset the server sent — usually UTC
+/// (`2026-08-03T18:15:00+00:00`), but any valid offset parses. Rendering one verbatim both leaks a
+/// machine format into the UI and reads as the wrong timezone, so they're formatted the way the
+/// frontend's automatic format does: a localized relative description resolved against the device's
+/// own timezone, the same "In 56 minutes" a tile card shows.
+///
+/// `date` states are different — a bare calendar day with no time or zone — so they're kept in UTC
+/// end to end and rendered as a localized date, preserving the day the server meant.
 public enum EntityTimestampFormatter {
     /// Home Assistant sends fractional seconds for `last_triggered`-style states but plain seconds
     /// for plenty of `timestamp` sensors, and `ISO8601DateFormatter` rejects whichever of the two it
@@ -20,9 +24,11 @@ public enum EntityTimestampFormatter {
     }
 
     /// `device_class: date` states carry no time or zone (`2026-08-03`), so they're parsed — and
-    /// below, formatted — in UTC to keep the calendar day the server meant.
+    /// below, formatted — in UTC to keep the calendar day the server meant. UTC is already
+    /// `ISO8601DateFormatter`'s default, but the day-preservation guarantee shouldn't rest on it.
     private static let dateOnlyFormatter = with(ISO8601DateFormatter()) {
         $0.formatOptions = [.withFullDate]
+        $0.timeZone = TimeZone(secondsFromGMT: 0)
     }
 
     /// Parses a timestamp state, with or without fractional seconds. Nil for the states that aren't

--- a/Sources/Shared/Domain/EntityTimestampFormatter.swift
+++ b/Sources/Shared/Domain/EntityTimestampFormatter.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Formats the ISO 8601 states Home Assistant reports for datetime-backed entities: `device_class:
+/// timestamp` / `device_class: date` sensors, and the last-triggered state of buttons and scenes.
+///
+/// The server sends those states as machine-readable UTC (`2026-08-03T18:15:00+00:00`), so rendering
+/// them verbatim both leaks an unreadable format into the UI and reads as the wrong timezone. This
+/// mirrors the frontend's automatic time format instead — a localized relative description in the
+/// device's own timezone, the same "In 56 minutes" a tile card shows.
+public enum EntityTimestampFormatter {
+    /// Home Assistant sends fractional seconds for `last_triggered`-style states but plain seconds
+    /// for plenty of `timestamp` sensors, and `ISO8601DateFormatter` rejects whichever of the two it
+    /// wasn't configured for — so both spellings get their own formatter.
+    private static let fractionalSecondsFormatter = with(ISO8601DateFormatter()) {
+        $0.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    }
+
+    private static let wholeSecondsFormatter = with(ISO8601DateFormatter()) {
+        $0.formatOptions = [.withInternetDateTime]
+    }
+
+    /// `device_class: date` states carry no time or zone (`2026-08-03`), so they're parsed — and
+    /// below, formatted — in UTC to keep the calendar day the server meant.
+    private static let dateOnlyFormatter = with(ISO8601DateFormatter()) {
+        $0.formatOptions = [.withFullDate]
+    }
+
+    /// Parses a timestamp state, with or without fractional seconds. Nil for the states that aren't
+    /// timestamps at all (`unavailable`, `unknown`, or an entity that simply isn't datetime-backed).
+    public static func date(from state: String) -> Date? {
+        fractionalSecondsFormatter.date(from: state) ?? wholeSecondsFormatter.date(from: state)
+    }
+
+    /// A localized relative description of a timestamp state — "In 56 minutes", "2 hours ago" — in
+    /// the device's timezone. Nil when the state isn't a parsable timestamp, so callers can fall
+    /// back to their usual rendering.
+    public static func relativeDescription(for state: String) -> String? {
+        guard let timestamp = date(from: state) else { return nil }
+        // Built per call rather than cached: the formatter snapshots the current locale, and the
+        // watch app outlives a region change.
+        let formatter = RelativeDateTimeFormatter()
+        return formatter.localizedString(for: timestamp, relativeTo: Current.date())
+    }
+
+    /// A localized absolute description of a `device_class: date` state — "Aug 3, 2026". Nil when
+    /// the state isn't a parsable date.
+    public static func dateDescription(for state: String) -> String? {
+        guard let day = dateOnlyFormatter.date(from: state) else { return nil }
+        let formatter = with(DateFormatter()) {
+            $0.dateStyle = .medium
+            $0.timeStyle = .none
+            $0.timeZone = TimeZone(secondsFromGMT: 0)
+        }
+        return formatter.string(from: day)
+    }
+}

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -1,3 +1,5 @@
+import Foundation
+import HAKit
 @testable import Shared
 import Testing
 
@@ -496,5 +498,110 @@ struct DomainFeatureSupportTests {
                 #expect(!excluded.contains(domain), "\(name) domain \(domain) must not be in appDatabaseExcluded")
             }
         }
+    }
+}
+
+struct DomainTimestampStateTests {
+    /// 2026-08-03 18:15:00 UTC — the dishwasher finish time from the report, and the instant every
+    /// test below measures against so the relative wording is deterministic.
+    private static let referenceDate = Date(timeIntervalSince1970: 1_785_780_900)
+
+    private func makeEntity(
+        entityId: String,
+        state: String,
+        attributes: [String: Any] = [:]
+    ) throws -> HAEntity {
+        try HAEntity(
+            entityId: entityId,
+            state: state,
+            lastChanged: Self.referenceDate,
+            lastUpdated: Self.referenceDate,
+            attributes: attributes,
+            context: .init(id: "context", userId: nil, parentId: nil)
+        )
+    }
+
+    /// Runs `body` with "now" frozen an hour before the reference timestamp, so a sensor reporting
+    /// that timestamp is always exactly one hour in the future.
+    private func withFrozenClock<T>(_ body: () throws -> T) rethrows -> T {
+        let previousDate = Current.date
+        Current.date = { Self.referenceDate.addingTimeInterval(-3600) }
+        defer { Current.date = previousDate }
+        return try body()
+    }
+
+    @Test func timestampSensorRendersRelativeTimeInsteadOfRawISOString() throws {
+        let entity = try makeEntity(
+            entityId: "sensor.dishwasher_programme_finish_time",
+            state: "2026-08-03T18:15:00+00:00",
+            attributes: ["device_class": "timestamp"]
+        )
+
+        let formatter = RelativeDateTimeFormatter()
+        let now = Self.referenceDate.addingTimeInterval(-3600)
+        let expected = formatter.localizedString(for: Self.referenceDate, relativeTo: now).leadingCapitalized
+
+        let description = withFrozenClock {
+            Domain.sensor.contextualStateDescription(for: entity)
+        }
+
+        // The raw UTC string is what the watch used to show; anything relative is an improvement,
+        // but pin the wording so a formatter regression is caught.
+        #expect(description != "2026-08-03T18:15:00+00:00")
+        #expect(description == expected)
+    }
+
+    /// The old parser required fractional seconds, so every sensor reporting plain seconds fell
+    /// through to the raw string. Both spellings must resolve to the same instant.
+    @Test func timestampParsingAcceptsBothISOSpellings() {
+        #expect(EntityTimestampFormatter.date(from: "2026-08-03T18:15:00+00:00") == Self.referenceDate)
+        #expect(EntityTimestampFormatter.date(from: "2026-08-03T18:15:00.000000+00:00") == Self.referenceDate)
+        #expect(EntityTimestampFormatter.date(from: "2026-08-03T20:15:00+02:00") == Self.referenceDate)
+    }
+
+    @Test func unavailableTimestampSensorKeepsItsLocalizedWording() throws {
+        let entity = try makeEntity(
+            entityId: "sensor.dishwasher_programme_finish_time",
+            state: Domain.State.unavailable.rawValue,
+            attributes: ["device_class": "timestamp"]
+        )
+
+        let description = Domain.sensor.contextualStateDescription(for: entity)
+        #expect(description == entity.localizedState.leadingCapitalized)
+        #expect(description != Domain.State.unavailable.rawValue)
+    }
+
+    @Test func dateSensorRendersLocalizedDateWithoutShiftingTheDay() throws {
+        let entity = try makeEntity(
+            entityId: "sensor.next_bin_collection",
+            state: "2026-08-03",
+            attributes: ["device_class": "date"]
+        )
+
+        let formatter = with(DateFormatter()) {
+            $0.dateStyle = .medium
+            $0.timeStyle = .none
+            $0.timeZone = TimeZone(secondsFromGMT: 0)
+        }
+
+        let description = Domain.sensor.contextualStateDescription(for: entity)
+        #expect(description != "2026-08-03")
+        #expect(description == formatter.string(from: Self.referenceDate))
+    }
+
+    @Test func nonTimestampSensorsAreUnaffected() throws {
+        let entity = try makeEntity(
+            entityId: "sensor.power_consumed",
+            state: "0.203",
+            attributes: ["device_class": "power", "unit_of_measurement": "kW"]
+        )
+
+        #expect(Domain.sensor.contextualStateDescription(for: entity) == "0.203 kW")
+    }
+
+    @Test func timestampFormatterRejectsNonTimestampStates() {
+        #expect(EntityTimestampFormatter.date(from: "unavailable") == nil)
+        #expect(EntityTimestampFormatter.relativeDescription(for: "on") == nil)
+        #expect(EntityTimestampFormatter.dateDescription(for: "not a date") == nil)
     }
 }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Sensors with `device_class: timestamp` were displayed as the raw state the server sends, so the Apple Watch showed `2026-08-03T18:1…` in UTC where a tile card for the same entity shows `In 56 minutes`.

`Domain.contextualStateDescription` now formats the datetime device classes the way the frontend's automatic format does — `timestamp` relative and `date` localized. The ISO 8601 parser also accepts timestamps without fractional seconds, which the previous button/scene-only parser rejected.

Since the formatting lives in the shared `Domain` helper, the watch item list, watch entity details, watch control screens and CarPlay all pick it up.

## Screenshots

<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository

No documentation change needed — this corrects how an existing state is rendered and adds no new functionality.

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Covered by new tests in `Tests/Shared/Domain.test.swift`: relative rendering, both ISO spellings plus a non-UTC offset, the `unavailable` fallback, day preservation for `device_class: date`, and a regression guard that entities with a unit are unaffected.

Watch complications go through a separate formatter (`WatchWidgetLiveFetch`) with its own precision/unit config and are not changed here.
