### PR TITLE
Fix stand-by loading logo not animating

### DIFF
--- a/Sources/App/Frontend/WebView/Views/AnimatedSVGView.swift
+++ b/Sources/App/Frontend/WebView/Views/AnimatedSVGView.swift
@@ -1,23 +1,25 @@
 import SwiftUI
-import WebKit
 
 /// Renders an animated SVG bundled with the app inside a transparent, non-interactive
-/// `WKWebView`. WebKit plays the document's CSS keyframe and SMIL animations natively,
+/// `AnimatedSVGWebView`. WebKit plays the document's CSS keyframe and SMIL animations natively,
 /// which SVGKit cannot do. Used for the loading logo on `HomeAssistantStandByView`.
 ///
-/// The view is vended by `AnimatedSVGWebViewCache`, which keeps it warm (preloaded at
-/// launch) so it appears without WKWebView's cold-start delay. The SVG should declare a
-/// `viewBox` so it scales to fill; the wrapper HTML forces it to 100% width/height on a
-/// transparent background.
+/// The view is vended by `AnimatedSVGWebViewCache`, which keeps it warm (preloaded at launch) so it
+/// appears without WKWebView's cold-start delay. The SVG should declare a `viewBox` so it scales to
+/// fill; the wrapper HTML forces it to 100% width/height on a transparent background.
 struct AnimatedSVGView: UIViewRepresentable {
     /// Name of the `.svg` resource in the main bundle (without extension).
     let resourceName: String
 
-    func makeUIView(context: Context) -> WKWebView {
+    func makeUIView(context: Context) -> AnimatedSVGWebView {
         AnimatedSVGWebViewCache.shared.webView(for: resourceName)
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    func updateUIView(_ uiView: AnimatedSVGWebView, context: Context) {
+        // Another chance to catch a page WebKit stopped or reclaimed while it was off-screen; it
+        // costs nothing when the animation is already running.
+        uiView.resumeAnimationIfNeeded()
+    }
 }
 
 #Preview {

--- a/Sources/App/Frontend/WebView/Views/AnimatedSVGWebView.swift
+++ b/Sources/App/Frontend/WebView/Views/AnimatedSVGWebView.swift
@@ -1,0 +1,224 @@
+import Shared
+import UIKit
+import WebKit
+
+/// A transparent, non-interactive `WKWebView` that renders an animated SVG bundled with the app and
+/// keeps it animating. WebKit plays the document's CSS keyframe and SMIL animations natively, which
+/// SVGKit cannot do.
+///
+/// Keeping it animating is the hard part. The instance vended by `AnimatedSVGWebViewCache` is
+/// preloaded off-screen at launch and is unparented again every time the loading logo goes away, and
+/// WebKit does not keep an off-screen page running: it pauses the page's animations, and it may
+/// suspend or terminate the web content process backing the view. That leaves the document frozen
+/// mid-loop, stalled mid-load, or blank — and none of those states recover on their own. Because the
+/// loading logo draws a pixel-identical static logo behind this view, they all look the same to the
+/// user: a logo that simply does not animate. It shows up most on a cold launch over a slow
+/// connection, where the loader stays up long enough to notice and the busier launch makes WebKit
+/// more likely to suspend or reclaim the off-screen page in the first place.
+///
+/// So the view re-checks itself whenever it is attached to a window or the app returns to the
+/// foreground: it resumes animations that are not running and reloads the document when the page is
+/// gone. A watchdog covers loads that never finish, since a load interrupted by process suspension
+/// neither completes nor fails.
+@MainActor
+final class AnimatedSVGWebView: WKWebView {
+    private enum State {
+        /// A load is in flight and the watchdog is armed.
+        case loading
+        /// The document finished loading; its animations may still need resuming.
+        case loaded
+        /// The load failed or stalled, or its web content process died — only a fresh load recovers.
+        case needsReload
+    }
+
+    /// How long a load may take before it counts as stalled. Generous enough for a cold launch
+    /// spinning up WebKit, short enough that a stuck logo heals while the loader is still on screen.
+    private static let loadTimeout: Duration = .seconds(2)
+    /// Stops a document that cannot render (missing resource, repeatedly crashing content process)
+    /// from reloading forever behind the loading logo. Reset once the document is confirmed animating.
+    private static let maximumConsecutiveLoads = 3
+
+    /// Name of the `.svg` resource in the main bundle (without extension).
+    let resourceName: String
+
+    private var state: State = .needsReload
+    private var consecutiveLoads = 0
+    private var loadWatchdog: Task<Void, Never>?
+
+    init(resourceName: String) {
+        self.resourceName = resourceName
+        super.init(frame: .zero, configuration: WKWebViewConfiguration())
+        isOpaque = false
+        backgroundColor = .clear
+        scrollView.backgroundColor = .clear
+        scrollView.isScrollEnabled = false
+        // Let taps fall through to the logo dismiss gesture behind the view.
+        isUserInteractionEnabled = false
+        navigationDelegate = self
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        load()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        resumeAnimationIfNeeded()
+    }
+
+    /// Gets the document animating again now that it can be seen. Safe to call repeatedly: a running
+    /// animation is left untouched, so this never restarts a healthy loop from its first frame.
+    func resumeAnimationIfNeeded() {
+        guard window != nil else { return }
+        switch state {
+        case .loading:
+            // A load that stalled off-screen never fails, so give it a deadline rather than
+            // restarting a load that may be one frame away from painting.
+            startLoadWatchdog()
+        case .loaded:
+            Task { await resumeAnimation() }
+        case .needsReload:
+            load()
+        }
+    }
+
+    private func resumeAnimation() async {
+        do {
+            let hasAnimations = try await evaluateJavaScript(Self.resumeAnimationsScript) as? Bool
+            if hasAnimations == true {
+                // Confirmed animating: whatever it took to get here worked, so the retry budget is
+                // free again for the next time WebKit stops the page.
+                consecutiveLoads = 0
+                return
+            }
+            // The page answered but has nothing to animate: the SVG never parsed, or the document
+            // was replaced.
+            Current.Log.error("Animated SVG \(resourceName) has no animations to resume, reloading")
+            load()
+        } catch {
+            // Evaluation fails outright when the web content process is gone: the page is blank and
+            // only a fresh load brings it back.
+            let reason = error.localizedDescription
+            Current.Log.error("Animated SVG \(resourceName) failed to resume (\(reason)), reloading")
+            load()
+        }
+    }
+
+    /// (Re)loads the bundled SVG document. Also used as the recovery path, since a page whose content
+    /// process died cannot be revived any other way.
+    private func load() {
+        guard consecutiveLoads < Self.maximumConsecutiveLoads else {
+            Current.Log.error("Giving up on animated SVG \(resourceName) after \(consecutiveLoads) failed loads")
+            return
+        }
+        guard
+            let url = Bundle.main.url(forResource: resourceName, withExtension: "svg"),
+            let svg = try? String(contentsOf: url, encoding: .utf8) else {
+            state = .needsReload
+            Current.Log.error("Missing or unreadable animated SVG resource \(resourceName).svg")
+            return
+        }
+        consecutiveLoads += 1
+        state = .loading
+        loadHTMLString(Self.html(embedding: svg), baseURL: Bundle.main.bundleURL)
+        startLoadWatchdog()
+    }
+
+    /// WebKit suspends — and under memory pressure terminates — the web content process of a view
+    /// that is not on screen, which is exactly where the preloaded instance waits between launch and
+    /// the loading logo appearing. A load interrupted that way neither finishes nor fails, so only a
+    /// timeout notices it.
+    private func startLoadWatchdog() {
+        loadWatchdog?.cancel()
+        loadWatchdog = Task { [weak self] in
+            try? await Task.sleep(for: Self.loadTimeout)
+            guard !Task.isCancelled, let self, state == .loading else { return }
+            Current.Log.error("Animated SVG \(resourceName) did not finish loading in time")
+            markNeedsReload()
+        }
+    }
+
+    private func markNeedsReload() {
+        loadWatchdog?.cancel()
+        state = .needsReload
+        // Reloading off-screen would only stall again; the next attach picks it up.
+        guard window != nil else { return }
+        load()
+    }
+
+    @objc private func applicationWillEnterForeground() {
+        // WebKit is free to reclaim the page while the app is backgrounded, so never assume the
+        // document that was animating at suspension is still there.
+        resumeAnimationIfNeeded()
+    }
+
+    /// Resumes every animation the document is not currently running, and reports whether it has any
+    /// animations at all — an empty list means there is no SVG left to animate.
+    private static let resumeAnimationsScript = """
+    (function() {
+        var animations = document.getAnimations ? document.getAnimations() : [];
+        animations.forEach(function(animation) {
+            if (animation.playState !== 'running') {
+                animation.play();
+            }
+        });
+        return animations.length > 0;
+    })()
+    """
+
+    private static func html(embedding svg: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+        <style>
+        html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: transparent; overflow: hidden; }
+        body { display: flex; align-items: center; justify-content: center; }
+        svg { width: 100%; height: 100%; display: block; }
+        </style>
+        </head>
+        <body>
+        \(svg)
+        </body>
+        </html>
+        """
+    }
+}
+
+extension AnimatedSVGWebView: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loadWatchdog?.cancel()
+        state = .loaded
+        // The document may have loaded while the page was hidden, which leaves its animations
+        // paused; this is a no-op when they are already running.
+        resumeAnimationIfNeeded()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        Current.Log.error("Animated SVG \(resourceName) failed to load: \(error.localizedDescription)")
+        markNeedsReload()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        Current.Log.error("Animated SVG \(resourceName) failed provisional load: \(error.localizedDescription)")
+        markNeedsReload()
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Current.Log.error("Animated SVG \(resourceName) web content process terminated")
+        markNeedsReload()
+    }
+}

--- a/Sources/App/Frontend/WebView/Views/AnimatedSVGWebViewCache.swift
+++ b/Sources/App/Frontend/WebView/Views/AnimatedSVGWebViewCache.swift
@@ -1,102 +1,46 @@
-import Shared
 import UIKit
-import WebKit
 
-/// Keeps a warm, already-loaded `WKWebView` instance for animated SVGs so the loading logo
-/// appears instantly instead of paying WKWebView's web-content-process spin-up and
-/// first-paint cost the moment `HomeAssistantStandByView` is shown.
+/// Keeps a warm, already-loaded `AnimatedSVGWebView` instance for animated SVGs so the loading logo
+/// appears instantly instead of paying WKWebView's web-content-process spin-up and first-paint cost
+/// the moment `HomeAssistantStandByView` is shown.
 ///
-/// The warm instance is handed out only while it is unattached. If it is already in a view
-/// hierarchy (e.g. two multi-window scenes show the loading logo at once), a fresh instance
-/// is created for the second caller, since a single `WKWebView` cannot live in two hierarchies
-/// at the same time.
+/// The warm instance is handed out only while it is unattached. If it is already in a view hierarchy
+/// (e.g. two multi-window scenes show the loading logo at once), a fresh instance is created for the
+/// second caller, since a single `WKWebView` cannot live in two hierarchies at the same time.
 ///
-/// Handing the warm instance out a second time reloads its SVG first: while it sat unparented
-/// between appearances, WebKit paused the page and may have suspended or terminated its web
-/// content process, which freezes the animation permanently. Reloading restarts the loop.
+/// Whether an instance is still animating after sitting off-screen — unparented between appearances,
+/// or unparented since the launch preload — is `AnimatedSVGWebView`'s own problem: it re-checks and
+/// recovers itself every time it is attached to a window.
 @MainActor
 final class AnimatedSVGWebViewCache {
     static let shared = AnimatedSVGWebViewCache()
 
-    private var warmWebViews: [String: WKWebView] = [:]
-    private var vendedResourceNames: Set<String> = []
+    private var warmWebViews: [String: AnimatedSVGWebView] = [:]
 
     private init() {}
 
-    /// Eagerly builds and starts loading the warm web view for `resourceName` (e.g. at app
-    /// launch) so it is ready before first use.
+    /// Eagerly builds and starts loading the warm web view for `resourceName` (e.g. at app launch) so
+    /// it is ready before first use.
     func preload(_ resourceName: String) {
         _ = warmWebView(for: resourceName)
     }
 
     /// Returns a loaded web view for `resourceName`. Reuses the warm instance when it is free,
     /// otherwise creates and loads a fresh one so it can be parented independently.
-    func webView(for resourceName: String) -> WKWebView {
+    func webView(for resourceName: String) -> AnimatedSVGWebView {
         let warm = warmWebView(for: resourceName)
         guard warm.superview == nil else {
-            let webView = Self.makeWebView()
-            Self.loadSVG(named: resourceName, into: webView)
-            return webView
-        }
-        if vendedResourceNames.contains(resourceName) {
-            // WebKit paused this page while it was unparented (and may have suspended or killed
-            // its content process), leaving the animation frozen — reload so it loops again.
-            // The first hand-out skips this: the preloaded document is still fresh, and reloading
-            // would forfeit the warm first paint the cache exists to provide.
-            Self.loadSVG(named: resourceName, into: warm)
-        } else {
-            vendedResourceNames.insert(resourceName)
+            return AnimatedSVGWebView(resourceName: resourceName)
         }
         return warm
     }
 
-    private func warmWebView(for resourceName: String) -> WKWebView {
+    private func warmWebView(for resourceName: String) -> AnimatedSVGWebView {
         if let existing = warmWebViews[resourceName] {
             return existing
         }
-        let webView = Self.makeWebView()
-        Self.loadSVG(named: resourceName, into: webView)
+        let webView = AnimatedSVGWebView(resourceName: resourceName)
         warmWebViews[resourceName] = webView
         return webView
-    }
-
-    private static func makeWebView() -> WKWebView {
-        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        webView.isOpaque = false
-        webView.backgroundColor = .clear
-        webView.scrollView.backgroundColor = .clear
-        webView.scrollView.isScrollEnabled = false
-        // Let taps fall through to the logo dismiss gesture behind the view.
-        webView.isUserInteractionEnabled = false
-        return webView
-    }
-
-    private static func loadSVG(named resourceName: String, into webView: WKWebView) {
-        guard
-            let url = Bundle.main.url(forResource: resourceName, withExtension: "svg"),
-            let svg = try? String(contentsOf: url, encoding: .utf8) else {
-            Current.Log.error("Missing or unreadable animated SVG resource \(resourceName).svg")
-            return
-        }
-        webView.loadHTMLString(html(embedding: svg), baseURL: Bundle.main.bundleURL)
-    }
-
-    private static func html(embedding svg: String) -> String {
-        """
-        <!DOCTYPE html>
-        <html>
-        <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-        <style>
-        html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: transparent; overflow: hidden; }
-        body { display: flex; align-items: center; justify-content: center; }
-        svg { width: 100%; height: 100%; display: block; }
-        </style>
-        </head>
-        <body>
-        \(svg)
-        </body>
-        </html>
-        """
     }
 }

--- a/Tests/App/WebView/AnimatedSVGWebViewTests.swift
+++ b/Tests/App/WebView/AnimatedSVGWebViewTests.swift
@@ -1,0 +1,96 @@
+@testable import HomeAssistant
+import UIKit
+import XCTest
+
+@MainActor
+final class AnimatedSVGWebViewTests: XCTestCase {
+    private var window: UIWindow!
+
+    override func setUp() {
+        super.setUp()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+    }
+
+    override func tearDown() {
+        window = nil
+        super.tearDown()
+    }
+
+    func testWarmWebViewIsReusedWhileItIsUnparented() {
+        let resourceName = "cache-identity-unparented"
+
+        let first = AnimatedSVGWebViewCache.shared.webView(for: resourceName)
+        let second = AnimatedSVGWebViewCache.shared.webView(for: resourceName)
+
+        XCTAssertIdentical(first, second)
+    }
+
+    func testParentedWarmWebViewIsNotHandedOutASecondTime() {
+        let resourceName = "cache-identity-parented"
+        let first = AnimatedSVGWebViewCache.shared.webView(for: resourceName)
+        window.addSubview(first)
+
+        let second = AnimatedSVGWebViewCache.shared.webView(for: resourceName)
+
+        XCTAssertNotIdentical(first, second)
+        XCTAssertEqual(second.resourceName, resourceName)
+    }
+
+    func testAnimationRunsOnceTheViewIsOnScreen() async {
+        let webView = AnimatedSVGWebView(resourceName: HomeAssistantStandByView.loadingLogoResourceName)
+
+        window.addSubview(webView)
+
+        let isAnimating = await waitUntilAnimating(webView)
+        XCTAssertTrue(isAnimating, "The loading logo should animate as soon as it is on screen")
+    }
+
+    /// The reported bug: WebKit stops the page while the view sits off-screen — unparented between
+    /// appearances, or unparented since the launch preload — and nothing used to restart it, so the
+    /// logo came back frozen. Pausing the animations stands in for what WebKit does off-screen.
+    func testReattachingResumesAnAnimationThatWasStoppedOffScreen() async throws {
+        let webView = AnimatedSVGWebView(resourceName: HomeAssistantStandByView.loadingLogoResourceName)
+        window.addSubview(webView)
+        let startedAnimating = await waitUntilAnimating(webView)
+        XCTAssertTrue(startedAnimating)
+
+        _ = try await webView.evaluateJavaScript(Self.pauseAnimationsScript)
+        let isAnimatingWhilePaused = try await webView.evaluateJavaScript(Self.isAnimatingScript) as? Bool
+        XCTAssertEqual(isAnimatingWhilePaused, false, "Precondition: the animations should be stopped")
+
+        webView.removeFromSuperview()
+        window.addSubview(webView)
+
+        let resumed = await waitUntilAnimating(webView)
+        XCTAssertTrue(resumed, "Re-attaching the view should get the logo animating again")
+    }
+
+    /// Polls the document instead of waiting a fixed delay: both the initial load and the resume run
+    /// asynchronously inside WebKit, so there is no notification to await.
+    private func waitUntilAnimating(_ webView: AnimatedSVGWebView, attempts: Int = 100) async -> Bool {
+        for _ in 0 ..< attempts {
+            let result = try? await webView.evaluateJavaScript(Self.isAnimatingScript)
+            if result as? Bool == true {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        return false
+    }
+
+    private static let isAnimatingScript = """
+    (function() {
+        var animations = document.getAnimations ? document.getAnimations() : [];
+        return animations.length > 0 && animations.every(function(animation) {
+            return animation.playState === 'running';
+        });
+    })()
+    """
+
+    private static let pauseAnimationsScript = """
+    (function() {
+        document.getAnimations().forEach(function(animation) { animation.pause(); });
+        return true;
+    })()
+    """
+}


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The loading logo on the stand-by screen sometimes shows up frozen, most often on a cold launch over a slow connection where the loader stays on screen long enough to notice.

The logo is a `WKWebView` playing a bundled animated SVG. It is preloaded off-screen at launch and unparented again every time the loader goes away, and WebKit does not keep an off-screen page running: it pauses the page's animations, and it may suspend or terminate the web content process behind it. That leaves the document frozen mid-loop, stalled mid-load, or blank, and nothing recovered from any of those. Since a pixel-identical static logo is drawn behind the web view, all of them look the same — a logo that simply does not animate.

Loading and recovery now live in `AnimatedSVGWebView`, which re-checks itself whenever it is attached to a window or the app returns to the foreground: it resumes animations that are not running, reloads when the page is gone, and watchdogs loads that never finish (a load interrupted by process suspension neither completes nor fails). Reloads are capped so a document that cannot render does not reload forever. The cache is back to only deciding which instance to hand out.

## Screenshots

No visual change — the logo looks the same, it just keeps animating.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Added tests cover the cache's hand-out rules, that the logo animates once on screen, and that an animation stopped while off-screen resumes when the view is re-attached.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HzgkLRFCgVBkUDNyMUWGoZ)_