### PR TITLE
Support multiple pipelines and medium size in Assist widget

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "announcement.drop_support.title" = "Important update";
 "app_intents.assist.pipeline.default.title" = "Default";
 "app_intents.assist.pipeline.title" = "Pipeline";
+"app_intents.assist.pipelines.title" = "Pipelines";
 "app_intents.assist.preferred_pipeline.title" = "Preferred";
 "app_intents.assist.refresh_warning.title" = "Can't find your Assist pipeline? Open Assist in the app to refresh pipelines list.";
 "app_intents.assist_prompt.description" = "Send a text prompt to Assist";
@@ -2490,6 +2491,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.actions.title" = "Actions";
 "widgets.assist.action_title" = "Ask Assist";
 "widgets.assist.description" = "Open Assist in the app";
+"widgets.assist.not_configured" = "No Pipelines Configured";
 "widgets.assist.title" = "Assist";
 "widgets.assist.unknown_configuration" = "Configure";
 "widgets.automation.trigger.title" = "Trigger automation";

--- a/Sources/Extensions/Widgets/Assist/WidgetAssist.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssist.swift
@@ -11,16 +11,13 @@ struct WidgetAssist: Widget {
             intent: WidgetAssistAppIntent.self,
             provider: WidgetAssistProvider(),
             content: { entry in
-                Group {
-                    if #available(iOS 18.0, *) {
-                        WidgetAssistViewTintedWrapper(entry: entry)
-                            .widgetBackground(Color.clear)
-                    } else {
-                        WidgetAssistView(entry: entry, tinted: false)
-                            .widgetBackground(Color.clear)
-                    }
+                // Widget background and tap destinations are family dependent,
+                // so `WidgetAssistView` applies them per branch.
+                if #available(iOS 18.0, *) {
+                    WidgetAssistViewTintedWrapper(entry: entry)
+                } else {
+                    WidgetAssistView(entry: entry, tinted: false)
                 }
-                .widgetURL(entry.widgetURL)
             }
         )
         .contentMarginsDisabledIfAvailable()
@@ -31,6 +28,6 @@ struct WidgetAssist: Widget {
     }
 
     private var supportedFamilies: [WidgetFamily] {
-        [.systemSmall, .accessoryCircular]
+        [.systemSmall, .systemMedium, .accessoryCircular]
     }
 }

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistAppIntent.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistAppIntent.swift
@@ -12,8 +12,23 @@ struct WidgetAssistAppIntent: WidgetConfigurationIntent, CustomIntentMigratedApp
         .init("widgets.assist.description", defaultValue: "Ask Home Assistant Assist")
     )
 
+    /// Legacy single-pipeline selection, kept so widgets configured before multi-pipeline support
+    /// (and migrated SiriKit intents) resolve their stored value. Hidden from the configuration UI
+    /// by `parameterSummary` — new selections go through `pipelines`.
     @Parameter(title: .init("app_intents.assist.pipeline.title", defaultValue: "Pipeline"))
     var pipeline: AssistPipelineEntity?
