### PR TITLE
Add Assist and Assist prompt items to Apple Watch

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -840,7 +840,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "magic_item.action.script.title" = "Script";
 "magic_item.add" = "Add";
 "magic_item.assist_prompt.navigation_title" = "Assist prompt";
-"magic_item.assist_prompt.prompt.footer" = "When executed in CarPlay, this prompt will be sent to Assist and the response will be played as audio. Make sure the selected Assist pipeline has text-to-speech configured.";
+"magic_item.assist_prompt.prompt.footer" = "When executed, this prompt will be sent to Assist and the response will be played as audio. Make sure the selected Assist pipeline has text-to-speech configured.";
 "magic_item.assist_prompt.prompt.title" = "Prompt";
 "magic_item.assist_prompt.title.title" = "Title";
 "magic_item.background_color.title" = "Background color";
@@ -2094,6 +2094,7 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.configuration.layout.title" = "Layout";
 "watch.configuration.new_folder.title" = "New Folder";
 "watch.configuration.save.title" = "Save";
+"watch.configuration.show_assist.footer" = "Displays Assist as a button in the toolbar at the top of the Apple Watch home screen. To run a specific pipeline or prompt from the items list, add it as an item instead.";
 "watch.configuration.show_assist.title" = "Show Assist";
 "watch.configurator.delete.button" = "Delete Complication";
 "watch.configurator.delete.message" = "Are you sure you want to delete this Complication? This cannot be undone.";

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/FolderDetailView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/FolderDetailView.swift
@@ -46,16 +46,29 @@ struct FolderDetailView: View {
             }
         }
         .sheet(item: $addItemDestination) { destination in
-            MagicItemAddView(
-                context: .watch,
-                initialItemType: destination.magicItemType,
-                visiblePickerOptions: [destination.pickerOption],
-                allowMultipleSelection: true
-            ) { itemToAdd in
-                guard let itemToAdd else { return }
-                viewModel.addItemToFolder(folderId: folderId, item: itemToAdd)
+            switch destination {
+            case .entity, .area, .complication, .assist:
+                if let magicItemType = destination.magicItemType, let pickerOption = destination.pickerOption {
+                    MagicItemAddView(
+                        context: .watch,
+                        initialItemType: magicItemType,
+                        visiblePickerOptions: [pickerOption],
+                        allowMultipleSelection: true
+                    ) { itemToAdd in
+                        guard let itemToAdd else { return }
+                        viewModel.addItemToFolder(folderId: folderId, item: itemToAdd)
+                    }
+                    .preferredColorScheme(.dark)
+                }
+            case .assistPrompt:
+                NavigationView {
+                    AssistPromptMagicItemView(mode: .add) { itemToAdd in
+                        viewModel.addItemToFolder(folderId: folderId, item: itemToAdd)
+                    }
+                }
+                .navigationViewStyle(.stack)
+                .preferredColorScheme(.dark)
             }
-            .preferredColorScheme(.dark)
         }
         .sheet(isPresented: $showEditFolder) {
             if let folder {
@@ -86,6 +99,15 @@ struct FolderDetailView: View {
             // Nothing to customize: a complication renders from its own configuration, so a name or
             // color set here would be silently ignored. Swipe removes it, as for any other row.
             itemLabel(item: item, itemInfo: itemInfo)
+        } else if item.type == .assistPrompt {
+            NavigationLink {
+                AssistPromptMagicItemView(mode: .edit, item: item) { updatedMagicItem in
+                    viewModel.updateItemInFolder(folderId: folderId, item: updatedMagicItem)
+                }
+                .environment(\.colorScheme, .dark)
+            } label: {
+                itemLabel(item: item, itemInfo: itemInfo)
+            }
         } else {
             NavigationLink {
                 MagicItemCustomizationView(mode: .edit, context: .watch, item: item) { updatedMagicItem in

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemDestination.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemDestination.swift
@@ -7,10 +7,14 @@ enum WatchAddItemDestination: String, Identifiable {
     case entity
     case area
     case complication
+    case assist
+    /// Created in a dedicated editor (pipeline + title + prompt) rather than picked from a list, so
+    /// it has no `MagicItemAddView` picker of its own.
+    case assistPrompt
 
     var id: String { rawValue }
 
-    var magicItemType: MagicItemAddType {
+    var magicItemType: MagicItemAddType? {
         switch self {
         case .entity:
             return .entities
@@ -18,10 +22,14 @@ enum WatchAddItemDestination: String, Identifiable {
             return .areas
         case .complication:
             return .complications
+        case .assist:
+            return .assistPipelines
+        case .assistPrompt:
+            return nil
         }
     }
 
-    var pickerOption: MagicItemAddView.PickerOption {
+    var pickerOption: MagicItemAddView.PickerOption? {
         switch self {
         case .entity:
             return .entities
@@ -29,6 +37,10 @@ enum WatchAddItemDestination: String, Identifiable {
             return .areas
         case .complication:
             return .complications
+        case .assist:
+            return .assistPipelines
+        case .assistPrompt:
+            return nil
         }
     }
 }

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemMenu.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemMenu.swift
@@ -38,6 +38,32 @@ struct WatchAddItemMenu: View {
                 }
             }
 
+            Button {
+                onSelectDestination(.assist)
+            } label: {
+                Label {
+                    Text(L10n.Widgets.Action.Name.assist)
+                } icon: {
+                    Image(uiImage: MaterialDesignIcons.microphoneIcon.image(
+                        ofSize: .init(width: 18, height: 18),
+                        color: .label
+                    ))
+                }
+            }
+
+            Button {
+                onSelectDestination(.assistPrompt)
+            } label: {
+                Label {
+                    Text(L10n.MagicItem.ItemType.AssistPrompt.title)
+                } icon: {
+                    Image(uiImage: MaterialDesignIcons.messageProcessingOutlineIcon.image(
+                        ofSize: .init(width: 18, height: 18),
+                        color: .label
+                    ))
+                }
+            }
+
             // Only offered once a rectangular complication exists — this screen adds an existing one,
             // it never creates one, so with none configured the entry would lead to an empty list.
             if hasComplications {

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -70,16 +70,29 @@ struct WatchConfigurationView: View {
             }
         })
         .sheet(item: $addItemDestination, content: { destination in
-            MagicItemAddView(
-                context: .watch,
-                initialItemType: destination.magicItemType,
-                visiblePickerOptions: [destination.pickerOption],
-                allowMultipleSelection: true
-            ) { itemToAdd in
-                guard let itemToAdd else { return }
-                viewModel.addItem(itemToAdd)
+            switch destination {
+            case .entity, .area, .complication, .assist:
+                if let magicItemType = destination.magicItemType, let pickerOption = destination.pickerOption {
+                    MagicItemAddView(
+                        context: .watch,
+                        initialItemType: magicItemType,
+                        visiblePickerOptions: [pickerOption],
+                        allowMultipleSelection: true
+                    ) { itemToAdd in
+                        guard let itemToAdd else { return }
+                        viewModel.addItem(itemToAdd)
+                    }
+                    .preferredColorScheme(.dark)
+                }
+            case .assistPrompt:
+                NavigationView {
+                    AssistPromptMagicItemView(mode: .add) { itemToAdd in
+                        viewModel.addItem(itemToAdd)
+                    }
+                }
+                .navigationViewStyle(.stack)
+                .preferredColorScheme(.dark)
             }
-            .preferredColorScheme(.dark)
         })
         .alert(viewModel.errorMessage ?? L10n.errorLabel, isPresented: $viewModel.showError) {
             Button(action: {}, label: {
@@ -203,7 +216,7 @@ struct WatchConfigurationView: View {
     }
 
     private var assistSection: some View {
-        Section("Assist") {
+        Section {
             Toggle(isOn: $viewModel.watchConfig.assist.showAssist, label: {
                 Text(verbatim: L10n.Watch.Configuration.ShowAssist.title)
             })
@@ -217,6 +230,10 @@ struct WatchConfigurationView: View {
                     )
                 }
             }
+        } header: {
+            Text(verbatim: L10n.Widgets.Action.Name.assist)
+        } footer: {
+            Text(verbatim: L10n.Watch.Configuration.ShowAssist.footer)
         }
     }
 
@@ -247,6 +264,15 @@ struct WatchConfigurationView: View {
             // configuration, so a name or color set here would be silently ignored. Edit the
             // complication itself under Complications instead.
             itemRow(item: item, info: info)
+        } else if item.type == .assistPrompt {
+            NavigationLink {
+                AssistPromptMagicItemView(mode: .edit, item: item) { updatedMagicItem in
+                    viewModel.updateItem(updatedMagicItem)
+                }
+                .environment(\.colorScheme, .dark)
+            } label: {
+                itemRow(item: item, info: info)
+            }
         } else {
             NavigationLink {
                 MagicItemCustomizationView(mode: .edit, context: .watch, item: item) { updatedMagicItem in
@@ -264,7 +290,9 @@ struct WatchConfigurationView: View {
             Image(uiImage: image(for: item, itemInfo: info, color: .haPrimary))
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.name(info: info))
-                if let contextSubtitle = info.contextSubtitle {
+                // Assist-prompt items show the prompt that will be sent; everything else shows the
+                // Server • Area • Device context line.
+                if let contextSubtitle = promptSubtitle(for: item) ?? info.contextSubtitle {
                     Text(contextSubtitle)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -275,6 +303,16 @@ struct WatchConfigurationView: View {
             Image(systemSymbol: .line3Horizontal)
                 .foregroundStyle(.gray)
         }
+    }
+
+    private func promptSubtitle(for item: MagicItem) -> String? {
+        guard item.type == .assistPrompt,
+              let assistPrompt = item.assistPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !assistPrompt.isEmpty else {
+            return nil
+        }
+
+        return assistPrompt
     }
 
     private func image(
@@ -315,6 +353,7 @@ extension WatchConfigurationView: SettingsScreenSearchable {
             SettingsSearchEntry(L10n.Watch.Configuration.AddItem.title),
             SettingsSearchEntry(L10n.Watch.Configuration.AddFolder.title),
             SettingsSearchEntry(L10n.Watch.Configuration.ShowAssist.title),
+            SettingsSearchEntry(L10n.MagicItem.ItemType.AssistPrompt.title),
             SettingsSearchEntry(L10n.Watch.Configuration.HideAreas.title),
             SettingsSearchEntry(L10n.Watch.Labels.SelectedPipeline.title),
         ]

--- a/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
+++ b/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
@@ -74,7 +74,7 @@ struct MagicItemCustomizationView: View {
     }
 
     private func save() {
-        if context == .carPlay, viewModel.item.type == .assistPipeline {
+        if Self.skipsConfirmation(context: context, item: viewModel.item) {
             viewModel.item.customization?.requiresConfirmation = false
         }
 
@@ -236,7 +236,7 @@ struct MagicItemCustomizationView: View {
         // A watch sensor is only displayed — tapping it opens its details screen and runs nothing,
         // so there is no action to confirm. Neither does an area entry, which opens the area's
         // entities.
-        if !(context == .carPlay && viewModel.item.type == .assistPipeline),
+        if !Self.skipsConfirmation(context: context, item: viewModel.item),
            viewModel.item.type != .area,
            !(context == .watch && viewModel.item.isWatchDisplayOnly) {
             Section {
@@ -310,6 +310,12 @@ struct MagicItemCustomizationView: View {
                     viewModel.item.action = .runScript(newValue.serverId, newValue.entityId)
                 }
         }
+    }
+
+    /// An Assist pipeline in CarPlay or on the watch starts a voice session instead of running a
+    /// service, so asking for confirmation first has nothing to confirm.
+    private static func skipsConfirmation(context: MagicItemAddView.Context, item: MagicItem) -> Bool {
+        [.carPlay, .watch].contains(context) && item.type == .assistPipeline
     }
 
     private func preventNilCustomization() {

--- a/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
+++ b/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
@@ -312,10 +312,11 @@ struct MagicItemCustomizationView: View {
         }
     }
 
-    /// An Assist pipeline in CarPlay or on the watch starts a voice session instead of running a
-    /// service, so asking for confirmation first has nothing to confirm.
+    /// An Assist item in CarPlay or on the watch starts an Assist session instead of running a
+    /// service, so asking for confirmation first has nothing to confirm — and `MagicItemProvider`
+    /// clears the flag on both Assist types anyway.
     private static func skipsConfirmation(context: MagicItemAddView.Context, item: MagicItem) -> Bool {
-        [.carPlay, .watch].contains(context) && item.type == .assistPipeline
+        [.carPlay, .watch].contains(context) && item.isAssist
     }
 
     private func preventNilCustomization() {

--- a/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
+++ b/Sources/CarPlay/Templates/QuickAccess/CarPlayQuickAccessTemplate.swift
@@ -907,7 +907,7 @@ final class CarPlayQuickAccessTemplate: CarPlayTemplateProvider {
     }
 
     private func isAssistItem(_ magicItem: MagicItem) -> Bool {
-        magicItem.type == .assistPipeline || magicItem.type == .assistPrompt
+        magicItem.isAssist
     }
 
     private func assistTitle(for magicItem: MagicItem, info: MagicItem.Info) -> String {

--- a/Sources/HAWatchCommunicationMessages/Sources/AssistTextInputPayload.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/AssistTextInputPayload.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Payload of an `assistTextInput` message (watch → phone): the written prompt to run through an
+/// Assist pipeline. Key names cross the wire — never rename them.
+public struct AssistTextInputPayload {
+    public let text: String
+    public let pipelineId: String
+    public let serverId: String
+
+    public init(text: String, pipelineId: String, serverId: String) {
+        self.text = text
+        self.pipelineId = pipelineId
+        self.serverId = serverId
+    }
+
+    public init?(content: [String: Any]) {
+        guard let text = content["text"] as? String,
+              let pipelineId = content["pipelineId"] as? String,
+              let serverId = content["serverId"] as? String else {
+            return nil
+        }
+        self.text = text
+        self.pipelineId = pipelineId
+        self.serverId = serverId
+    }
+
+    public var content: [String: Any] {
+        [
+            "text": text,
+            "pipelineId": pipelineId,
+            "serverId": serverId,
+        ]
+    }
+}

--- a/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateMessages.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateMessages.swift
@@ -8,6 +8,11 @@ public enum InteractiveImmediateMessages: String, CaseIterable {
     case pushAction = "PushAction"
     case assistPipelinesFetch
     case assistAudioDataChunked
+    /// Watch → phone: run an Assist pipeline with a written prompt instead of a recording,
+    /// `{text, pipelineId, serverId}`. The phone runs the pipeline and streams the result back
+    /// through the same `assistIntentEndResponse`/`assistTTSResponse`/`assistError` messages the
+    /// audio flow uses.
+    case assistTextInput
     case watchConfig
     /// Watch → phone: ask the phone for the list of items the user can add to the watch
     /// configuration (scripts/scenes/automations across all servers). The phone owns the entity

--- a/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
+++ b/Sources/HAWatchCommunicationMessages/Sources/InteractiveImmediateResponses.swift
@@ -12,6 +12,9 @@ public enum InteractiveImmediateResponses: String, CaseIterable {
     /// `{acknowledged, chunkIndex, totalChunks}`. The watch sends the next chunk only after
     /// receiving this, so audio streams with backpressure instead of flooding the session.
     case assistAudioChunkAck
+    /// Phone → watch: acknowledgement that an `assistTextInput` prompt was handed to the pipeline.
+    /// The pipeline's own output follows through `assistIntentEndResponse` / `assistTTSResponse`.
+    case assistTextInputAck
     case assistSTTResponse
     case assistIntentEndResponse
     case assistTTSResponse

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -74,6 +74,12 @@ public struct MagicItem: Codable, Equatable, Hashable {
         type == .entity && domain?.isWatchDisplayOnly == true
     }
 
+    /// True for the item types that start an Assist session (a pipeline, or a written prompt) rather
+    /// than calling a service.
+    public var isAssist: Bool {
+        type == .assistPipeline || type == .assistPrompt
+    }
+
     /// Domain retrieved from id when item is entity else nil
     public var domain: Domain? {
         if let domainString = id.split(separator: ".").first, let domain = Domain(rawValue: String(domainString)) {

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -95,9 +95,9 @@ final class MagicItemProvider: MagicItemProviderProtocol {
             return
         }
         carPlayConfig.quickAccessItems = migrateItemsIfNeeded(items: carPlayConfig.quickAccessItems)
-        carPlayConfig.quickAccessItems = normalizeCarPlayItems(carPlayConfig.quickAccessItems)
+        carPlayConfig.quickAccessItems = normalizeAssistItems(carPlayConfig.quickAccessItems)
         if let tabFolders = carPlayConfig.tabFolders {
-            carPlayConfig.tabFolders = normalizeCarPlayItems(migrateItemsIfNeeded(items: tabFolders))
+            carPlayConfig.tabFolders = normalizeAssistItems(migrateItemsIfNeeded(items: tabFolders))
         }
 
         do {
@@ -120,7 +120,7 @@ final class MagicItemProvider: MagicItemProviderProtocol {
             completion()
             return
         }
-        watchConfig.items = migrateItemsIfNeeded(items: watchConfig.items)
+        watchConfig.items = normalizeAssistItems(migrateItemsIfNeeded(items: watchConfig.items))
 
         do {
             try Current.database().write { db in
@@ -428,15 +428,17 @@ final class MagicItemProvider: MagicItemProviderProtocol {
         )
     }
 
-    private func normalizeCarPlayItems(_ items: [MagicItem]) -> [MagicItem] {
+    /// Assist items always render with the Assist icon color and never ask for confirmation —
+    /// running one opens a voice session rather than calling a service.
+    private func normalizeAssistItems(_ items: [MagicItem]) -> [MagicItem] {
         items.map { item in
             if item.type == .folder {
                 var item = item
-                item.items = normalizeCarPlayItems(item.items ?? [])
+                item.items = normalizeAssistItems(item.items ?? [])
                 return item
             }
 
-            guard item.type == .assistPipeline || item.type == .assistPrompt else { return item }
+            guard item.isAssist else { return item }
 
             var item = item
             var customization = item.customization ?? .init()

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2884,7 +2884,7 @@ public enum L10n {
       /// Assist prompt
       public static var navigationTitle: String { return L10n.tr("Localizable", "magic_item.assist_prompt.navigation_title") }
       public enum Prompt {
-        /// When executed in CarPlay, this prompt will be sent to Assist and the response will be played as audio. Make sure the selected Assist pipeline has text-to-speech configured.
+        /// When executed, this prompt will be sent to Assist and the response will be played as audio. Make sure the selected Assist pipeline has text-to-speech configured.
         public static var footer: String { return L10n.tr("Localizable", "magic_item.assist_prompt.prompt.footer") }
         /// Prompt
         public static var title: String { return L10n.tr("Localizable", "magic_item.assist_prompt.prompt.title") }
@@ -6838,6 +6838,8 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "watch.configuration.save.title") }
       }
       public enum ShowAssist {
+        /// Displays Assist as a button in the toolbar at the top of the Apple Watch home screen. To run a specific pipeline or prompt from the items list, add it as an item instead.
+        public static var footer: String { return L10n.tr("Localizable", "watch.configuration.show_assist.footer") }
         /// Show Assist
         public static var title: String { return L10n.tr("Localizable", "watch.configuration.show_assist.title") }
       }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -170,6 +170,8 @@ final class WatchCommunicatorService {
                     assistPipelinesFetch(message: message)
                 case .assistAudioDataChunked:
                     handleAssistAudioChunkedMessage(message)
+                case .assistTextInput:
+                    handleAssistTextInputMessage(message)
                 case .magicItemPressed:
                     magicItemPressed(message: message)
                 case .serversConfigSync:
@@ -901,6 +903,44 @@ extension WatchCommunicatorService {
             audioSampleRate: payload.sampleRate,
             tts: true
         ))
+    }
+
+    /// Run an Assist pipeline with the prompt written on the watch. There is no audio to upload, so
+    /// unlike the recording flow this starts the pipeline as soon as the message arrives; the
+    /// response travels back through the same delegate messages.
+    private func handleAssistTextInputMessage(_ message: HAWatchConnectivity.InteractiveImmediateMessage) {
+        // Every path acknowledges: the watch treats a missing reply as a delivery failure and would
+        // report that on top of the failure reported here.
+        let acknowledge: () -> Void = {
+            message.reply(.init(identifier: InteractiveImmediateResponses.assistTextInputAck.rawValue))
+        }
+        // Failures are also pushed as `assistError`, which the watch routes to the chat UI, so the
+        // user sees a reason rather than an endless spinner.
+        let reportFailure: (String, String) -> Void = { [weak self] code, description in
+            self?.sendMessage(message: .init(
+                identifier: InteractiveImmediateResponses.assistError.rawValue,
+                content: AssistErrorPayload(code: code, message: description).content
+            ))
+            acknowledge()
+        }
+
+        guard let payload = AssistTextInputPayload(content: message.content) else {
+            Current.Log.error("Invalid assist text input message data")
+            reportFailure("invalid_payload", "The iPhone could not read the prompt")
+            return
+        }
+        guard let server = assistTargetServer(for: payload.serverId) else {
+            Current.Log.error("Assist prompt targets unknown server \(payload.serverId)")
+            reportFailure("unknown_server", "Server not found on iPhone")
+            return
+        }
+
+        initAssistServiceIfNeeded(server: server).assist(source: .text(
+            input: payload.text,
+            pipelineId: payload.pipelineId,
+            expectTTS: true
+        ))
+        acknowledge()
     }
 
     private func initAssistServiceIfNeeded(server: Server) -> AssistServiceProtocol {

--- a/Sources/WatchApp/Assist/WatchAssistService.swift
+++ b/Sources/WatchApp/Assist/WatchAssistService.swift
@@ -43,6 +43,35 @@ final class WatchAssistService: ObservableObject {
         }
     }
 
+    /// Run the pipeline with a written prompt instead of a recording. The phone owns the WebSocket
+    /// connection, so — exactly like the audio flow — it runs the pipeline and streams the response
+    /// back through the immediate-message observers.
+    func assist(text: String, completion: @escaping (Error?) -> Void) {
+        guard Communicator.shared.currentReachability == .immediatelyReachable else {
+            completion(WatchSendError.notImmediate)
+            return
+        }
+
+        Communicator.shared.send(.init(
+            identifier: InteractiveImmediateMessages.assistTextInput.rawValue,
+            content: AssistTextInputPayload(
+                text: text,
+                pipelineId: pipelineId,
+                serverId: serverId
+            ).content,
+            reply: { _ in
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+            }
+        ), priority: .userAction, errorHandler: { error in
+            Current.Log.error("Assist prompt failed to reach the iPhone: \(error.localizedDescription)")
+            DispatchQueue.main.async {
+                completion(error)
+            }
+        })
+    }
+
     func assist(audioURL: URL, sampleRate: Double, completion: @escaping (Error?) -> Void) {
         cancellable?.cancel()
         guard Communicator.shared.currentReachability == .immediatelyReachable else {

--- a/Sources/WatchApp/Assist/WatchAssistView+Build.swift
+++ b/Sources/WatchApp/Assist/WatchAssistView+Build.swift
@@ -2,7 +2,8 @@ import Foundation
 import Shared
 
 extension WatchAssistView {
-    static func build(serverId: String, pipelineId: String) -> WatchAssistView {
+    /// `prompt` is set by an Assist prompt item: the session sends that text instead of recording.
+    static func build(serverId: String, pipelineId: String, prompt: String? = nil) -> WatchAssistView {
         // The whole view-model expression is passed as an autoclosure so it only runs when SwiftUI
         // first creates the view's @StateObject storage. This builder is called from a
         // `fullScreenCover` content closure, which re-evaluates on every parent re-render (config
@@ -13,7 +14,8 @@ extension WatchAssistView {
             assistService: WatchAssistService(serverId: serverId, pipelineId: pipelineId),
             audioRecorder: WatchAudioRecorder(),
             audioPlayer: AudioPlayer(),
-            immediateCommunicatorService: .shared
+            immediateCommunicatorService: .shared,
+            prompt: prompt
         ))
     }
 }

--- a/Sources/WatchApp/Assist/WatchAssistViewModel.swift
+++ b/Sources/WatchApp/Assist/WatchAssistViewModel.swift
@@ -23,6 +23,9 @@ final class WatchAssistViewModel: ObservableObject {
     private let audioRecorder: any WatchAudioRecorderProtocol
     private let audioPlayer: any AudioPlayerProtocol
     private let immediateCommunicatorService: ImmediateCommunicatorService
+    /// Written prompt of an Assist prompt item: the session sends it instead of listening. `nil`
+    /// for a regular voice session.
+    private let prompt: String?
 
     @Published var assistService: WatchAssistService
 
@@ -30,12 +33,14 @@ final class WatchAssistViewModel: ObservableObject {
         assistService: WatchAssistService,
         audioRecorder: any WatchAudioRecorderProtocol,
         audioPlayer: any AudioPlayerProtocol,
-        immediateCommunicatorService: ImmediateCommunicatorService
+        immediateCommunicatorService: ImmediateCommunicatorService,
+        prompt: String? = nil
     ) {
         self.audioRecorder = audioRecorder
         self.immediateCommunicatorService = immediateCommunicatorService
         self.assistService = assistService
         self.audioPlayer = audioPlayer
+        self.prompt = prompt
         audioRecorder.delegate = self
         immediateCommunicatorService.addObserver(.init(delegate: self))
     }
@@ -45,7 +50,30 @@ final class WatchAssistViewModel: ObservableObject {
     }
 
     func initialRoutine() {
-        assist()
+        if let prompt = prompt?.trimmingCharacters(in: .whitespacesAndNewlines), !prompt.isEmpty {
+            sendPrompt(prompt)
+        } else {
+            assist()
+        }
+    }
+
+    /// Send an Assist prompt item's text through the pipeline. The prompt itself is echoed into the
+    /// chat straight away — a text run produces no speech-to-text event, so nothing else would show
+    /// what was asked.
+    private func sendPrompt(_ prompt: String) {
+        guard assistService.deviceReachable else {
+            state = .idle
+            showUnreacheableMessage()
+            return
+        }
+        appendChatItem(.init(content: prompt, itemType: .input))
+        state = .waitingForPipelineResponse
+        assistService.assist(text: prompt) { [weak self] error in
+            guard let error else { return }
+            Current.Log.error("Failed to send Assist prompt from watch: \(error.localizedDescription)")
+            self?.appendChatItem(.init(content: L10n.Assist.Watch.NotReachable.title, itemType: .error))
+            self?.updateState(state: .idle)
+        }
     }
 
     /// (Re)subscribe to phone responses. Called on every appearance: `endRoutine()` unsubscribes

--- a/Sources/WatchApp/Home/Edit/WatchAssistPipelineOption.swift
+++ b/Sources/WatchApp/Home/Edit/WatchAssistPipelineOption.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Shared
+
+/// One choice in the watch's Assist pickers: a server's pipeline, or that server's "Preferred"
+/// pipeline (empty id, resolved by the server at run time). Read from the mirrored `AssistPipelines`
+/// table, so the add flow works with the iPhone out of range.
+struct WatchAssistPipelineOption: Identifiable, Hashable {
+    let serverId: String
+    let serverName: String
+    let pipelineId: String
+    let name: String
+
+    var id: String { "\(serverId)|\(pipelineId)" }
+
+    /// True for the entry that lets the server pick — it can't reuse a pipeline's identity.
+    var isPreferred: Bool { pipelineId.isEmpty }
+
+    /// Every mirrored server's pipelines, each group preceded by its "Preferred" entry. Servers
+    /// without any cached pipeline are omitted.
+    static func all() -> [WatchAssistPipelineOption] {
+        let configs = ((try? AssistPipelines.config()) ?? nil) ?? []
+        return configs.flatMap { config -> [WatchAssistPipelineOption] in
+            guard !config.pipelines.isEmpty else { return [] }
+            let serverName = Current.servers.server(forServerIdentifier: config.serverId)?.info.name ?? config.serverId
+            let preferred = WatchAssistPipelineOption(
+                serverId: config.serverId,
+                serverName: serverName,
+                pipelineId: "",
+                name: L10n.Watch.Config.Assist.preferred
+            )
+            return [preferred] + config.pipelines.map { pipeline in
+                WatchAssistPipelineOption(
+                    serverId: config.serverId,
+                    serverName: serverName,
+                    pipelineId: pipeline.id,
+                    name: pipeline.name
+                )
+            }
+        }
+    }
+
+    /// The item this option adds to the configuration. "Preferred" can't key its identity on the
+    /// empty pipeline id, so it gets a UUID and carries the marker in `assistPipelineId` — the same
+    /// rule the iPhone and CarPlay add flows follow.
+    func makePipelineItem() -> MagicItem {
+        MagicItem(
+            id: isPreferred ? UUID().uuidString : pipelineId,
+            serverId: serverId,
+            type: .assistPipeline,
+            customization: .init(iconColor: MagicItem.defaultAssistIconColorHex),
+            assistPipelineId: isPreferred ? "" : nil
+        )
+    }
+}

--- a/Sources/WatchApp/Home/Edit/WatchAssistPipelineSelectionView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchAssistPipelineSelectionView.swift
@@ -1,0 +1,64 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Pipeline chooser for the on-watch Assist prompt flow: one section per server, holding that
+/// server's pipelines (its "Preferred" entry first). The server is the section header rather than a
+/// prefix on every row, matching the iPhone's Assist pipeline picker.
+struct WatchAssistPipelineSelectionView: View {
+    let options: [WatchAssistPipelineOption]
+    @Binding var selectedOptionId: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// Servers in the order their pipelines were loaded, so the sections don't reshuffle.
+    private var serverIds: [String] {
+        var seen = Set<String>()
+        return options.map(\.serverId).filter { seen.insert($0).inserted }
+    }
+
+    var body: some View {
+        List {
+            ForEach(serverIds, id: \.self) { serverId in
+                section(for: options.filter { $0.serverId == serverId })
+            }
+        }
+        .navigationTitle(Text(verbatim: L10n.Watch.Config.Assist.pipeline))
+    }
+
+    @ViewBuilder
+    private func section(for serverOptions: [WatchAssistPipelineOption]) -> some View {
+        Section {
+            ForEach(serverOptions) { option in
+                Button {
+                    selectedOptionId = option.id
+                    dismiss()
+                } label: {
+                    if option.id == selectedOptionId {
+                        Label(option.name, systemSymbol: .checkmark)
+                    } else {
+                        Text(verbatim: option.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        } header: {
+            if let serverName = serverOptions.first?.serverName {
+                Text(verbatim: serverName)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        WatchAssistPipelineSelectionView(
+            options: [
+                .init(serverId: "1", serverName: "Home", pipelineId: "", name: "Preferred"),
+                .init(serverId: "1", serverName: "Home", pipelineId: "p1", name: "Home Assistant"),
+                .init(serverId: "2", serverName: "Cabin", pipelineId: "", name: "Preferred"),
+            ],
+            selectedOptionId: .constant("1|")
+        )
+    }
+}

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddAssistListView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddAssistListView.swift
@@ -1,0 +1,92 @@
+import Shared
+import SwiftUI
+
+/// The on-watch list of Assist pipelines that can be added as items, read from the mirrored
+/// database so the flow works with the iPhone out of range. Picking one commits immediately —
+/// there is nothing else to configure, and the name and icon can be changed afterwards from the
+/// item's edit screen.
+struct WatchConfigAddAssistListView: View {
+    let viewModel: WatchHomeViewModel
+    /// When set, the pipeline goes into this folder instead of the root.
+    let folderId: String?
+    let finish: () -> Void
+
+    /// `nil` until the first load finishes, which is what puts the spinner on screen.
+    @State private var options: [WatchAssistPipelineOption]?
+
+    private var groupedOptions: [String: [WatchAssistPipelineOption]] {
+        Dictionary(grouping: options ?? [], by: \.serverId)
+    }
+
+    private var showsServerHeaders: Bool {
+        groupedOptions.count > 1
+    }
+
+    var body: some View {
+        Group {
+            if options == nil {
+                ProgressView()
+                    .progressViewStyle(.circular)
+            } else if options?.isEmpty ?? true {
+                List {
+                    Text(verbatim: L10n.Watch.Config.Assist.noPipelines)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                List {
+                    ForEach(groupedOptions.keys.sorted(), id: \.self) { serverId in
+                        section(for: groupedOptions[serverId] ?? [])
+                    }
+                }
+            }
+        }
+        .navigationTitle(Text(verbatim: L10n.Widgets.Action.Name.assist))
+        .onAppear(perform: load)
+    }
+
+    @ViewBuilder
+    private func section(for serverOptions: [WatchAssistPipelineOption]) -> some View {
+        Section {
+            // Plain rows, like the add flow's other pickers: the home screen's row style is
+            // full-bleed and would push the text under the screen's edge here.
+            ForEach(serverOptions) { option in
+                Button {
+                    add(option)
+                } label: {
+                    Text(verbatim: option.name)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        } header: {
+            if showsServerHeaders, let serverName = serverOptions.first?.serverName {
+                Text(verbatim: serverName)
+            }
+        }
+    }
+
+    private func load() {
+        // Kept once loaded: the mirror doesn't change while the sheet is open.
+        guard options == nil else { return }
+        options = WatchAssistPipelineOption.all()
+    }
+
+    private func add(_ option: WatchAssistPipelineOption) {
+        let item = option.makePipelineItem()
+        let info = Current.magicItemProvider().getInfo(for: item)
+        if let folderId {
+            viewModel.addItemToFolder(folderId: folderId, item: item, info: info)
+        } else {
+            viewModel.addItem(item, info: info)
+        }
+        viewModel.saveConfig()
+        finish()
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return NavigationView {
+        WatchConfigAddAssistListView(viewModel: WatchHomeViewModel(), folderId: nil, finish: {})
+    }
+}

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddAssistPromptView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddAssistPromptView.swift
@@ -39,11 +39,13 @@ struct WatchConfigAddAssistPromptView: View {
                     .foregroundStyle(.secondary)
             } else {
                 Section {
-                    Picker(L10n.Watch.Config.Assist.pipeline, selection: $selectedOptionId) {
-                        ForEach(options) { option in
-                            Text(verbatim: pickerLabel(for: option))
-                                .tag(Optional(option.id))
-                        }
+                    NavigationLink {
+                        WatchAssistPipelineSelectionView(
+                            options: options,
+                            selectedOptionId: $selectedOptionId
+                        )
+                    } label: {
+                        pipelineLabel
                     }
                 }
 
@@ -72,12 +74,27 @@ struct WatchConfigAddAssistPromptView: View {
         .onAppear(perform: load)
     }
 
-    /// Several servers can each offer a "Preferred" entry, so the server name is part of the label
-    /// when there is more than one.
-    private func pickerLabel(for option: WatchAssistPipelineOption) -> String {
-        let serverIds = Set(options.map(\.serverId))
-        guard serverIds.count > 1 else { return option.name }
-        return "\(option.serverName) • \(option.name)"
+    /// The chooser's summary row. Several servers can each offer a "Preferred" entry, so which
+    /// server the choice belongs to is shown underneath — once, rather than on every option.
+    private var pipelineLabel: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            Text(verbatim: L10n.Watch.Config.Assist.pipeline)
+            if let selectedOption {
+                Text(verbatim: selectedOption.name)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if hasMultipleServers {
+                    Text(verbatim: selectedOption.serverName)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var hasMultipleServers: Bool {
+        Set(options.map(\.serverId)).count > 1
     }
 
     private func load() {

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddAssistPromptView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddAssistPromptView.swift
@@ -1,0 +1,116 @@
+import Shared
+import SwiftUI
+
+/// Creates an Assist prompt item on the watch: pick the pipeline that will run it, name it, and
+/// write the prompt (dictation or scribble). Running the item sends the prompt straight to Assist,
+/// so there is nothing to listen to.
+struct WatchConfigAddAssistPromptView: View {
+    let viewModel: WatchHomeViewModel
+    /// When set, the prompt goes into this folder instead of the root.
+    let folderId: String?
+    let finish: () -> Void
+
+    @State private var options: [WatchAssistPipelineOption] = []
+    @State private var selectedOptionId: String?
+    @State private var title = ""
+    @State private var prompt = ""
+
+    private var selectedOption: WatchAssistPipelineOption? {
+        options.first(where: { $0.id == selectedOptionId })
+    }
+
+    private var canSave: Bool {
+        selectedOption != nil && !trimmedTitle.isEmpty && !trimmedPrompt.isEmpty
+    }
+
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedPrompt: String {
+        prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        List {
+            if options.isEmpty {
+                Text(verbatim: L10n.Watch.Config.Assist.noPipelines)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                Section {
+                    Picker(L10n.Watch.Config.Assist.pipeline, selection: $selectedOptionId) {
+                        ForEach(options) { option in
+                            Text(verbatim: pickerLabel(for: option))
+                                .tag(Optional(option.id))
+                        }
+                    }
+                }
+
+                Section {
+                    TextField(L10n.MagicItem.AssistPrompt.Title.title, text: $title)
+                } header: {
+                    Text(verbatim: L10n.MagicItem.AssistPrompt.Title.title)
+                }
+
+                Section {
+                    TextField(L10n.MagicItem.AssistPrompt.Prompt.title, text: $prompt)
+                } header: {
+                    Text(verbatim: L10n.MagicItem.AssistPrompt.Prompt.title)
+                }
+
+                Section {
+                    Button(action: save) {
+                        Text(verbatim: L10n.Watch.Config.Edit.addButton)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .disabled(!canSave)
+                }
+            }
+        }
+        .navigationTitle(Text(verbatim: L10n.MagicItem.AssistPrompt.navigationTitle))
+        .onAppear(perform: load)
+    }
+
+    /// Several servers can each offer a "Preferred" entry, so the server name is part of the label
+    /// when there is more than one.
+    private func pickerLabel(for option: WatchAssistPipelineOption) -> String {
+        let serverIds = Set(options.map(\.serverId))
+        guard serverIds.count > 1 else { return option.name }
+        return "\(option.serverName) • \(option.name)"
+    }
+
+    private func load() {
+        guard options.isEmpty else { return }
+        options = WatchAssistPipelineOption.all()
+        selectedOptionId = selectedOptionId ?? options.first?.id
+    }
+
+    private func save() {
+        guard let selectedOption else { return }
+        let item = MagicItem(
+            id: UUID().uuidString,
+            serverId: selectedOption.serverId,
+            type: .assistPrompt,
+            customization: .init(iconColor: MagicItem.defaultAssistIconColorHex),
+            displayText: trimmedTitle,
+            assistPrompt: trimmedPrompt,
+            assistPipelineId: selectedOption.pipelineId
+        )
+        let info = Current.magicItemProvider().getInfo(for: item)
+        if let folderId {
+            viewModel.addItemToFolder(folderId: folderId, item: item, info: info)
+        } else {
+            viewModel.addItem(item, info: info)
+        }
+        viewModel.saveConfig()
+        finish()
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return NavigationView {
+        WatchConfigAddAssistPromptView(viewModel: WatchHomeViewModel(), folderId: nil, finish: {})
+    }
+}

--- a/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigAddView.swift
@@ -74,6 +74,29 @@ struct WatchConfigAddView: View {
                 chooserRow(icon: .textureBoxIcon, title: L10n.Watch.Config.Add.area)
             }
 
+            NavigationLink {
+                WatchConfigAddAssistListView(
+                    viewModel: viewModel,
+                    folderId: folderId,
+                    finish: { dismiss() }
+                )
+            } label: {
+                chooserRow(icon: .microphoneIcon, title: L10n.Widgets.Action.Name.assist)
+            }
+
+            NavigationLink {
+                WatchConfigAddAssistPromptView(
+                    viewModel: viewModel,
+                    folderId: folderId,
+                    finish: { dismiss() }
+                )
+            } label: {
+                chooserRow(
+                    icon: .messageProcessingOutlineIcon,
+                    title: L10n.MagicItem.ItemType.AssistPrompt.title
+                )
+            }
+
             if hasComplications {
                 NavigationLink {
                     WatchConfigAddComplicationListView(

--- a/Sources/WatchApp/Home/Edit/WatchConfigItemEditView.swift
+++ b/Sources/WatchApp/Home/Edit/WatchConfigItemEditView.swift
@@ -35,6 +35,8 @@ struct WatchConfigItemEditView: View {
     @State private var backgroundColorHex: String?
     @State private var textColorHex: String?
     @State private var useCustomColors: Bool
+    /// Only used by an Assist prompt item — the text it sends when run.
+    @State private var assistPrompt: String
 
     init(
         mode: Mode,
@@ -60,6 +62,7 @@ struct WatchConfigItemEditView: View {
         _useCustomColors = State(
             initialValue: item.customization?.backgroundColor != nil || item.customization?.textColor != nil
         )
+        _assistPrompt = State(initialValue: item.assistPrompt ?? "")
     }
 
     private var isFolder: Bool { originalItem.type == .folder }
@@ -70,6 +73,9 @@ struct WatchConfigItemEditView: View {
     /// icon, colors and confirmation here would all be silently ignored. Its row is in this editor
     /// only so it can be removed from the list, which is what the screen shows for it.
     private var isComplication: Bool { originalItem.type == .complication }
+
+    /// An Assist prompt carries the text it sends, which is editable here alongside its name.
+    private var isAssistPrompt: Bool { originalItem.type == .assistPrompt }
 
     var body: some View {
         List {
@@ -89,8 +95,16 @@ struct WatchConfigItemEditView: View {
                     }
                 }
             }
-            // Folders, areas, complications and sensors never run anything, so nothing to confirm.
-            if !isFolder, !isArea, !isComplication, !originalItem.isWatchDisplayOnly {
+            if isAssistPrompt {
+                Section {
+                    TextField(L10n.MagicItem.AssistPrompt.Prompt.title, text: $assistPrompt)
+                } header: {
+                    Text(verbatim: L10n.MagicItem.AssistPrompt.Prompt.title)
+                }
+            }
+            // Folders, areas, complications, sensors and Assist items never run a service, so there
+            // is nothing to confirm.
+            if !isFolder, !isArea, !isComplication, !originalItem.isAssist, !originalItem.isWatchDisplayOnly {
                 Section {
                     Toggle(isOn: $requiresConfirmation) {
                         Text(verbatim: L10n.Watch.Config.Edit.requireConfirmation)
@@ -192,6 +206,12 @@ struct WatchConfigItemEditView: View {
             customization.textColor = nil
         }
         item.customization = customization
+        if isAssistPrompt {
+            let trimmedPrompt = assistPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Keep the original prompt rather than saving an empty one, which would leave the item
+            // with nothing to send.
+            item.assistPrompt = trimmedPrompt.isEmpty ? originalItem.assistPrompt : trimmedPrompt
+        }
         return item
     }
 

--- a/Sources/WatchApp/Home/MagicItemRow/WatchAssistItemRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchAssistItemRow.swift
@@ -1,0 +1,133 @@
+import Shared
+import SwiftUI
+
+/// An Assist pipeline or Assist prompt configured as a home item. Tapping opens the full-screen
+/// Assist session owned by `WatchHomeView`: a pipeline item starts listening, a prompt item sends
+/// its text straight away.
+struct WatchAssistItemRow: View {
+    let item: MagicItem
+    let itemInfo: MagicItem.Info
+    var layout: WatchLayout = .list
+    @Environment(\.watchPresentAssist) private var presentAssist
+
+    var body: some View {
+        Button {
+            presentAssist(.session(
+                serverId: item.serverId,
+                // An empty id is the "Preferred" pipeline; a pipeline item without an override runs
+                // the pipeline its own id points at.
+                pipelineId: item.assistPipelineId ?? item.id,
+                prompt: item.type == .assistPrompt ? item.assistPrompt : nil
+            ))
+        } label: {
+            label
+        }
+        .modify { view in
+            if layout == .grid {
+                view.watchHomeItemGridStyle(tint: backgroundForWatchItem)
+            } else {
+                view
+                    .frame(maxWidth: .infinity)
+                    .watchHomeItemRowStyle(tint: backgroundForWatchItem)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var label: some View {
+        if layout == .grid {
+            gridIcon
+        } else {
+            WatchHomeItemLabel(
+                name: item.name(info: itemInfo),
+                subtitle: subtitle,
+                textColor: textColor,
+                icon: { iconView }
+            )
+        }
+    }
+
+    /// A prompt item shows the text it will send — the name alone doesn't say what will be asked.
+    private var subtitle: String? {
+        guard item.type == .assistPrompt,
+              let prompt = item.assistPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !prompt.isEmpty else {
+            return nil
+        }
+        return prompt
+    }
+
+    private var iconColor: UIColor {
+        if let hex = item.customization?.iconColor ?? itemInfo.customization?.iconColor {
+            .init(hex: hex)
+        } else {
+            .white
+        }
+    }
+
+    private var iconView: some View {
+        VStack {
+            Image(uiImage: item.icon(info: itemInfo).image(
+                ofSize: .init(width: 24, height: 24),
+                color: iconColor
+            ))
+            .foregroundStyle(Color(uiColor: iconColor))
+            .padding()
+        }
+        .watchRowIconContainer(color: iconColor)
+    }
+
+    private var gridIcon: some View {
+        Image(uiImage: item.icon(info: itemInfo).image(
+            ofSize: .init(width: 28, height: 28),
+            color: iconColor
+        ))
+        .foregroundStyle(Color(uiColor: iconColor))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .accessibilityLabel(Text(item.name(info: itemInfo)))
+    }
+
+    private var textColor: Color {
+        if let textColor = item.customization?.textColor {
+            .init(uiColor: .init(hex: textColor))
+        } else {
+            .white
+        }
+    }
+
+    private var backgroundForWatchItem: Color? {
+        if let backgroundColor = item.customization?.backgroundColor {
+            Color(uiColor: .init(hex: backgroundColor))
+        } else {
+            nil
+        }
+    }
+}
+
+#Preview {
+    MaterialDesignIcons.register()
+    return List {
+        WatchAssistItemRow(
+            item: .init(
+                id: "pipeline-1",
+                serverId: "1",
+                type: .assistPipeline,
+                customization: .init(iconColor: MagicItem.defaultAssistIconColorHex)
+            ),
+            itemInfo: .init(id: "1-pipeline-1", name: "Home Assistant", iconName: "mdi:microphone")
+        )
+        WatchAssistItemRow(
+            item: .init(
+                id: "prompt-1",
+                serverId: "1",
+                type: .assistPrompt,
+                customization: .init(iconColor: MagicItem.defaultAssistIconColorHex),
+                displayText: "Good night",
+                assistPrompt: "Turn off all the lights",
+                assistPipelineId: ""
+            ),
+            itemInfo: .init(id: "1-prompt-1", name: "Preferred", iconName: "mdi:message-processing-outline")
+        )
+    }
+}

--- a/Sources/WatchApp/Home/WatchAssistPresentation.swift
+++ b/Sources/WatchApp/Home/WatchAssistPresentation.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// What the watch's full-screen Assist cover should show. Presented from the home screen's toolbar
+/// button, the Assist complication, and Assist/Assist prompt items in the configuration.
+enum WatchAssistPresentation: Identifiable {
+    /// A pipeline session. An empty `pipelineId` means the server's preferred pipeline, and `prompt`
+    /// — set by an Assist prompt item — is sent as text instead of recording.
+    case session(serverId: String, pipelineId: String, prompt: String?)
+    /// Assist was requested before its configuration reached the watch (e.g. a cold launch from the
+    /// complication), so there is no pipeline to run yet.
+    case unconfigured
+
+    var id: String {
+        switch self {
+        case let .session(serverId, pipelineId, prompt):
+            return "\(serverId)|\(pipelineId)|\(prompt ?? "")"
+        case .unconfigured:
+            return "__unconfigured__"
+        }
+    }
+}

--- a/Sources/WatchApp/Home/WatchAssistPresentation.swift
+++ b/Sources/WatchApp/Home/WatchAssistPresentation.swift
@@ -10,10 +10,12 @@ enum WatchAssistPresentation: Identifiable {
     /// complication), so there is no pipeline to run yet.
     case unconfigured
 
+    /// The prompt is reduced to a fingerprint rather than embedded: the id only has to tell two
+    /// sessions apart, and it must not carry what the user wrote into logs or diagnostics.
     var id: String {
         switch self {
         case let .session(serverId, pipelineId, prompt):
-            return "\(serverId)|\(pipelineId)|\(prompt ?? "")"
+            return "\(serverId)|\(pipelineId)|\(prompt.map { String($0.hashValue) } ?? "")"
         case .unconfigured:
             return "__unconfigured__"
         }

--- a/Sources/WatchApp/Home/WatchFolderContentView.swift
+++ b/Sources/WatchApp/Home/WatchFolderContentView.swift
@@ -95,6 +95,8 @@ struct WatchFolderContentView: View {
             ForEach((folder?.items ?? []).filter { $0.type != .complication }, id: \.serverUniqueId) { item in
                 if item.type == .area {
                     WatchAreaItemRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
+                } else if item.isAssist {
+                    WatchAssistItemRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 } else {
                     WatchMagicViewRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 }
@@ -133,6 +135,8 @@ struct WatchFolderContentView: View {
             )
         } else if item.type == .complication {
             WatchComplicationRow(item: item, itemInfo: viewModel.info(for: item))
+        } else if item.isAssist {
+            WatchAssistItemRow(item: item, itemInfo: viewModel.info(for: item))
         } else {
             WatchMagicViewRow(
                 item: item,

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -8,7 +8,9 @@ struct WatchHomeView: View {
     /// When false, the view skips the network/database refresh on appear. Used by previews to render
     /// injected sample data.
     private let autoLoad: Bool
-    @State private var showAssist = false
+    /// The Assist session on screen, if any: the toolbar button and the complication run the
+    /// configured pipeline, while Assist items run their own (see `WatchAssistItemRow`).
+    @State private var assistPresentation: WatchAssistPresentation?
     @State private var showSettings = false
     @State private var isEditing = false
     /// The stack's path. Rows push by appending through the `watchNavigate` environment action —
@@ -83,29 +85,33 @@ struct WatchHomeView: View {
         .environment(\.watchNavigate, WatchNavigateAction { destination in
             navigationPath.append(destination)
         })
+        .environment(\.watchPresentAssist, WatchPresentAssistAction { presentation in
+            assistPresentation = presentation
+        })
         ._statusBarHidden(true)
         .onReceive(NotificationCenter.default.publisher(for: AssistDefaultComplication.launchNotification)) { _ in
-            showAssist = true
+            presentConfiguredAssist()
         }
         // The Assist complication opens the app via a `homeassistant://assist` widget URL. Depending on
         // launch state watchOS delivers this either as an opened URL or as a browsing-web user activity.
         .onOpenURL { url in
-            if isAssistDeepLink(url) { showAssist = true }
+            if isAssistDeepLink(url) { presentConfiguredAssist() }
         }
         .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
-            if isAssistDeepLink(activity.webpageURL) { showAssist = true }
+            if isAssistDeepLink(activity.webpageURL) { presentConfiguredAssist() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .watchConfigDidChange)) { _ in
             viewModel.loadCache()
         }
-        .fullScreenCover(isPresented: $showAssist, content: {
-            if let serverId = viewModel.watchConfig.assist.serverId,
-               let pipelineId = viewModel.watchConfig.assist.pipelineId {
+        .fullScreenCover(item: $assistPresentation, content: { presentation in
+            switch presentation {
+            case let .session(serverId, pipelineId, prompt):
                 WatchAssistView.build(
                     serverId: serverId,
-                    pipelineId: pipelineId
+                    pipelineId: pipelineId,
+                    prompt: prompt
                 )
-            } else {
+            case .unconfigured:
                 // Assist isn't configured yet (e.g. cold launch before the config synced). Surface a
                 // message instead of crashing; the user can retry once configuration is available.
                 Text(verbatim: L10n.Watch.Assist.LackConfig.Error.title)
@@ -180,7 +186,7 @@ struct WatchHomeView: View {
             // Consume a launch requested from the complication before this view existed (cold launch).
             if AssistDefaultComplication.pendingLaunch {
                 AssistDefaultComplication.pendingLaunch = false
-                showAssist = true
+                presentConfiguredAssist()
             }
             updateIPhoneReachability(Communicator.shared.currentReachability)
             startReachabilityObservation()
@@ -244,7 +250,7 @@ struct WatchHomeView: View {
                 viewModel: viewModel,
                 isEditing: $isEditing,
                 iPhoneNotReachable: $iPhoneNotReachable,
-                onAssist: { showAssist = true },
+                onAssist: { presentConfiguredAssist() },
                 onAdd: { activeSheet = .add }
             )
             listContent
@@ -325,6 +331,8 @@ struct WatchHomeView: View {
                     WatchFolderRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 } else if item.type == .area {
                     WatchAreaItemRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
+                } else if item.isAssist {
+                    WatchAssistItemRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 } else {
                     WatchMagicViewRow(item: item, itemInfo: viewModel.info(for: item), layout: .grid)
                 }
@@ -431,12 +439,25 @@ struct WatchHomeView: View {
             )
         } else if item.type == .complication {
             WatchComplicationRow(item: item, itemInfo: viewModel.info(for: item))
+        } else if item.isAssist {
+            WatchAssistItemRow(item: item, itemInfo: viewModel.info(for: item))
         } else {
             WatchMagicViewRow(
                 item: item,
                 itemInfo: viewModel.info(for: item),
                 subtitle: viewModel.serverName(for: item)
             )
+        }
+    }
+
+    /// Open Assist with the pipeline chosen in the watch configuration — the toolbar button, the
+    /// complication and the `homeassistant://assist` deep link all land here.
+    private func presentConfiguredAssist() {
+        if let serverId = viewModel.watchConfig.assist.serverId,
+           let pipelineId = viewModel.watchConfig.assist.pipelineId {
+            assistPresentation = .session(serverId: serverId, pipelineId: pipelineId, prompt: nil)
+        } else {
+            assistPresentation = .unconfigured
         }
     }
 

--- a/Sources/WatchApp/Home/WatchPresentAssistAction.swift
+++ b/Sources/WatchApp/Home/WatchPresentAssistAction.swift
@@ -1,0 +1,28 @@
+import Shared
+import SwiftUI
+
+/// Environment action rows use to open the full-screen Assist cover.
+///
+/// The cover is owned by `WatchHomeView` — a single cover for the toolbar button, the complication
+/// launch and the Assist items — so rows anywhere in the stack (folders included) ask for it through
+/// this action instead of presenting one of their own.
+struct WatchPresentAssistAction {
+    let present: (WatchAssistPresentation) -> Void
+
+    func callAsFunction(_ presentation: WatchAssistPresentation) {
+        present(presentation)
+    }
+
+    fileprivate struct Key: EnvironmentKey {
+        static let defaultValue = WatchPresentAssistAction { presentation in
+            Current.Log.error("watchPresentAssist used outside WatchHomeView's stack: \(presentation.id)")
+        }
+    }
+}
+
+extension EnvironmentValues {
+    var watchPresentAssist: WatchPresentAssistAction {
+        get { self[WatchPresentAssistAction.Key.self] }
+        set { self[WatchPresentAssistAction.Key.self] = newValue }
+    }
+}

--- a/Sources/WatchApp/WatchConfigAssistView.swift
+++ b/Sources/WatchApp/WatchConfigAssistView.swift
@@ -17,6 +17,10 @@ struct WatchConfigAssistView: View {
                 Toggle(isOn: $viewModel.showAssist) {
                     Text(verbatim: L10n.Watch.Config.Assist.show)
                 }
+            } footer: {
+                Text(verbatim: L10n.Watch.Configuration.ShowAssist.footer)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
 
             if viewModel.showAssist {

--- a/Tests/App/MagicItem/MagicItemProviderTests.swift
+++ b/Tests/App/MagicItem/MagicItemProviderTests.swift
@@ -147,6 +147,36 @@ struct MagicItemProviderTests {
         #expect(sut.getInfo(for: .init(id: "light.one", serverId: "1", type: .scene)) == nil)
     }
 
+    @Test mutating func migrateWatchAssistItemsNormalizesUnsupportedCustomization() async throws {
+        var watchConfig = WatchConfig()
+        watchConfig.items = [
+            .init(
+                id: "pipeline.one",
+                serverId: "1",
+                type: .assistPipeline,
+                customization: .init(requiresConfirmation: true)
+            ),
+        ]
+
+        try await Current.database().write { [watchConfig] db in
+            try WatchConfig.deleteAll(db)
+            try watchConfig.insert(db)
+        }
+
+        await withCheckedContinuation { continuation in
+            sut.migrateWatchConfig {
+                continuation.resume()
+            }
+        }
+
+        // Assist opens a voice session instead of calling a service, so it never confirms and always
+        // carries the Assist icon color.
+        let item = try WatchConfig.config()?.items.first
+        #expect(item?.type == .assistPipeline)
+        #expect(item?.customization?.requiresConfirmation == false)
+        #expect(item?.customization?.iconColor == MagicItem.defaultAssistIconColorHex)
+    }
+
     @Test mutating func migrateCarPlayAssistItemsNormalizesUnsupportedCustomization() async throws {
         var carPlayConfig = CarPlayConfig()
         carPlayConfig.quickAccessItems = [


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Assist and Assist prompt can now be added to the Apple Watch home items, the same way CarPlay Quick Access already supports them. They can be added both from the iPhone watch configuration and from the watch itself.

- An Assist item opens the Assist session with the chosen pipeline.
- An Assist prompt item sends its text to the pipeline (relayed by the iPhone) and plays the response.
- The existing watch Assist configuration now has a footer explaining that it controls the Assist button in the watch home toolbar, so it isn't confused with the new items.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Adding an Assist prompt uses a new watch ↔ iPhone message so the phone can run the pipeline with text instead of audio.
