### PR TITLE
Add Deeplink option to entity Add to menu

### DIFF
--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -1,0 +1,78 @@
+import Shared
+import SwiftUI
+
+struct DeeplinkView: View {
+    @StateObject private var viewModel: DeeplinkViewModel
+    private let onClose: (() -> Void)?
+
+    init(viewModel: DeeplinkViewModel, onClose: (() -> Void)? = nil) {
+        self._viewModel = .init(wrappedValue: viewModel)
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    AppleLikeListTopRowHeader(
+                        image: .linkVariantIcon,
+                        title: L10n.Deeplink.title,
+                        subtitle: L10n.Deeplink.description
+                    )
+                    .listRowBackground(Color.clear)
+                }
+
+                Section {
+                    Text(viewModel.deeplink)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(Color(uiColor: .secondaryLabel))
+                        .textSelection(.enabled)
+                    if viewModel.didCopy {
+                        Label {
+                            Text(L10n.Deeplink.copied)
+                        } icon: {
+                            Image(systemSymbol: .checkmarkCircleFill)
+                        }
+                        .font(.subheadline)
+                        .foregroundStyle(Color.green)
+                        .transition(.opacity)
+                    }
+                }
+
+                Section(footer: Text(L10n.Deeplink.IncludeServer.subtitle(viewModel.serverName))) {
+                    Toggle(L10n.Deeplink.IncludeServer.title, isOn: $viewModel.includeServer.animation())
+                        .onChange(of: viewModel.includeServer) { _ in
+                            viewModel.includeServerChanged()
+                        }
+                }
+
+                if viewModel.includeServer {
+                    Section {
+                        Button {
+                            viewModel.copyToClipboard()
+                        } label: {
+                            Text(L10n.Deeplink.copyToClipboard)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.primaryButton)
+                        .listRowBackground(Color.clear)
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    CloseButton(alternativeAction: onClose)
+                }
+            }
+            .onAppear {
+                viewModel.copyToClipboard()
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
+#Preview {
+    DeeplinkView(viewModel: DeeplinkViewModel(entityId: "light.mesa_de_jantar", serverName: "Home"))
+}

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -65,17 +65,17 @@ struct DeeplinkView: View {
                             }
                     }
                 }
-
-                Section {
-                    Button {
-                        viewModel.copyToClipboard()
-                    } label: {
-                        Text(L10n.Deeplink.copyToClipboard)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.primaryButton)
-                    .listRowBackground(Color.clear)
+            }
+            .safeAreaInset(edge: .bottom) {
+                Button {
+                    viewModel.copyToClipboard()
+                } label: {
+                    Text(L10n.Deeplink.copyToClipboard)
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.primaryButton)
+                .padding(.horizontal, DesignSystem.Spaces.two)
+                .padding(.bottom, DesignSystem.Spaces.two)
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -57,24 +57,24 @@ struct DeeplinkView: View {
                     }
                 }
 
