### PR TITLE
Warn when the app is force closed

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -59,6 +59,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let debugSwift = DebugSwift()
     #endif
     private var zoneManager: ZoneManager?
+    private var forceQuitNotifier: ForceQuitNotifier?
     #if targetEnvironment(macCatalyst)
     private let statusItemManager = StatusItemManager()
     #endif
@@ -125,6 +126,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Current.clientEventStore.addEvent(event)
 
         zoneManager = ZoneManager()
+        forceQuitNotifier = ForceQuitNotifier()
 
         BackgroundRefreshManager.register()
         BackgroundRefreshManager.scheduleAppRefresh()

--- a/Sources/App/Notifications/ForceQuitNotifier.swift
+++ b/Sources/App/Notifications/ForceQuitNotifier.swift
@@ -1,0 +1,64 @@
+import CoreLocation
+import Foundation
+import Shared
+import UIKit
+
+/// Warns the user, with a local notification, that closing the app from the app switcher stops its
+/// background features — location updates, sensors, local push — until the app is opened again.
+///
+/// iOS posts `willTerminateNotification` when the app is killed while it is still running in the
+/// background, which is exactly the moment worth explaining. The warning can be turned off in
+/// Settings › Notifications.
+final class ForceQuitNotifier {
+    /// Termination only leaves the app a few seconds, so we wait — briefly — for the notification
+    /// center to take the request before the process goes away.
+    private static let deliveryTimeout: TimeInterval = 2
+
+    /// `CLLocationManager`'s status is not part of `Current`, so it is injected to keep this testable.
+    private let locationPermissionStatus: () -> CLAuthorizationStatus
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        locationPermissionStatus: @escaping () -> CLAuthorizationStatus = { Current.location.permissionStatus }
+    ) {
+        self.locationPermissionStatus = locationPermissionStatus
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(applicationWillTerminate),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    @objc private func applicationWillTerminate() {
+        notifyIfNeeded()
+    }
+
+    func notifyIfNeeded() {
+        guard shouldNotify else { return }
+
+        Current.Log.info("App is terminating, warning the user about background features stopping")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        Current.notificationDispatcher.send(
+            .init(
+                id: .forceQuit,
+                title: L10n.ForceQuit.Notification.title,
+                body: L10n.ForceQuit.Notification.body
+            ),
+            completion: { semaphore.signal() }
+        )
+        _ = semaphore.wait(timeout: .now() + Self.deliveryTimeout)
+    }
+
+    /// The warning is only useful when closing the app actually costs the user something, so it is
+    /// limited to devices that are signed in and set up to report location in the background.
+    private var shouldNotify: Bool {
+        // Quitting is an ordinary, deliberate action on the Mac rather than something to warn about.
+        guard !Current.isCatalyst else { return false }
+        guard Current.settingsStore.notifyOnForceQuit else { return false }
+        guard !Current.servers.all.isEmpty else { return false }
+        guard locationPermissionStatus() == .authorizedAlways else { return false }
+        return Current.settingsStore.locationSources.isAnyEnabled
+    }
+}

--- a/Sources/App/Notifications/ForceQuitNotifier.swift
+++ b/Sources/App/Notifications/ForceQuitNotifier.swift
@@ -39,15 +39,19 @@ final class ForceQuitNotifier {
 
         Current.Log.info("App is terminating, warning the user about background features stopping")
 
+        // Sending off the caller's thread keeps the completion — and so the signal we are waiting on —
+        // from ever landing on the thread that is blocked here.
         let semaphore = DispatchSemaphore(value: 0)
-        Current.notificationDispatcher.send(
-            .init(
-                id: .forceQuit,
-                title: L10n.ForceQuit.Notification.title,
-                body: L10n.ForceQuit.Notification.body
-            ),
-            completion: { semaphore.signal() }
-        )
+        DispatchQueue.global(qos: .userInitiated).async {
+            Current.notificationDispatcher.send(
+                .init(
+                    id: .forceQuit,
+                    title: L10n.ForceQuit.Notification.title,
+                    body: L10n.ForceQuit.Notification.body
+                ),
+                completion: { semaphore.signal() }
+            )
+        }
         _ = semaphore.wait(timeout: .now() + Self.deliveryTimeout)
     }
 

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -510,6 +510,8 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "flight_greetings.empty_state.configure_hint" = "Configure flight greetings in Settings";
 "flight_greetings.empty_state.title" = "Have a nice flight";
 "flight_greetings.greeting" = "Have a nice flight!";