+
+    // ATTENTION: Unfortunately these sizes below can't be retrieved dynamically from widget family sizes.
+    // Check ``WidgetFamilySizes.swift`` as source of truth
+    @Parameter(
+        title: .init("app_intents.assist.pipelines.title", defaultValue: "Pipelines"),
+        size: [
+            .systemSmall: 1,
+            .systemMedium: 6,
+            .accessoryCircular: 1,
+        ]
+    )
+    var pipelines: [AssistPipelineEntity]?
 
     @Parameter(
         title: .init("app_intents.controls.assist.parameter.with_voice", defaultValue: "With voice"),
@@ -22,6 +37,9 @@ struct WidgetAssistAppIntent: WidgetConfigurationIntent, CustomIntentMigratedApp
     var withVoice: Bool
 
     static var parameterSummary: some ParameterSummary {
-        Summary()
+        Summary {
+            \.$pipelines
+            \.$withVoice
+        }
     }
 }

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistProvider.swift
@@ -4,10 +4,19 @@ import WidgetKit
 
 struct WidgetAssistEntry: TimelineEntry {
     var date = Date()
-    var pipeline: AssistPipelineEntity?
+    var pipelines: [AssistPipelineEntity] = []
     var withVoice = true
+    /// True for the gallery sample, whose pipelines belong to no real server — the view uses this
+    /// to skip the server-name subtitle rather than resolving one that doesn't apply.
+    var isPreview = false
 
+    /// Whole-widget destination used by the families that show a single pipeline
+    /// (`systemSmall`, `accessoryCircular`).
     var widgetURL: URL {
+        Self.widgetURL(for: pipelines.first, withVoice: withVoice)
+    }
+
+    static func widgetURL(for pipeline: AssistPipelineEntity?, withVoice: Bool) -> URL {
         let serverId = pipeline?.serverId.isEmpty == false
             ? pipeline?.serverId
             : Current.servers.all.first?.identifier.rawValue
@@ -24,22 +33,26 @@ struct WidgetAssistProvider: AppIntentTimelineProvider {
     typealias Entry = WidgetAssistEntry
     typealias Intent = WidgetAssistAppIntent
 
-    private var defaultEntry: WidgetAssistEntry {
-        WidgetAssistEntry(
-            pipeline: Current.servers.all.first.map { .preferred(serverId: $0.identifier.rawValue) },
-            withVoice: true
-        )
-    }
-
     func placeholder(in context: Context) -> WidgetAssistEntry {
         .init()
     }
 
-    /// Mocked entry for the widget gallery — see `WidgetPreviewSample`.
-    private var previewEntry: WidgetAssistEntry {
-        WidgetAssistEntry(
-            pipeline: .preferred(serverId: WidgetPreviewSample.serverId),
-            withVoice: true
+    /// Mocked entry for the widget gallery — see `WidgetPreviewSample`. "Home Assistant" is the
+    /// server's default pipeline name (a brand name, not translated), giving the medium family a
+    /// second tile without a preview-only string.
+    private func previewEntry(in context: Context) -> WidgetAssistEntry {
+        let samplePipelines: [AssistPipelineEntity] = [
+            .preferred(serverId: WidgetPreviewSample.serverId),
+            .init(
+                id: "sample-pipeline",
+                serverId: WidgetPreviewSample.serverId,
+                name: "Home Assistant"
+            ),
+        ]
+        return WidgetAssistEntry(
+            pipelines: Array(samplePipelines.prefix(WidgetFamilySizes.size(for: context.family))),
+            withVoice: true,
+            isPreview: true
         )
     }
 
@@ -47,23 +60,32 @@ struct WidgetAssistProvider: AppIntentTimelineProvider {
         // `context.isPreview` is WidgetKit's hook for the gallery, which renders with an
         // unconfigured intent. Serve the mock there so the picker reads nothing.
         if context.isPreview {
-            return previewEntry
+            return previewEntry(in: context)
         }
-        guard let pipeline = configuration.pipeline else {
-            return defaultEntry
-        }
-        return WidgetAssistEntry(pipeline: pipeline, withVoice: configuration.withVoice)
+        return entry(for: configuration, in: context)
     }
 
     func timeline(for configuration: Intent, in context: Context) async -> Timeline<Entry> {
         if context.isPreview {
-            return Timeline(entries: [previewEntry], policy: .never)
+            return Timeline(entries: [previewEntry(in: context)], policy: .never)
         }
-        return Timeline(entries: [
-            WidgetAssistEntry(
-                pipeline: configuration.pipeline ?? defaultEntry.pipeline,
-                withVoice: configuration.withVoice
-            ),
-        ], policy: .never)
+        return Timeline(entries: [entry(for: configuration, in: context)], policy: .never)
+    }
+
+    private func entry(for configuration: Intent, in context: Context) -> Entry {
+        // Widgets configured before multi-pipeline support carry their selection in the
+        // legacy single `pipeline` parameter.
+        let configured = configuration.pipelines
+            ?? configuration.pipeline.map { [$0] }
+            ?? []
+        let pipelines = configured.isEmpty ? defaultPipelines : configured
+        return WidgetAssistEntry(
+            pipelines: Array(pipelines.prefix(WidgetFamilySizes.size(for: context.family))),
+            withVoice: configuration.withVoice
+        )
+    }
+
+    private var defaultPipelines: [AssistPipelineEntity] {
+        Current.servers.all.first.map { [.preferred(serverId: $0.identifier.rawValue)] } ?? []
     }
 }

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistView.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistView.swift
@@ -8,7 +8,7 @@ struct WidgetAssistView: View {
     private let tinted: Bool
 
     private var subtitle: String {
-        guard let pipeline = entry.pipeline else {
+        guard let pipeline = entry.pipelines.first else {
             return L10n.Widgets.Assist.unknownConfiguration
         }
 
@@ -29,13 +29,50 @@ struct WidgetAssistView: View {
         switch widgetFamily {
         case .accessoryCircular:
             accessoryCircular
-        default:
+                .widgetBackground(Color.clear)
+                .widgetURL(entry.widgetURL)
+        case .systemSmall:
             singleHomeScreenItem
+                .widgetBackground(Color.clear)
+                .widgetURL(entry.widgetURL)
+        default:
+            pipelinesGrid
         }
     }
 
     private var accessoryCircular: some View {
         WidgetCircularView(icon: MaterialDesignIcons.messageProcessingOutlineIcon)
+    }
+
+    /// One tile per configured pipeline, each deep linking straight into its own Assist
+    /// conversation. Backgrounds and tinting are handled by `WidgetBasicContainerView`.
+    private var pipelinesGrid: some View {
+        WidgetBasicContainerView(
+            emptyViewGenerator: {
+                AnyView(WidgetEmptyView(message: L10n.Widgets.Assist.notConfigured))
+            },
+            contents: {
+                let showSubtitle = !entry.isPreview && Current.servers.all.count > 1
+                return entry.pipelines.map { pipeline in
+                    WidgetBasicViewModel(
+                        id: pipeline.id,
+                        title: pipeline.name,
+                        subtitle: showSubtitle ? serverName(for: pipeline) : nil,
+                        interactionType: .widgetURL(
+                            WidgetAssistEntry.widgetURL(for: pipeline, withVoice: entry.withVoice)
+                        ),
+                        icon: .messageProcessingOutlineIcon
+                    )
+                }
+            }(),
+            type: .button
+        )
+    }
+
+    private func serverName(for pipeline: AssistPipelineEntity) -> String? {
+        let server = Current.servers.all.first { $0.identifier.rawValue == pipeline.serverId }
+            ?? Current.servers.all.first
+        return server?.info.name
     }
 
     private var singleHomeScreenItem: some View {
@@ -75,4 +112,16 @@ struct WidgetAssistView: View {
         .padding(DesignSystem.Spaces.two)
         .background(tinted ? Color.clear : Color(uiColor: .systemBackground))
     }
+}
+
+#Preview {
+    WidgetAssistView(
+        entry: .init(
+            pipelines: [
+                .init(id: "preview-pipeline", serverId: "preview-server", name: "Home Assistant"),
+            ],
+            isPreview: true
+        ),
+        tinted: false
+    )
 }

--- a/Sources/Shared/Common/URLComponents+WidgetAuthenticity.swift
+++ b/Sources/Shared/Common/URLComponents+WidgetAuthenticity.swift
@@ -13,6 +13,11 @@ public extension URLComponents {
     private static let serverName = "server"
 
     mutating func insertWidgetAuthenticity() {
+        // Idempotent: deep link builders and widget views may each add authenticity,
+        // and a duplicated token would survive the single pop on the receiving side.
+        guard queryItems?.contains(where: {
+            $0.name == Self.authenticityName && $0.value == Current.settingsStore.widgetAuthenticityToken
+        }) != true else { return }
         queryItems = (queryItems ?? []) + [
             URLQueryItem(name: Self.authenticityName, value: Current.settingsStore.widgetAuthenticityToken),
         ]

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -268,6 +268,10 @@ public enum L10n {
           public static var title: String { return L10n.tr("Localizable", "app_intents.assist.pipeline.default.title") }
         }
       }
+      public enum Pipelines {
+        /// Pipelines
+        public static var title: String { return L10n.tr("Localizable", "app_intents.assist.pipelines.title") }
+      }
       public enum PreferredPipeline {
         /// Preferred
         public static var title: String { return L10n.tr("Localizable", "app_intents.assist.preferred_pipeline.title") }
@@ -8082,6 +8086,8 @@ public enum L10n {
       public static var actionTitle: String { return L10n.tr("Localizable", "widgets.assist.action_title") }
       /// Open Assist in the app
       public static var description: String { return L10n.tr("Localizable", "widgets.assist.description") }
+      /// No Pipelines Configured
+      public static var notConfigured: String { return L10n.tr("Localizable", "widgets.assist.not_configured") }
       /// Assist
       public static var title: String { return L10n.tr("Localizable", "widgets.assist.title") }
       /// Configure

--- a/Tests/Shared/URLComponents+WidgetAuthenticity.test.swift
+++ b/Tests/Shared/URLComponents+WidgetAuthenticity.test.swift
@@ -44,6 +44,26 @@ class URLComponentsWidgetAuthenticityTests: XCTestCase {
         }
     }
 
+    func testInsertTwiceAddsSingleAuthenticityItem() throws {
+        for urlString in [
+            "homeassistant://navigate/good",
+            "homeassistant://assist?serverId=1&pipelineId=2&startListening=true",
+        ] {
+            var components = try XCTUnwrap(URLComponents(string: urlString))
+            components.insertWidgetAuthenticity()
+            components.insertWidgetAuthenticity()
+            XCTAssertTrue(components.popWidgetAuthenticity())
+            XCTAssertEqual(components.string, urlString)
+
+            let url = try XCTUnwrap(URL(string: urlString))
+                .withWidgetAuthenticity()
+                .withWidgetAuthenticity()
+            var urlComponents = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: true))
+            XCTAssertTrue(urlComponents.popWidgetAuthenticity())
+            XCTAssertEqual(urlComponents.string, urlString)
+        }
+    }
+
     func testInsertServer() throws {
         let servers = FakeServerManager(initial: 1)
         let server = servers.all[0]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The Assist widget now supports selecting multiple assist pipelines and adds the systemMedium family. The medium widget renders one tile per pipeline (same tile grid as the Open Page widget), each deep linking into its own Assist conversation. Small and lock-screen circular keep their existing single-pipeline look. Existing widget configurations keep working through the legacy single pipeline parameter.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes


---
_Generated by [Claude Code](https://claude.ai/code/session_01VJxjU1iUAEoMceofAjQcyW)_