-                Section(footer: Text(L10n.Deeplink.IncludeServer.subtitle(viewModel.serverName))) {
-                    Toggle(L10n.Deeplink.IncludeServer.title, isOn: $viewModel.includeServer.animation())
-                        .onChange(of: viewModel.includeServer) { _ in
-                            viewModel.includeServerChanged()
-                        }
+                if viewModel.hasMultipleServers {
+                    Section(footer: Text(L10n.Deeplink.IncludeServer.subtitle(viewModel.serverName))) {
+                        Toggle(L10n.Deeplink.IncludeServer.title, isOn: $viewModel.includeServer.animation())
+                            .onChange(of: viewModel.includeServer) { _ in
+                                viewModel.includeServerChanged()
+                            }
+                    }
                 }
 
-                if viewModel.includeServer {
-                    Section {
-                        Button {
-                            viewModel.copyToClipboard()
-                        } label: {
-                            Text(L10n.Deeplink.copyToClipboard)
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.primaryButton)
-                        .listRowBackground(Color.clear)
+                Section {
+                    Button {
+                        viewModel.copyToClipboard()
+                    } label: {
+                        Text(L10n.Deeplink.copyToClipboard)
+                            .frame(maxWidth: .infinity)
                     }
+                    .buttonStyle(.primaryButton)
+                    .listRowBackground(Color.clear)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct DeeplinkView: View {
     @StateObject private var viewModel: DeeplinkViewModel
+    @State private var isDeeplinkExpanded = false
     private let onClose: (() -> Void)?
 
     init(viewModel: DeeplinkViewModel, onClose: (() -> Void)? = nil) {
@@ -23,10 +24,27 @@ struct DeeplinkView: View {
                 }
 
                 Section {
-                    Text(viewModel.deeplink)
-                        .font(.system(.footnote, design: .monospaced))
-                        .foregroundStyle(Color(uiColor: .secondaryLabel))
-                        .textSelection(.enabled)
+                    HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spaces.one) {
+                        Text(viewModel.deeplink)
+                            .font(.system(.footnote, design: .monospaced))
+                            .foregroundStyle(Color(uiColor: .secondaryLabel))
+                            .lineLimit(isDeeplinkExpanded ? nil : 1)
+                            .truncationMode(.middle)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button {
+                            withAnimation { isDeeplinkExpanded.toggle() }
+                        } label: {
+                            Image(systemSymbol: isDeeplinkExpanded ? .chevronUp : .chevronDown)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel(
+                            isDeeplinkExpanded
+                                ? L10n.Component.CollapsibleView.collapse
+                                : L10n.Component.CollapsibleView.expand
+                        )
+                    }
                     if viewModel.didCopy {
                         Label {
                             Text(L10n.Deeplink.copied)

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Shared
+import SwiftUI
+import UIKit
+
+final class DeeplinkViewModel: ObservableObject {
+    let entityId: String
+    let serverName: String
+
+    @Published var includeServer = false
+    @Published var didCopy = false
+
+    private var resetWorkItem: DispatchWorkItem?
+
+    init(entityId: String, serverName: String) {
+        self.entityId = entityId
+        self.serverName = serverName
+    }
+
+    var deeplink: String {
+        let url = includeServer
+            ? AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId, serverName: serverName)
+            : AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId)
+        return url?.absoluteString ?? ""
+    }
+
+    func copyToClipboard() {
+        UIPasteboard.general.string = deeplink
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        resetWorkItem?.cancel()
+        withAnimation { didCopy = true }
+        let workItem = DispatchWorkItem { [weak self] in
+            withAnimation { self?.didCopy = false }
+        }
+        resetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: workItem)
+    }
+
+    func includeServerChanged() {
+        if includeServer {
+            resetWorkItem?.cancel()
+            withAnimation { didCopy = false }
+        } else {
+            copyToClipboard()
+        }
+    }
+}

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
@@ -17,6 +17,10 @@ final class DeeplinkViewModel: ObservableObject {
         self.serverName = serverName
     }
 
+    var hasMultipleServers: Bool {
+        Current.servers.all.count > 1
+    }
+
     var deeplink: String {
         let url = includeServer
             ? AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId, serverName: serverName)
@@ -37,11 +41,7 @@ final class DeeplinkViewModel: ObservableObject {
     }
 
     func includeServerChanged() {
-        if includeServer {
-            resetWorkItem?.cancel()
-            withAnimation { didCopy = false }
-        } else {
-            copyToClipboard()
-        }
+        resetWorkItem?.cancel()
+        withAnimation { didCopy = false }
     }
 }

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
@@ -3,7 +3,6 @@ import Shared
 import SwiftUI
 import UIKit
 
-@MainActor
 final class DeeplinkViewModel: ObservableObject {
     let entityId: String
     let serverName: String

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
@@ -37,7 +37,7 @@ final class DeeplinkViewModel: ObservableObject {
             withAnimation { self?.didCopy = false }
         }
         resetWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: workItem)
     }
 
     func includeServerChanged() {

--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkViewModel.swift
@@ -3,6 +3,7 @@ import Shared
 import SwiftUI
 import UIKit
 
+@MainActor
 final class DeeplinkViewModel: ObservableObject {
     let entityId: String
     let serverName: String

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToAction.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToAction.swift
@@ -46,6 +46,7 @@ enum EntityAddToActionType: String, Codable {
     case watchItem
     case customWidget
     case macToolbarItem
+    case deeplink
 }
 
 // MARK: - Action Implementations
@@ -87,6 +88,16 @@ struct MacToolbarItemAction: EntityAddToAction {
 
     func text() -> String {
         L10n.WebView.AddTo.Option.MacToolbar.title
+    }
+}
+
+/// Action to build a deep link that opens the entity's more info dialog
+struct DeeplinkAction: EntityAddToAction {
+    var mdiIcon: String { "mdi:link-variant" }
+    var actionType: String { EntityAddToActionType.deeplink.rawValue }
+
+    func text() -> String {
+        L10n.WebView.AddTo.Option.Deeplink.title
     }
 }
 
@@ -177,6 +188,8 @@ private struct AnyEntityAddToAction: Codable {
             self.action = try container.decode(CustomWidgetAction.self, forKey: .data)
         case .macToolbarItem:
             self.action = try container.decode(MacToolbarItemAction.self, forKey: .data)
+        case .deeplink:
+            self.action = try container.decode(DeeplinkAction.self, forKey: .data)
         }
     }
 
@@ -208,6 +221,12 @@ private struct AnyEntityAddToAction: Codable {
             }
         case .macToolbarItem:
             if let typed = action as? MacToolbarItemAction {
+                try container.encode(typed, forKey: .data)
+            } else {
+                throw EntityAddToError.encodingFailed
+            }
+        case .deeplink:
+            if let typed = action as? DeeplinkAction {
                 try container.encode(typed, forKey: .data)
             } else {
                 throw EntityAddToError.encodingFailed

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -60,6 +60,11 @@ final class EntityAddToHandler {
                     actions.append(MacToolbarItemAction())
                 }
 
+                // Deep links are available on all platforms for any entity
+                if domain != nil {
+                    actions.append(DeeplinkAction())
+                }
+
                 seal.fulfill(actions)
             }
         }
@@ -107,6 +112,10 @@ final class EntityAddToHandler {
 
                 case .macToolbarItem:
                     addToMacToolbar(entityId: entityId, webViewController: webViewController)
+                    seal.fulfill(())
+
+                case .deeplink:
+                    openDeeplink(entityId: entityId, webViewController: webViewController)
                     seal.fulfill(())
 
                 case .none:
@@ -188,6 +197,28 @@ final class EntityAddToHandler {
         } catch {
             Current.Log.error("Failed to add entity \(entityId) to Mac toolbar: \(error.localizedDescription)")
         }
+    }
+
+    private func openDeeplink(entityId: String, webViewController: WebViewControllerProtocol) {
+        Current.Log.info("Opening deeplink for entity \(entityId)")
+
+        let hostingController = DeeplinkView(
+            viewModel: DeeplinkViewModel(
+                entityId: entityId,
+                serverName: webViewController.server.info.name
+            ),
+            onClose: { [weak webViewController] in
+                webViewController?.dismissOverlayController(animated: true, completion: nil)
+            }
+        ).embeddedInHostingController()
+
+        if !Current.isCatalyst, let sheet = hostingController.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+        }
+
+        webViewController.presentOverlayController(controller: hostingController, animated: true)
     }
 
     private func openWidgetBuilder(

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -212,7 +212,11 @@ final class EntityAddToHandler {
         ).embeddedInHostingController()
 
         if !Current.isCatalyst, let sheet = hostingController.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+            let tallDetent = UISheetPresentationController.Detent.custom(identifier: .init("deeplinkTall")) { context in
+                context.maximumDetentValue * 0.85
+            }
+            sheet.detents = [tallDetent, .large()]
+            sheet.selectedDetentIdentifier = tallDetent.identifier
             sheet.prefersGrabberVisible = true
             sheet.prefersScrollingExpandsWhenScrolledToEdge = false
         }

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -212,11 +212,7 @@ final class EntityAddToHandler {
         ).embeddedInHostingController()
 
         if !Current.isCatalyst, let sheet = hostingController.sheetPresentationController {
-            let tallDetent = UISheetPresentationController.Detent.custom(identifier: .init("deeplinkTall")) { context in
-                context.maximumDetentValue * 0.85
-            }
-            sheet.detents = [tallDetent, .large()]
-            sheet.selectedDetentIdentifier = tallDetent.identifier
+            sheet.detents = [.medium(), .large()]
             sheet.prefersGrabberVisible = true
             sheet.prefersScrollingExpandsWhenScrolledToEdge = false
         }

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -207,12 +207,18 @@ final class EntityAddToHandler {
                 serverName: webViewController.server.info.name
             ),
             onClose: { [weak webViewController] in
-                webViewController?.dismissOverlayController(animated: true, completion: nil)
+                webViewController?.overlayedController?.dismiss(animated: true, completion: nil)
             }
         ).embeddedInHostingController()
 
-        if !Current.isCatalyst, let sheet = hostingController.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+        if Current.isCatalyst {
+            hostingController.modalPresentationStyle = .formSheet
+        } else if let sheet = hostingController.sheetPresentationController {
+            let detent = UISheetPresentationController.Detent.custom(identifier: .init("deeplink")) { context in
+                context.maximumDetentValue * 0.7
+            }
+            sheet.detents = [detent, .large()]
+            sheet.selectedDetentIdentifier = detent.identifier
             sheet.prefersGrabberVisible = true
             sheet.prefersScrollingExpandsWhenScrolledToEdge = false
         }

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -60,7 +60,6 @@ final class EntityAddToHandler {
                     actions.append(MacToolbarItemAction())
                 }
 
-                // Deep links are available on all platforms for any entity
                 if domain != nil {
                     actions.append(DeeplinkAction())
                 }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -451,6 +451,12 @@
 "database_updater.toast.syncing_with_progress" = "Syncing server data... (%li/%li)";
 "database_updater.toast.title" = "Updating %@";
 "debug.reset.entities_database.title" = "Reset app entities database";
+"deeplink.copied" = "Copied to clipboard";
+"deeplink.copy_to_clipboard" = "Copy to clipboard";
+"deeplink.description" = "Copy a link that opens this entity in the app.";
+"deeplink.include_server.subtitle" = "In case you have multiple servers configured in the app, this deeplink will be specifically to %@.";
+"deeplink.include_server.title" = "Include server";
+"deeplink.title" = "Deeplink";
 "delete" = "Delete";
 "device_name.primary_button.title" = "Save";
 "device_name.subtitle" = "This is used to identify your device in your Home Assistant.";
@@ -2443,6 +2449,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "watch.sync.starting" = "Starting sync…";
 "web_view.add_to.option.AppleWatch.title" = "Apple Watch";
 "web_view.add_to.option.CarPlay.title" = "CarPlay";
+"web_view.add_to.option.Deeplink.title" = "Deeplink";
 "web_view.add_to.option.MacToolbar.title" = "Mac Toolbar";
 "web_view.add_to.option.Widget.title" = "Widget";
 "web_view.empty_state.body" = "Please check your connection or try again later. If Home Assistant is restarting it will reconnect after it is back online.";

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -162,7 +162,6 @@ public enum AppConstants {
         var components = URLComponents(string: "\(AppConstants.deeplinkURL.absoluteString)navigate/")
         components?.queryItems = [
             URLQueryItem(name: AppConstants.QueryItems.openMoreInfoDialog.rawValue, value: entityId),
-            URLQueryItem(name: AppConstants.QueryItems.isComingFromAppIntent.rawValue, value: "true"),
         ]
         return components?.url
     }

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -158,6 +158,21 @@ public enum AppConstants {
         )?.withWidgetAuthenticity()
     }
 
+    public static func openEntityMoreInfoDeeplinkURL(entityId: String) -> URL? {
+        URL(
+            string: "\(AppConstants.deeplinkURL.absoluteString)navigate/?\(AppConstants.QueryItems.openMoreInfoDialog.rawValue)=\(entityId)&\(AppConstants.QueryItems.isComingFromAppIntent.rawValue)=true"
+        )
+    }
+
+    public static func openEntityMoreInfoDeeplinkURL(entityId: String, serverName: String) -> URL? {
+        guard let base = openEntityMoreInfoDeeplinkURL(entityId: entityId),
+              var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.queryItems = (components.queryItems ?? []) + [URLQueryItem(name: "server", value: serverName)]
+        return components.url
+    }
+
     public static func openCameraDeeplinkURL(entityId: String, serverId: String) -> URL? {
         URL(
             string: "\(AppConstants.deeplinkURL.absoluteString)camera/?entityId=\(entityId)&serverId=\(serverId)&\(AppConstants.QueryItems.isComingFromAppIntent.rawValue)=true"

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -159,9 +159,12 @@ public enum AppConstants {
     }
 
     public static func openEntityMoreInfoDeeplinkURL(entityId: String) -> URL? {
-        URL(
-            string: "\(AppConstants.deeplinkURL.absoluteString)navigate/?\(AppConstants.QueryItems.openMoreInfoDialog.rawValue)=\(entityId)&\(AppConstants.QueryItems.isComingFromAppIntent.rawValue)=true"
-        )
+        var components = URLComponents(string: "\(AppConstants.deeplinkURL.absoluteString)navigate/")
+        components?.queryItems = [
+            URLQueryItem(name: AppConstants.QueryItems.openMoreInfoDialog.rawValue, value: entityId),
+            URLQueryItem(name: AppConstants.QueryItems.isComingFromAppIntent.rawValue, value: "true"),
+        ]
+        return components?.url
     }
 
     public static func openEntityMoreInfoDeeplinkURL(entityId: String, serverName: String) -> URL? {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1669,6 +1669,25 @@ public enum L10n {
     }
   }
 
+  public enum Deeplink {
+    /// Copied to clipboard
+    public static var copied: String { return L10n.tr("Localizable", "deeplink.copied") }
+    /// Copy to clipboard
+    public static var copyToClipboard: String { return L10n.tr("Localizable", "deeplink.copy_to_clipboard") }
+    /// Copy a link that opens this entity in the app.
+    public static var description: String { return L10n.tr("Localizable", "deeplink.description") }
+    /// Deeplink
+    public static var title: String { return L10n.tr("Localizable", "deeplink.title") }
+    public enum IncludeServer {
+      /// In case you have multiple servers configured in the app, this deeplink will be specifically to %@.
+      public static func subtitle(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "deeplink.include_server.subtitle", String(describing: p1))
+      }
+      /// Include server
+      public static var title: String { return L10n.tr("Localizable", "deeplink.include_server.title") }
+    }
+  }
+
   public enum DeviceName {
     /// This is used to identify your device in your Home Assistant.
     public static var subtitle: String { return L10n.tr("Localizable", "device_name.subtitle") }
@@ -7934,6 +7953,10 @@ public enum L10n {
         public enum CarPlay {
           /// CarPlay
           public static var title: String { return L10n.tr("Localizable", "web_view.add_to.option.CarPlay.title") }
+        }
+        public enum Deeplink {
+          /// Deeplink
+          public static var title: String { return L10n.tr("Localizable", "web_view.add_to.option.Deeplink.title") }
         }
         public enum MacToolbar {
           /// Mac Toolbar

--- a/Tests/App/AppConstants.test.swift
+++ b/Tests/App/AppConstants.test.swift
@@ -86,8 +86,8 @@ struct AppConstantsTests {
             "URL should contain more-info-entity-id query parameter"
         )
         assert(
-            result?.contains("isComingFromAppIntent=true") == true,
-            "URL should contain isComingFromAppIntent=true"
+            result?.contains("isComingFromAppIntent") == false,
+            "Minimal URL should not contain isComingFromAppIntent"
         )
         assert(result?.contains("server=") == false, "Minimal URL should not contain a server query parameter")
         assert(
@@ -110,8 +110,8 @@ struct AppConstantsTests {
             "URL should contain more-info-entity-id query parameter"
         )
         assert(
-            result?.contains("isComingFromAppIntent=true") == true,
-            "URL should contain isComingFromAppIntent=true"
+            result?.contains("isComingFromAppIntent") == false,
+            "URL should not contain isComingFromAppIntent"
         )
         assert(result?.contains("server=My%20Home") == true, "URL should contain the URL-encoded server name")
     }

--- a/Tests/App/AppConstants.test.swift
+++ b/Tests/App/AppConstants.test.swift
@@ -76,6 +76,46 @@ struct AppConstantsTests {
         )
     }
 
+    @Test func testOpenEntityMoreInfoDeeplinkURL() async throws {
+        let entityId = "light.living_room"
+        let result = AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId)?.absoluteString
+
+        assert(result?.contains("navigate/?") == true, "URL should contain navigate/? with empty path")
+        assert(
+            result?.contains("more-info-entity-id=\(entityId)") == true,
+            "URL should contain more-info-entity-id query parameter"
+        )
+        assert(
+            result?.contains("isComingFromAppIntent=true") == true,
+            "URL should contain isComingFromAppIntent=true"
+        )
+        assert(result?.contains("server=") == false, "Minimal URL should not contain a server query parameter")
+        assert(
+            result?.contains("avoidUnnecessaryReload") == false,
+            "Minimal URL should not contain avoidUnnecessaryReload"
+        )
+        assert(
+            result?.contains("widgetAuthenticity") == false,
+            "Minimal URL should not contain widgetAuthenticity"
+        )
+    }
+
+    @Test func testOpenEntityMoreInfoDeeplinkURLWithServer() async throws {
+        let entityId = "light.living_room"
+        let result = AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId, serverName: "My Home")?
+            .absoluteString
+
+        assert(
+            result?.contains("more-info-entity-id=\(entityId)") == true,
+            "URL should contain more-info-entity-id query parameter"
+        )
+        assert(
+            result?.contains("isComingFromAppIntent=true") == true,
+            "URL should contain isComingFromAppIntent=true"
+        )
+        assert(result?.contains("server=My%20Home") == true, "URL should contain the URL-encoded server name")
+    }
+
     @available(iOS 16.0, *)
     @Test func testTodoListAddItemURL() async throws {
         let listId = "todo.shopping_list"


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new **Deeplink** option to the entity "Add to" menu. Selecting it opens a native screen that copies a deep link to that entity's more info dialog to the clipboard. By default the link is minimal and does not include a server, so it works out of the box on single-server setups. An "Include server" toggle lets you pin the link to the current server for multi-server setups.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
_To be added._

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
