### PR TITLE
Fix Mac distribution build

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1575,6 +1575,7 @@
 				DeviceRegistryEntry.swift,
 				DeviceWrapper.swift,
 				DeviceWrapperBatteryObserver.swift,
+				EntityComponentIconsService.swift,
 				EntityFuzzySearch/BitapSearcher.swift,
 				EntityFuzzySearch/EntityFuzzySearchIndex.swift,
 				EntityFuzzySearch/FuzzyDocument.swift,


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the failing Mac distribution build. `EntityComponentIconsService.swift` lives in `Sources/Shared/Environment`, a folder the `MacBridge` bundle target synchronizes wholesale, so the file was compiled into `MacBridge`. It imports `HAKit` unconditionally, but `MacBridge` does not link `HAKit`, so the archive failed with an unresolved module dependency. This excludes the file from the `MacBridge` target, matching how the other unguarded `HAKit` importers in that folder are already handled.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — build/project configuration fix only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
