### PR TITLE
Respect cloud opt-out when suggesting a re-auth URL

### DIFF
--- a/Sources/App/Container/OnboardingStateObservable.swift
+++ b/Sources/App/Container/OnboardingStateObservable.swift
@@ -103,9 +103,10 @@ final class OnboardingStateObservable: ObservableObject {
         }
     }
 
+    /// Available URL types for re-authentication, ordered by preference: remote UI > external > internal.
+    /// Remote UI is skipped when the user opted out of Home Assistant Cloud.
     func availableReauthURLTypes(for server: Server) -> [ConnectionInfo.URLType] {
-        let preferenceOrder: [ConnectionInfo.URLType] = [.remoteUI, .external, .internal]
-        return preferenceOrder.filter { server.info.connection.address(for: $0) != nil }
+        server.info.connection.availableAuthenticationURLTypes
     }
 
     /// Re-authenticates a server recovered from a keychain-mirror restore, then shows its web view.

--- a/Sources/App/Container/OnboardingStateObservable.swift
+++ b/Sources/App/Container/OnboardingStateObservable.swift
@@ -104,7 +104,8 @@ final class OnboardingStateObservable: ObservableObject {
     }
 
     /// Available URL types for re-authentication, ordered by preference: remote UI > external > internal.
-    /// Remote UI is skipped when the user opted out of Home Assistant Cloud.
+    /// Remote UI is skipped when the user opted out of Home Assistant Cloud, unless it is the only URL
+    /// configured for the server.
     func availableReauthURLTypes(for server: Server) -> [ConnectionInfo.URLType] {
         server.info.connection.availableAuthenticationURLTypes
     }

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
@@ -135,7 +135,7 @@ extension WebViewController {
             style: style ?? emptyStateStyle(for: connectionState),
             server: server,
             showsErrorDetailsButton: shouldShowErrorDetailsButton,
-            availableReauthURLTypes: availableReauthURLTypes(for: server),
+            availableReauthURLTypes: server.info.connection.availableAuthenticationURLTypes,
             retryAction: { [weak self] in
                 self?.retryClearingFrontendCache()
             },
@@ -144,10 +144,5 @@ extension WebViewController {
             reauthAction: { [weak self] urlType in self?.performReauthentication(using: urlType) },
             dismissAction: { [weak self] in self?.hideEmptyState() }
         )
-    }
-
-    /// Available URL types for re-authentication, ordered by preference: remote UI > external > internal.
-    private func availableReauthURLTypes(for server: Server) -> [ConnectionInfo.URLType] {
-        [.remoteUI, .external, .internal].filter { server.info.connection.address(for: $0) != nil }
     }
 }

--- a/Sources/HANetworking/Sources/ConnectionInfo.swift
+++ b/Sources/HANetworking/Sources/ConnectionInfo.swift
@@ -337,15 +337,15 @@ public struct ConnectionInfo: Codable, Equatable {
     /// URL types that can be used to authenticate against this server, ordered by preference:
     /// remote UI > external > internal.
     ///
-    /// Remote UI is only offered when the user opted into Home Assistant Cloud (`useCloud`), matching
-    /// the URL selection performed by `evaluateActiveURL()`: a server can keep a remote UI URL around
-    /// while the user connects through their own external URL, and authenticating against the cloud URL
-    /// in that case would ignore that choice.
+    /// Remote UI is dropped when the user opted out of Home Assistant Cloud (`useCloud`): a server can
+    /// keep a remote UI URL around while the user connects through their own external URL, and
+    /// authenticating against the cloud URL in that case would ignore that choice. This generally
+    /// follows how `evaluateActiveURL()` picks a URL, with one deliberate exception — when remote UI is
+    /// the only configured URL it is returned regardless of `useCloud`, since an empty list would leave
+    /// no way to authenticate at all.
     public var availableAuthenticationURLTypes: [URLType] {
         let configured: [URLType] = [.remoteUI, .external, .internal].filter { address(for: $0) != nil }
         let respectingCloudPreference = configured.filter { $0 != .remoteUI || useCloud }
-        // Remote UI opted out of but the only URL configured: still offer it, since dropping it would
-        // leave no way to authenticate at all.
         return respectingCloudPreference.isEmpty ? configured : respectingCloudPreference
     }
 

--- a/Sources/HANetworking/Sources/ConnectionInfo.swift
+++ b/Sources/HANetworking/Sources/ConnectionInfo.swift
@@ -334,6 +334,21 @@ public struct ConnectionInfo: Codable, Equatable {
         }
     }
 
