### PR TITLE
Match frontend entity icons in the picker and CarPlay

### DIFF
--- a/Sources/App/Settings/EntityPicker/EntityRowView.swift
+++ b/Sources/App/Settings/EntityPicker/EntityRowView.swift
@@ -60,8 +60,11 @@ struct EntityRowView: View {
             subtitle = (entity?.contextualSubtitle).orEmpty
             let fallbackIcon = Domain(entityId: (entity?.entityId).orEmpty)?.icon(deviceClass: entity?.rawDeviceClass)
             if let entity {
+                // Prefer the entity's own icon override, then the frontend-matching default resolved
+                // from the backend `entity_component` map at sync time, then the domain fallback.
+                let iconName = entity.icon?.isEmpty == false ? entity.icon : entity.resolvedIcon
                 icon = MaterialDesignIcons(
-                    serversideValueNamed: entity.icon.orEmpty,
+                    serversideValueNamed: iconName.orEmpty,
                     fallback: fallbackIcon ?? .dotsGridIcon
                 ).image(
                     ofSize: .init(width: iconSize.width, height: iconSize.height),

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -149,8 +149,9 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
 
     private func displayContent() -> DisplayContent {
         var displayText = entity.attributes.friendlyName ?? entity.entityId
+        let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
         var iconColor = entity.carPlayIconColor()
-        var image = entity.getMDI().carPlayIcon(color: iconColor)
+        var image = entity.getMDI(componentIcons: componentIcons).carPlayIcon(color: iconColor)
 
         if let magicItem, let magicItemInfo {
             displayText = magicItem.name(info: magicItemInfo)
@@ -172,7 +173,7 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
                 // Dynamic entity icons should reflect the live server-provided color,
                 // matching the main entities/controls views instead of saved quick-access tint.
                 iconColor = entity.carPlayIconColor()
-                image = entity.getMDI().carPlayIcon(color: iconColor)
+                image = entity.getMDI(componentIcons: componentIcons).carPlayIcon(color: iconColor)
             }
         }
 

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -52,6 +52,7 @@ public enum DatabaseTables {
         case icon
         case rawDeviceClass
         case entityCategory
+        case resolvedIcon
     }
 
     public enum WatchConfig: String, CaseIterable {

--- a/Sources/HAModels/Sources/HAAppEntity.swift
+++ b/Sources/HAModels/Sources/HAAppEntity.swift
@@ -30,11 +30,17 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
     /// to the live `friendly_name`, then the `entityId`. Readers should use this directly — it is already
     /// the name to show, so no per-read registry lookup is needed.
     public let name: String
+    /// The entity's own icon override: the entity-registry icon when the user set one, otherwise the
+    /// live `attributes.icon`. Populated by `AppEntitiesModel`, matching the frontend's precedence.
     public let icon: String?
     public let rawDeviceClass: String?
     /// The registry entity category index (config / diagnostic), copied from
     /// `EntityRegistryListForDisplay.Entity.entityCategory` at write time; `nil` for ordinary entities.
     public let entityCategory: Int?
+    /// The frontend's default icon for this entity's domain + device class, resolved from the backend
+    /// `entity_component` map at write time (stateless). Used when there is no `icon` override so
+    /// pickers render the same glyph the frontend does. `nil` when the map was unavailable.
+    public let resolvedIcon: String?
 
     public init(
         id: String,
@@ -45,6 +51,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         icon: String?,
         rawDeviceClass: String?,
         entityCategory: Int? = nil,
+        resolvedIcon: String? = nil,
     ) {
         self.id = id
         self.entityId = entityId
@@ -54,6 +61,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         self.icon = icon
         self.rawDeviceClass = rawDeviceClass
         self.entityCategory = entityCategory
+        self.resolvedIcon = resolvedIcon
     }
 
     public enum ConfigInclude {

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -77,17 +77,35 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
             registryRows.compactMap { row in row.entityCategory.map { (row.entityId, $0) } },
             uniquingKeysWith: { first, _ in first }
         )
+        // The user's entity-registry icon override wins over the live `attributes.icon`, matching the
+        // frontend's precedence (see `ha-state-icon.ts`).
+        let registryIcons: [String: String] = Dictionary(
+            registryRows.compactMap { row in row.icon.map { (row.entityId, $0) } },
+            uniquingKeysWith: { first, _ in first }
+        )
 
-        let appEntities = appRelatedEntities.map({ HAAppEntity(
-            id: ServerEntity.uniqueId(serverId: serverId, entityId: $0.entityId),
-            entityId: $0.entityId,
-            serverId: serverId,
-            domain: $0.domain,
-            name: registryNames[$0.entityId] ?? $0.attributes.friendlyName ?? $0.entityId,
-            icon: $0.attributes.icon,
-            rawDeviceClass: $0.attributes.dictionary["device_class"] as? String,
-            entityCategory: registryEntityCategories[$0.entityId]
-        ) }).sorted(by: { $0.id < $1.id })
+        // The frontend resolves the icon from the backend `entity_component` map; we resolve the
+        // stateless default here and bake it into `resolvedIcon` so pickers render the same glyph
+        // without a live connection. `nil` when the map isn't available (old server / not yet fetched).
+        let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
+
+        let appEntities = appRelatedEntities.map { entity -> HAAppEntity in
+            let deviceClass = entity.attributes.dictionary["device_class"] as? String
+            let resolvedIcon = componentIcons.flatMap { map in
+                EntityIconResolver.componentDefaultIcon(domain: entity.domain, deviceClass: deviceClass, map: map)
+            }
+            return HAAppEntity(
+                id: ServerEntity.uniqueId(serverId: serverId, entityId: entity.entityId),
+                entityId: entity.entityId,
+                serverId: serverId,
+                domain: entity.domain,
+                name: registryNames[entity.entityId] ?? entity.attributes.friendlyName ?? entity.entityId,
+                icon: registryIcons[entity.entityId] ?? entity.attributes.icon,
+                rawDeviceClass: deviceClass,
+                entityCategory: registryEntityCategories[entity.entityId],
+                resolvedIcon: resolvedIcon
+            )
+        }.sorted(by: { $0.id < $1.id })
 
         do {
             // Uses GRDB's async read/write so the database work is performed off the main thread

--- a/Sources/Shared/Database/Tables/HAppEntityTable.swift
+++ b/Sources/Shared/Database/Tables/HAppEntityTable.swift
@@ -21,6 +21,7 @@ final class HAppEntityTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.AppEntity.icon.rawValue, .text)
                     t.column(DatabaseTables.AppEntity.rawDeviceClass.rawValue, .text)
                     t.column(DatabaseTables.AppEntity.entityCategory.rawValue, .integer)
+                    t.column(DatabaseTables.AppEntity.resolvedIcon.rawValue, .text)
                 }
             }
         } else {

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -296,11 +296,11 @@ public enum Domain: String, CaseIterable {
         case .script:
             image = .scriptTextOutlineIcon
         case .switch:
-            image = .lightSwitchIcon
+            image = .toggleSwitchVariantIcon
         case .sensor:
             image = .eyeIcon
         case .binarySensor:
-            image = .eyeIcon
+            image = .radioboxBlankIcon
         case .zone:
             image = .mapIcon
         case .person:
@@ -376,7 +376,7 @@ public enum Domain: String, CaseIterable {
         case .vacuum:
             image = .robotVacuumIcon
         case .valve:
-            image = .pipeValveIcon
+            image = .valveOpenIcon
         case .wakeWord:
             image = .microphoneIcon
         case .waterHeater:
@@ -391,6 +391,9 @@ public enum Domain: String, CaseIterable {
         return image
     }
 
+    /// Cover fallback icons, mirroring the frontend's `cover/icons.json` `entity_component` map
+    /// (device class → open/closed default). The `_` (no/unknown device class) default is a window,
+    /// matching the frontend, not curtains.
     private func imageForCover(deviceClass: DeviceClass, state: State) -> MaterialDesignIcons {
         if state == .closed {
             switch deviceClass {
@@ -401,11 +404,19 @@ public enum Domain: String, CaseIterable {
             case .shutter:
                 return MaterialDesignIcons.windowShutterIcon
             case .blind:
-                return MaterialDesignIcons.blindsVerticalClosedIcon
+                return MaterialDesignIcons.blindsHorizontalClosedIcon
             case .shade:
                 return MaterialDesignIcons.rollerShadeClosedIcon
-            default:
+            case .curtain:
                 return MaterialDesignIcons.curtainsClosedIcon
+            case .door:
+                return MaterialDesignIcons.doorClosedIcon
+            case .damper:
+                return MaterialDesignIcons.circleSlice8Icon
+            case .window:
+                return MaterialDesignIcons.windowClosedIcon
+            default:
+                return MaterialDesignIcons.windowClosedIcon
             }
         } else {
             switch deviceClass {
@@ -416,11 +427,17 @@ public enum Domain: String, CaseIterable {
             case .shutter:
                 return MaterialDesignIcons.windowShutterOpenIcon
             case .blind:
-                return MaterialDesignIcons.blindsOpenIcon
+                return MaterialDesignIcons.blindsHorizontalIcon
             case .shade:
                 return MaterialDesignIcons.rollerShadeIcon
-            default:
+            case .curtain:
                 return MaterialDesignIcons.curtainsIcon
+            case .door:
+                return MaterialDesignIcons.doorOpenIcon
+            case .damper:
+                return MaterialDesignIcons.circleIcon
+            default:
+                return MaterialDesignIcons.windowOpenIcon
             }
         }
     }

--- a/Sources/Shared/Domain/EntityComponentIcons.swift
+++ b/Sources/Shared/Domain/EntityComponentIcons.swift
@@ -1,0 +1,36 @@
+import Foundation
+import HAKit
+
+/// A single icon entry from an integration's `icons.json` `entity_component` map, keyed by device
+/// class (or `_` for the no-device-class default). Mirrors the frontend's `ComponentIcons` leaf in
+/// `home-assistant/frontend` `src/data/icons.ts`. `state_attributes` are omitted: the app resolves
+/// the entity's own icon, not per-attribute badges.
+public struct EntityComponentIcon: Codable, Equatable {
+    public let defaultIcon: String?
+    public let state: [String: String]?
+    public let range: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case defaultIcon = "default"
+        case state
+        case range
+    }
+}
+
+/// `domain` → (`device_class` | `_`) → icon entry, as returned by `frontend/get_icons` for the
+/// `entity_component` category.
+public typealias EntityComponentIconsMap = [String: [String: EntityComponentIcon]]
+
+public struct EntityComponentIconsResponse: HADataDecodable {
+    public let resources: EntityComponentIconsMap
+
+    public init(data: HAData) throws {
+        guard case let .dictionary(dictionary) = data,
+              let resources = dictionary["resources"] else {
+            self.resources = [:]
+            return
+        }
+        let jsonData = try JSONSerialization.data(withJSONObject: resources)
+        self.resources = (try? JSONDecoder().decode(EntityComponentIconsMap.self, from: jsonData)) ?? [:]
+    }
+}

--- a/Sources/Shared/Domain/EntityIconResolver.swift
+++ b/Sources/Shared/Domain/EntityIconResolver.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Resolves an entity's icon the way `home-assistant/frontend` does (`src/data/icons.ts`
+/// `getEntityIcon` plus the `stateIcon` special-cases in `src/common/entity/state_icon.ts`), from the
+/// backend `entity_component` icon map. The user/registry `icon` override is applied by callers.
+/// Integration `translation_key` platform icons (the frontend's step before `stateIcon`) are not yet
+/// resolved: a known gap, so entities that rely on them fall through to the component map. This covers
+/// the `stateIcon` special-cases and the state / range / default component resolution.
+public enum EntityIconResolver {
+    /// The stateless default icon for a domain + device class (the `default` of the matching entry,
+    /// or the domain's `_` entry). Used for the picker's saved icon, which has no live state.
+    public static func componentDefaultIcon(
+        domain: String,
+        deviceClass: String?,
+        map: EntityComponentIconsMap
+    ) -> String? {
+        translations(domain: domain, deviceClass: deviceClass, map: map)?.defaultIcon
+    }
+
+    /// The full, state-aware resolution: the hardcoded `stateIcon` special-cases first, then the
+    /// component `state` → `range` → `default` chain. Returns `nil` when nothing matches so the
+    /// caller can fall back to its own default.
+    public static func icon(
+        domain: String,
+        deviceClass: String?,
+        state: String?,
+        attributes: [String: Any],
+        map: EntityComponentIconsMap?
+    ) -> String? {
+        if let stateIcon = stateIcon(domain: domain, state: state, attributes: attributes) {
+            return stateIcon
+        }
+        guard let map,
+              let translations = translations(domain: domain, deviceClass: deviceClass, map: map) else {
+            return nil
+        }
+        return iconFromTranslations(state: state, translations: translations)
+    }
+
+    static func translations(
+        domain: String,
+        deviceClass: String?,
+        map: EntityComponentIconsMap
+    ) -> EntityComponentIcon? {
+        guard let domainIcons = map[domain] else { return nil }
+        if let deviceClass, let match = domainIcons[deviceClass] {
+            return match
+        }
+        return domainIcons["_"]
+    }
+
+    static func iconFromTranslations(state: String?, translations: EntityComponentIcon) -> String? {
+        if let state, let match = translations.state?[state] {
+            return match
+        }
+        if let state, let range = translations.range, let value = Double(state) {
+            return iconFromRange(value: value, range: range) ?? translations.defaultIcon
+        }
+        return translations.defaultIcon
+    }
+
+    static func iconFromRange(value: Double, range: [String: String]) -> String? {
+        let sorted = range
+            .compactMap { key, _ -> (threshold: Double, key: String)? in
+                guard let threshold = Double(key) else { return nil }
+                return (threshold, key)
+            }
+            .sorted { $0.threshold < $1.threshold }
+        guard let first = sorted.first, value >= first.threshold else { return nil }
+        var selectedKey = first.key
+        for entry in sorted {
+            if value >= entry.threshold {
+                selectedKey = entry.key
+            } else {
+                break
+            }
+        }
+        return range[selectedKey]
+    }
+
+    static func stateIcon(domain: String, state: String?, attributes: [String: Any]) -> String? {
+        switch domain {
+        case Domain.update.rawValue:
+            if updateIsInstalling(attributes) {
+                return "mdi:package-down"
+            }
+            return state == "on" ? "mdi:package-up" : "mdi:package"
+        case Domain.deviceTracker.rawValue:
+            let sourceType = attributes["source_type"] as? String
+            if sourceType == "router" {
+                return state == "home" ? "mdi:lan-connect" : "mdi:lan-disconnect"
+            }
+            if sourceType == "bluetooth" || sourceType == "bluetooth_le" {
+                return state == "home" ? "mdi:bluetooth-connect" : "mdi:bluetooth"
+            }
+            return state == "not_home" ? "mdi:account-arrow-right" : "mdi:account"
+        case Domain.sun.rawValue:
+            guard let state else { return nil }
+            return state == "above_horizon" ? "mdi:white-balance-sunny" : "mdi:weather-night"
+        case Domain.inputDatetime.rawValue:
+            if (attributes["has_date"] as? Bool) != true {
+                return "mdi:clock"
+            }
+            if (attributes["has_time"] as? Bool) != true {
+                return "mdi:calendar"
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private static func updateIsInstalling(_ attributes: [String: Any]) -> Bool {
+        if let inProgress = attributes["in_progress"] as? Bool {
+            return inProgress
+        }
+        if let inProgress = attributes["in_progress"] as? NSNumber {
+            return inProgress != 0
+        }
+        return false
+    }
+}

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -407,6 +407,9 @@ public extension Version {
     static let canNavigateMoreInfoDialogThroughFrontend: Version = .init(major: 2026, minor: 1, prerelease: "any0")
     /// Frontend introduces the quickbar with Ctrl+K keyboard shortcut in 2026.2
     static let quickSearchKeyboardShortcut: Version = .init(major: 2026, minor: 2, prerelease: "any0")
+    /// `frontend/get_icons` supports the `entity_component` category, letting the app resolve entity
+    /// icons from the same backend data the frontend uses, from 2024.2.
+    static let frontendGetIconsEntityComponent: Version = .init(major: 2024, minor: 2, prerelease: "any0")
     /// Core accepts `in_zones` in update_location payloads from 2026.6.0.
     static let inZonesOnLocationUpdate: Version = .init(major: 2026, minor: 6, patch: 0, prerelease: "any0")
     /// Frontend sends `frontend/loaded` when its launch screen is removed from 2026.8.0.

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -386,6 +386,16 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
         }
         if isUpdateCancelled() { return }
 
+        // Step 2.5: Entity component icons (`frontend/get_icons`). Populates the in-memory map that
+        // Step 3 uses to resolve each entity's frontend-matching default icon. Sequential to respect
+        // the WebSocket id ordering noted above.
+        do {
+            let timer = ProfilingTimer("Step 2.5 (Entity component icons)")
+            await Current.entityComponentIcons().fetch(for: server)
+            timer.end()
+        }
+        if isUpdateCancelled() { return }
+
         // Step 3: Persist entities. Deferred until here (after Step 2) on purpose so `AppEntitiesModel`
         // resolves each entity's display name from the just-saved registry and bakes it into
         // `HAAppEntity.name`. HAKit completions fire on the main queue; the Set construction and DB

--- a/Sources/Shared/Environment/EntityComponentIconsService.swift
+++ b/Sources/Shared/Environment/EntityComponentIconsService.swift
@@ -1,0 +1,57 @@
+import Foundation
+import HAKit
+
+public protocol EntityComponentIconsProviderProtocol {
+    func iconsMap(for serverId: String) -> EntityComponentIconsMap?
+    @discardableResult
+    func fetch(for server: Server) async -> EntityComponentIconsMap?
+}
+
+/// Fetches and caches, per server, the `entity_component` icon map the frontend uses to resolve
+/// entity icons (`frontend/get_icons`). Kept in memory only: the resolved default icon is persisted
+/// per entity on `HAAppEntity` (so pickers work offline), while this live map lets state-aware
+/// surfaces resolve the current icon without persisting volatile state.
+final class EntityComponentIconsService: EntityComponentIconsProviderProtocol {
+    static var shared: EntityComponentIconsProviderProtocol = EntityComponentIconsService()
+
+    private var request: HACancellable?
+    /// [ServerId: EntityComponentIconsMap]
+    private var maps: [String: EntityComponentIconsMap] = [:]
+
+    func iconsMap(for serverId: String) -> EntityComponentIconsMap? {
+        maps[serverId]
+    }
+
+    @discardableResult
+    func fetch(for server: Server) async -> EntityComponentIconsMap? {
+        guard server.info.version >= .frontendGetIconsEntityComponent else {
+            return nil
+        }
+        guard let connection = Current.api(for: server)?.connection else {
+            Current.Log.error("No API available to fetch entity component icons")
+            return nil
+        }
+
+        request?.cancel()
+        let map: EntityComponentIconsMap = await withCheckedContinuation { continuation in
+            request = connection.send(
+                HATypedRequest<EntityComponentIconsResponse>.frontendGetIcons(category: "entity_component"),
+                completion: { result in
+                    switch result {
+                    case let .success(data):
+                        continuation.resume(returning: data.resources)
+                    case let .failure(error):
+                        Current.Log.error(userInfo: [
+                            "Failed to retrieve entity component icons": error.localizedDescription,
+                        ])
+                        continuation.resume(returning: [:])
+                    }
+                }
+            )
+        }
+        if !map.isEmpty {
+            maps[server.identifier.rawValue] = map
+        }
+        return map
+    }
+}

--- a/Sources/Shared/Environment/EntityComponentIconsService.swift
+++ b/Sources/Shared/Environment/EntityComponentIconsService.swift
@@ -14,12 +14,17 @@ public protocol EntityComponentIconsProviderProtocol {
 final class EntityComponentIconsService: EntityComponentIconsProviderProtocol {
     static var shared: EntityComponentIconsProviderProtocol = EntityComponentIconsService()
 
-    private var request: HACancellable?
+    /// Guards `maps` and `requests`, both of which are read/written from concurrent per-server tasks.
+    private let lock = NSLock()
     /// [ServerId: EntityComponentIconsMap]
     private var maps: [String: EntityComponentIconsMap] = [:]
+    /// In-flight request per server, so a fetch for one server never cancels another's.
+    private var requests: [String: HACancellable] = [:]
 
     func iconsMap(for serverId: String) -> EntityComponentIconsMap? {
-        maps[serverId]
+        lock.lock()
+        defer { lock.unlock() }
+        return maps[serverId]
     }
 
     @discardableResult
@@ -32,9 +37,13 @@ final class EntityComponentIconsService: EntityComponentIconsProviderProtocol {
             return nil
         }
 
-        request?.cancel()
+        let serverId = server.identifier.rawValue
+        lock.lock()
+        requests[serverId]?.cancel()
+        lock.unlock()
+
         let map: EntityComponentIconsMap = await withCheckedContinuation { continuation in
-            request = connection.send(
+            let request = connection.send(
                 HATypedRequest<EntityComponentIconsResponse>.frontendGetIcons(category: "entity_component"),
                 completion: { result in
                     switch result {
@@ -48,10 +57,17 @@ final class EntityComponentIconsService: EntityComponentIconsProviderProtocol {
                     }
                 }
             )
+            lock.lock()
+            requests[serverId] = request
+            lock.unlock()
         }
+
+        lock.lock()
+        requests[serverId] = nil
         if !map.isEmpty {
-            maps[server.identifier.rawValue] = map
+            maps[serverId] = map
         }
+        lock.unlock()
         return map
     }
 }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -235,6 +235,10 @@ public class AppEnvironment {
         AreasService.shared
     }
 
+    public var entityComponentIcons: () -> EntityComponentIconsProviderProtocol = {
+        EntityComponentIconsService.shared
+    }
+
     /// APNs environment string for token reporting. "sandbox" in DEBUG builds, "production" otherwise.
     /// TestFlight uses distribution signing and routes through the production APNs endpoint.
     public var apnsEnvironment: String {

--- a/Sources/Shared/HAEntity+CarPlay.swift
+++ b/Sources/Shared/HAEntity+CarPlay.swift
@@ -49,58 +49,76 @@ public extension HAEntity {
         )
     }
 
-    /// Returns the appropriate icon for the entity based on its state, without applying color
-    /// This is useful when you want to apply a custom color to a state-based icon
-    func getMDI() -> MaterialDesignIcons {
-        var image = MaterialDesignIcons.bookmarkIcon
-
+    /// Returns the appropriate icon for the entity based on its state, without applying color.
+    /// This is useful when you want to apply a custom color to a state-based icon.
+    ///
+    /// When `componentIcons` (the backend `entity_component` map from `frontend/get_icons`) is
+    /// provided, the icon is resolved the way the frontend does via `EntityIconResolver`, falling
+    /// back to the app's hand-maintained mapping only when the map has nothing for the entity. With
+    /// no map it keeps the legacy behavior, so callers without one are unaffected.
+    func getMDI(componentIcons: EntityComponentIconsMap? = nil) -> MaterialDesignIcons {
         if let icon = attributes.icon?.normalizingIconString {
-            image = MaterialDesignIcons(named: icon)
-        } else {
-            guard let domain = Domain(rawValue: domain) else { return image }
-            switch domain {
-            case .button:
-                image = getButtonIcon()
-            case .cover:
-                image = getCoverIcon()
-            case .inputBoolean:
-                image = getInputBooleanIcon()
-            case .inputButton:
-                image = .gestureTapButtonIcon
-            case .light:
-                image = .lightbulbIcon
-            case .lock:
-                image = getLockIcon()
-            case .scene:
-                image = .paletteOutlineIcon
-            case .script:
-                image = .scriptTextOutlineIcon
-            case .switch:
-                image = getSwitchIcon()
-            case .sensor:
-                image = .eyeIcon
-            case .binarySensor:
-                image = .eyeIcon
-            case .zone:
-                image = .mapIcon
-            case .person:
-                image = .accountIcon
-            case .camera:
-                image = .cameraIcon
-            case .fan:
-                image = .fanIcon
-            case .automation:
-                image = .homeAutomationIcon
-            case .todo:
-                image = .checkboxMarkedOutlineIcon
-            case .climate:
-                image = .homeThermometerOutlineIcon
-            default:
-                image = domain.icon(deviceClass: deviceClass.rawValue, state: Domain.State(rawValue: state))
-            }
+            return MaterialDesignIcons(named: icon)
         }
 
-        return image
+        let fallback = hardcodedMDI()
+
+        if let componentIcons,
+           let resolved = EntityIconResolver.icon(
+               domain: domain,
+               deviceClass: attributes.dictionary["device_class"] as? String,
+               state: state,
+               attributes: attributes.dictionary,
+               map: componentIcons
+           ) {
+            return MaterialDesignIcons(serversideValueNamed: resolved, fallback: fallback)
+        }
+
+        return fallback
+    }
+
+    private func hardcodedMDI() -> MaterialDesignIcons {
+        guard let domain = Domain(rawValue: domain) else { return .bookmarkIcon }
+        switch domain {
+        case .button:
+            return getButtonIcon()
+        case .cover:
+            return getCoverIcon()
+        case .inputBoolean:
+            return getInputBooleanIcon()
+        case .inputButton:
+            return .gestureTapButtonIcon
+        case .light:
+            return .lightbulbIcon
+        case .lock:
+            return getLockIcon()
+        case .scene:
+            return .paletteOutlineIcon
+        case .script:
+            return .scriptTextOutlineIcon
+        case .switch:
+            return getSwitchIcon()
+        case .sensor:
+            return .eyeIcon
+        case .binarySensor:
+            return .eyeIcon
+        case .zone:
+            return .mapIcon
+        case .person:
+            return .accountIcon
+        case .camera:
+            return .cameraIcon
+        case .fan:
+            return .fanIcon
+        case .automation:
+            return .homeAutomationIcon
+        case .todo:
+            return .checkboxMarkedOutlineIcon
+        case .climate:
+            return .homeThermometerOutlineIcon
+        default:
+            return domain.icon(deviceClass: deviceClass.rawValue, state: Domain.State(rawValue: state))
+        }
     }
 
     private func getInputBooleanIcon() -> MaterialDesignIcons {

--- a/Sources/Shared/HAEntity+CarPlay.swift
+++ b/Sources/Shared/HAEntity+CarPlay.swift
@@ -101,7 +101,7 @@ public extension HAEntity {
         case .sensor:
             return .eyeIcon
         case .binarySensor:
-            return .eyeIcon
+            return .radioboxBlankIcon
         case .zone:
             return .mapIcon
         case .person:

--- a/Sources/Shared/HATypedRequest+App.swift
+++ b/Sources/Shared/HATypedRequest+App.swift
@@ -218,6 +218,13 @@ public extension HATypedRequest {
         ))
     }
 
+    static func frontendGetIcons(category: String) -> HATypedRequest<EntityComponentIconsResponse> {
+        HATypedRequest<EntityComponentIconsResponse>(request: .init(
+            type: .webSocket("frontend/get_icons"),
+            data: ["category": category]
+        ))
+    }
+
     static func getItemFromTodoList(listId: String) -> HATypedRequest<TodoListRawResponse> {
         HATypedRequest<TodoListRawResponse>(
             request:

--- a/Tests/Shared/EntityIconResolver.test.swift
+++ b/Tests/Shared/EntityIconResolver.test.swift
@@ -1,0 +1,234 @@
+@testable import Shared
+import Testing
+
+struct EntityIconResolverTests {
+    // MARK: - stateIcon special cases
+
+    @Test func updateStateIcon() {
+        #expect(EntityIconResolver.icon(
+            domain: "update",
+            deviceClass: nil,
+            state: "on",
+            attributes: [:],
+            map: nil
+        ) == "mdi:package-up")
+
+        #expect(EntityIconResolver.icon(
+            domain: "update",
+            deviceClass: nil,
+            state: "off",
+            attributes: [:],
+            map: nil
+        ) == "mdi:package")
+
+        #expect(EntityIconResolver.icon(
+            domain: "update",
+            deviceClass: nil,
+            state: "on",
+            attributes: ["in_progress": true],
+            map: nil
+        ) == "mdi:package-down")
+    }
+
+    @Test func deviceTrackerStateIcon() {
+        #expect(EntityIconResolver.icon(
+            domain: "device_tracker",
+            deviceClass: nil,
+            state: "home",
+            attributes: ["source_type": "router"],
+            map: nil
+        ) == "mdi:lan-connect")
+
+        #expect(EntityIconResolver.icon(
+            domain: "device_tracker",
+            deviceClass: nil,
+            state: "not_home",
+            attributes: ["source_type": "bluetooth"],
+            map: nil
+        ) == "mdi:bluetooth")
+
+        #expect(EntityIconResolver.icon(
+            domain: "device_tracker",
+            deviceClass: nil,
+            state: "not_home",
+            attributes: [:],
+            map: nil
+        ) == "mdi:account-arrow-right")
+
+        #expect(EntityIconResolver.icon(
+            domain: "device_tracker",
+            deviceClass: nil,
+            state: "home",
+            attributes: [:],
+            map: nil
+        ) == "mdi:account")
+    }
+
+    @Test func sunStateIcon() {
+        #expect(EntityIconResolver.icon(
+            domain: "sun",
+            deviceClass: nil,
+            state: "above_horizon",
+            attributes: [:],
+            map: nil
+        ) == "mdi:white-balance-sunny")
+
+        #expect(EntityIconResolver.icon(
+            domain: "sun",
+            deviceClass: nil,
+            state: "below_horizon",
+            attributes: [:],
+            map: nil
+        ) == "mdi:weather-night")
+    }
+
+    @Test func inputDatetimeStateIcon() {
+        #expect(EntityIconResolver.icon(
+            domain: "input_datetime",
+            deviceClass: nil,
+            state: nil,
+            attributes: ["has_date": false, "has_time": true],
+            map: nil
+        ) == "mdi:clock")
+
+        #expect(EntityIconResolver.icon(
+            domain: "input_datetime",
+            deviceClass: nil,
+            state: nil,
+            attributes: ["has_date": true, "has_time": false],
+            map: nil
+        ) == "mdi:calendar")
+
+        // With both date and time there is no special-case icon; without a map it falls through to nil.
+        #expect(EntityIconResolver.icon(
+            domain: "input_datetime",
+            deviceClass: nil,
+            state: nil,
+            attributes: ["has_date": true, "has_time": true],
+            map: nil
+        ) == nil)
+    }
+
+    // MARK: - Component resolution precedence
+
+    @Test func stateMatchTakesPrecedenceOverRangeAndDefault() {
+        let map: EntityComponentIconsMap = [
+            "sensor": [
+                "battery": EntityComponentIcon(
+                    defaultIcon: "mdi:battery",
+                    state: ["on": "mdi:battery-charging"],
+                    range: ["0": "mdi:battery-outline", "50": "mdi:battery-50"]
+                ),
+            ],
+        ]
+
+        #expect(EntityIconResolver.icon(
+            domain: "sensor",
+            deviceClass: "battery",
+            state: "on",
+            attributes: [:],
+            map: map
+        ) == "mdi:battery-charging")
+    }
+
+    @Test func defaultUsedWhenNoStateOrRangeMatches() {
+        let map: EntityComponentIconsMap = [
+            "sensor": [
+                "_": EntityComponentIcon(defaultIcon: "mdi:eye", state: nil, range: nil),
+            ],
+        ]
+
+        #expect(EntityIconResolver.icon(
+            domain: "sensor",
+            deviceClass: nil,
+            state: "whatever",
+            attributes: [:],
+            map: map
+        ) == "mdi:eye")
+    }
+
+    @Test func deviceClassEntryPreferredOverUnderscoreDefault() {
+        let map: EntityComponentIconsMap = [
+            "sensor": [
+                "_": EntityComponentIcon(defaultIcon: "mdi:eye", state: nil, range: nil),
+                "temperature": EntityComponentIcon(defaultIcon: "mdi:thermometer", state: nil, range: nil),
+            ],
+        ]
+
+        #expect(EntityIconResolver.componentDefaultIcon(
+            domain: "sensor",
+            deviceClass: "temperature",
+            map: map
+        ) == "mdi:thermometer")
+
+        #expect(EntityIconResolver.componentDefaultIcon(
+            domain: "sensor",
+            deviceClass: "humidity",
+            map: map
+        ) == "mdi:eye")
+    }
+
+    // MARK: - Range threshold selection
+
+    @Test func rangeSelectsHighestThresholdNotAboveValue() {
+        let map: EntityComponentIconsMap = [
+            "sensor": [
+                "battery": EntityComponentIcon(
+                    defaultIcon: "mdi:battery",
+                    state: nil,
+                    range: [
+                        "0": "mdi:battery-outline",
+                        "20": "mdi:battery-20",
+                        "50": "mdi:battery-50",
+                        "90": "mdi:battery-90",
+                    ]
+                ),
+            ],
+        ]
+
+        func icon(for state: String) -> String? {
+            EntityIconResolver.icon(
+                domain: "sensor",
+                deviceClass: "battery",
+                state: state,
+                attributes: [:],
+                map: map
+            )
+        }
+
+        #expect(icon(for: "0") == "mdi:battery-outline")
+        #expect(icon(for: "35") == "mdi:battery-20")
+        #expect(icon(for: "50") == "mdi:battery-50")
+        #expect(icon(for: "100") == "mdi:battery-90")
+    }
+
+    @Test func rangeBelowLowestThresholdFallsBackToDefault() {
+        let map: EntityComponentIconsMap = [
+            "sensor": [
+                "battery": EntityComponentIcon(
+                    defaultIcon: "mdi:battery",
+                    state: nil,
+                    range: ["10": "mdi:battery-10", "50": "mdi:battery-50"]
+                ),
+            ],
+        ]
+
+        #expect(EntityIconResolver.icon(
+            domain: "sensor",
+            deviceClass: "battery",
+            state: "5",
+            attributes: [:],
+            map: map
+        ) == "mdi:battery")
+    }
+
+    @Test func noMatchReturnsNilSoCallerCanFallBack() {
+        #expect(EntityIconResolver.icon(
+            domain: "sensor",
+            deviceClass: nil,
+            state: "on",
+            attributes: [:],
+            map: [:]
+        ) == nil)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The entity picker and CarPlay entity rows showed different icons than the Home Assistant frontend. The frontend resolves entity icons from each integration's `icons.json` `entity_component` map, fetched at runtime via the `frontend/get_icons` WebSocket command; the app instead relied on a hand-maintained per-domain table, so entities without an explicit icon (most sensors, binary sensors, switches, covers, valves) rendered a generic or wrong glyph.

This makes the app resolve icons the same way the frontend does:

- Fetch the `entity_component` icon map per server (core 2024.2+) during the database update, and bake each entity's default icon into the entity cache at sync time so the picker matches the frontend even offline.
- Port the frontend's resolver (state → range → default, plus the `update` / `device_tracker` / `sun` / `input_datetime` special cases) and use it for live CarPlay icons.
- Align the remaining hardcoded fallback icons with the frontend's defaults for the offline / older-server case.

The entity's own icon override still wins, now using the entity-registry icon before `attributes.icon` to match the frontend's precedence.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
- Integration `translation_key` platform icons (the frontend's step before the component map) are not resolved yet; entities relying on them fall through to the component default. Noted as a known gap in `EntityIconResolver`.
- `HAAppEntity.icon` now resolves to the registry icon before `attributes.icon`, which also affects other consumers of that field (widgets, Magic Items, add-item lists).
