### PR TITLE
Hide clean cache and reload button in stand-by on Mac Catalyst

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -140,7 +140,11 @@ struct HomeAssistantStandByView: View {
     private var showsOHFBrandingFooter: Bool {
         // Mirrors the clean-cache button's render condition, so the footer only yields the bottom
         // space when that button actually appears.
-        !showsEmptyState && !(showsCleanCacheButton && onCleanCacheAndReload != nil)
+        !showsEmptyState && !showsCleanCacheAndReloadButton
+    }
+
+    private var showsCleanCacheAndReloadButton: Bool {
+        showsCleanCacheButton && onCleanCacheAndReload != nil && !Current.isCatalyst
     }
 
     private func content(safeAreaInsets: EdgeInsets) -> some View {
@@ -196,7 +200,7 @@ struct HomeAssistantStandByView: View {
             if let emptyState {
                 actionButtons(for: emptyState)
                     .opacity(contentOpacity)
-            } else if showsCleanCacheButton, onCleanCacheAndReload != nil {
+            } else if showsCleanCacheAndReloadButton {
                 cleanCacheButton
                     .transition(.opacity)
             }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Hides the "Clean cache and reload" button from the stand-by / loading screen on Mac Catalyst, where it should not appear.

## Screenshots
N/A — the change removes a button on Mac Catalyst only.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
