### PR TITLE
Add complication source to details and gauge widgets

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		42C60FA62F081DA90071A6F6 /* DeviceClassProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */; };
 		42C60FA72F081DA90071A6F6 /* DeviceClassProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */; };
 		42D14C49301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C48301BAF950058088E /* HAWatchComplications */; };
+		42D14CA1301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14CA0301BAF950058088E /* HAWatchComplications */; };
 		42D14C4B301BAFA10058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C4A301BAFA10058088E /* HAWatchComplications */; };
 		42D14C4D301BAFAC0058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C4C301BAFAC0058088E /* HAWatchComplications */; };
 		42D14C4E301BAFC80058088E /* RectangularComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C46301BAD2E0058088E /* RectangularComplicationSnapshot.test.swift */; };
@@ -765,6 +766,10 @@
 				AppIntents/ShortcutAppIntentSupport.swift,
 				AppIntents/UpdateLocationAppIntent.swift,
 				AppIntents/UpdateSensorsAppIntent.swift,
+				"AppIntents/Widget/Complication/ComplicationRenderContext+WidgetRenderModels.swift",
+				AppIntents/Widget/Complication/WidgetCircularComplicationAppEntity.swift,
+				AppIntents/Widget/Complication/WidgetComplicationResolver.swift,
+				AppIntents/Widget/Complication/WidgetRectangularComplicationAppEntity.swift,
 				AppIntents/Widget/Details/WidgetDetailsAppIntent.swift,
 				AppIntents/Widget/Details/WidgetDetailsAttributeAppEntity.swift,
 				AppIntents/Widget/Energy/WidgetEnergyAppIntent.swift,
@@ -2051,6 +2056,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				42D14CA1301BAF950058088E /* HAWatchComplications in Frameworks */,
 				E33F645682064B22AC4CDFBB /* SFSafeSymbols in Frameworks */,
 				42886D422FFE8853004EB33B /* PromiseKitDynamic in Frameworks */,
 				42886D3E2FFE884E004EB33B /* HAKit in Frameworks */,
@@ -2759,6 +2765,7 @@
 			);
 			name = "Extensions-Widgets";
 			packageProductDependencies = (
+				42D14CA0301BAF950058088E /* HAWatchComplications */,
 				C6ACD1840F0E4F5FBFDDE88B /* SFSafeSymbols */,
 				42886D3D2FFE884E004EB33B /* HAKit */,
 				42886D412FFE8853004EB33B /* PromiseKitDynamic */,
@@ -6004,6 +6011,11 @@
 			productName = ObjectMapper;
 		};
 		42D14C48301BAF950058088E /* HAWatchComplications */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
+			productName = HAWatchComplications;
+		};
+		42D14CA0301BAF950058088E /* HAWatchComplications */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
 			productName = HAWatchComplications;

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2573,7 +2573,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.custom.subtitle" = "Create widgets with your own style";
 "widgets.custom.title" = "Custom widgets";
 "widgets.details.description" = "Display states using from Home Assistant in text";
-"widgets.details.description_with_warning" = "Display states using from Home Assistant in text. ATTENTION: User needs to be admin for templating access";
+"widgets.details.gallery_description" = "Display an entity, a watch complication, or a template from Home Assistant as text";
 "widgets.details.parameters.action" = "Action";
 "widgets.details.parameters.details_template" = "Details Text Template (only in rectangular family)";
 "widgets.details.parameters.lower_template" = "Lower Text Template";
@@ -2600,7 +2600,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.energy.title" = "Energy";
 "widgets.entity_state.placeholder" = "Entity state";
 "widgets.gauge.description" = "Display numeric states from Home Assistant in a gauge";
-"widgets.gauge.description_with_warning" = "Display numeric states from Home Assistant in a gauge. ATTENTION: User needs to be admin for templating access";
+"widgets.gauge.gallery_description" = "Display an entity, a watch complication, or a template from Home Assistant in a gauge";
 "widgets.gauge.parameters.action" = "Action";
 "widgets.gauge.parameters.gauge_type" = "Gauge Type";
 "widgets.gauge.parameters.gauge_type.capacity" = "Capacity";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2488,6 +2488,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.commonly_used_entities.description" = "Display your commonly used entities based on your usage patterns.";
 "widgets.commonly_used_entities.empty.description" = "No commonly used entities found. Use Home Assistant to build your usage history.";
 "widgets.commonly_used_entities.title" = "Common Controls";
+"widgets.content_source.complication" = "Complication";
 "widgets.content_source.entity" = "Entity";
 "widgets.content_source.template" = "Template";
 "widgets.content_source.title" = "Source";
@@ -2621,6 +2622,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.open_page.title" = "Open Page";
 "widgets.param.server.title" = "Server";
 "widgets.parameters.attribute" = "Attribute";
+"widgets.parameters.complication" = "Complication";
 "widgets.parameters.entity" = "Entity";
 "widgets.preview.custom.description" = "Create your own widget inside the App and then display it here.";
 "widgets.preview.custom.title" = "Custom widget";

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/AllFamiliesComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/AllFamiliesComplicationPreview.swift
@@ -223,7 +223,7 @@ struct AllFamiliesComplicationPreview: View {
         }
     }
 
