### PR TITLE
Add refresh and hidden-entity search to entity picker

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -472,6 +472,8 @@
 "entity_picker.filter.server.title" = "Servers";
 "entity_picker.list.area.no_area.title" = "No area";
 "entity_picker.placeholder" = "Pick entity";
+"entity_picker.refresh.updating" = "Updating…";
+"entity_picker.reload" = "Reload";
 "entity_picker.remove_all" = "Remove all";
 "entity_picker.search.placeholder" = "Entity name, ID, area name, device name...";
 "entity_picker.select_all" = "Select all";

--- a/Sources/App/Settings/EntityPicker/EntityFilterPickerView.swift
+++ b/Sources/App/Settings/EntityPicker/EntityFilterPickerView.swift
@@ -60,6 +60,7 @@ struct EntityFilterPickerView: View {
         } label: {
             compactLabel
         }
+        .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)
         .font(DesignSystem.Font.callout)
         .foregroundStyle(.secondary)
@@ -71,7 +72,9 @@ struct EntityFilterPickerView: View {
                     .glassEffect(.regular.interactive(), in: .capsule)
                     .contentShape(Capsule())
             } else {
-                view.clipShape(.capsule)
+                view
+                    .background(.tileBackground)
+                    .clipShape(.capsule)
             }
         }
     }
@@ -130,7 +133,9 @@ struct EntityFilterPickerView: View {
                     .glassEffect(.regular.interactive(), in: .capsule)
                     .contentShape(Capsule())
             } else {
-                view.clipShape(.capsule)
+                view
+                    .background(.tileBackground)
+                    .clipShape(.capsule)
             }
         }
     }

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -92,8 +92,8 @@ struct EntityPicker: View {
         #endif
         .navigationViewStyle(.stack)
         #if !targetEnvironment(macCatalyst)
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
         #endif
     }
 
@@ -146,15 +146,15 @@ struct EntityPicker: View {
         }
         .animation(.easeInOut(duration: 0.35), value: viewModel.isRefreshing)
         #if targetEnvironment(macCatalyst)
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                reloadToolbarButton
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    reloadToolbarButton
+                }
             }
-        }
         #else
-        .refreshable {
-            await viewModel.refresh()
-        }
+            .refreshable {
+                await viewModel.refresh()
+            }
         #endif
     }
 

--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -91,32 +91,31 @@ struct EntityPicker: View {
         }
         #endif
         .navigationViewStyle(.stack)
