### PR TITLE
Migrate remaining legacy Siri intents to App Intents

### DIFF
--- a/Sources/Extensions/AppIntents/AssistPromptAppIntent.swift
+++ b/Sources/Extensions/AppIntents/AssistPromptAppIntent.swift
@@ -2,7 +2,10 @@ import AppIntents
 import Foundation
 import Shared
 
-struct AssistPromptAppIntent: AppIntent {
+struct AssistPromptAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit AssistIntent
+    static let intentClassName = "AssistIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.assist_prompt.title",
         defaultValue: "Assist prompt"

--- a/Sources/Extensions/AppIntents/GetCameraSnapshotAppIntent.swift
+++ b/Sources/Extensions/AppIntents/GetCameraSnapshotAppIntent.swift
@@ -4,7 +4,10 @@ import UIKit
 import UniformTypeIdentifiers
 
 @available(iOS 17.0, *)
-struct GetCameraSnapshotAppIntent: AppIntent {
+struct GetCameraSnapshotAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit GetCameraImageIntent
+    static let intentClassName = "GetCameraImageIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.get_camera_snapshot.title",
         defaultValue: "Get camera snapshot"

--- a/Sources/Extensions/AppIntents/PerformActionAppIntent.swift
+++ b/Sources/Extensions/AppIntents/PerformActionAppIntent.swift
@@ -3,7 +3,10 @@ import Foundation
 import Shared
 
 @available(iOS 17.0, *)
-struct PerformActionAppIntent: AppIntent {
+struct PerformActionAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit CallServiceIntent
+    static let intentClassName = "CallServiceIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.perform_action.title",
         defaultValue: "Perform action"

--- a/Sources/Extensions/AppIntents/RenderTemplateAppIntent.swift
+++ b/Sources/Extensions/AppIntents/RenderTemplateAppIntent.swift
@@ -2,7 +2,10 @@ import AppIntents
 import HAKit
 import Shared
 
-struct RenderTemplateAppIntent: AppIntent {
+struct RenderTemplateAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit RenderTemplateIntent
+    static let intentClassName = "RenderTemplateIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.render_template.title",
         defaultValue: "Render template"

--- a/Sources/Extensions/AppIntents/UpdateLocationAppIntent.swift
+++ b/Sources/Extensions/AppIntents/UpdateLocationAppIntent.swift
@@ -2,7 +2,10 @@ import AppIntents
 import CoreLocation
 import Shared
 
-struct UpdateLocationAppIntent: AppIntent {
+struct UpdateLocationAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit SendLocationIntent
+    static let intentClassName = "SendLocationIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.update_location.title",
         defaultValue: "Update location"

--- a/Sources/Extensions/AppIntents/UpdateSensorsAppIntent.swift
+++ b/Sources/Extensions/AppIntents/UpdateSensorsAppIntent.swift
@@ -1,7 +1,10 @@
 import AppIntents
 import Shared
 
-struct UpdateSensorsAppIntent: AppIntent {
+struct UpdateSensorsAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit UpdateSensorsIntent
+    static let intentClassName = "UpdateSensorsIntent"
+
     static var title: LocalizedStringResource = .init(
         "app_intents.update_sensors.title",
         defaultValue: "Update sensors"

--- a/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
+++ b/Sources/Extensions/Widgets/OpenPage/OpenPageAppIntent.swift
@@ -5,7 +5,10 @@ import SwiftUI
 
 // AppIntent that open app needs to have it's target the widget extension AND app target!
 @available(iOS 18, *)
-struct OpenPageAppIntent: AppIntent {
+struct OpenPageAppIntent: AppIntent, CustomIntentMigratedAppIntent {
+    // Carries over shortcuts built with the deprecated SiriKit OpenPageIntent
+    static let intentClassName = "OpenPageIntent"
+
     static var title: LocalizedStringResource = .init(
         "widgets.controls.open_page.configuration.title",
         defaultValue: "Open Page"


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The old SiriKit `Intents.intentdefinition` was removed, but only 3 of the 10 legacy intents declared a migration to their App Intent replacement. This adds `CustomIntentMigratedAppIntent` conformance to the remaining 7 so that shortcuts users already built keep working after updating instead of silently disappearing.

Mapped intents:

| App Intent | Legacy intent |
|---|---|
| `PerformActionAppIntent` | `CallServiceIntent` |
| `UpdateLocationAppIntent` | `SendLocationIntent` |
| `GetCameraSnapshotAppIntent` | `GetCameraImageIntent` |
| `RenderTemplateAppIntent` | `RenderTemplateIntent` |
| `UpdateSensorsAppIntent` | `UpdateSensorsIntent` |
| `AssistPromptAppIntent` | `AssistIntent` |
| `OpenPageAppIntent` | `OpenPageIntent` |

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A – no UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The action migrates for all mapped intents. For intents whose parameter shape changed (notably `CallService` → `PerformActionAppIntent`), the action carries over but some parameter values may not, since the system maps parameters by name.
