### PR TITLE
Add Assist start mode setting

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1162,6 +1162,7 @@
 				AssistSession.swift,
 				AssistSettingsView.swift,
 				AssistSettingsViewModel.swift,
+				"AssistStartMode+App.swift",
 				AssistView.swift,
 				"AssistView+Build.swift",
 				AssistViewModel.swift,

--- a/Sources/App/Assist/AssistSession.swift
+++ b/Sources/App/Assist/AssistSession.swift
@@ -9,6 +9,8 @@ struct AssistSessionContext {
     let server: Server
     let pipelineId: String
     let autoStartRecording: Bool
+    /// Places the keyboard in the text input as soon as Assist appears.
+    let focusInputOnAppear: Bool
 }
 
 final class AssistSession: ObservableObject {

--- a/Sources/App/Assist/AssistSettingsView.swift
+++ b/Sources/App/Assist/AssistSettingsView.swift
@@ -46,6 +46,7 @@ struct AssistSettingsView: View {
     var body: some View {
         NavigationView {
             Form {
+                startMode
                 muteToggle
                 labs
             }
@@ -66,6 +67,21 @@ struct AssistSettingsView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var startMode: some View {
+        Section {
+            Picker(selection: $viewModel.configuration.startMode) {
+                ForEach(AssistStartMode.allCases) { mode in
+                    Text(mode.localizedTitle)
+                        .tag(mode)
+                }
+            } label: {
+                toggleLabel(symbol: .textBubble, text: L10n.Assist.Settings.StartMode.title)
+            }
+        } footer: {
+            Text(L10n.Assist.Settings.StartMode.footer)
         }
     }
 

--- a/Sources/App/Assist/AssistStartMode+App.swift
+++ b/Sources/App/Assist/AssistStartMode+App.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Shared
+
+extension AssistStartMode {
+    var localizedTitle: String {
+        switch self {
+        case .auto: return L10n.Assist.Settings.StartMode.auto
+        case .voice: return L10n.Assist.Settings.StartMode.voice
+        case .text: return L10n.Assist.Settings.StartMode.text
+        }
+    }
+}

--- a/Sources/App/Assist/AssistView+Build.swift
+++ b/Sources/App/Assist/AssistView+Build.swift
@@ -6,6 +6,7 @@ extension AssistView {
         server: Server,
         preferredPipelineId: String = "",
         autoStartRecording: Bool = false,
+        focusInputOnAppear: Bool = false,
         showCloseButton: Bool = true
     ) -> AssistView {
         let viewModel = AssistViewModel(
@@ -14,7 +15,8 @@ extension AssistView {
             audioRecorder: AudioRecorder(),
             audioPlayer: AudioPlayer(),
             assistService: AssistService(server: server),
-            autoStartRecording: autoStartRecording
+            autoStartRecording: autoStartRecording,
+            focusInputOnAppear: focusInputOnAppear
         )
         return .init(viewModel: viewModel, showCloseButton: showCloseButton)
     }

--- a/Sources/App/Assist/AssistViewModel.swift
+++ b/Sources/App/Assist/AssistViewModel.swift
@@ -27,6 +27,7 @@ final class AssistViewModel: NSObject, ObservableObject {
     private var audioPlayer: AudioPlayerProtocol
     private var assistService: AssistServiceProtocol
     private(set) var autoStartRecording: Bool
+    private(set) var focusInputOnAppear: Bool
 
     private(set) var canSendAudioData = false
     private var configObservationCancellable: AnyDatabaseCancellable?
@@ -44,6 +45,7 @@ final class AssistViewModel: NSObject, ObservableObject {
         audioPlayer: AudioPlayerProtocol,
         assistService: AssistServiceProtocol,
         autoStartRecording: Bool,
+        focusInputOnAppear: Bool = false,
         speechTranscriber: (any SpeechTranscriberProtocol)? = nil,
         speechSynthesizer: (any SpeechSynthesizerProtocol)? = nil
     ) {
@@ -53,6 +55,7 @@ final class AssistViewModel: NSObject, ObservableObject {
         self.audioPlayer = audioPlayer
         self.assistService = assistService
         self.autoStartRecording = autoStartRecording
+        self.focusInputOnAppear = focusInputOnAppear
         self.speechTranscriber = speechTranscriber
         self.speechSynthesizer = speechSynthesizer
         self.configuration = AssistConfiguration.config
@@ -286,8 +289,10 @@ final class AssistViewModel: NSObject, ObservableObject {
         if autoStartRecording {
             Current.Log.info("Auto start recording triggered in Assist")
             autoStartRecording = false
+            focusInputOnAppear = false
             assistWithAudio()
-        } else if Current.isCatalyst {
+        } else if focusInputOnAppear || Current.isCatalyst {
+            focusInputOnAppear = false
             focusOnInput = true
         }
     }
@@ -460,6 +465,7 @@ extension AssistViewModel: AssistSessionDelegate {
             }
             preferredPipelineId = context.pipelineId
             autoStartRecording = context.autoStartRecording
+            focusInputOnAppear = context.focusInputOnAppear
             initialRoutine()
         }
     }

--- a/Sources/App/Assist/MacWindow/AssistWindowView.swift
+++ b/Sources/App/Assist/MacWindow/AssistWindowView.swift
@@ -15,6 +15,7 @@ struct AssistWindowView: View {
                 server: server,
                 preferredPipelineId: model.preferredPipelineId,
                 autoStartRecording: model.autoStartRecording,
+                focusInputOnAppear: model.focusInputOnAppear,
                 showCloseButton: false
             )
             .id(model.revision)
@@ -28,13 +29,20 @@ final class AssistWindowModel: ObservableObject {
     @Published private(set) var server: Server?
     @Published private(set) var preferredPipelineId = ""
     @Published private(set) var autoStartRecording = false
+    @Published private(set) var focusInputOnAppear = false
     /// Bumped on each `configure` so the Assist window builds a fresh session when reused for a new request.
     @Published private(set) var revision = 0
 
-    func configure(server: Server, preferredPipelineId: String, autoStartRecording: Bool) {
+    func configure(
+        server: Server,
+        preferredPipelineId: String,
+        autoStartRecording: Bool,
+        focusInputOnAppear: Bool = false
+    ) {
         self.server = server
         self.preferredPipelineId = preferredPipelineId
         self.autoStartRecording = autoStartRecording
+        self.focusInputOnAppear = focusInputOnAppear
         revision += 1
     }
 }

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -17,7 +17,7 @@ protocol WebViewExternalMessageHandlerProtocol {
     // TODO: Move these methods below to their proper handlers
     func scanImprov()
     func stopImprovScanIfNeeded()
-    func showAssist(server: Server, pipeline: String, autoStartRecording: Bool)
+    func showAssist(server: Server, pipeline: String, autoStartRecording: Bool, focusInputOnAppear: Bool)
 }
 
 final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessageHandlerProtocol {
@@ -151,7 +151,9 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
                 showAssist(
                     server: webViewController.server,
                     pipeline: pipelineId ?? "",
-                    autoStartRecording: startMode.resolveAutoStartRecording(frontendRequested: startListening ?? false)
+                    autoStartRecording: startMode.resolveAutoStartRecording(frontendRequested: startListening ?? false),
+                    // Asking for text explicitly means the user wants to type, so save them a tap.
+                    focusInputOnAppear: startMode == .text
                 )
             case .assistSettings:
                 showAssistSettingsViewController()
@@ -494,12 +496,18 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
         ))
     }
 
-    func showAssist(server: Server, pipeline: String = "", autoStartRecording: Bool = false) {
+    func showAssist(
+        server: Server,
+        pipeline: String = "",
+        autoStartRecording: Bool = false,
+        focusInputOnAppear: Bool = false
+    ) {
         if AssistSession.shared.inProgress {
             AssistSession.shared.requestNewSession(.init(
                 server: server,
                 pipelineId: pipeline,
-                autoStartRecording: autoStartRecording
+                autoStartRecording: autoStartRecording,
+                focusInputOnAppear: focusInputOnAppear
             ))
             return
         }
@@ -510,7 +518,8 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             AssistWindowModel.shared.configure(
                 server: server,
                 preferredPipelineId: pipeline,
-                autoStartRecording: autoStartRecording
+                autoStartRecording: autoStartRecording,
+                focusInputOnAppear: focusInputOnAppear
             )
             Current.sceneManager.activateAnyScene(for: .assist)
         } else {
@@ -518,7 +527,8 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             let assistView = UIHostingController(rootView: AssistView.build(
                 server: server,
                 preferredPipelineId: pipeline,
-                autoStartRecording: autoStartRecording
+                autoStartRecording: autoStartRecording,
+                focusInputOnAppear: focusInputOnAppear
             ))
             assistView.modalPresentationStyle = .fullScreen
             assistView.modalTransitionStyle = .crossDissolve

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -145,10 +145,13 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             case .assistShow:
                 let startListening = incomingMessage.Payload?["start_listening"] as? Bool
                 let pipelineId = incomingMessage.Payload?["pipeline_id"] as? String
+                // The user can override what the frontend asks for, this only applies to Assist
+                // opened from the dashboard.
+                let startMode = AssistConfiguration.config.startMode
                 showAssist(
                     server: webViewController.server,
                     pipeline: pipelineId ?? "",
-                    autoStartRecording: startListening ?? false
+                    autoStartRecording: startMode.resolveAutoStartRecording(frontendRequested: startListening ?? false)
                 )
             case .assistSettings:
                 showAssistSettingsViewController()

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -185,7 +185,8 @@ class IncomingURLHandler {
                     webViewController.webViewExternalMessageHandler.showAssist(
                         server: server,
                         pipeline: pipelineId,
-                        autoStartRecording: startlistening
+                        autoStartRecording: startlistening,
+                        focusInputOnAppear: false
                     )
                 }
             case .createCustomWidget:

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -183,6 +183,11 @@
 "assist.settings.on_device_tts.voice" = "Voice";
 "assist.settings.section.experimental.title" = "Experimental";
 "assist.settings.section.labs.title" = "More";
+"assist.settings.start_mode.auto" = "Auto";
+"assist.settings.start_mode.footer" = "Controls how Assist starts when you trigger it from a Home Assistant dashboard. \"Auto\" follows what the dashboard asks for, while \"Voice\" and \"Text\" always override it. This does not apply to widgets, shortcuts or other app features.";
+"assist.settings.start_mode.text" = "Text";
+"assist.settings.start_mode.title" = "Assist start mode";
+"assist.settings.start_mode.voice" = "Voice";
 "assist.settings.title" = "Assist Settings";
 "assist.settings.tts_mute.footer" = "When enabled, Assist will not play audio responses even if the pipeline has text-to-speech configured. You will still see text responses.";
 "assist.settings.tts_mute.toggle" = "Mute voice responses";

--- a/Sources/Extensions/Widgets/Assist/AssistAppIntent.swift
+++ b/Sources/Extensions/Widgets/Assist/AssistAppIntent.swift
@@ -33,7 +33,8 @@ struct AssistAppIntent: AppIntent {
                     webViewController.webViewExternalMessageHandler.showAssist(
                         server: server,
                         pipeline: pipeline.pipelineId ?? "",
-                        autoStartRecording: withVoice
+                        autoStartRecording: withVoice,
+                        focusInputOnAppear: false
                     )
                 }
         }

--- a/Sources/HAModels/Sources/AssistConfiguration.swift
+++ b/Sources/HAModels/Sources/AssistConfiguration.swift
@@ -13,6 +13,8 @@ public struct AssistConfiguration: Codable, Identifiable, Equatable, Persistable
     public var muteTTS: Bool = false
     public var enableOnDeviceTTS: Bool = false
     public var onDeviceTTSVoiceIdentifier: String? = nil
+    /// How Assist opens when triggered from the frontend dashboard.
+    public var startMode: AssistStartMode = .auto
 
     /// Custom row initializer to handle NULL values from migrated columns.
     public init(row: Row) throws {
@@ -22,6 +24,7 @@ public struct AssistConfiguration: Codable, Identifiable, Equatable, Persistable
         self.muteTTS = row[DatabaseTables.AssistConfiguration.muteTTS.rawValue] ?? false
         self.enableOnDeviceTTS = row[DatabaseTables.AssistConfiguration.enableOnDeviceTTS.rawValue] ?? false
         self.onDeviceTTSVoiceIdentifier = row[DatabaseTables.AssistConfiguration.onDeviceTTSVoiceIdentifier.rawValue]
+        self.startMode = row[DatabaseTables.AssistConfiguration.startMode.rawValue] ?? .auto
     }
 
     public init(
@@ -30,7 +33,8 @@ public struct AssistConfiguration: Codable, Identifiable, Equatable, Persistable
         onDeviceSTTLocaleIdentifier: String? = nil,
         muteTTS: Bool = false,
         enableOnDeviceTTS: Bool = false,
-        onDeviceTTSVoiceIdentifier: String? = nil
+        onDeviceTTSVoiceIdentifier: String? = nil,
+        startMode: AssistStartMode = .auto
     ) {
         self.id = id
         self.enableOnDeviceSTT = enableOnDeviceSTT
@@ -38,5 +42,6 @@ public struct AssistConfiguration: Codable, Identifiable, Equatable, Persistable
         self.muteTTS = muteTTS
         self.enableOnDeviceTTS = enableOnDeviceTTS
         self.onDeviceTTSVoiceIdentifier = onDeviceTTSVoiceIdentifier
+        self.startMode = startMode
     }
 }

--- a/Sources/HAModels/Sources/AssistStartMode.swift
+++ b/Sources/HAModels/Sources/AssistStartMode.swift
@@ -1,0 +1,29 @@
+import Foundation
+import GRDB
+
+/// How Assist should open when it is triggered from the Home Assistant frontend dashboard.
+///
+/// Only applies to the `assist/show` external bus message; widgets, shortcuts and other in-app
+/// entry points keep asking for the mode they were configured with.
+public enum AssistStartMode: String, Codable, CaseIterable, Identifiable, DatabaseValueConvertible, Sendable {
+    /// Follow whatever the frontend requested in the `assist/show` message.
+    case auto
+    /// Always start listening, ignoring what the frontend requested.
+    case voice
+    /// Always start with the text input, ignoring what the frontend requested.
+    case text
+
+    public var id: String { rawValue }
+
+    /// Resolves whether Assist should start recording, given what the frontend asked for.
+    public func resolveAutoStartRecording(frontendRequested: Bool) -> Bool {
+        switch self {
+        case .auto:
+            return frontendRequested
+        case .voice:
+            return true
+        case .text:
+            return false
+        }
+    }
+}

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -197,6 +197,7 @@ public enum DatabaseTables {
         case muteTTS
         case enableOnDeviceTTS
         case onDeviceTTSVoiceIdentifier
+        case startMode
     }
 
     public enum AllowedTag: String, CaseIterable {

--- a/Sources/Shared/Database/Tables/AssistConfigurationTable.swift
+++ b/Sources/Shared/Database/Tables/AssistConfigurationTable.swift
@@ -20,6 +20,7 @@ struct AssistConfigurationTable: DatabaseTableProtocol {
                     table.column(DatabaseTables.AssistConfiguration.muteTTS.rawValue, .boolean)
                     table.column(DatabaseTables.AssistConfiguration.enableOnDeviceTTS.rawValue, .boolean)
                     table.column(DatabaseTables.AssistConfiguration.onDeviceTTSVoiceIdentifier.rawValue, .text)
+                    table.column(DatabaseTables.AssistConfiguration.startMode.rawValue, .text)
                 }
             }
         } else {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -755,6 +755,18 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "assist.settings.section.labs.title") }
         }
       }
+      public enum StartMode {
+        /// Auto
+        public static var auto: String { return L10n.tr("Localizable", "assist.settings.start_mode.auto") }
+        /// Controls how Assist starts when you trigger it from a Home Assistant dashboard. "Auto" follows what the dashboard asks for, while "Voice" and "Text" always override it. This does not apply to widgets, shortcuts or other app features.
+        public static var footer: String { return L10n.tr("Localizable", "assist.settings.start_mode.footer") }
+        /// Text
+        public static var text: String { return L10n.tr("Localizable", "assist.settings.start_mode.text") }
+        /// Assist start mode
+        public static var title: String { return L10n.tr("Localizable", "assist.settings.start_mode.title") }
+        /// Voice
+        public static var voice: String { return L10n.tr("Localizable", "assist.settings.start_mode.voice") }
+      }
       public enum TtsMute {
         /// When enabled, Assist will not play audio responses even if the pipeline has text-to-speech configured. You will still see text responses.
         public static var footer: String { return L10n.tr("Localizable", "assist.settings.tts_mute.footer") }

--- a/Tests/App/Assist/AssistStartMode.test.swift
+++ b/Tests/App/Assist/AssistStartMode.test.swift
@@ -1,0 +1,29 @@
+@testable import HomeAssistant
+import Shared
+import Testing
+
+struct AssistStartModeTests {
+    @Test func autoFollowsFrontendRequest() {
+        #expect(AssistStartMode.auto.resolveAutoStartRecording(frontendRequested: true))
+        #expect(AssistStartMode.auto.resolveAutoStartRecording(frontendRequested: false) == false)
+    }
+
+    @Test func voiceAlwaysStartsRecording() {
+        #expect(AssistStartMode.voice.resolveAutoStartRecording(frontendRequested: true))
+        #expect(AssistStartMode.voice.resolveAutoStartRecording(frontendRequested: false))
+    }
+
+    @Test func textNeverStartsRecording() {
+        #expect(AssistStartMode.text.resolveAutoStartRecording(frontendRequested: true) == false)
+        #expect(AssistStartMode.text.resolveAutoStartRecording(frontendRequested: false) == false)
+    }
+
+    @Test func defaultConfigurationUsesAuto() {
+        #expect(AssistConfiguration().startMode == .auto)
+    }
+
+    @Test func eachModeHasItsOwnTitle() {
+        let titles = AssistStartMode.allCases.map(\.localizedTitle)
+        #expect(Set(titles).count == AssistStartMode.allCases.count)
+    }
+}

--- a/Tests/App/Assist/AssistViewModel.test.swift
+++ b/Tests/App/Assist/AssistViewModel.test.swift
@@ -20,6 +20,7 @@ final class AssistViewModelTests: XCTestCase {
 
     private func makeSut(
         autoStartRecording: Bool = false,
+        focusInputOnAppear: Bool = false,
         speechTranscriber: (any SpeechTranscriberProtocol)? = nil,
         speechSynthesizer: (any SpeechSynthesizerProtocol)? = nil
     ) -> AssistViewModel {
@@ -29,6 +30,7 @@ final class AssistViewModelTests: XCTestCase {
             audioPlayer: mockAudioPlayer,
             assistService: mockAssistService,
             autoStartRecording: autoStartRecording,
+            focusInputOnAppear: focusInputOnAppear,
             speechTranscriber: speechTranscriber,
             speechSynthesizer: speechSynthesizer
         )
@@ -52,6 +54,29 @@ final class AssistViewModelTests: XCTestCase {
         XCTAssertTrue(mockAudioPlayer.pauseCalled)
         XCTAssertFalse(sut.autoStartRecording)
         XCTAssertEqual(sut.inputText, "")
+        XCTAssertTrue(mockAudioRecorder.startRecordingCalled)
+    }
+
+    @MainActor
+    func testOnAppearFocusInput() async throws {
+        sut = makeSut(focusInputOnAppear: true)
+        mockAssistService.pipelineResponse = .init(preferredPipeline: "", pipelines: [])
+
+        sut.initialRoutine()
+        await Task.yield()
+        XCTAssertTrue(sut.focusOnInput)
+        XCTAssertFalse(sut.focusInputOnAppear)
+        XCTAssertFalse(mockAudioRecorder.startRecordingCalled)
+    }
+
+    @MainActor
+    func testOnAppearAutoStartRecordingIgnoresFocusInput() async throws {
+        sut = makeSut(autoStartRecording: true, focusInputOnAppear: true)
+        mockAssistService.pipelineResponse = .init(preferredPipeline: "", pipelines: [])
+
+        sut.initialRoutine()
+        await Task.yield()
+        XCTAssertFalse(sut.focusOnInput)
         XCTAssertTrue(mockAudioRecorder.startRecordingCalled)
     }
 

--- a/Tests/App/WebView/Mocks/MockWebViewExternalMessageHandler.swift
+++ b/Tests/App/WebView/Mocks/MockWebViewExternalMessageHandler.swift
@@ -16,7 +16,12 @@ final class MockWebViewExternalMessageHandler: WebViewExternalMessageHandlerProt
     var scanImprovCalled = false
     var stopImprovScanIfNeededCalled = false
     var showAssistCalled = false
-    var showAssistParams: (server: Shared.Server, pipeline: String, autoStartRecording: Bool)?
+    var showAssistParams: (
+        server: Shared.Server,
+        pipeline: String,
+        autoStartRecording: Bool,
+        focusInputOnAppear: Bool
+    )?
 
     var sendExternalBusReturnValue: PromiseKit.Promise<Void> = PromiseKit.Promise.value(())
 
@@ -45,8 +50,8 @@ final class MockWebViewExternalMessageHandler: WebViewExternalMessageHandlerProt
         stopImprovScanIfNeededCalled = true
     }
 
-    func showAssist(server: Shared.Server, pipeline: String, autoStartRecording: Bool) {
+    func showAssist(server: Shared.Server, pipeline: String, autoStartRecording: Bool, focusInputOnAppear: Bool) {
         showAssistCalled = true
-        showAssistParams = (server, pipeline, autoStartRecording)
+        showAssistParams = (server, pipeline, autoStartRecording, focusInputOnAppear)
     }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The frontend usually asks the app to open Assist in voice mode, and some users would rather always land on the text input instead.

This adds an "Assist start mode" option to Assist settings with three choices:

- **Auto** (default): follows what the frontend asks for, current behaviour
- **Voice**: always starts listening
- **Text**: always starts with the text input

The override is only applied to the `assist/show` external bus message, so widgets, shortcuts and other app entry points keep the mode they were configured with. The footer in settings makes that explicit.

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

The setting is stored in the existing `AssistConfiguration` database record via a new `startMode` column, which existing rows pick up through the usual column migration and default to `auto`.