-    private func context(for family: WatchComplicationConfig.Family) -> ComplicationPreviewContext {
+    private func context(for family: WatchComplicationConfig.Family) -> ComplicationRenderContext {
         if isUnconfigured {
             return .mock(config: config, family: family)
         }
@@ -255,7 +255,7 @@ struct AllFamiliesComplicationPreview: View {
                         .image(ofSize: CGSize(width: 64, height: 64), color: color)
                 )
             }
-            return ComplicationPreviewContext(
+            return ComplicationRenderContext(
                 config: familyConfig, value: value, fraction: fraction, iconImage: iconImage
             )
         }

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/CircularComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/CircularComplicationPreview.swift
@@ -4,10 +4,10 @@ import SwiftUI
 
 /// iPhone preview of the circular complication. Renders through the shared
 /// `CircularComplicationContentView` (the exact same view the watch uses), mapping the editor's
-/// `ComplicationPreviewContext` into the shared render model — so the preview can't drift from the
+/// `ComplicationRenderContext` into the shared render model — so the preview can't drift from the
 /// on-watch rendering.
 struct CircularComplicationPreview: View {
-    let context: ComplicationPreviewContext
+    let context: ComplicationRenderContext
 
     var body: some View {
         CircularComplicationContentView(model: renderModel)

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/CornerComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/CornerComplicationPreview.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// `CornerComplicationContentView` approximation. Both sides resolve their text / gauge through
 /// `CornerComplicationRenderModel`.
 struct CornerComplicationPreview: View {
-    let context: ComplicationPreviewContext
+    let context: ComplicationRenderContext
 
     var body: some View {
         CornerComplicationContentView(model: renderModel)
@@ -34,7 +34,7 @@ struct CornerComplicationPreview: View {
 #if DEBUG
 /// Renders every corner permutation side by side so the layout can be checked at a glance.
 private struct CornerVariantsPreview: View {
-    let variants: [(String, ComplicationPreviewContext)] = [
+    let variants: [(String, ComplicationRenderContext)] = [
         ("Icon + name + value + gauge", .previewCorner()),
         ("Value + name + gauge", .previewCorner(showIcon: false)),
         ("Value + name", .previewCorner(showIcon: false, gauge: false)),

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/InlineComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/InlineComplicationPreview.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// Inline has no icon or custom colors (watchOS renders it in the face tint). Renders through the
 /// shared `InlineComplicationContentView`, so it can't drift from the on-watch rendering.
 struct InlineComplicationPreview: View {
-    let context: ComplicationPreviewContext
+    let context: ComplicationRenderContext
 
     var body: some View {
         // The whole line is the title slot's formula ("{name} - {value}" by default), matching the

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/RectangularComplicationPreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/RectangularComplicationPreview.swift
@@ -4,10 +4,10 @@ import SwiftUI
 
 /// iPhone preview of the rectangular complication. Renders through the shared
 /// `RectangularComplicationContentView` (the exact same view the watch uses), mapping the editor's
-/// `ComplicationPreviewContext` into the shared render model — so the preview can't drift from the
+/// `ComplicationRenderContext` into the shared render model — so the preview can't drift from the
 /// on-watch rendering.
 struct RectangularComplicationPreview: View {
-    let context: ComplicationPreviewContext
+    let context: ComplicationRenderContext
 
     var body: some View {
         RectangularComplicationContentView(model: renderModel)
@@ -40,7 +40,7 @@ struct RectangularComplicationPreview: View {
 #if DEBUG
 import SFSafeSymbols
 
-private extension ComplicationPreviewContext {
+private extension ComplicationRenderContext {
     /// Rectangular sample with independently toggleable text slots + gauge, so the previews can show
     /// off the full layout: title / subtitle / value (gauge or text) / bottom text. The subtitle and
     /// bottom-text slots the watch hides by default are made visible here with sample text.
@@ -53,7 +53,7 @@ private extension ComplicationPreviewContext {
         gauge: Bool = true,
         icon: Bool = true,
         textColor: String? = nil
-    ) -> ComplicationPreviewContext {
+    ) -> ComplicationRenderContext {
         var config = WatchComplicationConfig(
             serverId: "preview",
             widgetFamily: .rectangular,
@@ -83,7 +83,7 @@ private extension ComplicationPreviewContext {
                 for: .rectangular
             )
         }
-        return ComplicationPreviewContext(
+        return ComplicationRenderContext(
             config: config,
             value: value,
             fraction: gauge ? 0.68 : nil,
@@ -106,7 +106,7 @@ private func whiteSymbol(_ symbol: SFSymbol, size: CGFloat = 22) -> UIImage {
 
 /// Renders the preview on a dark rounded "watch face" so the complication's default white text is
 /// legible — on the watch the face is black, so a light preview canvas would hide every text slot.
-private func rectangularFace(_ context: ComplicationPreviewContext) -> some View {
+private func rectangularFace(_ context: ComplicationRenderContext) -> some View {
     RectangularComplicationPreview(context: context)
         .background(.black, in: .rect(cornerRadius: 14))
 }

--- a/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/Preview/WatchComplicationLivePreview.swift
@@ -4,72 +4,10 @@ import PromiseKit
 import Shared
 import SwiftUI
 
-/// The resolved rendering inputs a per-family preview needs. Bundled so the family views stay small and
-/// don't each re-derive the same styling from the config.
-struct ComplicationPreviewContext {
-    let config: WatchComplicationConfig
-    /// The value text (already unit-appended when applicable).
-    let value: String
-    /// The gauge fraction (0...1), or nil when there's no gauge value.
-    let fraction: Double?
-    /// The icon image, already gated by the "show icon" toggle (nil when hidden or none).
-    let iconImage: Image?
-    /// Raw entity attributes (entity kind), so slot formulas referencing `{attr:…}` resolve in the
-    /// preview exactly like on the watch.
-    var attributes: [String: Any] = [:]
-    /// Pre-rendered templates for formula resolution. The preview only renders the main text
-    /// template; extra templates in customized slot formulas resolve empty here and render on the
-    /// watch.
-    var renderedTemplates: [String: String] = [:]
-
-    private var family: WatchComplicationConfig.Family { config.widgetFamily }
-
-    var name: String { config.faceName }
-    var showsValue: Bool { config.isSlotVisible(.value, for: family) }
-    var showsName: Bool { config.isSlotVisible(.title, for: family) }
-    var showsSubtitle: Bool { config.isSlotVisible(.subtitle, for: family) }
-    var showsBottomText: Bool { config.isSlotVisible(.bottomText, for: family) }
-    var showsMin: Bool { config.showsMin(for: family) }
-    var showsMax: Bool { config.showsMax(for: family) }
-    /// Whether a gauge is drawn — needs both the toggle on and an actual value.
-    var showsGauge: Bool { config.showsGauge(for: family) && fraction != nil }
-    var range: (min: Double, max: Double)? { config.gaugeRange(for: family) }
-    var gaugeStyle: WatchComplicationConfig.GaugeStyle { config.gaugeStyle(for: family) }
-
-    /// Gauge/ring tint; defaults to the accent color.
-    var tint: Color { config.tint(for: family).map { Color(uiColor: UIColor($0)) } ?? .accentColor }
-    /// Value/text color; defaults to white for contrast on the dark preview face.
-    var textColor: Color { config.textColor(for: family).map { Color(uiColor: UIColor(hex: $0)) } ?? .white }
-    /// Per-slot bottom text color override; nil falls back to `textColor` in the rendered view.
-    var bottomTextColor: Color? { config.slotColor(.bottomText, for: family).map { Color(uiColor: UIColor(hex: $0)) } }
-
-    /// Min/max are whole numbers.
-    func label(_ value: Double) -> String { String(Int(value.rounded())) }
-
-    // MARK: - Slot texts (same resolution as the watch's snapshot builder)
-
-    private func slotText(_ slot: ComplicationSlot) -> String {
-        ComplicationFormulaResolver.resolve(
-            config.formula(for: slot, family: family),
-            context: ComplicationFormulaContext(
-                entityName: name,
-                formattedState: value,
-                attributeValue: { attributes[$0].map { String(describing: $0) } },
-                renderedTemplates: renderedTemplates
-            )
-        )
-    }
-
-    var titleText: String { slotText(.title) }
-    var valueText: String { slotText(.value) }
-    var subtitleText: String { slotText(.subtitle) }
-    var bottomText: String { slotText(.bottomText) }
-}
-
 #if DEBUG
-extension ComplicationPreviewContext {
+extension ComplicationRenderContext {
     /// Sample context used by the per-family preview SwiftUI previews.
-    static func preview(_ family: WatchComplicationConfig.Family, gauge: Bool = true) -> ComplicationPreviewContext {
+    static func preview(_ family: WatchComplicationConfig.Family, gauge: Bool = true) -> ComplicationRenderContext {
         var config = WatchComplicationConfig(
             serverId: "preview",
             widgetFamily: family,
@@ -81,7 +19,7 @@ extension ComplicationPreviewContext {
             config.gaugeMin = 0
             config.gaugeMax = 100
         }
-        return ComplicationPreviewContext(
+        return ComplicationRenderContext(
             config: config,
             value: "68%",
             fraction: gauge ? 0.68 : nil,
@@ -98,7 +36,7 @@ extension ComplicationPreviewContext {
         showName: Bool = true,
         showIcon: Bool = true,
         gauge: Bool = true
-    ) -> ComplicationPreviewContext {
+    ) -> ComplicationRenderContext {
         var config = WatchComplicationConfig(serverId: "preview", widgetFamily: .corner, name: name)
         if gauge {
             config.gaugeMin = 0
@@ -114,7 +52,7 @@ extension ComplicationPreviewContext {
             ),
             for: .corner
         )
-        return ComplicationPreviewContext(
+        return ComplicationRenderContext(
             config: config,
             value: value,
             fraction: gauge ? 0.68 : nil,
@@ -123,101 +61,6 @@ extension ComplicationPreviewContext {
     }
 }
 #endif
-
-extension ComplicationPreviewContext {
-    /// Build a context for `family` from already-fetched entity data. Centralizes the value / unit /
-    /// fraction / icon resolution so the single-family and all-families previews render identically off
-    /// one fetch.
-    static func entity(
-        config: WatchComplicationConfig,
-        family: WatchComplicationConfig.Family,
-        state: String,
-        attributes: [String: Any]
-    ) -> ComplicationPreviewContext {
-        var familyConfig = config
-        familyConfig.widgetFamily = family
-
-        // Value is shared across families: the chosen attribute (or the state), formatted with the
-        // resolved unit + precision.
-        let raw = config.valueAttribute.flatMap { attributes[$0] }.map { String(describing: $0) } ?? state
-        let resolvedUnit: String? = {
-            if let attribute = config.valueAttribute {
-                return WatchComplicationConfig.attributeUnit(
-                    attribute: attribute,
-                    attributes: attributes,
-                    domain: config.entityId?.components(separatedBy: ".").first
-                )
-            }
-            return attributes["unit_of_measurement"] as? String
-        }()
-        let unit: String? = {
-            guard config.showsUnit() else { return nil }
-            if let override = config.unitOverride, !override.isEmpty { return override }
-            return resolvedUnit
-        }()
-        let precision = config.valuePrecision ?? config.entityId.flatMap {
-            EntityRegistryListForDisplay.Entity.displayPrecision(serverId: config.serverId, entityId: $0)
-        }
-        let value = state.isEmpty ? "" : WatchComplicationLivePreview.formatValue(raw, unit: unit, precision: precision)
-
-        // Fraction depends on the family's gauge range.
-        var fraction: Double?
-        if let range = familyConfig.gaugeRange(for: family) {
-            let source: Any = familyConfig.gaugeAttribute(for: family).flatMap { attributes[$0] }
-                ?? config.valueAttribute.flatMap { attributes[$0] }
-                ?? state
-            if let rawNumber = WatchComplication.percentileNumber(from: source), range.max > range.min {
-                fraction = min(max((Double(rawNumber) - range.min) / (range.max - range.min), 0), 1)
-            }
-        }
-
-        // Icon is gated by the icon slot's visibility (same resolution the watch uses).
-        var iconImage: Image?
-        if familyConfig.isSlotVisible(.icon, for: family), let iconName = config.iconName {
-            let color = config.iconColor.map { UIColor(hex: $0) } ?? .white
-            iconImage = Image(
-                uiImage: MaterialDesignIcons(serversideValueNamed: iconName)
-                    .image(ofSize: CGSize(width: 64, height: 64), color: color)
-            )
-        }
-
-        return ComplicationPreviewContext(
-            config: familyConfig,
-            value: value,
-            fraction: fraction,
-            iconImage: iconImage,
-            attributes: attributes
-        )
-    }
-
-    /// A representative placeholder shown before the user picks an entity/template, so every size renders
-    /// meaningful sample content instead of an empty face. Honors the config's toggles, colors, chosen
-    /// icon, and any typed name.
-    static func mock(
-        config: WatchComplicationConfig,
-        family: WatchComplicationConfig.Family
-    ) -> ComplicationPreviewContext {
-        var familyConfig = config
-        familyConfig.widgetFamily = family
-        familyConfig.gaugeMin = familyConfig.gaugeMin ?? 0
-        familyConfig.gaugeMax = familyConfig.gaugeMax ?? 100
-        if familyConfig.name == nil, familyConfig.entityDisplayName == nil, familyConfig.entityId == nil {
-            familyConfig.name = "Battery"
-        }
-        // The face's name token ignores the complication name for the entity kind, so the pre-entity
-        // mock needs a stand-in entity name for the title to render.
-        if familyConfig.entityDisplayName == nil, familyConfig.entityId == nil {
-            familyConfig.entityDisplayName = familyConfig.name
-        }
-        var iconImage: Image?
-        if familyConfig.isSlotVisible(.icon, for: family) {
-            let icon = config.iconName.map { MaterialDesignIcons(serversideValueNamed: $0) } ?? .gaugeIcon
-            let color = config.iconColor.map { UIColor(hex: $0) } ?? .white
-            iconImage = Image(uiImage: icon.image(ofSize: CGSize(width: 64, height: 64), color: color))
-        }
-        return ComplicationPreviewContext(config: familyConfig, value: "72%", fraction: 0.72, iconImage: iconImage)
-    }
-}
 
 /// A live approximation of the watch complication, rendered on iPhone with current data so the user
 /// sees the real result before saving. Entity complications fetch their value over the plain REST
@@ -355,7 +198,7 @@ struct WatchComplicationLivePreview: View {
         }
     }
 
-    private var context: ComplicationPreviewContext {
+    private var context: ComplicationRenderContext {
         switch config.kind {
         case .entity:
             return .entity(
@@ -365,7 +208,7 @@ struct WatchComplicationLivePreview: View {
                 attributes: entityAttributes
             )
         case .customTemplate:
-            return ComplicationPreviewContext(
+            return ComplicationRenderContext(
                 config: config,
                 value: value,
                 fraction: fraction,
@@ -500,17 +343,6 @@ struct WatchComplicationLivePreview: View {
     }
 
     static func formatValue(_ state: String, unit: String?, precision: Int?) -> String {
-        var text = state
-        if let precision, let number = Double(state) {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.minimumFractionDigits = precision
-            formatter.maximumFractionDigits = precision
-            text = formatter.string(from: NSNumber(value: number)) ?? state
-        }
-        if let unit, !unit.isEmpty {
-            text += " \(unit)"
-        }
-        return text
+        ComplicationRenderContext.formatValue(state, unit: unit, precision: precision)
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/Complication/ComplicationRenderContext+WidgetRenderModels.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/ComplicationRenderContext+WidgetRenderModels.swift
@@ -1,0 +1,52 @@
+import HAWatchComplications
+import Shared
+
+/// Maps a resolved complication into the `HAWatchComplications` render models the lock-screen widgets
+/// draw with.
+///
+/// Deliberately a field-for-field mirror of the in-app editor's `RectangularComplicationPreview` /
+/// `CircularComplicationPreview` — the widgets render through the exact same content views, so if the
+/// two mappings drift the lock screen stops matching the watch.
+@available(iOS 17.0, *)
+extension ComplicationRenderContext {
+    var rectangularRenderModel: RectangularComplicationRenderModel {
+        RectangularComplicationRenderModel(
+            iconImage: iconImage,
+            showsIcon: iconImage != nil,
+            title: titleText,
+            showsName: showsName,
+            subtitle: subtitleText,
+            showsSubtitle: showsSubtitle,
+            fraction: showsGauge ? fraction : nil,
+            minLabel: showsMin ? range.map { label($0.min) } : nil,
+            maxLabel: showsMax ? range.map { label($0.max) } : nil,
+            valueText: valueText,
+            showsValue: showsValue,
+            bottomText: bottomText,
+            showsBottomText: showsBottomText,
+            tint: tint,
+            // nil lets the content view use `.primary`, which the lock screen renders white and the
+            // Home Screen adapts — the editor preview can hardcode white only because it draws on a
+            // black face.
+            textColor: configuredTextColor,
+            bottomTextColor: bottomTextColor
+        )
+    }
+
+    var circularRenderModel: CircularComplicationRenderModel {
+        CircularComplicationRenderModel(
+            iconImage: iconImage,
+            showsIcon: iconImage != nil,
+            valueText: valueText,
+            showsValue: showsValue,
+            title: titleText,
+            showsName: showsName,
+            fraction: showsGauge ? fraction : nil,
+            isCapacityGauge: gaugeStyle == .capacity,
+            minLabel: showsMin ? range.map { label($0.min) } : nil,
+            maxLabel: showsMax ? range.map { label($0.max) } : nil,
+            tint: tint,
+            textColor: configuredTextColor
+        )
+    }
+}

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetCircularComplicationAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetCircularComplicationAppEntity.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import Foundation
+import Shared
+
+/// One of the user's circular watch complications, offered to the gauge widget's complication source.
+/// `id` is the `WatchComplicationConfig` id.
+///
+/// Circular only: the gauge widget renders the circular complication style, so only complications laid
+/// out for that family are offered.
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct WidgetCircularComplicationAppEntity: AppEntity {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(
+        name: .init("widgets.parameters.complication", defaultValue: "Complication")
+    )
+    static let defaultQuery = WidgetCircularComplicationAppEntityQuery()
+
+    var id: String
+    var name: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    init(config: WatchComplicationConfig) {
+        self.init(id: config.id, name: config.displayName)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct WidgetCircularComplicationAppEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [WidgetCircularComplicationAppEntity] {
+        WidgetComplicationResolver.configs(family: .circular)
+            .filter { identifiers.contains($0.id) }
+            .map(WidgetCircularComplicationAppEntity.init(config:))
+    }
+
+    func suggestedEntities() async throws -> IntentItemCollection<WidgetCircularComplicationAppEntity> {
+        .init(items: WidgetComplicationResolver.configs(family: .circular)
+            .map(WidgetCircularComplicationAppEntity.init(config:)))
+    }
+}

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetCircularComplicationAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetCircularComplicationAppEntity.swift
@@ -40,7 +40,8 @@ struct WidgetCircularComplicationAppEntityQuery: EntityQuery {
     }
 
     func suggestedEntities() async throws -> IntentItemCollection<WidgetCircularComplicationAppEntity> {
-        .init(items: WidgetComplicationResolver.configs(family: .circular)
-            .map(WidgetCircularComplicationAppEntity.init(config:)))
+        let items = WidgetComplicationResolver.configs(family: .circular)
+            .map(WidgetCircularComplicationAppEntity.init(config:))
+        return .init(items: items)
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
@@ -1,0 +1,157 @@
+import Foundation
+import HAKit
+import Shared
+
+/// Loads a watch complication the user already built and resolves it into the shared
+/// `ComplicationRenderContext`, so a lock-screen widget can render it through the very same content
+/// views the watch and the complication editor use.
+@available(iOS 17.0, *)
+enum WidgetComplicationResolver {
+    enum ResolveError: Error {
+        case noComplication
+        case noServer
+        case unavailable
+    }
+
+    /// The user's complications for a family, in the order they appear in the app.
+    static func configs(family: WatchComplicationConfig.Family) -> [WatchComplicationConfig] {
+        do {
+            return try WatchComplicationConfig.all().filter { $0.widgetFamily == family }
+        } catch {
+            Current.Log.error("Failed to load complication configs for widget: \(error)")
+            return []
+        }
+    }
+
+    /// Resolves the complication with `id` against live data. Entity complications read the plain
+    /// `/states` API; template complications render their templates server-side (admin only, same as
+    /// the widgets' template source).
+    static func context(
+        id: String,
+        family: WatchComplicationConfig.Family
+    ) async throws -> ComplicationRenderContext {
+        guard let config = configs(family: family).first(where: { $0.id == id }) else {
+            Current.Log.error("Failed to render complication widget: complication \(id) no longer exists")
+            throw ResolveError.noComplication
+        }
+        guard let server = Current.servers.all.first(where: { $0.identifier.rawValue == config.serverId }) else {
+            Current.Log.error("Failed to render complication widget: server \(config.serverId) no longer exists")
+            throw ResolveError.noServer
+        }
+
+        switch config.kind {
+        case .entity:
+            return try await entityContext(config: config, family: family, server: server)
+        case .customTemplate:
+            return await templateContext(config: config, family: family, server: server)
+        }
+    }
+
+    private static func entityContext(
+        config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family,
+        server: Server
+    ) async throws -> ComplicationRenderContext {
+        guard let entityId = config.entityId else {
+            throw ResolveError.noComplication
+        }
+        guard let fetched = await ControlEntityProvider(domains: []).rawState(server: server, entityId: entityId) else {
+            Current.Log.error("Failed to fetch state for complication widget entity \(entityId)")
+            throw ResolveError.unavailable
+        }
+        return .entity(
+            config: config,
+            family: family,
+            state: fetched.state,
+            attributes: fetched.attributes
+        )
+    }
+
+    /// Template complications render their text, gauge and color templates server-side. A template
+    /// that fails to render keeps the statically configured value rather than blanking the face, which
+    /// is what the watch does too.
+    private static func templateContext(
+        config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family,
+        server: Server
+    ) async -> ComplicationRenderContext {
+        var familyConfig = config
+        familyConfig.widgetFamily = family
+
+        let value = await render(config.customTextTemplate, server: server) ?? ""
+        let renderedGauge = await render(config.customGaugeTemplate, server: server)
+        let fraction = renderedGauge
+            .flatMap { WatchComplication.percentileNumber(from: $0) }
+            .map { Swift.min(Swift.max(Double($0), 0), 1) }
+
+        // Color templates override the static pickers on every size, exactly as on the watch.
+        if let iconColor = await renderColor(config.customIconColorTemplate, server: server) {
+            familyConfig.iconColor = iconColor
+        }
+        let gaugeColor = await renderColor(config.customGaugeColorTemplate, server: server)
+        let textColor = await renderColor(config.customTextColorTemplate, server: server)
+        var options = familyConfig.options(for: family)
+        options.tint = gaugeColor ?? options.tint
+        options.textColor = textColor ?? options.textColor
+        // A template complication gauges off its gauge template, not a numeric range: the watch draws
+        // one whenever that template rendered, unless the size explicitly turned the gauge off.
+        if options.showGauge != false {
+            options.showGauge = fraction != nil
+        }
+        familyConfig.setOptions(options, for: family)
+
+        // Slot formulas may reference further templates; each is rendered once, the main one reused.
+        var renderedTemplates: [String: String] = [:]
+        if let mainTemplate = config.customTextTemplate {
+            renderedTemplates[mainTemplate] = value
+        }
+        let slotTemplates = Set((familyConfig.families ?? [:]).values
+            .flatMap { ($0.slots ?? [:]).values }
+            .flatMap { $0.formula?.templates ?? [] })
+            .subtracting(renderedTemplates.keys)
+        for template in slotTemplates {
+            if let rendered = await render(template, server: server) {
+                renderedTemplates[template] = rendered
+            }
+        }
+
+        return ComplicationRenderContext(
+            config: familyConfig,
+            value: value,
+            fraction: fraction,
+            iconImage: ComplicationRenderContext.icon(for: familyConfig, family: family),
+            renderedTemplates: renderedTemplates
+        )
+    }
+
+    private static func renderColor(_ template: String?, server: Server) async -> String? {
+        guard let rendered = await render(template, server: server) else { return nil }
+        return WatchComplicationConfig.normalizedHexColor(from: rendered)
+    }
+
+    private static func render(_ template: String?, server: Server) async -> String? {
+        guard let template, !template.isEmpty, let connection = Current.api(for: server)?.connection else {
+            return nil
+        }
+        let result = await withCheckedContinuation { continuation in
+            connection.send(.init(
+                type: .rest(.post, "template"),
+                data: ["template": template],
+                shouldRetry: true
+            )) { result in
+                continuation.resume(returning: result)
+            }
+        }
+        switch result {
+        case let .success(data):
+            guard case let .primitive(response) = data, let rendered = response as? String else {
+                Current.Log.error("Failed to render complication widget template: bad response data")
+                return nil
+            }
+            return rendered
+        case let .failure(error):
+            Current.Log.error("Failed to render complication widget template: \(error)")
+            return nil
+        }
+    }
+}

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
@@ -105,9 +105,8 @@ enum WidgetComplicationResolver {
         if let mainTemplate = config.customTextTemplate {
             renderedTemplates[mainTemplate] = value
         }
-        let slotTemplates = Set((familyConfig.families ?? [:]).values
-            .flatMap { ($0.slots ?? [:]).values }
-            .flatMap { $0.formula?.templates ?? [] })
+        let slotConfigs = (familyConfig.families ?? [:]).values.flatMap { ($0.slots ?? [:]).values }
+        let slotTemplates = Set(slotConfigs.flatMap { $0.formula?.templates ?? [] })
             .subtracting(renderedTemplates.keys)
         for template in slotTemplates {
             if let rendered = await render(template, server: server) {

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetComplicationResolver.swift
@@ -67,9 +67,9 @@ enum WidgetComplicationResolver {
         )
     }
 
-    /// Template complications render their text, gauge and color templates server-side. A template
-    /// that fails to render keeps the statically configured value rather than blanking the face, which
-    /// is what the watch does too.
+    /// Template complications render their text, gauge and color templates server-side, the way the
+    /// watch does. A color template that fails to render keeps the statically configured color; a text
+    /// or gauge template that fails leaves that slot empty, since it has no static value to fall back on.
     private static func templateContext(
         config: WatchComplicationConfig,
         family: WatchComplicationConfig.Family,

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetRectangularComplicationAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetRectangularComplicationAppEntity.swift
@@ -40,7 +40,8 @@ struct WidgetRectangularComplicationAppEntityQuery: EntityQuery {
     }
 
     func suggestedEntities() async throws -> IntentItemCollection<WidgetRectangularComplicationAppEntity> {
-        .init(items: WidgetComplicationResolver.configs(family: .rectangular)
-            .map(WidgetRectangularComplicationAppEntity.init(config:)))
+        let items = WidgetComplicationResolver.configs(family: .rectangular)
+            .map(WidgetRectangularComplicationAppEntity.init(config:))
+        return .init(items: items)
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/Complication/WidgetRectangularComplicationAppEntity.swift
+++ b/Sources/Extensions/AppIntents/Widget/Complication/WidgetRectangularComplicationAppEntity.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import Foundation
+import Shared
+
+/// One of the user's rectangular watch complications, offered to the details widget's complication
+/// source. `id` is the `WatchComplicationConfig` id.
+///
+/// Rectangular only: the details widget's accessory family is rectangular, so mirroring a complication
+/// designed for any other family would render a layout it was never laid out for.
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct WidgetRectangularComplicationAppEntity: AppEntity {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(
+        name: .init("widgets.parameters.complication", defaultValue: "Complication")
+    )
+    static let defaultQuery = WidgetRectangularComplicationAppEntityQuery()
+
+    var id: String
+    var name: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    init(config: WatchComplicationConfig) {
+        self.init(id: config.id, name: config.displayName)
+    }
+}
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct WidgetRectangularComplicationAppEntityQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [WidgetRectangularComplicationAppEntity] {
+        WidgetComplicationResolver.configs(family: .rectangular)
+            .filter { identifiers.contains($0.id) }
+            .map(WidgetRectangularComplicationAppEntity.init(config:))
+    }
+
+    func suggestedEntities() async throws -> IntentItemCollection<WidgetRectangularComplicationAppEntity> {
+        .init(items: WidgetComplicationResolver.configs(family: .rectangular)
+            .map(WidgetRectangularComplicationAppEntity.init(config:)))
+    }
+}

--- a/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntent.swift
@@ -13,7 +13,7 @@ struct WidgetDetailsAppIntent: WidgetConfigurationIntent {
         )
     )
 
-    @Parameter(title: .init("widgets.content_source.title", defaultValue: "Source"), default: .template)
+    @Parameter(title: .init("widgets.content_source.title", defaultValue: "Source"), default: .entity)
     var source: WidgetContentSourceAppEnum
 
     @Parameter(title: .init("widgets.details.parameters.server", defaultValue: "Server"), default: nil)
@@ -27,6 +27,11 @@ struct WidgetDetailsAppIntent: WidgetConfigurationIntent {
     /// Optional attribute of `entity` to read instead of its state (nil = state), like the watch builder.
     @Parameter(title: .init("widgets.parameters.attribute", defaultValue: "Attribute"))
     var attribute: WidgetDetailsAttributeAppEntity?
+
+    /// Rectangular watch complication mirrored when `source` is `.complication`, rendered through the
+    /// very same content view the watch and the complication editor use.
+    @Parameter(title: .init("widgets.parameters.complication", defaultValue: "Complication"))
+    var complication: WidgetRectangularComplicationAppEntity?
 
     @Parameter(
         title: .init("widgets.details.parameters.upper_template", defaultValue: "Upper Text Template"),
@@ -113,6 +118,25 @@ struct WidgetDetailsAppIntent: WidgetConfigurationIntent {
                         \.$source
                         \.$entity
                         \.$attribute
+
+                        \.$runScript
+                    }
+                }
+            }
+            Case(.complication) {
+                When(\WidgetDetailsAppIntent.$runScript, .equalTo, true) {
+                    Summary {
+                        \.$source
+                        \.$complication
+
+                        \.$runScript
+                        \.$script
+                        \.$showConfirmationNotification
+                    }
+                } otherwise: {
+                    Summary {
+                        \.$source
+                        \.$complication
 
                         \.$runScript
                     }

--- a/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntent.swift
@@ -8,8 +8,8 @@ struct WidgetDetailsAppIntent: WidgetConfigurationIntent {
     static let title: LocalizedStringResource = .init("widgets.details.title", defaultValue: "Details")
     static let description = IntentDescription(
         .init(
-            "widgets.details.description_with_warning",
-            defaultValue: "Display states using from Home Assistant in text. ATTENTION: User needs to be admin to use this feature"
+            "widgets.details.gallery_description",
+            defaultValue: "Display an entity, a watch complication, or a template from Home Assistant as text"
         )
     )
 

--- a/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Details/WidgetDetailsAppIntentTimelineProvider.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import HAKit
+import HAWatchComplications
 import Shared
 import WidgetKit
 
@@ -70,9 +71,36 @@ struct WidgetDetailsAppIntentTimelineProvider: AppIntentTimelineProvider {
         switch configuration.source {
         case .entity:
             return try await entityEntry(for: configuration)
+        case .complication:
+            return try await complicationEntry(for: configuration)
         case .template:
             return try await templateEntry(for: configuration)
         }
+    }
+
+    /// Mirrors one of the user's rectangular watch complications. The rectangular family draws the
+    /// resolved render model through the shared complication content view; the inline family, which has
+    /// no complication layout of its own, falls back to the resolved title and value on one line.
+    private func complicationEntry(for configuration: WidgetDetailsAppIntent) async throws -> Entry {
+        guard let complication = configuration.complication else {
+            Current.Log.error("Failed to fetch data for details widget: No complication selected")
+            throw WidgetDetailsDataError.noComplication
+        }
+        let context = try await WidgetComplicationResolver.context(id: complication.id, family: .rectangular)
+        let inlineText = [context.titleText, context.valueText]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        return .init(
+            upperText: inlineText.isEmpty ? nil : inlineText,
+            lowerText: nil,
+            detailsText: nil,
+            complicationModel: context.rectangularRenderModel,
+
+            runScript: configuration.runScript,
+            script: configuration.script,
+            showConfirmationNotification: configuration.showConfirmationNotification
+        )
     }
 
     /// Builds the widget from a single picked entity's live state, fetched over the REST `/states`
@@ -188,6 +216,9 @@ struct WidgetDetailsEntry: TimelineEntry {
     var upperText: String?
     var lowerText: String?
     var detailsText: String?
+    /// Set only by the complication source: the rectangular family renders this through the shared
+    /// watch complication content view instead of the three text lines.
+    var complicationModel: RectangularComplicationRenderModel?
 
     var runScript: Bool
     var script: IntentScriptEntity?
@@ -197,6 +228,7 @@ struct WidgetDetailsEntry: TimelineEntry {
 enum WidgetDetailsDataError: Error {
     case noServers
     case noEntity
+    case noComplication
     case apiError
     case badResponse
 }

--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntent.swift
@@ -8,8 +8,8 @@ struct WidgetGaugeAppIntent: WidgetConfigurationIntent {
     static let title: LocalizedStringResource = .init("widgets.gauge.title", defaultValue: "Actions")
     static let description = IntentDescription(
         .init(
-            "widgets.gauge.description_with_warning",
-            defaultValue: "Display numeric states from Home Assistant in a gauge, ATTENTION: User needs to be admin to use this feature"
+            "widgets.gauge.gallery_description",
+            defaultValue: "Display an entity, a watch complication, or a template from Home Assistant in a gauge"
         )
     )
 

--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntent.swift
@@ -13,7 +13,7 @@ struct WidgetGaugeAppIntent: WidgetConfigurationIntent {
         )
     )
 
-    @Parameter(title: .init("widgets.content_source.title", defaultValue: "Source"), default: .template)
+    @Parameter(title: .init("widgets.content_source.title", defaultValue: "Source"), default: .entity)
     var source: WidgetContentSourceAppEnum
 
     @Parameter(title: .init("widgets.gauge.parameters.gauge_type", defaultValue: "Gauge Type"), default: .normal)
@@ -30,6 +30,12 @@ struct WidgetGaugeAppIntent: WidgetConfigurationIntent {
     /// Optional attribute of `entity` to read instead of its state (nil = state), like the watch builder.
     @Parameter(title: .init("widgets.parameters.attribute", defaultValue: "Attribute"))
     var attribute: WidgetGaugeAttributeAppEntity?
+
+    /// Circular watch complication mirrored when `source` is `.complication`, rendered through the very
+    /// same content view the watch and the complication editor use. The complication carries its own
+    /// gauge style, so `gaugeType` does not apply to it.
+    @Parameter(title: .init("widgets.parameters.complication", defaultValue: "Complication"))
+    var complication: WidgetCircularComplicationAppEntity?
 
     /// Numeric value mapped to an empty gauge (fill 0) when using the entity source.
     @Parameter(title: .init("widgets.gauge.parameters.min_value", defaultValue: "Minimum Value"), default: 0)
@@ -160,6 +166,25 @@ struct WidgetGaugeAppIntent: WidgetConfigurationIntent {
 
                         \.$minValue
                         \.$maxValue
+
+                        \.$runScript
+                    }
+                }
+            }
+            Case(.complication) {
+                When(\WidgetGaugeAppIntent.$runScript, .equalTo, true) {
+                    Summary {
+                        \.$source
+                        \.$complication
+
+                        \.$runScript
+                        \.$script
+                        \.$showConfirmationNotification
+                    }
+                } otherwise: {
+                    Summary {
+                        \.$source
+                        \.$complication
 
                         \.$runScript
                     }

--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import HAKit
+import HAWatchComplications
 import Shared
 import WidgetKit
 
@@ -76,9 +77,35 @@ struct WidgetGaugeAppIntentTimelineProvider: AppIntentTimelineProvider {
         switch configuration.source {
         case .entity:
             return try await entityEntry(for: configuration)
+        case .complication:
+            return try await complicationEntry(for: configuration)
         case .template:
             return try await templateEntry(for: configuration)
         }
+    }
+
+    /// Mirrors one of the user's circular watch complications: the entry carries the resolved render
+    /// model and the view draws it through the shared complication content view, so the complication's
+    /// own gauge style, colors and slots decide how it looks — not the widget's `gaugeType`.
+    private func complicationEntry(for configuration: WidgetGaugeAppIntent) async throws -> Entry {
+        guard let complication = configuration.complication else {
+            Current.Log.error("Failed to fetch data for gauge widget: No complication selected")
+            throw WidgetGaugeDataError.noComplication
+        }
+        let context = try await WidgetComplicationResolver.context(id: complication.id, family: .circular)
+
+        return .init(
+            gaugeType: configuration.gaugeType,
+
+            value: context.showsGauge ? (context.fraction ?? 0) : 0,
+
+            valueLabel: context.valueText,
+            complicationModel: context.circularRenderModel,
+
+            runScript: configuration.runScript,
+            script: configuration.script,
+            showConfirmationNotification: configuration.showConfirmationNotification
+        )
     }
 
     /// Builds the gauge from a single picked entity's live state, fetched over the REST `/states`
@@ -224,6 +251,9 @@ struct WidgetGaugeEntry: TimelineEntry {
     var label: String?
     var min: String?
     var max: String?
+    /// Set only by the complication source: every family renders this through the shared circular
+    /// watch complication content view instead of the widget's own gauge.
+    var complicationModel: CircularComplicationRenderModel?
 
     var runScript: Bool
     var script: IntentScriptEntity?
@@ -233,6 +263,7 @@ struct WidgetGaugeEntry: TimelineEntry {
 enum WidgetGaugeDataError: Error {
     case noServers
     case noEntity
+    case noComplication
     case apiError
     case badResponse
 }

--- a/Sources/Extensions/AppIntents/Widget/WidgetContentSourceAppEnum.swift
+++ b/Sources/Extensions/AppIntents/Widget/WidgetContentSourceAppEnum.swift
@@ -6,6 +6,10 @@ enum WidgetContentSourceAppEnum: String, Codable, Sendable, AppEnum {
     /// The widget picks a single entity and its value is generated automatically from the entity's state.
     case entity
 
+    /// The widget mirrors one of the watch complications the user already built, rendered by the very
+    /// same views the watch and the complication editor use.
+    case complication
+
     /// The user provides Jinja templates rendered by the server (requires an admin user).
     case template
 
@@ -14,6 +18,10 @@ enum WidgetContentSourceAppEnum: String, Codable, Sendable, AppEnum {
     )
     static var caseDisplayRepresentations: [WidgetContentSourceAppEnum: DisplayRepresentation] = [
         .entity: DisplayRepresentation(title: .init("widgets.content_source.entity", defaultValue: "Entity")),
+        .complication: DisplayRepresentation(title: .init(
+            "widgets.content_source.complication",
+            defaultValue: "Complication"
+        )),
         .template: DisplayRepresentation(title: .init("widgets.content_source.template", defaultValue: "Template")),
     ]
 }

--- a/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
@@ -25,7 +25,7 @@ struct WidgetDetails: Widget {
         }
         .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.Widgets.Details.title)
-        .description(L10n.Widgets.Details.descriptionWithWarning)
+        .description(L10n.Widgets.Details.galleryDescription)
         .supportedFamilies(WidgetDetailsSupportedFamilies.families)
         .disfavoredInCarPlayIfAvailable(for: WidgetDetailsSupportedFamilies.families)
     }

--- a/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetails.swift
@@ -1,3 +1,4 @@
+import HAWatchComplications
 import Intents
 import Shared
 import SwiftUI
@@ -46,3 +47,29 @@ enum WidgetDetailsSupportedFamilies {
         .accessoryRectangular,
     ]
 }
+
+// A mirrored watch complication: the entry carries the render model and the widget draws it through
+// the shared rectangular complication content view.
+@available(iOS 17, *)
+#Preview(as: .accessoryRectangular, widget: {
+    WidgetDetails()
+}, timeline: {
+    WidgetDetailsEntry(
+        upperText: "Battery 68%",
+        complicationModel: RectangularComplicationRenderModel(
+            title: "Battery",
+            showsName: true,
+            subtitle: "Kitchen",
+            showsSubtitle: true,
+            fraction: 0.68,
+            minLabel: "0",
+            maxLabel: "100",
+            valueText: "68%",
+            showsValue: true,
+            tint: .green
+        ),
+        runScript: false,
+        script: nil,
+        showConfirmationNotification: true
+    )
+})

--- a/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetailsView.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Details/WidgetDetailsView.swift
@@ -1,3 +1,4 @@
+import HAWatchComplications
 import SwiftUI
 import WidgetKit
 
@@ -8,7 +9,11 @@ struct WidgetDetailsView: View {
     var entry: WidgetDetailsEntry
 
     var body: some View {
-        if family == .accessoryRectangular {
+        // The complication source renders through the very same content view the watch and the
+        // complication editor use, so a mirrored complication looks identical on the lock screen.
+        if family == .accessoryRectangular, let model = entry.complicationModel {
+            RectangularComplicationContentView(model: model)
+        } else if family == .accessoryRectangular {
             VStack(alignment: .leading) {
                 if entry.upperText != nil {
                     Text(entry.upperText!)

--- a/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
@@ -1,3 +1,4 @@
+import HAWatchComplications
 import Intents
 import Shared
 import SwiftUI
@@ -88,6 +89,32 @@ enum WidgetGaugeSupportedFamilies {
         label: nil,
         min: "0",
         max: "100",
+        runScript: false,
+        script: nil,
+        showConfirmationNotification: true
+    )
+})
+
+// A mirrored watch complication: the entry carries the render model and the widget draws it through
+// the shared circular complication content view.
+@available(iOS 17, *)
+#Preview(as: .accessoryCircular, widget: {
+    WidgetGauge()
+}, timeline: {
+    WidgetGaugeEntry(
+        gaugeType: .normal,
+        value: 0.67,
+        valueLabel: "67%",
+        complicationModel: CircularComplicationRenderModel(
+            valueText: "67%",
+            showsValue: true,
+            title: "Battery",
+            showsName: true,
+            fraction: 0.67,
+            minLabel: "0",
+            maxLabel: "100",
+            tint: .green
+        ),
         runScript: false,
         script: nil,
         showConfirmationNotification: true

--- a/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGauge.swift
@@ -25,7 +25,7 @@ struct WidgetGauge: Widget {
         }
         .contentMarginsDisabledIfAvailable()
         .configurationDisplayName(L10n.Widgets.Gauge.title)
-        .description(L10n.Widgets.Gauge.descriptionWithWarning)
+        .description(L10n.Widgets.Gauge.galleryDescription)
         .supportedFamilies(WidgetGaugeSupportedFamilies.families)
     }
 

--- a/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGaugeView.swift
+++ b/Sources/Extensions/Widgets/Lockscreen/Gauge/WidgetGaugeView.swift
@@ -1,3 +1,4 @@
+import HAWatchComplications
 import Shared
 import SwiftUI
 import WidgetKit
@@ -11,11 +12,33 @@ struct WidgetGaugeView: View {
     private static let systemSmallPadding: CGFloat = 10
 
     var body: some View {
-        switch family {
-        case .systemSmall:
-            homeScreen
-        default:
-            nativeGauge
+        // A mirrored complication renders through the very same content view the watch and the
+        // complication editor use, so it carries its own gauge style, colors and slots.
+        if let model = entry.complicationModel {
+            complication(model)
+        } else {
+            switch family {
+            case .systemSmall:
+                homeScreen
+            default:
+                nativeGauge
+            }
+        }
+    }
+
+    /// The complication content view. The lock screen renders it bare, the way the watch face does.
+    /// The Home Screen is full-color, so the complication gets the black face it was designed for —
+    /// its white text and icon would otherwise be invisible on a light tile.
+    @ViewBuilder private func complication(_ model: CircularComplicationRenderModel) -> some View {
+        if family == .systemSmall {
+            CircularComplicationContentView(model: model)
+                .padding(Self.systemSmallPadding)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.black, in: .circle)
+                .environment(\.colorScheme, .dark)
+                .padding(Self.systemSmallPadding)
+        } else {
+            CircularComplicationContentView(model: model)
         }
     }
 

--- a/Sources/HAWatchComplications/Sources/CircularComplicationRenderModel.swift
+++ b/Sources/HAWatchComplications/Sources/CircularComplicationRenderModel.swift
@@ -2,9 +2,10 @@ import SwiftUI
 
 /// The resolved, target-agnostic rendering inputs for the circular complication.
 ///
-/// Both the on-watch `WatchWidgetComplicationSnapshot` (in the WatchWidgets extension) and the in-app
-/// editor's `ComplicationPreviewContext` map their own data into this one struct, so a single
-/// `CircularComplicationContentView` renders identically in the real complication and the preview.
+/// Both the on-watch `WatchWidgetComplicationSnapshot` (in the WatchWidgets extension) and the shared
+/// `ComplicationRenderContext` (the in-app editor preview and the iPhone lock-screen widgets) map their
+/// own data into this one struct, so a single `CircularComplicationContentView` renders identically
+/// everywhere the complication appears.
 public struct CircularComplicationRenderModel {
     public var iconImage: Image?
     public var showsIcon: Bool

--- a/Sources/HAWatchComplications/Sources/InlineComplicationRenderModel.swift
+++ b/Sources/HAWatchComplications/Sources/InlineComplicationRenderModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 ///
 /// Inline is a single line of text with no icon or custom colors — watchOS renders it in the face's
 /// tint. Both the on-watch `WatchWidgetComplicationSnapshot` and the in-app editor's
-/// `ComplicationPreviewContext` resolve the whole line into `text`, so `InlineComplicationContentView`
+/// `ComplicationRenderContext` resolve the whole line into `text`, so `InlineComplicationContentView`
 /// renders identically in the real complication and the preview.
 public struct InlineComplicationRenderModel {
     /// The whole resolved line (e.g. the title slot's "{name} - {value}" formula).

--- a/Sources/HAWatchComplications/Sources/RectangularComplicationRenderModel.swift
+++ b/Sources/HAWatchComplications/Sources/RectangularComplicationRenderModel.swift
@@ -2,9 +2,10 @@ import SwiftUI
 
 /// The resolved, target-agnostic rendering inputs for the rectangular complication.
 ///
-/// Both the on-watch `WatchWidgetComplicationSnapshot` (in the WatchWidgets extension) and the in-app
-/// editor's `ComplicationPreviewContext` map their own data into this one struct, so a single
-/// `RectangularComplicationContentView` renders identically in the real complication and the preview.
+/// Both the on-watch `WatchWidgetComplicationSnapshot` (in the WatchWidgets extension) and the shared
+/// `ComplicationRenderContext` (the in-app editor preview and the iPhone lock-screen widgets) map their
+/// own data into this one struct, so a single `RectangularComplicationContentView` renders identically
+/// everywhere the complication appears.
 /// This is the seam that guarantees the preview can't drift from the watch.
 public struct RectangularComplicationRenderModel {
     public var iconImage: Image?

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -117,6 +117,39 @@ public final class ControlEntityProvider {
         return state["attributes"] as? [String: Any]
     }
 
+    /// Fetches an entity's raw state string and attributes in one REST `/states` call, with no
+    /// precision or capitalization applied. Callers that do their own formatting (the complication
+    /// render pipeline, which owns precision + unit) need the untouched value.
+    public func rawState(server: Server, entityId: String) async -> (state: String, attributes: [String: Any])? {
+        guard let connection = Current.api(for: server)?.connection else {
+            Current.Log.error("No API available to fetch raw state data")
+            return nil
+        }
+
+        let result = await withCheckedContinuation { continuation in
+            connection.send(.init(
+                type: .rest(.get, "states/\(entityId)"),
+                shouldRetry: true
+            )) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        guard let data = try? result.get() else {
+            if case let .failure(error) = result {
+                Current.Log.error("Failed to get raw state: \(error)")
+            }
+            return nil
+        }
+
+        guard case let .dictionary(json) = data, let state = json["state"] as? String else {
+            Current.Log.error("Failed to get raw state: bad response data")
+            return nil
+        }
+
+        return (state, json["attributes"] as? [String: Any] ?? [:])
+    }
+
     public func state(server: Server, entityId: String) async -> State? {
         guard let connection = Current.api(for: server)?.connection else {
             Current.Log.error("No API available to fetch state data")

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -8370,8 +8370,8 @@ public enum L10n {
     public enum Details {
       /// Display states using from Home Assistant in text
       public static var description: String { return L10n.tr("Localizable", "widgets.details.description") }
-      /// Display states using from Home Assistant in text. ATTENTION: User needs to be admin for templating access
-      public static var descriptionWithWarning: String { return L10n.tr("Localizable", "widgets.details.description_with_warning") }
+      /// Display an entity, a watch complication, or a template from Home Assistant as text
+      public static var galleryDescription: String { return L10n.tr("Localizable", "widgets.details.gallery_description") }
       /// Details
       public static var title: String { return L10n.tr("Localizable", "widgets.details.title") }
       public enum Parameters {
@@ -8436,8 +8436,8 @@ public enum L10n {
     public enum Gauge {
       /// Display numeric states from Home Assistant in a gauge
       public static var description: String { return L10n.tr("Localizable", "widgets.gauge.description") }
-      /// Display numeric states from Home Assistant in a gauge. ATTENTION: User needs to be admin for templating access
-      public static var descriptionWithWarning: String { return L10n.tr("Localizable", "widgets.gauge.description_with_warning") }
+      /// Display an entity, a watch complication, or a template from Home Assistant in a gauge
+      public static var galleryDescription: String { return L10n.tr("Localizable", "widgets.gauge.gallery_description") }
       /// Gauge
       public static var title: String { return L10n.tr("Localizable", "widgets.gauge.title") }
       public enum Parameters {

--- a/Sources/Shared/Watch/Complications/ComplicationRenderContext.swift
+++ b/Sources/Shared/Watch/Complications/ComplicationRenderContext.swift
@@ -55,7 +55,7 @@ public struct ComplicationRenderContext {
     public var gaugeStyle: WatchComplicationConfig.GaugeStyle { config.gaugeStyle(for: family) }
 
     /// Gauge/ring tint; defaults to the accent color.
-    public var tint: Color { config.tint(for: family).map { Color(uiColor: UIColor($0)) } ?? .accentColor }
+    public var tint: Color { config.tint(for: family).map { Color(uiColor: UIColor(hex: $0)) } ?? .accentColor }
     /// The configured value/text color, or nil when the complication sets none — so a surface that
     /// isn't drawing on the black watch face can fall back to its own primary color.
     public var configuredTextColor: Color? {
@@ -125,7 +125,9 @@ public extension ComplicationRenderContext {
         let precision = config.valuePrecision ?? config.entityId.flatMap {
             EntityRegistryListForDisplay.Entity.displayPrecision(serverId: config.serverId, entityId: $0)
         }
-        let value = state.isEmpty ? "" : formatValue(raw, unit: unit, precision: precision)
+        // Gated on the resolved value, not the state: an entity whose state is empty can still have a
+        // value attribute selected, and blanking that would drop a value the face does have.
+        let value = raw.isEmpty ? "" : formatValue(raw, unit: unit, precision: precision)
 
         // Fraction depends on the family's gauge range.
         var fraction: Double?

--- a/Sources/Shared/Watch/Complications/ComplicationRenderContext.swift
+++ b/Sources/Shared/Watch/Complications/ComplicationRenderContext.swift
@@ -1,0 +1,208 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+/// The resolved rendering inputs a complication face needs, derived once from a
+/// `WatchComplicationConfig` plus the live entity state (or rendered templates).
+///
+/// Lives in `Shared` because three surfaces render the very same complication: the watch itself, the
+/// in-app editor preview, and the iPhone lock-screen widgets that can mirror a complication. Each of
+/// them maps this context into the `HAWatchComplications` render models, so the value / unit /
+/// precision / fraction / slot resolution is decided in exactly one place.
+public struct ComplicationRenderContext {
+    public let config: WatchComplicationConfig
+    /// The value text (already unit-appended when applicable).
+    public let value: String
+    /// The gauge fraction (0...1), or nil when there's no gauge value.
+    public let fraction: Double?
+    /// The icon image, already gated by the "show icon" toggle (nil when hidden or none).
+    public let iconImage: Image?
+    /// Raw entity attributes (entity kind), so slot formulas referencing `{attr:…}` resolve
+    /// exactly like on the watch.
+    public var attributes: [String: Any] = [:]
+    /// Pre-rendered templates for formula resolution. A caller that only renders the main text
+    /// template leaves extra templates in customized slot formulas resolving empty here.
+    public var renderedTemplates: [String: String] = [:]
+
+    public init(
+        config: WatchComplicationConfig,
+        value: String,
+        fraction: Double?,
+        iconImage: Image?,
+        attributes: [String: Any] = [:],
+        renderedTemplates: [String: String] = [:]
+    ) {
+        self.config = config
+        self.value = value
+        self.fraction = fraction
+        self.iconImage = iconImage
+        self.attributes = attributes
+        self.renderedTemplates = renderedTemplates
+    }
+
+    private var family: WatchComplicationConfig.Family { config.widgetFamily }
+
+    public var name: String { config.faceName }
+    public var showsValue: Bool { config.isSlotVisible(.value, for: family) }
+    public var showsName: Bool { config.isSlotVisible(.title, for: family) }
+    public var showsSubtitle: Bool { config.isSlotVisible(.subtitle, for: family) }
+    public var showsBottomText: Bool { config.isSlotVisible(.bottomText, for: family) }
+    public var showsMin: Bool { config.showsMin(for: family) }
+    public var showsMax: Bool { config.showsMax(for: family) }
+    /// Whether a gauge is drawn — needs both the toggle on and an actual value.
+    public var showsGauge: Bool { config.showsGauge(for: family) && fraction != nil }
+    public var range: (min: Double, max: Double)? { config.gaugeRange(for: family) }
+    public var gaugeStyle: WatchComplicationConfig.GaugeStyle { config.gaugeStyle(for: family) }
+
+    /// Gauge/ring tint; defaults to the accent color.
+    public var tint: Color { config.tint(for: family).map { Color(uiColor: UIColor($0)) } ?? .accentColor }
+    /// The configured value/text color, or nil when the complication sets none — so a surface that
+    /// isn't drawing on the black watch face can fall back to its own primary color.
+    public var configuredTextColor: Color? {
+        config.textColor(for: family).map { Color(uiColor: UIColor(hex: $0)) }
+    }
+
+    /// Value/text color; defaults to white for contrast on the dark complication face.
+    public var textColor: Color { configuredTextColor ?? .white }
+    /// Per-slot bottom text color override; nil falls back to `textColor` in the rendered view.
+    public var bottomTextColor: Color? {
+        config.slotColor(.bottomText, for: family).map { Color(uiColor: UIColor(hex: $0)) }
+    }
+
+    /// Min/max are whole numbers.
+    public func label(_ value: Double) -> String { String(Int(value.rounded())) }
+
+    // MARK: - Slot texts (same resolution as the watch's snapshot builder)
+
+    private func slotText(_ slot: ComplicationSlot) -> String {
+        ComplicationFormulaResolver.resolve(
+            config.formula(for: slot, family: family),
+            context: ComplicationFormulaContext(
+                entityName: name,
+                formattedState: value,
+                attributeValue: { attributes[$0].map { String(describing: $0) } },
+                renderedTemplates: renderedTemplates
+            )
+        )
+    }
+
+    public var titleText: String { slotText(.title) }
+    public var valueText: String { slotText(.value) }
+    public var subtitleText: String { slotText(.subtitle) }
+    public var bottomText: String { slotText(.bottomText) }
+}
+
+public extension ComplicationRenderContext {
+    /// Build a context for `family` from already-fetched entity data. Centralizes the value / unit /
+    /// fraction / icon resolution so every surface renders identically off one fetch.
+    static func entity(
+        config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family,
+        state: String,
+        attributes: [String: Any]
+    ) -> ComplicationRenderContext {
+        var familyConfig = config
+        familyConfig.widgetFamily = family
+
+        // Value is shared across families: the chosen attribute (or the state), formatted with the
+        // resolved unit + precision.
+        let raw = config.valueAttribute.flatMap { attributes[$0] }.map { String(describing: $0) } ?? state
+        let resolvedUnit: String? = {
+            if let attribute = config.valueAttribute {
+                return WatchComplicationConfig.attributeUnit(
+                    attribute: attribute,
+                    attributes: attributes,
+                    domain: config.entityId?.components(separatedBy: ".").first
+                )
+            }
+            return attributes["unit_of_measurement"] as? String
+        }()
+        let unit: String? = {
+            guard config.showsUnit() else { return nil }
+            if let override = config.unitOverride, !override.isEmpty { return override }
+            return resolvedUnit
+        }()
+        let precision = config.valuePrecision ?? config.entityId.flatMap {
+            EntityRegistryListForDisplay.Entity.displayPrecision(serverId: config.serverId, entityId: $0)
+        }
+        let value = state.isEmpty ? "" : formatValue(raw, unit: unit, precision: precision)
+
+        // Fraction depends on the family's gauge range.
+        var fraction: Double?
+        if let range = familyConfig.gaugeRange(for: family) {
+            let source: Any = familyConfig.gaugeAttribute(for: family).flatMap { attributes[$0] }
+                ?? config.valueAttribute.flatMap { attributes[$0] }
+                ?? state
+            if let rawNumber = WatchComplication.percentileNumber(from: source), range.max > range.min {
+                fraction = min(max((Double(rawNumber) - range.min) / (range.max - range.min), 0), 1)
+            }
+        }
+
+        return ComplicationRenderContext(
+            config: familyConfig,
+            value: value,
+            fraction: fraction,
+            iconImage: icon(for: familyConfig, family: family),
+            attributes: attributes
+        )
+    }
+
+    /// A representative placeholder shown before the user picks an entity/template, so every size renders
+    /// meaningful sample content instead of an empty face. Honors the config's toggles, colors, chosen
+    /// icon, and any typed name.
+    static func mock(
+        config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family
+    ) -> ComplicationRenderContext {
+        var familyConfig = config
+        familyConfig.widgetFamily = family
+        familyConfig.gaugeMin = familyConfig.gaugeMin ?? 0
+        familyConfig.gaugeMax = familyConfig.gaugeMax ?? 100
+        if familyConfig.name == nil, familyConfig.entityDisplayName == nil, familyConfig.entityId == nil {
+            familyConfig.name = "Battery"
+        }
+        // The face's name token ignores the complication name for the entity kind, so the pre-entity
+        // mock needs a stand-in entity name for the title to render.
+        if familyConfig.entityDisplayName == nil, familyConfig.entityId == nil {
+            familyConfig.entityDisplayName = familyConfig.name
+        }
+        return ComplicationRenderContext(
+            config: familyConfig,
+            value: "72%",
+            fraction: 0.72,
+            iconImage: icon(for: familyConfig, family: family, fallback: .gaugeIcon)
+        )
+    }
+
+    /// The complication's icon, gated by the icon slot's visibility (the same resolution the watch
+    /// uses). `fallback` stands in when the config has no icon of its own.
+    static func icon(
+        for config: WatchComplicationConfig,
+        family: WatchComplicationConfig.Family,
+        fallback: MaterialDesignIcons? = nil
+    ) -> Image? {
+        guard config.isSlotVisible(.icon, for: family) else { return nil }
+        guard let icon = config.iconName.map({ MaterialDesignIcons(serversideValueNamed: $0) }) ?? fallback else {
+            return nil
+        }
+        let color = config.iconColor.map { UIColor(hex: $0) } ?? .white
+        return Image(uiImage: icon.image(ofSize: CGSize(width: 64, height: 64), color: color))
+    }
+
+    /// Formats a raw value for display: Home Assistant's (or the user's) decimal precision, then the
+    /// unit appended when there is one.
+    static func formatValue(_ state: String, unit: String?, precision: Int?) -> String {
+        var text = state
+        if let precision, let number = Double(state) {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.minimumFractionDigits = precision
+            formatter.maximumFractionDigits = precision
+            text = formatter.string(from: NSNumber(value: number)) ?? state
+        }
+        if let unit, !unit.isEmpty {
+            text += " \(unit)"
+        }
+        return text
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The details and gauge lock screen widgets defaulted their source to Template, which requires an admin user and a hand-written template before the widget shows anything. Both now default to Entity.

Both also gain a third source, Complication: you pick one of the watch complications you already built and the widget mirrors it on the lock screen, drawn with the same views the watch and the complication editor use — the rectangular layout for the details widget, the circular one for the gauge widget. Each widget only offers the complications built for the family it can reproduce.

To avoid a third copy of the value/unit/precision/gauge/slot resolution, the editor's `ComplicationPreviewContext` moves into `Shared` as `ComplicationRenderContext` and the widgets resolve through it.

The "ATTENTION: User needs to be admin" warning is dropped from both widget descriptions, since it only ever applied to the template source and that is no longer the default. The copy moves to a new `widgets.*.gallery_description` key so translations are refreshed instead of keeping the old warning.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
To be added.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
On the Home Screen (`systemSmall`, gauge widget only) a mirrored complication is drawn on a black circular face, since complications are designed for the watch's black face and their white text and icons would be invisible on a light tile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjVpcrdFmYmLg8enFDH8V9)_