### PR TITLE
Send a location update when the app is opened

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -97,6 +97,7 @@ class LifecycleManager {
 
     @objc private func didEnterBackground() {
         isActive = false
+        needsAppOpenLocationUpdate = true
         AppDatabaseSuspension.suspend()
         Current.backgroundTask(withName: BackgroundTask.lifecycleManagerDidEnterBackground.rawValue) { _ in
             when(fulfilled: Current.apis.map { api in
@@ -132,6 +133,24 @@ class LifecycleManager {
             })
         }.cauterize()
         refreshNetworkInformation()
+        sendLocationUpdateForAppOpenIfNeeded()
+    }
+
+    /// Tracks whether the next `didBecomeActive` counts as opening the app (cold launch or return from
+    /// the background). Reactivations inside a foreground session — dismissing a system alert or the
+    /// app switcher — don't pass through `didEnterBackground`, so they don't re-arm this.
+    private var needsAppOpenLocationUpdate = true
+
+    private func sendLocationUpdateForAppOpenIfNeeded() {
+        guard needsAppOpenLocationUpdate else { return }
+        needsAppOpenLocationUpdate = false
+
+        HomeAssistantAPI.manuallyUpdate(
+            applicationState: UIApplication.shared.applicationState,
+            type: .appOpened
+        ).catch { error in
+            Current.Log.error("failed to update location on app open: \(error)")
+        }
     }
 
     private func refreshNetworkInformation() {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1038,6 +1038,13 @@ public class HomeAssistantAPI {
             case .programmatic: return false
             }
         }
+
+        var locationUpdateTrigger: LocationUpdateTrigger {
+            switch self {
+            case .appOpened: return .Launch
+            case .userRequested, .programmatic: return .Manual
+            }
+        }
     }
 
     public static func manuallyUpdate(
@@ -1070,16 +1077,18 @@ public class HomeAssistantAPI {
                     }
                 }
             }.then { () -> Promise<Void> in
+                let trigger = type.locationUpdateTrigger
+
                 func updateWithoutLocation() -> Promise<Void> {
-                    when(fulfilled: Current.apis.map { $0.UpdateSensors(trigger: .Manual) })
+                    when(fulfilled: Current.apis.map { $0.UpdateSensors(trigger: trigger) })
                 }
 
                 if Current.settingsStore.isLocationEnabled(for: applicationState) {
                     return firstly {
-                        Current.location.oneShotLocation(.Manual, nil)
+                        Current.location.oneShotLocation(trigger, nil)
                     }.then { location in
                         when(fulfilled: Current.apis.map { api in
-                            api.SubmitLocation(updateType: .Manual, location: location, zone: nil)
+                            api.SubmitLocation(updateType: trigger, location: location, zone: nil)
                         }).asVoid()
                     }.recover { error -> Promise<Void> in
                         if error is CLError || error is OneShotError {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -1032,10 +1032,12 @@ public class HomeAssistantAPI {
         case appOpened
         case programmatic
 
+        /// Only explicitly user-initiated updates may show the temporary full-accuracy prompt;
+        /// app-open updates run on every foreground, where a recurring system prompt would be intrusive.
         var allowsTemporaryAccess: Bool {
             switch self {
-            case .userRequested, .appOpened: return true
-            case .programmatic: return false
+            case .userRequested: return true
+            case .appOpened, .programmatic: return false
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Opening the app never submitted a location update: launch/foreground only ran `Connect` → `UpdateSensors`, which refreshes sensors but never sends the `update_location` webhook, so the device tracker stayed stale until a pull-to-refresh. `LifecycleManager` now triggers a manual location update (`.appOpened`) on `didBecomeActive`, once per foreground session (re-armed on `didEnterBackground`), and app-open updates report the `Launch` trigger in location history.

## Screenshots
N/A, no UI changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