+        #if !targetEnvironment(macCatalyst)
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
+        #endif
     }
 
     private var content: some View {
-        List {
-            Section {
-                TextField(L10n.EntityPicker.Search.placeholder, text: $viewModel.searchTerm)
-                    .focused($isSearchFocused)
-                    .textFieldStyle(.plain)
-                    .padding()
-                    .modify { view in
-                        if #available(iOS 26.0, *) {
-                            view
-                                .glassEffect(.regular.interactive(), in: .capsule)
-                                .contentShape(Capsule())
-
-                        } else {
-                            view
-                                .background(.tileBackground)
-                                .clipShape(.capsule)
-                        }
-                    }
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
+        VStack(spacing: 0) {
+            searchField
+                .padding(.horizontal, DesignSystem.Spaces.two)
+                .padding(.vertical, DesignSystem.Spaces.one)
+            list
+        }
+        .onAppear {
+            viewModel.fetchEntities()
+            if viewModel.selectedServerId == nil {
+                viewModel.selectedServerId = Current.servers.all.first?.identifier.rawValue
             }
+            isSearchFocused = true
+        }
+    }
+
+    private var list: some View {
+        List {
+            refreshProgressRow
             filtersView
             ForEach(viewModel.filteredGroups) { group in
                 Section {
@@ -145,14 +144,78 @@ struct EntityPicker: View {
         .safeAreaInset(edge: .bottom) {
             multipleSelectionConfirmButton
         }
-        .onAppear {
-            viewModel.fetchEntities()
-            if viewModel.selectedServerId == nil {
-                viewModel.selectedServerId = Current.servers.all.first?.identifier.rawValue
+        .animation(.easeInOut(duration: 0.35), value: viewModel.isRefreshing)
+        #if targetEnvironment(macCatalyst)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                reloadToolbarButton
             }
-            isSearchFocused = true
+        }
+        #else
+        .refreshable {
+            await viewModel.refresh()
+        }
+        #endif
+    }
+
+    private var searchField: some View {
+        capsuleFieldBackground(
+            TextField(L10n.EntityPicker.Search.placeholder, text: $viewModel.searchTerm)
+                .focused($isSearchFocused)
+                .textFieldStyle(.plain)
+                .padding()
+        )
+    }
+
+    @ViewBuilder
+    private func capsuleFieldBackground(_ content: some View) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .capsule)
+                .contentShape(Capsule())
+        } else {
+            content
+                .background(.tileBackground)
+                .clipShape(.capsule)
         }
     }
+
+    @ViewBuilder
+    private var refreshProgressRow: some View {
+        if viewModel.isRefreshing {
+            Section {
+                HStack(spacing: DesignSystem.Spaces.two) {
+                    ProgressView()
+                    Text(viewModel.refreshStatusText ?? L10n.EntityPicker.Refresh.updating)
+                        .font(DesignSystem.Font.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .transition(.opacity)
+            }
+        }
+    }
+
+    #if targetEnvironment(macCatalyst)
+    @ViewBuilder
+    private var reloadToolbarButton: some View {
+        if viewModel.isRefreshing {
+            ProgressView()
+                .controlSize(.small)
+                .transition(.opacity)
+        } else {
+            Button {
+                Task { await viewModel.refresh() }
+            } label: {
+                Image(systemSymbol: .arrowClockwise)
+            }
+            .accessibilityLabel(L10n.EntityPicker.reload)
+            .transition(.opacity)
+        }
+    }
+    #endif
 
     @ViewBuilder
     private func sectionHeader(for group: EntityPickerGroup) -> some View {

--- a/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
@@ -28,15 +28,23 @@ final class EntityPickerViewModel: ObservableObject {
     @Published var selectedGrouping: EntityGrouping = .area
     @Published var entitiesByDomain: [String: [HAAppEntity]] = [:]
     @Published var filteredGroups: [EntityPickerGroup] = []
+    @Published var isRefreshing = false
+    @Published var refreshStatusText: String?
 
     // Cached lookups to avoid recomputation on every filter
     private var cachedEntityToArea: [String: String] = [:]
     private var cachedAreaIdToEntityIds: [String: Set<String>] = [:]
     private var cachedEntitiesByServer: [String: [HAAppEntity]] = [:]
+    private var entitiesIncludingHidden: [HAAppEntity] = []
     private var fuzzyIndex: EntityFuzzySearchIndex?
 
     let domainFilter: [Domain]?
     private var filterTask: Task<Void, Never>?
+    private var filterGeneration = 0
+    private var refreshTimeoutTask: Task<Void, Never>?
+    private var minimumDisplayTask: Task<Void, Never>?
+    private var refreshStartedAt: Date?
+    private let minimumRefreshDisplaySeconds: TimeInterval = 1.5
     private var cancellables = Set<AnyCancellable>()
 
     /// Returns true if any filter (excluding server) has a non-default value
@@ -94,7 +102,31 @@ final class EntityPickerViewModel: ObservableObject {
                 guard let self else { return }
                 // Clear server-specific cache when server changes
                 cachedEntitiesByServer.removeAll()
+                // A refresh belongs to the previously selected server, so stop showing its progress here.
+                clearRefreshing()
                 fetchServerData(for: serverId)
+            }
+            .store(in: &cancellables)
+
+        // Reload the list once our in-progress refresh of the selected server finishes. Guarded by
+        // `isRefreshing` so unrelated background updates never mutate state mid-presentation.
+        NotificationCenter.default.publisher(for: .appDatabaseUpdaterDidFinishRoutine)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] notification in
+                guard let self, isRefreshing, matchesSelectedServer(notification) else { return }
+                finishRefreshing()
+                fetchEntities()
+            }
+            .store(in: &cancellables)
+
+        // Surface the updater's current phase (entities/devices/areas) while a refresh is in progress.
+        NotificationCenter.default.publisher(for: .appDatabaseUpdaterDidChangePhase)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] notification in
+                guard let self, isRefreshing, matchesSelectedServer(notification) else { return }
+                if let text = notification.userInfo?[AppDatabaseUpdaterUserInfo.phaseDescriptionKey] as? String {
+                    refreshStatusText = text
+                }
             }
             .store(in: &cancellables)
     }
@@ -145,13 +177,14 @@ final class EntityPickerViewModel: ObservableObject {
     }
 
     private func rebuildFuzzyIndex(for serverId: String) {
-        let serverEntities = entities.filter { $0.serverId == serverId }
+        let serverEntities = entitiesIncludingHidden.filter { $0.serverId == serverId }
         fuzzyIndex = EntityFuzzySearchIndex(entities: serverEntities, serverId: serverId)
     }
 
     func fetchEntities() {
         do {
             entities = try HAAppEntity.config()
+            entitiesIncludingHidden = try HAAppEntity.config(include: [.hidden])
 
             // Rebuild caches with current data before grouping, which reads the server cache.
             rebuildAreaCaches()
@@ -169,6 +202,66 @@ final class EntityPickerViewModel: ObservableObject {
         } catch {
             Current.Log.error("Failed to fetch entities for entity picker, error: \(error)")
         }
+    }
+
+    @MainActor
+    func refresh() async {
+        guard !isRefreshing,
+              let serverId = selectedServerId,
+              let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+            return
+        }
+
+        isRefreshing = true
+        refreshStartedAt = Current.date()
+
+        guard await server.activeURL() != nil else {
+            finishRefreshing()
+            return
+        }
+
+        refreshStatusText = L10n.EntityPicker.Refresh.updating
+        Current.appDatabaseUpdater.update(server: server, forceUpdate: true, showProgress: false)
+        scheduleRefreshTimeout(30)
+    }
+
+    private func scheduleRefreshTimeout(_ timeout: TimeInterval) {
+        refreshTimeoutTask?.cancel()
+        refreshTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            finishRefreshing()
+        }
+    }
+
+    private func finishRefreshing() {
+        let elapsed = refreshStartedAt.map { Current.date().timeIntervalSince($0) } ?? minimumRefreshDisplaySeconds
+        let remaining = minimumRefreshDisplaySeconds - elapsed
+        guard isRefreshing, remaining > 0 else {
+            clearRefreshing()
+            return
+        }
+        minimumDisplayTask?.cancel()
+        minimumDisplayTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            clearRefreshing()
+        }
+    }
+
+    private func clearRefreshing() {
+        refreshTimeoutTask?.cancel()
+        refreshTimeoutTask = nil
+        minimumDisplayTask?.cancel()
+        minimumDisplayTask = nil
+        refreshStartedAt = nil
+        isRefreshing = false
+        refreshStatusText = nil
+    }
+
+    private func matchesSelectedServer(_ notification: Notification) -> Bool {
+        guard let server = notification.object as? Server else { return false }
+        return server.identifier.rawValue == selectedServerId
     }
 
     private func groupByDomain() {
@@ -189,12 +282,15 @@ final class EntityPickerViewModel: ObservableObject {
 
     private func updateFilteredEntities() {
         filterTask?.cancel()
+        filterGeneration &+= 1
+        let generation = filterGeneration
         filterTask = Task {
-            await performFiltering()
+            await performFiltering(generation: generation)
         }
     }
 
-    private func performFiltering() async {
+    @MainActor
+    private func performFiltering(generation: Int) async {
         // Snapshot state needed for filtering
         let searchTerm = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
         let presetDomains = domainFilter.map { Set($0.map(\.rawValue)) }
@@ -239,9 +335,10 @@ final class EntityPickerViewModel: ObservableObject {
             }
         }.value
 
-        await MainActor.run {
-            self.filteredGroups = groups
-        }
+        // Back on the main actor: drop results from a superseded run so a slow older search can't
+        // clobber a newer one.
+        guard generation == filterGeneration else { return }
+        filteredGroups = groups
     }
 
     private static func groupPreservingOrder(
@@ -280,6 +377,15 @@ final class EntityPickerViewModel: ObservableObject {
     /// Exposes private updateFilteredEntities for unit tests
     func _test_updateFilteredEntities() {
         updateFilteredEntities()
+    }
+
+    /// Runs the filtering pipeline to completion so tests can assert on `filteredGroups` without racing
+    /// the debounce/Task hop that `updateFilteredEntities` introduces. The generation guard in
+    /// `performFiltering` ensures any still-running earlier task cannot clobber this result.
+    @MainActor
+    func _test_awaitFiltering() async {
+        updateFilteredEntities()
+        await filterTask?.value
     }
     #endif
 }

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
@@ -107,8 +107,12 @@ struct MagicItemAddView: View {
             #endif
         }
         .navigationViewStyle(.stack)
+        #if targetEnvironment(macCatalyst)
+        .frame(minWidth: 540, minHeight: 720)
+        #else
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
+        #endif
     }
 
     @ViewBuilder

--- a/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
+++ b/Sources/App/Settings/MagicItem/Add/MagicItemAddView.swift
@@ -108,10 +108,10 @@ struct MagicItemAddView: View {
         }
         .navigationViewStyle(.stack)
         #if targetEnvironment(macCatalyst)
-        .frame(minWidth: 540, minHeight: 720)
+            .frame(minWidth: 540, minHeight: 720)
         #else
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
         #endif
     }
 

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -18,6 +18,12 @@ public protocol AppDatabaseUpdaterProtocol {
 
 public extension Notification.Name {
     static let appDatabaseUpdaterDidFinishRoutine = Notification.Name("appDatabaseUpdaterDidFinishRoutine")
+    static let appDatabaseUpdaterDidChangePhase = Notification.Name("appDatabaseUpdaterDidChangePhase")
+}
+
+public enum AppDatabaseUpdaterUserInfo {
+    /// Localized description of the current update phase, carried by `.appDatabaseUpdaterDidChangePhase`.
+    public static let phaseDescriptionKey = "phaseDescription"
 }
 
 final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
@@ -431,6 +437,14 @@ final class AppDatabaseUpdater: AppDatabaseUpdaterProtocol {
 
     @MainActor
     private func presentProgressToast(_ phase: DatabaseUpdatePhase, server: Server, showProgress: Bool) {
+        // Broadcast the phase regardless of `showProgress` so screens like the entity picker can show
+        // inline progress without the toast.
+        NotificationCenter.default.post(
+            name: .appDatabaseUpdaterDidChangePhase,
+            object: server,
+            userInfo: [AppDatabaseUpdaterUserInfo.phaseDescriptionKey: phase.localizedDescription]
+        )
+
         guard showProgress, #available(iOS 18, *) else { return }
         ToastPresenter.shared.show(
             id: Self.progressToastID(serverId: server.identifier.rawValue),

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1710,6 +1710,8 @@ public enum L10n {
     }
     /// Pick entity
     public static var placeholder: String { return L10n.tr("Localizable", "entity_picker.placeholder") }
+    /// Reload
+    public static var reload: String { return L10n.tr("Localizable", "entity_picker.reload") }
     /// Remove all
     public static var removeAll: String { return L10n.tr("Localizable", "entity_picker.remove_all") }
     /// Select all
@@ -1751,6 +1753,10 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "entity_picker.list.area.no_area.title") }
         }
       }
+    }
+    public enum Refresh {
+      /// Updating…
+      public static var updating: String { return L10n.tr("Localizable", "entity_picker.refresh.updating") }
     }
     public enum Search {
       /// Entity name, ID, area name, device name...

--- a/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
+++ b/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
@@ -117,4 +117,49 @@ struct EntityPickerViewModelTests {
         vm.resetFilters()
         #expect(vm.hasActiveFilters == false)
     }
+
+    @Test("Hidden entities stay out of the browse list but surface when the user searches")
+    func hiddenEntitiesOnlyAppearWhileSearching() async throws {
+        let previousDatabase = Current.database
+        let database = try DatabaseQueue(path: ":memory:")
+        try HAppEntityTable().createIfNeeded(database: database)
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
+        try AppDeviceRegistryTable().createIfNeeded(database: database)
+        try AppAreaTable().createIfNeeded(database: database)
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        let serverId = "A"
+        let visible = HAAppEntity.make("light.kitchen", name: "Kitchen Light", domain: "light", serverId: serverId)
+        let hidden = HAAppEntity.make("light.hidden_lamp", name: "Hidden Lamp", domain: "light", serverId: serverId)
+
+        try await database.write { db in
+            try visible.insert(db)
+            try hidden.insert(db)
+            let registry = EntityRegistryListForDisplay.Entity(
+                serverId: serverId,
+                entityId: hidden.entityId,
+                hidden: true
+            )
+            try registry.insert(db)
+        }
+
+        let vm = EntityPickerViewModel(domainFilter: nil, selectedServerId: serverId)
+        vm.fetchEntities()
+
+        func entityIds() -> Set<String> {
+            Set(vm.filteredGroups.flatMap(\.entities).map(\.entityId))
+        }
+
+        // Browsing (no search term) keeps the hidden entity out.
+        vm.searchTerm = ""
+        await vm._test_awaitFiltering()
+        #expect(entityIds().contains("light.kitchen"))
+        #expect(!entityIds().contains("light.hidden_lamp"))
+
+        // Searching surfaces the hidden entity.
+        vm.searchTerm = "Hidden"
+        await vm._test_awaitFiltering()
+        #expect(entityIds().contains("light.hidden_lamp"))
+    }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Improves the entity picker:

- Adds pull-to-refresh on iOS (and a reload toolbar button on macOS) to update the entity list from the server, with inline progress that reflects the current update phase.
- Hidden entities no longer clutter the browse list but now surface when the user searches for them.
- Minor macOS/Catalyst presentation fixes for the entity and Magic Item pickers.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