+"force_quit.notification.body" = "Background updates such as location tracking and sensors stopped. Open Home Assistant again to resume them.";
+"force_quit.notification.title" = "Home Assistant is no longer running";
 "gestures.1_finger.title" = "Using one finger";
 "gestures.2_fingers.title" = "Using two fingers";
 "gestures.2_fingers_swipe_down.title" = "2 👆 swipe down";
@@ -1713,6 +1715,8 @@ Importing replaces every category listed on this screen, including app settings.
 "settings_details.notifications.categories_synced.footer_no_categories" = "Categories may be also defined in the .yaml configuration.";
 "settings_details.notifications.categories_synced.header" = "Synced Categories";
 "settings_details.notifications.documentation" = "Documentation";
+"settings_details.notifications.force_quit.description" = "Sends a notification when Home Assistant is closed from the app switcher, as a reminder that background updates such as location tracking stop until the app is opened again.";
+"settings_details.notifications.force_quit.title" = "Warn when app is closed";
 "settings_details.notifications.history.clear" = "Clear";
 "settings_details.notifications.history.clear_confirm.message" = "This cannot be undone.";
 "settings_details.notifications.history.clear_confirm.title" = "Are you sure you want to clear the notification history?";

--- a/Sources/App/Settings/ConfigurationTransfer/AppSettingsSnapshot.swift
+++ b/Sources/App/Settings/ConfigurationTransfer/AppSettingsSnapshot.swift
@@ -41,6 +41,7 @@ struct AppSettingsSnapshot: Codable, Equatable {
     var clearBadgeAutomatically: Bool?
     var macNativeFeaturesOnly: Bool?
     var receiveDebugNotifications: Bool?
+    var notifyOnForceQuit: Bool?
     /// Seconds between periodic sensor updates. A negative value means "disabled", matching how
     /// `SettingsStore.periodicUpdateInterval` stores a nil interval.
     var periodicUpdateIntervalSeconds: Double?
@@ -82,6 +83,7 @@ struct AppSettingsSnapshot: Codable, Equatable {
             clearBadgeAutomatically: store.clearBadgeAutomatically,
             macNativeFeaturesOnly: store.macNativeFeaturesOnly,
             receiveDebugNotifications: store.receiveDebugNotifications,
+            notifyOnForceQuit: store.notifyOnForceQuit,
             periodicUpdateIntervalSeconds: store.periodicUpdateInterval ?? -1,
             locationVisibility: store.locationVisibility.rawValue,
             menuItemTemplate: menuItemTemplateText,
@@ -148,6 +150,7 @@ struct AppSettingsSnapshot: Codable, Equatable {
         if let clearBadgeAutomatically { store.clearBadgeAutomatically = clearBadgeAutomatically }
         if let macNativeFeaturesOnly { store.macNativeFeaturesOnly = macNativeFeaturesOnly }
         if let receiveDebugNotifications { store.receiveDebugNotifications = receiveDebugNotifications }
+        if let notifyOnForceQuit { store.notifyOnForceQuit = notifyOnForceQuit }
         if let gestures { store.gestures = gestures }
         if let carPlayAssistDebugSettings { store.carPlayAssistDebugSettings = carPlayAssistDebugSettings }
     }

--- a/Sources/App/Settings/Notifications/NotificationSettingsView.swift
+++ b/Sources/App/Settings/Notifications/NotificationSettingsView.swift
@@ -20,6 +20,7 @@ struct NotificationSettingsView: View {
             overviewSection
             historySnoozeSoundsSection
             badgeSection
+            forceQuitSection
         }
         .toolbar {
             // `if` directly inside `.toolbar` requires iOS 16+ ToolbarContentBuilder.
@@ -119,6 +120,21 @@ struct NotificationSettingsView: View {
         }
     }
 
+    /// Quitting is an ordinary action on the Mac, so the warning — and its setting — are iOS only.
+    @ViewBuilder
+    private var forceQuitSection: some View {
+        if !Current.isCatalyst {
+            Section {
+                SwiftUI.Toggle(
+                    L10n.SettingsDetails.Notifications.ForceQuit.title,
+                    isOn: $viewModel.notifyOnForceQuit
+                )
+            } footer: {
+                Text(L10n.SettingsDetails.Notifications.ForceQuit.description)
+            }
+        }
+    }
+
     // MARK: - Actions
 
     private func handlePermissionTap() {
@@ -144,6 +160,12 @@ final class NotificationSettingsViewModel: ObservableObject {
     @Published var clearBadgeAutomatically: Bool = Current.settingsStore.clearBadgeAutomatically {
         didSet {
             Current.settingsStore.clearBadgeAutomatically = clearBadgeAutomatically
+        }
+    }
+
+    @Published var notifyOnForceQuit: Bool = Current.settingsStore.notifyOnForceQuit {
+        didSet {
+            Current.settingsStore.notifyOnForceQuit = notifyOnForceQuit
         }
     }
 
@@ -188,6 +210,13 @@ extension NotificationSettingsView: SettingsScreenSearchable {
             SettingsSearchEntry(L10n.SettingsDetails.Notifications.Sounds.title),
             SettingsSearchEntry(L10n.SettingsDetails.Notifications.BadgeSection.Button.title),
             SettingsSearchEntry(L10n.SettingsDetails.Notifications.BadgeSection.AutomaticSetting.title),
+            SettingsSearchEntry(L10n.SettingsDetails.Notifications.ForceQuit.title),
         ]
+    }
+}
+
+#Preview {
+    NavigationView {
+        NotificationSettingsView()
     }
 }

--- a/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
+++ b/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
@@ -2,7 +2,8 @@ import Foundation
 import UserNotifications
 
 public protocol LocalNotificationDispatcherProtocol {
-    /// - Parameter completion: Called once the notification center accepted (or rejected) the request.
+    /// - Parameter completion: Called once the send attempt finished, whether the notification center
+    ///   accepted the request, rejected it, or the notification was skipped without ever being sent.
     ///   Callers that need the request to land before they go away — e.g. during app termination — can
     ///   wait on it; everyone else uses the `send(_:)` convenience below.
     func send(_ notification: LocalNotificationDispatcher.Notification, completion: (() -> Void)?)

--- a/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
+++ b/Sources/Shared/Notifications/LocalNotificationDispatcher.swift
@@ -2,8 +2,17 @@ import Foundation
 import UserNotifications
 
 public protocol LocalNotificationDispatcherProtocol {
-    func send(_ notification: LocalNotificationDispatcher.Notification)
+    /// - Parameter completion: Called once the notification center accepted (or rejected) the request.
+    ///   Callers that need the request to land before they go away — e.g. during app termination — can
+    ///   wait on it; everyone else uses the `send(_:)` convenience below.
+    func send(_ notification: LocalNotificationDispatcher.Notification, completion: (() -> Void)?)
     func reschedule(_ content: UNNotificationContent, after delay: TimeInterval)
+}
+
+public extension LocalNotificationDispatcherProtocol {
+    func send(_ notification: LocalNotificationDispatcher.Notification) {
+        send(notification, completion: nil)
+    }
 }
 
 /// Sends local notifications
@@ -29,9 +38,10 @@ public final class LocalNotificationDispatcher: LocalNotificationDispatcherProto
 
     public init() {}
 
-    public func send(_ notification: Notification) {
+    public func send(_ notification: Notification, completion: (() -> Void)?) {
         if notification.id == .debug, !Current.settingsStore.receiveDebugNotifications {
             // Do not send debug notifications if the setting is disabled
+            completion?()
             return
         }
 
@@ -51,6 +61,7 @@ public final class LocalNotificationDispatcher: LocalNotificationDispatcherProto
                 Current.Log
                     .info("Error scheduling notification, id: \(notification.id) error: \(error.localizedDescription)")
             }
+            completion?()
         }
     }
 

--- a/Sources/Shared/Notifications/NotificationIdentifier.swift
+++ b/Sources/Shared/Notifications/NotificationIdentifier.swift
@@ -8,6 +8,7 @@ public enum NotificationIdentifier: String {
     case intentActivateFailed
     case intentPressFailed
     case serverUnreachable
+    case forceQuit
 
     // Debug
     case debug

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1877,6 +1877,15 @@ public enum L10n {
     }
   }
 
+  public enum ForceQuit {
+    public enum Notification {
+      /// Background updates such as location tracking and sensors stopped. Open Home Assistant again to resume them.
+      public static var body: String { return L10n.tr("Localizable", "force_quit.notification.body") }
+      /// Home Assistant is no longer running
+      public static var title: String { return L10n.tr("Localizable", "force_quit.notification.title") }
+    }
+  }
+
   public enum Gestures {
     public enum _1Finger {
       /// Using one finger
@@ -5689,6 +5698,12 @@ public enum L10n {
         public static var footerNoCategories: String { return L10n.tr("Localizable", "settings_details.notifications.categories_synced.footer_no_categories") }
         /// Synced Categories
         public static var header: String { return L10n.tr("Localizable", "settings_details.notifications.categories_synced.header") }
+      }
+      public enum ForceQuit {
+        /// Sends a notification when Home Assistant is closed from the app switcher, as a reminder that background updates such as location tracking stop until the app is opened again.
+        public static var description: String { return L10n.tr("Localizable", "settings_details.notifications.force_quit.description") }
+        /// Warn when app is closed
+        public static var title: String { return L10n.tr("Localizable", "settings_details.notifications.force_quit.title") }
       }
       public enum History {
         /// Clear

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -528,6 +528,11 @@ public class SettingsStore {
         public var significantLocationChange: Bool
         public var pushNotifications: Bool
 
+        /// Whether the app still has any reason to ask for a location in the background.
+        public var isAnyEnabled: Bool {
+            zone || backgroundFetch || significantLocationChange || pushNotifications
+        }
+
         static func key(for keyPath: KeyPath<LocationSource, Bool>) -> String {
             switch keyPath {
             case \.zone: return "locationUpdateOnZone"
@@ -577,6 +582,21 @@ public class SettingsStore {
         }
         set {
             prefs.set(newValue, forKey: "clearBadgeAutomatically")
+        }
+    }
+
+    /// Whether to warn, with a local notification, that force quitting the app stops background
+    /// features such as location tracking from working until it is opened again.
+    public var notifyOnForceQuit: Bool {
+        get {
+            if let value = prefs.object(forKey: "notifyOnForceQuit") as? NSNumber {
+                return value.boolValue
+            } else {
+                return true
+            }
+        }
+        set {
+            prefs.set(newValue, forKey: "notifyOnForceQuit")
         }
     }
 

--- a/Tests/App/Notifications/ForceQuitNotifierTests.swift
+++ b/Tests/App/Notifications/ForceQuitNotifierTests.swift
@@ -1,0 +1,104 @@
+import CoreLocation
+@testable import HomeAssistant
+@testable import Shared
+import UIKit
+import XCTest
+
+final class ForceQuitNotifierTests: XCTestCase {
+    private var dispatcher: MockLocalNotificationDispatcher!
+    private var previousDispatcher: LocalNotificationDispatcherProtocol!
+    private var previousServers: ServerManager!
+    private var previousNotifyOnForceQuit: Bool!
+    private var previousLocationSources: SettingsStore.LocationSource!
+
+    override func setUp() {
+        super.setUp()
+
+        previousDispatcher = Current.notificationDispatcher
+        previousServers = Current.servers
+        previousNotifyOnForceQuit = Current.settingsStore.notifyOnForceQuit
+        previousLocationSources = Current.settingsStore.locationSources
+
+        dispatcher = MockLocalNotificationDispatcher()
+        Current.notificationDispatcher = dispatcher
+        Current.servers = FakeServerManager(initial: 1)
+        Current.settingsStore.notifyOnForceQuit = true
+        Current.settingsStore.locationSources = .init(
+            zone: true,
+            backgroundFetch: true,
+            significantLocationChange: true,
+            pushNotifications: true
+        )
+    }
+
+    override func tearDown() {
+        Current.notificationDispatcher = previousDispatcher
+        Current.servers = previousServers
+        Current.settingsStore.notifyOnForceQuit = previousNotifyOnForceQuit
+        Current.settingsStore.locationSources = previousLocationSources
+
+        super.tearDown()
+    }
+
+    func testNotifiesWhenBackgroundLocationIsInUse() {
+        makeNotifier().notifyIfNeeded()
+
+        XCTAssertEqual(dispatcher.sentNotifications.map(\.id), [.forceQuit])
+    }
+
+    func testDoesNotNotifyWhenSettingIsDisabled() {
+        Current.settingsStore.notifyOnForceQuit = false
+
+        makeNotifier().notifyIfNeeded()
+
+        XCTAssertTrue(dispatcher.sentNotifications.isEmpty)
+    }
+
+    func testDoesNotNotifyWhenNoServerIsConfigured() {
+        Current.servers = FakeServerManager(initial: 0)
+
+        makeNotifier().notifyIfNeeded()
+
+        XCTAssertTrue(dispatcher.sentNotifications.isEmpty)
+    }
+
+    func testDoesNotNotifyWithoutAlwaysLocationPermission() {
+        makeNotifier(locationPermissionStatus: .authorizedWhenInUse).notifyIfNeeded()
+
+        XCTAssertTrue(dispatcher.sentNotifications.isEmpty)
+    }
+
+    func testDoesNotNotifyWhenEveryLocationSourceIsDisabled() {
+        Current.settingsStore.locationSources = .init(
+            zone: false,
+            backgroundFetch: false,
+            significantLocationChange: false,
+            pushNotifications: false
+        )
+
+        makeNotifier().notifyIfNeeded()
+
+        XCTAssertTrue(dispatcher.sentNotifications.isEmpty)
+    }
+
+    func testNotifiesWhenTheApplicationWillTerminate() {
+        let notificationCenter = NotificationCenter()
+        let notifier = makeNotifier(notificationCenter: notificationCenter)
+
+        notificationCenter.post(name: UIApplication.willTerminateNotification, object: nil)
+
+        XCTAssertEqual(dispatcher.sentNotifications.map(\.id), [.forceQuit])
+        // Keep the notifier alive until after the notification is posted.
+        withExtendedLifetime(notifier) {}
+    }
+
+    private func makeNotifier(
+        notificationCenter: NotificationCenter = NotificationCenter(),
+        locationPermissionStatus: CLAuthorizationStatus = .authorizedAlways
+    ) -> ForceQuitNotifier {
+        ForceQuitNotifier(
+            notificationCenter: notificationCenter,
+            locationPermissionStatus: { locationPermissionStatus }
+        )
+    }
+}

--- a/Tests/App/Notifications/ForceQuitNotifierTests.swift
+++ b/Tests/App/Notifications/ForceQuitNotifierTests.swift
@@ -85,11 +85,13 @@ final class ForceQuitNotifierTests: XCTestCase {
         let notificationCenter = NotificationCenter()
         let notifier = makeNotifier(notificationCenter: notificationCenter)
 
-        notificationCenter.post(name: UIApplication.willTerminateNotification, object: nil)
+        // The notification center holds its observer unretained, so the notifier has to stay alive
+        // for the whole post-and-assert.
+        withExtendedLifetime(notifier) {
+            notificationCenter.post(name: UIApplication.willTerminateNotification, object: nil)
 
-        XCTAssertEqual(dispatcher.sentNotifications.map(\.id), [.forceQuit])
-        // Keep the notifier alive until after the notification is posted.
-        withExtendedLifetime(notifier) {}
+            XCTAssertEqual(dispatcher.sentNotifications.map(\.id), [.forceQuit])
+        }
     }
 
     private func makeNotifier(

--- a/Tests/App/WebView/Mocks/MockLocalNotificationDispatcher.swift
+++ b/Tests/App/WebView/Mocks/MockLocalNotificationDispatcher.swift
@@ -3,12 +3,13 @@ import Foundation
 import UserNotifications
 
 final class MockLocalNotificationDispatcher: LocalNotificationDispatcherProtocol {
-    private var lastNotificationSent: LocalNotificationDispatcher.Notification?
+    private(set) var sentNotifications: [LocalNotificationDispatcher.Notification] = []
     private(set) var lastRescheduledContent: UNNotificationContent?
     private(set) var lastRescheduledDelay: TimeInterval?
 
-    func send(_ notification: LocalNotificationDispatcher.Notification) {
-        lastNotificationSent = notification
+    func send(_ notification: LocalNotificationDispatcher.Notification, completion: (() -> Void)?) {
+        sentNotifications.append(notification)
+        completion?()
     }
 
     func reschedule(_ content: UNNotificationContent, after delay: TimeInterval) {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Proposal for https://github.com/orgs/home-assistant/discussions/4421.

When the app is closed from the app switcher, iOS stops background updates (location, sensors) until it is opened again, and there is nothing telling the user that happened. This adds a local notification, sent on `UIApplication.willTerminateNotification`, explaining it — the same behaviour apps like Tile use.

To keep it from being noise, the warning is only sent when closing the app actually costs something: a server is configured, location permission is "Always", and at least one location source is enabled. It is skipped entirely on Mac, where quitting is a normal action.

A new "Warn when app is closed" toggle in Settings › Notifications turns it off. It defaults to on and is included in configuration import/export.

## Screenshots


## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`LocalNotificationDispatcher.send` gained an optional completion handler so termination can wait (up to 2s) for the notification center to accept the request before the process goes away.
