### PR TITLE
Fix entity picker search field spacing

### DIFF
--- a/Sources/App/Settings/EntityPicker/EntityPicker.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPicker.swift
@@ -101,7 +101,10 @@ struct EntityPicker: View {
         VStack(spacing: 0) {
             searchField
                 .padding(.horizontal, DesignSystem.Spaces.two)
-                .padding(.vertical, DesignSystem.Spaces.one)
+                // Top inset matches the horizontal one so the capsule sits concentric inside the sheet's
+                // rounded corners, and it keeps the field clear of the presentation drag indicator.
+                .padding(.top, DesignSystem.Spaces.two)
+                .padding(.bottom, DesignSystem.Spaces.one)
             list
         }
         .onAppear {


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The entity picker search field was too close to the top of the sheet, colliding with the drag indicator. Its top inset now matches the horizontal one, so the capsule sits concentric inside the sheet's rounded corners and clears the drag indicator.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_0127M1gW16cnrCMAKviwRG5a)_