+    /// URL types that can be used to authenticate against this server, ordered by preference:
+    /// remote UI > external > internal.
+    ///
+    /// Remote UI is only offered when the user opted into Home Assistant Cloud (`useCloud`), matching
+    /// the URL selection performed by `evaluateActiveURL()`: a server can keep a remote UI URL around
+    /// while the user connects through their own external URL, and authenticating against the cloud URL
+    /// in that case would ignore that choice.
+    public var availableAuthenticationURLTypes: [URLType] {
+        let configured: [URLType] = [.remoteUI, .external, .internal].filter { address(for: $0) != nil }
+        let respectingCloudPreference = configured.filter { $0 != .remoteUI || useCloud }
+        // Remote UI opted out of but the only URL configured: still offer it, since dropping it would
+        // leave no way to authenticate at all.
+        return respectingCloudPreference.isEmpty ? configured : respectingCloudPreference
+    }
+
     /// Returns a URL for troubleshooting purposes, such as displaying in error messages or running connectivity checks.
     /// This method provides read-only access to connection URLs that are otherwise private.
     /// - Parameter type: The type of URL to retrieve for troubleshooting

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -800,6 +800,70 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(info.invitationURL(), internalURL)
     }
 
+    func testAvailableAuthenticationURLTypesSkipsRemoteUIWhenCloudDisabled() {
+        var info = makeConnectionInfo(
+            externalURL: URL(string: "https://external.com:8123"),
+            internalURL: URL(string: "http://internal.com:8123"),
+            remoteUIURL: URL(string: "https://cloud.com:8123")
+        )
+
+        info.useCloud = false
+        XCTAssertEqual(info.availableAuthenticationURLTypes, [.external, .internal])
+    }
+
+    func testAvailableAuthenticationURLTypesIncludesRemoteUIWhenCloudEnabled() {
+        var info = makeConnectionInfo(
+            externalURL: URL(string: "https://external.com:8123"),
+            internalURL: URL(string: "http://internal.com:8123"),
+            remoteUIURL: URL(string: "https://cloud.com:8123")
+        )
+
+        info.useCloud = true
+        XCTAssertEqual(info.availableAuthenticationURLTypes, [.remoteUI, .external, .internal])
+    }
+
+    func testAvailableAuthenticationURLTypesOmitsUnconfiguredURLs() {
+        var info = makeConnectionInfo(
+            externalURL: URL(string: "https://external.com:8123"),
+            internalURL: nil,
+            remoteUIURL: nil
+        )
+
+        info.useCloud = true
+        XCTAssertEqual(info.availableAuthenticationURLTypes, [.external])
+    }
+
+    func testAvailableAuthenticationURLTypesFallsBackToRemoteUIWhenItIsTheOnlyURL() {
+        var info = makeConnectionInfo(
+            externalURL: nil,
+            internalURL: nil,
+            remoteUIURL: URL(string: "https://cloud.com:8123")
+        )
+
+        info.useCloud = false
+        XCTAssertEqual(info.availableAuthenticationURLTypes, [.remoteUI])
+    }
+
+    private func makeConnectionInfo(
+        externalURL: URL?,
+        internalURL: URL?,
+        remoteUIURL: URL?
+    ) -> ConnectionInfo {
+        ConnectionInfo(
+            externalURL: externalURL,
+            internalURL: internalURL,
+            cloudhookURL: nil,
+            remoteUIURL: remoteUIURL,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            connectionAccessSecurityLevel: .undefined
+        )
+    }
+
     func testFallbackToInternalURLWhenItIsHTTPS() async {
         let internalURL = URL(string: "https://internal.com:8123")
         var info = ConnectionInfo(


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The re-authentication empty state offered and preselected the remote UI URL whenever one was stored, even for users who turned Home Assistant Cloud off and connect through their external URL.

URL selection now lives in `ConnectionInfo.availableAuthenticationURLTypes`, which skips remote UI unless `useCloud` is set, matching how `evaluateActiveURL()` and `invitationURL()` already pick a URL. Remote UI is still offered when it is the only configured URL, so re-auth never ends up with no URL to connect to.

## Screenshots

No visual change; only which URL the existing picker defaults to.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes

Both re-auth entry points (the web view empty state and the recovered-server screen) had their own copy of the old rule; they now share the new one.
