### PR TITLE
Fix watch configuration add item menu icon colors

### DIFF
--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemMenu.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchAddItemMenu.swift
@@ -35,6 +35,7 @@ struct WatchAddItemMenu: View {
                         ofSize: .init(width: 18, height: 18),
                         color: .label
                     ))
+                    .renderingMode(.template)
                 }
             }
 
@@ -48,6 +49,7 @@ struct WatchAddItemMenu: View {
                         ofSize: .init(width: 18, height: 18),
                         color: .label
                     ))
+                    .renderingMode(.template)
                 }
             }
 
@@ -61,6 +63,7 @@ struct WatchAddItemMenu: View {
                         ofSize: .init(width: 18, height: 18),
                         color: .label
                     ))
+                    .renderingMode(.template)
                 }
             }
 


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The "add item" menu in the Apple Watch configuration rendered the Area, Assist and Assist prompt icons with a baked-in color instead of the default menu tint, so they didn't match the Entity and Add Folder icons. These icons now render as template images and inherit the default tint like the rest.

## Screenshots

<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
