### PR TITLE
Fix kiosk sensors being disabled without user input

### DIFF
--- a/Sources/Shared/Environment/KioskModeManager.swift
+++ b/Sources/Shared/Environment/KioskModeManager.swift
@@ -79,9 +79,13 @@ public final class KioskModeManager: ObservableObject {
 
     private let screensaverCommandSubject = PassthroughSubject<KioskScreensaverCommand, Never>()
     private var observation: AnyDatabaseCancellable?
+    /// The kiosk `enabled` flag the sensor sync last saw, used to detect actual transitions.
+    private var lastSyncedKioskEnabled: Bool
 
     public init() {
-        self.settings = (try? KioskSettings.current()) ?? KioskSettings()
+        let settings = (try? KioskSettings.current()) ?? KioskSettings()
+        self.settings = settings
+        self.lastSyncedKioskEnabled = settings.enabled
         observe()
     }
 
@@ -102,10 +106,16 @@ public final class KioskModeManager: ObservableObject {
         )
     }
 
-    /// The kiosk brightness, volume and screensaver sensors only make sense on a device acting as a
-    /// kiosk, so we keep them enabled only while kiosk mode is enabled. This runs for the observation's
-    /// initial value and every subsequent change, and is idempotent so it won't fire spurious updates.
+    /// Turns the kiosk brightness, volume and screensaver sensors on or off alongside kiosk mode,
+    /// but only when kiosk mode actually transitions. The observation also fires with its initial
+    /// value on every manager creation (each app launch, and once per process that touches
+    /// `Current.kiosk`); syncing on those deliveries would silently revert a user's explicit choice
+    /// in Settings → Sensors, which is how sensors kept deactivating without user input (#5261,
+    /// #5306).
     private func syncKioskSensorsEnabled(with settings: KioskSettings) {
+        guard settings.enabled != lastSyncedKioskEnabled else { return }
+        lastSyncedKioskEnabled = settings.enabled
+
         for sensorId in [WebhookSensorId.kioskBrightness, .kioskVolume, .kioskScreensaver] {
             guard Current.sensors.isEnabled(uniqueID: sensorId.rawValue) != settings.enabled else { continue }
             Current.sensors.setEnabled(settings.enabled, forUniqueID: sensorId.rawValue)

--- a/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
+++ b/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
@@ -4,6 +4,10 @@ import XCTest
 
 /// Covers the kiosk sensor enablement sync in `KioskModeManager`, in particular that it never
 /// deactivates sensors without an actual kiosk mode transition (issues #5261 / #5306).
+///
+/// `@MainActor` because the manager delivers its GRDB observation on the main queue and the wait
+/// helpers spin the main run loop.
+@MainActor
 final class KioskModeManagerSensorSyncTests: XCTestCase {
     private var database: DatabaseQueue!
     private var previousDatabase: (() -> DatabaseQueue)!

--- a/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
+++ b/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
@@ -1,0 +1,142 @@
+import GRDB
+@testable import Shared
+import XCTest
+
+/// Covers the kiosk sensor enablement sync in `KioskModeManager`, in particular that it never
+/// deactivates sensors without an actual kiosk mode transition (issues #5261 / #5306).
+final class KioskModeManagerSensorSyncTests: XCTestCase {
+    private var database: DatabaseQueue!
+    private var previousDatabase: (() -> DatabaseQueue)!
+
+    private let kioskSensorIds = [WebhookSensorId.kioskBrightness, .kioskVolume, .kioskScreensaver]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try KioskSettingsTable().createIfNeeded(database: database)
+        self.database = database
+        previousDatabase = Current.database
+        Current.database = { database }
+
+        SensorEnablementStore.resetForTesting()
+    }
+
+    override func tearDown() {
+        Current.database = previousDatabase
+        SensorEnablementStore.resetForTesting()
+        super.tearDown()
+    }
+
+    func testObservationWithoutTransitionDoesNotDisableUserEnabledSensors() throws {
+        // Kiosk mode is off (no persisted settings) and the user has the kiosk sensors enabled.
+        for sensorId in kioskSensorIds {
+            Current.sensors.setEnabled(true, forUniqueID: sensorId.rawValue)
+        }
+
+        let manager = KioskModeManager()
+        // An unrelated settings change fires the observation (after its initial delivery, which
+        // GRDB orders first) while `enabled` stays false the whole time.
+        try pumpObservation(of: manager)
+
+        for sensorId in kioskSensorIds {
+            XCTAssertTrue(
+                Current.sensors.isEnabled(uniqueID: sensorId.rawValue),
+                "\(sensorId.rawValue) must stay enabled: no kiosk mode transition happened"
+            )
+        }
+    }
+
+    func testEnablingKioskModeEnablesKioskSensors() throws {
+        for sensorId in kioskSensorIds {
+            Current.sensors.setEnabled(false, forUniqueID: sensorId.rawValue)
+        }
+
+        let manager = KioskModeManager()
+
+        try persistKioskSettings(enabled: true)
+        waitFor(manager, kioskEnabled: true)
+
+        for sensorId in kioskSensorIds {
+            XCTAssertTrue(
+                Current.sensors.isEnabled(uniqueID: sensorId.rawValue),
+                "\(sensorId.rawValue) must be enabled when kiosk mode turns on"
+            )
+        }
+    }
+
+    func testDisablingKioskModeDisablesKioskSensors() throws {
+        try persistKioskSettings(enabled: true)
+        for sensorId in kioskSensorIds {
+            Current.sensors.setEnabled(true, forUniqueID: sensorId.rawValue)
+        }
+
+        let manager = KioskModeManager()
+
+        try persistKioskSettings(enabled: false)
+        waitFor(manager, kioskEnabled: false)
+
+        for sensorId in kioskSensorIds {
+            XCTAssertFalse(
+                Current.sensors.isEnabled(uniqueID: sensorId.rawValue),
+                "\(sensorId.rawValue) must be disabled when kiosk mode turns off"
+            )
+        }
+    }
+
+    func testRelaunchAfterEnablingAllSensorsKeepsThemEnabled() throws {
+        // Regression for #5306: "Enable all sensors" followed by an app relaunch. Each launch
+        // creates a fresh manager whose observation fires with its initial value; that delivery
+        // must not turn the kiosk sensors back off while kiosk mode stayed off throughout.
+        for sensorId in kioskSensorIds {
+            Current.sensors.setEnabled(true, forUniqueID: sensorId.rawValue)
+        }
+
+        let firstLaunch = KioskModeManager()
+        try pumpObservation(of: firstLaunch)
+        let secondLaunch = KioskModeManager()
+        try pumpObservation(of: secondLaunch)
+
+        for sensorId in kioskSensorIds {
+            XCTAssertTrue(
+                Current.sensors.isEnabled(uniqueID: sensorId.rawValue),
+                "\(sensorId.rawValue) must survive relaunches while kiosk mode never changed"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func persistKioskSettings(enabled: Bool) throws {
+        try database.write { db in
+            var settings = try KioskSettings.fetchOne(db) ?? KioskSettings()
+            settings.enabled = enabled
+            try settings.insert(db, onConflict: .replace)
+        }
+    }
+
+    /// Flips an unrelated setting (`keepScreenOn`) and waits until the manager observes it. The
+    /// observation delivers values in order, so once this change arrives the initial delivery has
+    /// also happened — without `enabled` ever transitioning.
+    private func pumpObservation(of manager: KioskModeManager) throws {
+        let marker = !manager.settings.keepScreenOn
+        try database.write { db in
+            var settings = try KioskSettings.fetchOne(db) ?? KioskSettings()
+            settings.keepScreenOn = marker
+            try settings.insert(db, onConflict: .replace)
+        }
+        waitUntil("keepScreenOn marker observed") { manager.settings.keepScreenOn == marker }
+    }
+
+    private func waitFor(_ manager: KioskModeManager, kioskEnabled: Bool) {
+        waitUntil("kiosk enabled == \(kioskEnabled)") { manager.settings.enabled == kioskEnabled }
+    }
+
+    private func waitUntil(_ what: String, timeout: TimeInterval = 5, condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertTrue(condition(), "timed out waiting for \(what)")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The kiosk sensor sync in `KioskModeManager` ran on every delivery of its settings observation, including the initial value delivered each time the manager is created — every app launch. With kiosk mode off, that force-disabled the kiosk sensors and silently reverted choices made in Settings → Companion App → Manage Sensors, so "Enable all sensors" could never persist and re-enabled sensors kept turning themselves off.

The sync now only runs when the kiosk `enabled` flag actually transitions. Turning kiosk mode on/off still enables/disables the kiosk sensors, but launches and unrelated kiosk settings changes no longer override the user's sensor selection. Added unit tests covering the no-transition, transition and relaunch cases.

Fixes #5261
Fixes #5306

## Screenshots
No visual changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The same fix is on `releases/2026.7.4` for the 2026.7.4 hotfix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVVrfthgbkMCw99L9eXxqp)_