### PR TITLE
Use Mac-specific copy for General settings description

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1604,6 +1604,7 @@ Importing replaces every category listed on this screen, including app settings.
 "settings_details.general.app_icon.explanation.title" = "Each icon has 3 variants (iOS 18+), default, dark and tinted to react according to the selected iOS home screen style. Some icons are the same in dark mode or handled automatically by iOS.";
 "settings_details.general.app_icon.title" = "App Icon";
 "settings_details.general.body" = "Basic App configuration, App Icon and web page settings.";
+"settings_details.general.body_mac" = "Basic App configuration and web page settings.";
 "settings_details.general.device_name.title" = "Device Name";
 "settings_details.general.edge_to_edge.enabled.title" = "Enable";
 "settings_details.general.edge_to_edge.footer" = "Display Home Assistant UI from edge to edge on devices that support it. This is an experimental feature which can be removed at any time and also may cause layout issues.";

--- a/Sources/App/Settings/General/GeneralSettingsView.swift
+++ b/Sources/App/Settings/General/GeneralSettingsView.swift
@@ -16,7 +16,7 @@ struct GeneralSettingsView: View {
             AppleLikeListTopRowHeader(
                 image: .cogIcon,
                 title: L10n.SettingsDetails.General.title,
-                subtitle: L10n.SettingsDetails.General.body
+                subtitle: Current.isCatalyst ? L10n.SettingsDetails.General.bodyMac : L10n.SettingsDetails.General.body
             )
             appIconSelection
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -5263,6 +5263,8 @@ public enum L10n {
     public enum General {
       /// Basic App configuration, App Icon and web page settings.
       public static var body: String { return L10n.tr("Localizable", "settings_details.general.body") }
+      /// Basic App configuration and web page settings.
+      public static var bodyMac: String { return L10n.tr("Localizable", "settings_details.general.body_mac") }
       /// General
       public static var title: String { return L10n.tr("Localizable", "settings_details.general.title") }
       public enum AppIcon {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The General settings description mentioned the App Icon, but the App Icon picker is not available on Mac. On Mac the description now uses copy that omits the App Icon mention.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
