### PR TITLE
Disable launch splash on Mac Catalyst

### DIFF
--- a/Sources/App/Container/LaunchSplash/LaunchSplashOverlayState.swift
+++ b/Sources/App/Container/LaunchSplash/LaunchSplashOverlayState.swift
@@ -20,10 +20,21 @@ final class LaunchSplashOverlayState: ObservableObject {
 
     static let shared = LaunchSplashOverlayState()
 
-    @Published private(set) var phase: Phase = .waiting
+    @Published private(set) var phase: Phase
 
     /// Last frame reported by a destination logo, kept so previews can replay the transition.
     private(set) var latestDestinationLogoFrame: CGRect?
+
+    init() {
+        // macOS has no system launch screen to bridge from, so the fake splash is disabled on Catalyst
+        // by starting already `.finished`: the overlay renders nothing and every phase consumer
+        // (server-pill fade-in, logo anchors) behaves as if the launch hand-off already completed.
+        #if targetEnvironment(macCatalyst)
+        self.phase = .finished
+        #else
+        self.phase = .waiting
+        #endif
+    }
 
     /// Called by `launchSplashLogoAnchor()` whenever a destination logo lays out. The first report starts
     /// the hero transition; re-layout while the hero runs retargets it; anything later is a no-op.


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
macOS has no system launch screen for the fake launch splash to bridge from, so on Mac Catalyst its logo ended up off-center instead of matching the loading screen. This disables the splash overlay on Catalyst by starting its state as already finished, so the loading screen is shown directly. Every phase consumer (server pill fade-in, logo anchors) already treats that state as "hand-off complete", so nothing else needs special casing.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
