### PR TITLE
Add LATAM to in-flight Wi-Fi SSID list

### DIFF
--- a/Sources/App/FlightGreetings/InFlightWiFiSSIDs.swift
+++ b/Sources/App/FlightGreetings/InFlightWiFiSSIDs.swift
@@ -75,6 +75,7 @@ enum InFlightWiFiSSIDs {
         "iberia",
         "jal",
         "klm",
+        "latam",
         "sas",
         "southwest",
         "tap",


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Adds `latam` to the exact-match list of in-flight Wi-Fi SSIDs, so an SSID of exactly "LATAM" is detected as a flight. The substring pattern `latamplay` was already there, but the bare airline name was missing — other airlines already have both (e.g. `gol`/`golonline`, `klm`/`klmwifi`).

## Screenshots
N/A, no user-facing UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant# N/A

## Any other notes
None.