### PR TITLE
Trigger re-authentication when the websocket rejects the access token

### DIFF
--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1657,6 +1657,7 @@ extension HomeAssistantAPI: HAConnectionDelegate {
         case .ready:
             resetRejectedReconnectRecovery()
         case .disconnected(reason: .rejected):
+            invalidateRejectedAccessToken()
             scheduleRejectedReconnectRecoveryIfNeeded()
         case let .disconnected(reason: .waitingToReconnect(lastError: error, atLatest: _, retryCount: _)):
             guard let tokenFetchFailure = error as? TokenFetchFailure,
@@ -1668,6 +1669,17 @@ extension HomeAssistantAPI: HAConnectionDelegate {
         case .connecting, .authenticating, .disconnected(reason: .disconnected):
             break
         }
+    }
+
+    /// A rejected websocket means the server refused the access token we just authenticated with, even
+    /// though its client-side expiration still said it was valid — typically because the server was
+    /// rebuilt or the refresh token was revoked. The stored token is the one the socket authenticated
+    /// with (HAKit fetches it for every connect), so marking it rejected sends the next reconnect
+    /// through a real token refresh instead of re-sending the same rejected token until we give up.
+    /// The refresh either mints a working token or fails with 400...403, which is what surfaces the
+    /// re-authentication screen.
+    private func invalidateRejectedAccessToken() {
+        tokenManager.handleAccessTokenRejected(server.info.token.accessToken)
     }
 
     /// Recovers from a rejected websocket (`auth: invalid`): HAKit won't auto-reconnect a rejected

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -129,6 +129,25 @@ class HAAPITokenFetchFailureTests: XCTestCase {
         XCTAssertEqual(connection.state, .ready(version: "1.0-mock"))
     }
 
+    func testConnectionDelegateMarksAccessTokenRejectedWhenWebSocketIsRejected() {
+        let priorDelays = HomeAssistantAPI.rejectedReconnectDelays
+        HomeAssistantAPI.rejectedReconnectDelays = [0, 0, 0]
+        defer { HomeAssistantAPI.rejectedReconnectDelays = priorDelays }
+
+        // The token still looks valid to us (expires in an hour), so nothing would ever refresh it and
+        // every reconnect would re-send the token the server just rejected.
+        let server = Server.fake()
+        let api = HomeAssistantAPI(server: server)
+        let connection = RejectingMockConnection()
+        connection.delegate = api
+        api.connection = connection
+
+        connection.setState(.disconnected(reason: .rejected))
+        drainMainQueue(cycles: 20)
+
+        XCTAssertEqual(server.info.token.expiration, .distantPast)
+    }
+
     func testConnectionDelegateGivesUpAfterExhaustingRejectedReconnectBudget() {
         let priorDelays = HomeAssistantAPI.rejectedReconnectDelays
         HomeAssistantAPI.rejectedReconnectDelays = [0, 0, 0]


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The re-authentication screen only shows when a token refresh fails with 400...403. If the stored access token still looks valid to us but the server refuses it (e.g. the server was rebuilt), the websocket is rejected and no refresh ever happens, so every reconnect re-sends the same rejected token until the retry budget runs out and the user is left on the disconnected screen.

Mark the access token as rejected when the websocket is rejected, so the next reconnect goes through a real token refresh: it either mints a working token or fails and surfaces the re-authentication screen.

## Screenshots

No new UI, this makes the existing re-authentication screen appear in one more case.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Related to #5346.