### PR TITLE
Sync full database tables to Apple Watch

### DIFF
--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -52,6 +52,7 @@ public enum DatabaseTables {
         case icon
         case rawDeviceClass
         case entityCategory
+        case isHidden
         case resolvedIcon
     }
 

--- a/Sources/HAModels/Sources/HAAppEntity.swift
+++ b/Sources/HAModels/Sources/HAAppEntity.swift
@@ -8,8 +8,9 @@ import GRDB
 /// - `HAAppEntity` is every entity that currently has a state — including ones with no registry entry
 ///   (YAML/template/command-line entities, etc.) — and carries `domain` + `rawDeviceClass`, which the
 ///   registry does not. It's what pickers/widgets enumerate as "all selectable entities". It also
-///   copies the registry's `entityCategory` and hidden flag at write time so consumers that never
-///   receive the full registry (the watch) can still exclude config/diagnostic and hidden entities.
+///   copies the registry's `entityCategory` and hidden flag at write time so consumers can exclude
+///   config/diagnostic and hidden entities without a per-read registry join — including watches
+///   still on the legacy database mirror, which omits the registry entirely.
 /// - The registry is config metadata (area, hidden, decimal precision, the user's name) for the
 ///   registered, non-disabled subset, and is only consulted to filter/enrich those entities.
 ///

--- a/Sources/HAModels/Sources/HAAppEntity.swift
+++ b/Sources/HAModels/Sources/HAAppEntity.swift
@@ -8,8 +8,8 @@ import GRDB
 /// - `HAAppEntity` is every entity that currently has a state — including ones with no registry entry
 ///   (YAML/template/command-line entities, etc.) — and carries `domain` + `rawDeviceClass`, which the
 ///   registry does not. It's what pickers/widgets enumerate as "all selectable entities". It also
-///   copies the registry's `entityCategory` at write time so consumers that never receive the full
-///   registry (the watch) can still exclude config/diagnostic entities.
+///   copies the registry's `entityCategory` and hidden flag at write time so consumers that never
+///   receive the full registry (the watch) can still exclude config/diagnostic and hidden entities.
 /// - The registry is config metadata (area, hidden, decimal precision, the user's name) for the
 ///   registered, non-disabled subset, and is only consulted to filter/enrich those entities.
 ///
@@ -37,6 +37,11 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
     /// The registry entity category index (config / diagnostic), copied from
     /// `EntityRegistryListForDisplay.Entity.entityCategory` at write time; `nil` for ordinary entities.
     public let entityCategory: Int?
+    /// Whether the user hid this entity in the entity registry, copied from
+    /// `EntityRegistryListForDisplay.Entity.hidden` at write time; `nil` for entities that aren't
+    /// hidden (or have no registry row). Baked in for the same reason as `entityCategory`: consumers
+    /// that never receive the full registry (the watch) can still exclude hidden entities.
+    public let isHidden: Bool?
     /// The frontend's default icon for this entity's domain + device class, resolved from the backend
     /// `entity_component` map at write time (stateless). Used when there is no `icon` override so
     /// pickers render the same glyph the frontend does. `nil` when the map was unavailable.
@@ -51,6 +56,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         icon: String?,
         rawDeviceClass: String?,
         entityCategory: Int? = nil,
+        isHidden: Bool? = nil,
         resolvedIcon: String? = nil,
     ) {
         self.id = id
@@ -61,6 +67,7 @@ public struct HAAppEntity: Codable, Identifiable, FetchableRecord, PersistableRe
         self.icon = icon
         self.rawDeviceClass = rawDeviceClass
         self.entityCategory = entityCategory
+        self.isHidden = isHidden
         self.resolvedIcon = resolvedIcon
     }
 

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -77,6 +77,12 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
             registryRows.compactMap { row in row.entityCategory.map { (row.entityId, $0) } },
             uniquingKeysWith: { first, _ in first }
         )
+        // The registry hidden flag is baked in the same way, so consumers that never receive the
+        // full registry (the watch) can still exclude hidden entities.
+        let registryHiddenFlags: [String: Bool] = Dictionary(
+            registryRows.compactMap { row in row.isHidden ? (row.entityId, true) : nil },
+            uniquingKeysWith: { first, _ in first }
+        )
         // The user's entity-registry icon override wins over the live `attributes.icon`, matching the
         // frontend's precedence (see `ha-state-icon.ts`).
         let registryIcons: [String: String] = Dictionary(
@@ -103,6 +109,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
                 icon: registryIcons[entity.entityId] ?? entity.attributes.icon,
                 rawDeviceClass: deviceClass,
                 entityCategory: registryEntityCategories[entity.entityId],
+                isHidden: registryHiddenFlags[entity.entityId],
                 resolvedIcon: resolvedIcon
             )
         }.sorted(by: { $0.id < $1.id })

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -77,8 +77,9 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
             registryRows.compactMap { row in row.entityCategory.map { (row.entityId, $0) } },
             uniquingKeysWith: { first, _ in first }
         )
-        // The registry hidden flag is baked in the same way, so consumers that never receive the
-        // full registry (the watch) can still exclude hidden entities.
+        // The registry hidden flag is baked in the same way, so consumers can exclude hidden
+        // entities without a registry join — including watches on the legacy database mirror,
+        // which never receive the registry.
         let registryHiddenFlags: [String: Bool] = Dictionary(
             registryRows.compactMap { row in row.isHidden ? (row.entityId, true) : nil },
             uniquingKeysWith: { first, _ in first }

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -290,6 +290,22 @@ public enum WatchMirrorPushCoordinator {
     private static var pendingWork: DispatchWorkItem?
     private static var lastPushedData: Data?
 
+    private static let peerMirrorVersionKey = "watchMirrorPeerVersion"
+
+    /// The mirror version the paired watch advertised on its most recent sync request, persisted so
+    /// proactive pushes keep serving the right fidelity across launches. Defaults to legacy until a
+    /// versioned request arrives, and is overwritten by *every* request — including version-less
+    /// ones — so pairing an older watch drops back to the legacy payload it can decode.
+    public static var peerMirrorVersion: Int {
+        get {
+            let stored = UserDefaults.standard.integer(forKey: peerMirrorVersionKey)
+            return stored == 0 ? WatchDatabaseMirror.legacyVersion : stored
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: peerMirrorVersionKey)
+        }
+    }
+
     /// Request a push. Safe to call from anywhere and as often as needed — it debounces and de-dupes.
     public static func schedule(reason: Reason) {
         queue.async {
@@ -311,11 +327,17 @@ public enum WatchMirrorPushCoordinator {
             Current.Log.verbose("Skip watch mirror push (\(reason.logDescription)): watch unavailable")
             return
         }
+        // Serve the fidelity the paired watch advertised on its last sync request; a full-reference
+        // payload always travels compressed (and a legacy watch is never sent one — it couldn't
+        // decode the compressed bytes, let alone want the unfiltered tables).
+        let version = peerMirrorVersion
+        let compressed = version >= WatchDatabaseMirror.fullReferenceVersion
         let data: Data
         let digests: [String: String]
         do {
-            let snapshot = try WatchDatabaseMirror.snapshot()
-            data = try snapshot.encodeForWatch()
+            let snapshot = try WatchDatabaseMirror.snapshot(version: version)
+            let encoded = try snapshot.encodeForWatch()
+            data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
             digests = snapshot.tableDigests()
         } catch {
             Current.Log.error("Watch mirror push snapshot failed (\(reason.logDescription)): \(error)")
@@ -332,10 +354,14 @@ public enum WatchMirrorPushCoordinator {
         lastPushedData = data
         // The digests travel in the file-transfer metadata so the watch can store them after
         // applying this full mirror — keeping its next delta sync request accurate.
+        var metadata: [String: Any] = [WatchDatabaseMirror.digestsKey: digests]
+        if compressed {
+            metadata[WatchDatabaseMirror.compressedKey] = true
+        }
         Communicator.shared.transfer(HAWatchConnectivity.Blob(
             identifier: WatchDatabaseMirror.blobIdentifier,
             content: data,
-            metadata: [WatchDatabaseMirror.digestsKey: digests]
+            metadata: metadata
         )) { result in
             if case let .failure(error) = result {
                 Current.Log.error("Watch mirror push transfer failed (\(reason.logDescription)): \(error)")

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -316,10 +316,24 @@ public enum WatchMirrorPushCoordinator {
         }
     }
 
-    /// Clear the de-dup cache so the next `schedule` pushes even if the snapshot is unchanged. Used
-    /// after a failed transfer and by tests.
+    /// Digests of the tables the watch is believed to hold, from the last transfer this coordinator
+    /// handed off. Used to omit unchanged tables from the next push: a full-reference snapshot is
+    /// megabytes, and pushing all of it on every trigger saturates the WatchConnectivity link —
+    /// starving the interactive chunked pull, whose sends then fail as "not immediately reachable".
+    /// Cleared whenever a transfer fails, so the next push is complete again.
+    ///
+    /// Safe to be wrong: the watch adopts digests only for tables a payload actually carried, so a
+    /// push it never applied leaves its stored digests untouched and its next pull asks for the
+    /// tables it is really missing.
+    private static var lastPushedDigests: [String: String] = [:]
+
+    /// Clear the de-dup caches so the next `schedule` pushes a complete snapshot even if unchanged.
+    /// Used after a failed transfer and by tests.
     public static func reset() {
-        queue.async { lastPushedData = nil }
+        queue.async {
+            lastPushedData = nil
+            lastPushedDigests = [:]
+        }
     }
 
     private static func push(reason: Reason) {
@@ -334,11 +348,21 @@ public enum WatchMirrorPushCoordinator {
         let compressed = version >= WatchDatabaseMirror.fullReferenceVersion
         let data: Data
         let digests: [String: String]
+        let carriedKeys: Set<String>
         do {
             let snapshot = try WatchDatabaseMirror.snapshot(version: version)
-            let encoded = try snapshot.encodeForWatch()
-            data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
             digests = snapshot.tableDigests()
+            // Carry only what changed since the last transfer, the same way the watch-initiated
+            // pull does — a push that repeats the whole reference database would monopolize the
+            // link every time anything changes.
+            let payload = snapshot.omittingTables(matching: lastPushedDigests, currentDigests: digests)
+            carriedKeys = payload.carriedDigestKeys
+            guard !carriedKeys.isEmpty else {
+                Current.Log.verbose("Skip watch mirror push (\(reason.logDescription)): no table changed")
+                return
+            }
+            let encoded = try payload.encodeForWatch()
+            data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
         } catch {
             Current.Log.error("Watch mirror push snapshot failed (\(reason.logDescription)): \(error)")
             Current.clientEventStore.addEvent(.init(
@@ -352,8 +376,11 @@ public enum WatchMirrorPushCoordinator {
             return
         }
         lastPushedData = data
-        // The digests travel in the file-transfer metadata so the watch can store them after
-        // applying this full mirror — keeping its next delta sync request accurate.
+        // Omitted tables matched these digests already, so the whole map describes what the watch
+        // is believed to hold once this payload lands.
+        lastPushedDigests = digests
+        // The digests travel in the file-transfer metadata so the watch can store them — for the
+        // tables this payload carried — keeping its next delta sync request accurate.
         var metadata: [String: Any] = [WatchDatabaseMirror.digestsKey: digests]
         if compressed {
             metadata[WatchDatabaseMirror.compressedKey] = true
@@ -365,13 +392,18 @@ public enum WatchMirrorPushCoordinator {
         )) { result in
             if case let .failure(error) = result {
                 Current.Log.error("Watch mirror push transfer failed (\(reason.logDescription)): \(error)")
-                queue.async { lastPushedData = nil }
+                // The watch got nothing, so drop both beliefs: the next push rebuilds in full.
+                queue.async {
+                    lastPushedData = nil
+                    lastPushedDigests = [:]
+                }
             }
         }
         Current.clientEventStore.addEvent(.init(
-            text: "Pushed watch database mirror to Apple Watch (\(data.count) bytes) — \(reason.logDescription)",
+            text: "Pushed watch database mirror to Apple Watch (\(data.count) bytes, "
+                + "\(carriedKeys.sorted().joined(separator: "+"))) — \(reason.logDescription)",
             type: .database,
-            payload: ["reason": reason.rawValue, "bytes": data.count]
+            payload: ["reason": reason.rawValue, "bytes": data.count, "tables": carriedKeys.sorted()]
         ))
     }
 }

--- a/Sources/Shared/Database/Tables/HAppEntityTable.swift
+++ b/Sources/Shared/Database/Tables/HAppEntityTable.swift
@@ -21,6 +21,7 @@ final class HAppEntityTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.AppEntity.icon.rawValue, .text)
                     t.column(DatabaseTables.AppEntity.rawDeviceClass.rawValue, .text)
                     t.column(DatabaseTables.AppEntity.entityCategory.rawValue, .integer)
+                    t.column(DatabaseTables.AppEntity.isHidden.rawValue, .boolean)
                     t.column(DatabaseTables.AppEntity.resolvedIcon.rawValue, .text)
                 }
             }

--- a/Sources/Shared/Environment/WatchUserDefaults.swift
+++ b/Sources/Shared/Environment/WatchUserDefaults.swift
@@ -57,9 +57,28 @@ public final class WatchUserDefaults {
 
     // MARK: - Database mirror digests (delta sync)
 
-    /// Digest map issued by the phone with the last applied database mirror. Opaque to the watch —
-    /// stored verbatim and echoed on the next sync request. `nil` until the first sync (the phone
-    /// then sends the full snapshot).
+    /// Adopt the phone's digests for the tables a payload actually carried, keeping the stored
+    /// values for every other table.
+    ///
+    /// The phone issues its full current digest map with each payload, but a payload may omit
+    /// tables — a delta sync, a delta push, or a table the phone declined to send. Adopting a
+    /// digest for data the watch did not receive would claim it holds rows it does not, and the
+    /// omission would then repeat on every future sync. Merging only the carried keys keeps the
+    /// stored map an honest description of what is actually in the local database.
+    public func mergeDatabaseMirrorDigests(_ digests: [String: String]?, carrying keys: Set<String>) {
+        guard let digests, !keys.isEmpty else { return }
+        var merged = databaseMirrorDigests ?? [:]
+        for key in keys {
+            // A carried table with no digest (an older phone, or a read the phone couldn't hash)
+            // drops the stored entry so the table is requested again rather than assumed current.
+            merged[key] = digests[key]
+        }
+        databaseMirrorDigests = merged
+    }
+
+    /// Digest map describing the mirrored tables currently in the local database. Opaque to the
+    /// watch — the values come from the phone and are echoed on the next sync request. `nil` until
+    /// the first sync (the phone then sends the full snapshot).
     public var databaseMirrorDigests: [String: String]? {
         get { userDefaults.dictionary(forKey: WatchUserDefaultsKey.databaseMirrorDigests.rawValue)
             as? [String: String]

--- a/Sources/Shared/HAAppEntity.swift
+++ b/Sources/Shared/HAAppEntity.swift
@@ -52,26 +52,58 @@ public extension HAAppEntity {
         })
     }
 
-    /// Whether the watch can offer or render this entity, given the precomputed set of
-    /// watch-addable domain raw values: a watch-addable domain, no config/diagnostic category, and
-    /// not hidden in the entity registry (both baked into the row at write time; see
-    /// `AppEntitiesModel`). Every watch candidate list — area browsing, the home-screen areas mode,
-    /// the empty-area checks and the add flows — must use this same predicate so they all agree,
-    /// especially now that the mirrored entity table carries hidden and diagnostic rows too.
-    func isWatchCompatible(allowedDomains: Set<String>) -> Bool {
-        allowedDomains.contains(domain) && entityCategory == nil && isHidden != true
+    /// Whether the watch may offer this entity in a list it generates itself, given the precomputed
+    /// set of watch-addable domain raw values and the server's `watchExcludedEntityIds`.
+    ///
+    /// Excludes entities the user hid and config/diagnostic ones. This governs only the automatic
+    /// lists — area browsing, the home-screen areas mode, the empty-area checks and the add flows —
+    /// which is what "hidden" means in Home Assistant: it removes an entity from auto-generated
+    /// views. An entity the user deliberately added to the watch home screen still renders; those
+    /// items resolve through `MagicItemProvider` and never pass through this predicate.
+    ///
+    /// The row's own `isHidden`/`entityCategory` are checked too, but they are only refreshed when
+    /// the phone rewrites its entity table, so `excludedEntityIds` — read live from the mirrored
+    /// registry — is what makes the result correct on a server whose rows predate that write.
+    func isWatchCompatible(allowedDomains: Set<String>, excludedEntityIds: Set<String> = []) -> Bool {
+        allowedDomains.contains(domain)
+            && entityCategory == nil
+            && isHidden != true
+            && !excludedEntityIds.contains(entityId)
+    }
+
+    /// Entity ids a server's registry marks as hidden or as config/diagnostic.
+    ///
+    /// `HAAppEntity` carries both facts as columns baked in at write time, but a server whose
+    /// entities have not been rewritten since those columns shipped still stores `nil` for them,
+    /// and the watch would then offer entities the user hid. The full registry is mirrored to the
+    /// watch, so reading it directly makes the filter correct immediately rather than after the
+    /// phone's next entity write.
+    static func watchExcludedEntityIds(serverId: String) -> Set<String> {
+        let ids = try? Current.database().read { db in
+            try EntityRegistryListForDisplay.Entity
+                .filter(Column(DatabaseTables.DisplayEntityRegistry.serverId.rawValue) == serverId)
+                .filter(
+                    Column(DatabaseTables.DisplayEntityRegistry.hidden.rawValue) == true
+                        || Column(DatabaseTables.DisplayEntityRegistry.entityCategory.rawValue) != nil
+                )
+                .fetchAll(db)
+                .map(\.entityId)
+        }
+        return Set(ids ?? [])
     }
 
     /// Entity ids the watch area screens can render for a server: watch-addable domains, without
     /// config/diagnostic or hidden entities. Used to drop areas that would show an empty screen.
     static func watchAreaEntityIds(serverId: String) throws -> Set<String> {
         let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+        let excluded = watchExcludedEntityIds(serverId: serverId)
         let entities = try Current.database().read { db in
             try HAAppEntity
                 .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
                 .fetchAll(db)
         }
-        let compatible = entities.filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
+        let compatible = entities
+            .filter { $0.isWatchCompatible(allowedDomains: allowedDomains, excludedEntityIds: excluded) }
         return Set(compatible.map(\.entityId))
     }
 

--- a/Sources/Shared/HAAppEntity.swift
+++ b/Sources/Shared/HAAppEntity.swift
@@ -52,12 +52,13 @@ public extension HAAppEntity {
         })
     }
 
-    /// Whether the watch area screens can render this entity, given the precomputed set of
+    /// Whether the watch can offer or render this entity, given the precomputed set of
     /// watch-addable domain raw values: a watch-addable domain, no config/diagnostic category, and
     /// not hidden in the entity registry (both baked into the row at write time; see
-    /// `AppEntitiesModel`). Every watch area path must use this same predicate so browsing, the
-    /// home-screen mode and the empty-area checks all agree.
-    func isWatchAreaCompatible(allowedDomains: Set<String>) -> Bool {
+    /// `AppEntitiesModel`). Every watch candidate list — area browsing, the home-screen areas mode,
+    /// the empty-area checks and the add flows — must use this same predicate so they all agree,
+    /// especially now that the mirrored entity table carries hidden and diagnostic rows too.
+    func isWatchCompatible(allowedDomains: Set<String>) -> Bool {
         allowedDomains.contains(domain) && entityCategory == nil && isHidden != true
     }
 
@@ -70,7 +71,7 @@ public extension HAAppEntity {
                 .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
                 .fetchAll(db)
         }
-        let compatible = entities.filter { $0.isWatchAreaCompatible(allowedDomains: allowedDomains) }
+        let compatible = entities.filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
         return Set(compatible.map(\.entityId))
     }
 

--- a/Sources/Shared/HAAppEntity.swift
+++ b/Sources/Shared/HAAppEntity.swift
@@ -52,8 +52,17 @@ public extension HAAppEntity {
         })
     }
 
+    /// Whether the watch area screens can render this entity, given the precomputed set of
+    /// watch-addable domain raw values: a watch-addable domain, no config/diagnostic category, and
+    /// not hidden in the entity registry (both baked into the row at write time; see
+    /// `AppEntitiesModel`). Every watch area path must use this same predicate so browsing, the
+    /// home-screen mode and the empty-area checks all agree.
+    func isWatchAreaCompatible(allowedDomains: Set<String>) -> Bool {
+        allowedDomains.contains(domain) && entityCategory == nil && isHidden != true
+    }
+
     /// Entity ids the watch area screens can render for a server: watch-addable domains, without
-    /// config/diagnostic entities. Used to drop areas that would show an empty screen.
+    /// config/diagnostic or hidden entities. Used to drop areas that would show an empty screen.
     static func watchAreaEntityIds(serverId: String) throws -> Set<String> {
         let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
         let entities = try Current.database().read { db in
@@ -61,7 +70,7 @@ public extension HAAppEntity {
                 .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
                 .fetchAll(db)
         }
-        let compatible = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+        let compatible = entities.filter { $0.isWatchAreaCompatible(allowedDomains: allowedDomains) }
         return Set(compatible.map(\.entityId))
     }
 

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -309,6 +309,28 @@ public struct WatchDatabaseMirror: WatchCodable {
             try applyReferenceTables(in: db)
             try applyComplicationTables(in: db, includeRegistryRows: true)
         }
+        logApplyOutcome()
+    }
+
+    /// Record which tables a payload actually carried and what the database holds afterwards.
+    ///
+    /// A byte count alone can't distinguish "carried every table" from "carried one table and
+    /// retained the rest", and an apply that logs success can still leave a table empty — which is
+    /// exactly the shape of the sync problems seen on device. Logging both ends of the operation
+    /// makes a watch log enough on its own to tell which side lost the data.
+    private func logApplyOutcome() {
+        let carried = carriedDigestKeys.sorted().joined(separator: "+")
+        let counts = (try? Current.database().read { db in
+            [
+                "entities": try HAAppEntity.fetchCount(db),
+                "areas": try AppArea.fetchCount(db),
+                "registry": try EntityRegistryListForDisplay.Entity.fetchCount(db),
+                "devices": try AppDeviceRegistry.fetchCount(db),
+                "pipelines": try AssistPipelines.fetchCount(db),
+            ]
+        }) ?? [:]
+        let rows = counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }.joined(separator: " ")
+        Current.Log.info("Applied mirror carrying [\(carried.isEmpty ? "nothing" : carried)]; rows now \(rows)")
     }
 
     private func applyReferenceTables(in db: Database) throws {

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -170,6 +170,29 @@ public struct WatchDatabaseMirror: WatchCodable {
         return keys
     }
 
+    /// Digest keys whose mirrored table holds no rows in the local database (called on the watch).
+    ///
+    /// A stored digest asserts "this table is already here, at this version", and the phone uses that
+    /// assertion to omit the table from the next sync. If the table is actually empty — wiped by an
+    /// older build that accepted an authoritative empty payload, a failed apply, a "delete local
+    /// data" — the assertion is false and the omission repeats on every sync, so the table never
+    /// comes back. The visible symptom is a home screen that resolves no names and falls back to
+    /// showing entity ids, alongside syncs that transfer almost nothing.
+    ///
+    /// Dropping these keys before echoing the digests makes the phone send those tables again, so a
+    /// watch already stuck in that state repairs itself on its next sync.
+    public static func digestKeysForEmptyLocalTables() -> Set<String> {
+        (try? Current.database().read { db in
+            var keys: Set<String> = []
+            if try HAAppEntity.fetchCount(db) == 0 { keys.insert("entities") }
+            if try AppArea.fetchCount(db) == 0 { keys.insert("areas") }
+            if try AssistPipelines.fetchCount(db) == 0 { keys.insert("pipelines") }
+            if try EntityRegistryListForDisplay.Entity.fetchCount(db) == 0 { keys.insert("registry") }
+            if try AppDeviceRegistry.fetchCount(db) == 0 { keys.insert("devices") }
+            return keys
+        }) ?? []
+    }
+
     /// All `.entity` items the watch home screen renders, including those nested inside folders.
     private static func entityItems(in items: [MagicItem]) -> [MagicItem] {
         items.flatMap { item -> [MagicItem] in

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -321,12 +321,12 @@ public struct WatchDatabaseMirror: WatchCodable {
     private func logApplyOutcome() {
         let carried = carriedDigestKeys.sorted().joined(separator: "+")
         let counts = (try? Current.database().read { db in
-            [
-                "entities": try HAAppEntity.fetchCount(db),
-                "areas": try AppArea.fetchCount(db),
-                "registry": try EntityRegistryListForDisplay.Entity.fetchCount(db),
-                "devices": try AppDeviceRegistry.fetchCount(db),
-                "pipelines": try AssistPipelines.fetchCount(db),
+            try [
+                "entities": HAAppEntity.fetchCount(db),
+                "areas": AppArea.fetchCount(db),
+                "registry": EntityRegistryListForDisplay.Entity.fetchCount(db),
+                "devices": AppDeviceRegistry.fetchCount(db),
+                "pipelines": AssistPipelines.fetchCount(db),
             ]
         }) ?? [:]
         let rows = counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }.joined(separator: " ")

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -137,6 +137,39 @@ public struct WatchDatabaseMirror: WatchCodable {
         Set(Domain.watchAddable.map(\.rawValue))
     }
 
+    /// A reference table that reads back empty is carried as `nil` (retain) rather than as an
+    /// authoritative empty array.
+    ///
+    /// The phone's tables are emptied and rewritten by `AppDatabaseUpdater`, and a read that lands
+    /// on a transiently empty table (a refresh that fetched nothing, a reset, a wipe-and-rebuild in
+    /// progress) would otherwise tell the watch "the phone genuinely has no entities" and delete
+    /// every mirrored row — leaving the watch with a home screen that resolves nothing until the
+    /// next successful sync. A server that legitimately has zero entities/areas is not a state
+    /// worth propagating at the cost of that failure mode; the complication fields already follow
+    /// the same "only a successful read is authoritative" rule.
+    private static func retainingIfEmpty<T>(_ rows: [T]) -> [T]? {
+        rows.isEmpty ? nil : rows
+    }
+
+    /// Digest keys for the tables this payload actually carries.
+    ///
+    /// The watch merges only these into its stored digest map, so a table the phone omitted — as a
+    /// delta push, or because it read back empty — keeps its previous digest instead of adopting
+    /// the phone's. That is what makes omission self-healing: if the phone's belief about what the
+    /// watch holds is ever wrong, the watch still echoes its true digests on the next pull and the
+    /// missing table is carried then.
+    public var carriedDigestKeys: Set<String> {
+        var keys: Set<String> = []
+        if entities != nil { keys.insert("entities") }
+        if areas != nil { keys.insert("areas") }
+        if pipelines != nil { keys.insert("pipelines") }
+        if registry != nil { keys.insert("registry") }
+        if devices != nil { keys.insert("devices") }
+        if complications != nil, complicationConfigs != nil { keys.insert("complications") }
+        if servers != nil { keys.insert("servers") }
+        return keys
+    }
+
     /// All `.entity` items the watch home screen renders, including those nested inside folders.
     private static func entityItems(in items: [MagicItem]) -> [MagicItem] {
         items.flatMap { item -> [MagicItem] in
@@ -184,8 +217,8 @@ public struct WatchDatabaseMirror: WatchCodable {
 
         return try Current.database().read { db in
             let entities: [HAAppEntity]
-            var fullRegistry: [EntityRegistryListForDisplay.Entity]?
-            var devices: [AppDeviceRegistry]?
+            var fullRegistry: [EntityRegistryListForDisplay.Entity] = []
+            var devices: [AppDeviceRegistry] = []
             if version >= fullReferenceVersion {
                 // Full parity with the iPhone's reference tables: every row travels, including
                 // hidden and config/diagnostic entities — the watch filters at read time exactly
@@ -213,12 +246,14 @@ public struct WatchDatabaseMirror: WatchCodable {
             }
             let areas = try AppArea.fetchAll(db)
             let pipelines = try AssistPipelines.fetchAll(db)
+            // Every reference table goes through `retainingIfEmpty`: an empty read is never sent as
+            // an authoritative wipe (see its documentation).
             return WatchDatabaseMirror(
-                entities: entities,
-                areas: areas,
-                pipelines: pipelines,
-                registry: fullRegistry,
-                devices: devices,
+                entities: retainingIfEmpty(entities),
+                areas: retainingIfEmpty(areas),
+                pipelines: retainingIfEmpty(pipelines),
+                registry: retainingIfEmpty(fullRegistry),
+                devices: retainingIfEmpty(devices),
                 complications: complications,
                 complicationConfigs: configs,
                 registryEntities: registry,

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -9,10 +9,19 @@ import GRDB
 /// Assistant directly. Reference tables, complications, configs, and servers all travel on this
 /// mirror.
 ///
-/// Only what the add flow needs is included: entities of watch-supported domains, areas
-/// (for the context line), and Assist pipelines. Device / entity-registry tables are intentionally
-/// omitted — they're large and the context line works without them. Even so, this snapshot
-/// can exceed WatchConnectivity's per-message limit, so it is streamed as chunked guaranteed messages.
+/// The snapshot's fidelity depends on the mirror version the watch advertises on its sync request
+/// (`versionKey`):
+/// - **Legacy (v1)**: only what the add flow needs — entities of watch-supported domains minus the
+///   registry-hidden ones, areas (for the context line), and Assist pipelines. Device /
+///   entity-registry tables are omitted. Served to watches that don't advertise a version.
+/// - **Full reference (v2, `fullReferenceVersion`)**: every row of the server-reference tables the
+///   iPhone maintains — entities (all domains, hidden included), the full entity registry, the full
+///   device registry, areas and pipelines — so watch features can query the same data the same way
+///   iPhone features do, and new registry-derived behavior needs no per-field mirroring work.
+///   v2 payloads travel LZFSE-compressed (flagged via `compressedKey`) to offset the extra rows.
+///
+/// Either way the snapshot can exceed WatchConnectivity's per-message limit, so it is streamed as
+/// chunked guaranteed messages (or pushed whole over `transferFile`).
 public struct WatchDatabaseMirror: WatchCodable {
     /// Blob identifier used when the phone proactively *pushes* the mirror to the watch over
     /// `transferFile` (background-capable), in addition to the watch-initiated chunked pull.
@@ -20,6 +29,17 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// Key under which sync requests, sync-start replies and push metadata carry the per-table
     /// digest map used for delta syncs (see `tableDigests()`).
     public static let digestsKey = "digests"
+    /// Key under which the watch's sync request advertises the highest mirror version it
+    /// understands. Absent means a legacy build → the phone serves the v1 snapshot.
+    public static let versionKey = "mirrorVersion"
+    /// Key flagging an LZFSE-compressed payload: set in the sync-start reply (the assembled chunks
+    /// are compressed) and in push transfer metadata (the blob content is compressed). Absent means
+    /// plain property-list bytes, so a legacy phone's reply is decoded unchanged.
+    public static let compressedKey = "compressed"
+    /// The mirror served to watches that don't advertise a version (see the type doc).
+    public static let legacyVersion = 1
+    /// The full-reference mirror (see the type doc).
+    public static let fullReferenceVersion = 2
 
     /// The reference tables. All optional with the same retain semantics as the complication
     /// fields below: `nil` means "this sync did not carry the table" — either a delta sync where
@@ -27,6 +47,12 @@ public struct WatchDatabaseMirror: WatchCodable {
     public var entities: [HAAppEntity]?
     public var areas: [AppArea]?
     public var pipelines: [AssistPipelines]?
+    /// The full entity registry (`list_for_display`), carried from `fullReferenceVersion` onwards so
+    /// the watch holds the same registry the iPhone does. Same retain semantics as `entities`.
+    /// Distinct from `registryEntities` below, the per-entity precision slice kept for legacy builds.
+    public var registry: [EntityRegistryListForDisplay.Entity]?
+    /// The full device registry, carried from `fullReferenceVersion` onwards. Same retain semantics.
+    public var devices: [AppDeviceRegistry]?
     /// Legacy complications + modern configs so the watch reload routine is another chance to receive
     /// them (in addition to the background WatchConnectivity context push).
     ///
@@ -53,6 +79,8 @@ public struct WatchDatabaseMirror: WatchCodable {
         entities: [HAAppEntity]?,
         areas: [AppArea]?,
         pipelines: [AssistPipelines]?,
+        registry: [EntityRegistryListForDisplay.Entity]? = nil,
+        devices: [AppDeviceRegistry]? = nil,
         complications: [WatchComplication]? = nil,
         complicationConfigs: [WatchComplicationConfig]? = nil,
         registryEntities: [EntityRegistryListForDisplay.Entity] = [],
@@ -61,6 +89,8 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.entities = entities
         self.areas = areas
         self.pipelines = pipelines
+        self.registry = registry
+        self.devices = devices
         self.complications = complications
         self.complicationConfigs = complicationConfigs
         self.registryEntities = registryEntities
@@ -68,7 +98,7 @@ public struct WatchDatabaseMirror: WatchCodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case entities, areas, pipelines, complications, complicationConfigs, servers
+        case entities, areas, pipelines, registry, devices, complications, complicationConfigs, servers
         case registryEntities = "complicationEntities"
     }
 
@@ -85,6 +115,8 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.entities = try container.decodeIfPresent([HAAppEntity].self, forKey: .entities)
         self.areas = try container.decodeIfPresent([AppArea].self, forKey: .areas)
         self.pipelines = try container.decodeIfPresent([AssistPipelines].self, forKey: .pipelines)
+        self.registry = try container.decodeIfPresent([EntityRegistryListForDisplay.Entity].self, forKey: .registry)
+        self.devices = try container.decodeIfPresent([AppDeviceRegistry].self, forKey: .devices)
         self.complications = (try? container.decodeIfPresent([WatchComplication].self, forKey: .complications))
             .flatMap { $0 }
         self.complicationConfigs = (try? container.decodeIfPresent(
@@ -98,8 +130,9 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.servers = (try? container.decodeIfPresent(Data.self, forKey: .servers)).flatMap { $0 }
     }
 
-    /// Domains the watch can add (mirrors the iPhone watch picker), including the display-only
-    /// sensor domains — the watch resolves their names and icons from these rows too.
+    /// Domains the legacy (v1) mirror carries (mirrors the iPhone watch picker), including the
+    /// display-only sensor domains — the watch resolves their names and icons from these rows too.
+    /// The full-reference (v2) mirror carries every domain instead.
     private static var mirroredDomains: Set<String> {
         Set(Domain.watchAddable.map(\.rawValue))
     }
@@ -118,8 +151,9 @@ public struct WatchDatabaseMirror: WatchCodable {
         }
     }
 
-    /// Read the current reference tables from the local GRDB (called on the phone).
-    public static func snapshot() throws -> WatchDatabaseMirror {
+    /// Read the current reference tables from the local GRDB (called on the phone). Pass the mirror
+    /// version the receiving watch advertised; the default serves the legacy slice (see the type doc).
+    public static func snapshot(version: Int = legacyVersion) throws -> WatchDatabaseMirror {
         // A read failure sends `nil` (not `[]`) so the watch retains its rows rather than being told the
         // phone has none — only a successful read is authoritative.
         let complications = try? WatchComplication.all()
@@ -149,23 +183,42 @@ public struct WatchDatabaseMirror: WatchCodable {
         let servers = Current.servers.restorableState()
 
         return try Current.database().read { db in
-            // The watch never receives the full registry, so it can't filter hidden entities
-            // itself — exclude them here, matching the iPhone entity picker.
-            let hiddenKeys = try Set(
-                EntityRegistryListForDisplay.Entity.fetchAll(db)
-                    .filter(\.isHidden)
-                    .map { ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId) }
-            )
-            let entities = try HAAppEntity
-                .filter(mirroredDomains.contains(Column(DatabaseTables.AppEntity.domain.rawValue)))
-                .fetchAll(db)
-                .filter { !hiddenKeys.contains(ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId)) }
+            let entities: [HAAppEntity]
+            var fullRegistry: [EntityRegistryListForDisplay.Entity]?
+            var devices: [AppDeviceRegistry]?
+            if version >= fullReferenceVersion {
+                // Full parity with the iPhone's reference tables: every row travels, including
+                // hidden and config/diagnostic entities — the watch filters at read time exactly
+                // like the iPhone does. Sorted so the encoded payload (and therefore the delta-sync
+                // digests) stays stable across snapshots of unchanged data.
+                entities = try HAAppEntity.fetchAll(db).sorted { $0.id < $1.id }
+                fullRegistry = try EntityRegistryListForDisplay.Entity.fetchAll(db)
+                    .sorted { ($0.serverId, $0.entityId) < ($1.serverId, $1.entityId) }
+                devices = try AppDeviceRegistry.fetchAll(db).sorted { $0.id < $1.id }
+            } else {
+                // Legacy watches never receive the registry and their read paths predate the baked
+                // `isHidden` flag, so they can't filter hidden entities themselves — exclude them
+                // here, matching the iPhone entity picker.
+                let hiddenKeys = try Set(
+                    EntityRegistryListForDisplay.Entity.fetchAll(db)
+                        .filter(\.isHidden)
+                        .map { ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId) }
+                )
+                entities = try HAAppEntity
+                    .filter(mirroredDomains.contains(Column(DatabaseTables.AppEntity.domain.rawValue)))
+                    .fetchAll(db)
+                    .filter {
+                        !hiddenKeys.contains(ServerEntity.uniqueId(serverId: $0.serverId, entityId: $0.entityId))
+                    }
+            }
             let areas = try AppArea.fetchAll(db)
             let pipelines = try AssistPipelines.fetchAll(db)
             return WatchDatabaseMirror(
                 entities: entities,
                 areas: areas,
                 pipelines: pipelines,
+                registry: fullRegistry,
+                devices: devices,
                 complications: complications,
                 complicationConfigs: configs,
                 registryEntities: registry,
@@ -174,9 +227,25 @@ public struct WatchDatabaseMirror: WatchCodable {
         }
     }
 
+    // MARK: - Payload compression
+
+    /// Compress an encoded mirror for transfer. Full-reference (v2) payloads always travel
+    /// compressed — they carry every reference row — and the receiver knows via `compressedKey`,
+    /// never by guessing.
+    public static func compress(_ data: Data) throws -> Data {
+        try (data as NSData).compressed(using: .lzfse) as Data
+    }
+
+    /// Inverse of `compress(_:)`, called by the watch before decoding a payload whose sync reply or
+    /// push metadata carried the `compressedKey` flag.
+    public static func decompress(_ data: Data) throws -> Data {
+        try (data as NSData).decompressed(using: .lzfse) as Data
+    }
+
     /// Overwrite the local GRDB reference tables with this snapshot (called on the watch). The watch
-    /// only ever holds mirrored rows in these tables, so a full replace is correct. Registry rows
-    /// are upserted (not wiped) so they don't disturb other registry data.
+    /// only ever holds mirrored rows in these tables, so a full replace is correct. The legacy
+    /// `registryEntities` precision slice is upserted (not wiped) so a v1 payload doesn't disturb
+    /// registry rows a v2 sync delivered; a carried full `registry` replaces the table outright.
     public func apply() throws {
         try Current.database().write { db in
             try applyReferenceTables(in: db)
@@ -203,6 +272,21 @@ public struct WatchDatabaseMirror: WatchCodable {
             try AssistPipelines.deleteAll(db)
             for pipeline in pipelines {
                 try pipeline.insert(db)
+            }
+        }
+        // Full-reference tables (v2). The registry replace runs before the legacy
+        // `registryEntities` upsert in `applyComplicationTables` — those rows come from the same
+        // phone table, so re-upserting a subset afterwards is a no-op, not a conflict.
+        if let registry {
+            try EntityRegistryListForDisplay.Entity.deleteAll(db)
+            for entry in registry {
+                try entry.insert(db)
+            }
+        }
+        if let devices {
+            try AppDeviceRegistry.deleteAll(db)
+            for device in devices {
+                try device.insert(db)
             }
         }
     }
@@ -249,6 +333,12 @@ public struct WatchDatabaseMirror: WatchCodable {
         if let pipelines, let data = try? encoder.encode(pipelines) {
             digests["pipelines"] = Self.digest(of: [data])
         }
+        if let registry, let data = try? encoder.encode(registry) {
+            digests["registry"] = Self.digest(of: [data])
+        }
+        if let devices, let data = try? encoder.encode(devices) {
+            digests["devices"] = Self.digest(of: [data])
+        }
         // The complication tables travel and change together; one digest covers all three.
         if let complications, let complicationConfigs,
            let complicationsData = try? encoder.encode(complications),
@@ -284,6 +374,8 @@ public struct WatchDatabaseMirror: WatchCodable {
         if matches("entities") { copy.entities = nil }
         if matches("areas") { copy.areas = nil }
         if matches("pipelines") { copy.pipelines = nil }
+        if matches("registry") { copy.registry = nil }
+        if matches("devices") { copy.devices = nil }
         if matches("complications") {
             copy.complications = nil
             copy.complicationConfigs = nil

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -639,12 +639,12 @@ final class WatchCommunicatorService {
                     return
                 }
                 let transferId = UUID().uuidString
-                databaseSyncChunks[transferId] = DatabaseSyncTransfer(chunks: builtChunks)
+                self.databaseSyncChunks[transferId] = DatabaseSyncTransfer(chunks: builtChunks)
                 // Backstop for a watch that dies mid-pull and never starts another sync: a healthy pull
                 // completes in seconds (each chunk request has a 30s reply ceiling and one timeout fails
                 // the whole sync on the watch), so a buffer still around after this long is abandoned.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 600) { [weak self] in
-                    guard let self, databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
+                    guard let self, self.databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
                     Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
                 }
                 Current.Log

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -516,7 +516,7 @@ final class WatchCommunicatorService {
                 // `getInfo` adds to the context line when multiple servers are configured.
                 let serverPrefix = "\(server.info.name) • "
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }
@@ -584,10 +584,16 @@ final class WatchCommunicatorService {
             Current.Log.info("Dropping \(databaseSyncChunks.count) abandoned watch DB sync buffer(s)")
             databaseSyncChunks.removeAll()
         }
+        // The watch advertises the highest mirror version it understands; absent means a legacy
+        // build. Recorded so proactive pushes serve the same fidelity across launches — including
+        // dropping back to legacy when an older watch (no version key) is paired.
+        let version = message.content[WatchDatabaseMirror.versionKey] as? Int ?? WatchDatabaseMirror.legacyVersion
+        WatchMirrorPushCoordinator.peerMirrorVersion = version
+        let compressed = version >= WatchDatabaseMirror.fullReferenceVersion
         let data: Data
         let digests: [String: String]
         do {
-            var mirror = try WatchDatabaseMirror.snapshot()
+            var mirror = try WatchDatabaseMirror.snapshot(version: version)
             digests = mirror.tableDigests()
             // Delta sync: a watch that echoes previously-issued digests receives only the tables
             // that changed since (nil = retain). Watches that send no digests — older builds or a
@@ -596,7 +602,8 @@ final class WatchCommunicatorService {
                !stored.isEmpty {
                 mirror = mirror.omittingTables(matching: stored, currentDigests: digests)
             }
-            data = try mirror.encodeForWatch()
+            let encoded = try mirror.encodeForWatch()
+            data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
         } catch {
             Current.Log.error("Failed to build watch database mirror: \(error.localizedDescription)")
             message.reply(.init(identifier: responseId, content: ["error": true]))
@@ -623,13 +630,19 @@ final class WatchCommunicatorService {
             Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
         }
         Current.Log.info("Watch DB sync start: \(chunks.count) chunk(s), \(data.count) bytes, id \(transferId)")
-        message.reply(.init(identifier: responseId, content: [
+        var replyContent: [String: Any] = [
             "transferId": transferId,
             "totalChunks": chunks.count,
             "totalBytes": data.count,
             // The watch stores these after a successful apply and echoes them on the next sync.
             WatchDatabaseMirror.digestsKey: digests,
-        ]))
+        ]
+        // Explicit flag rather than inferred from the requested version: a watch that asked for v2
+        // but is answered by an older phone build gets no flag and decodes the plain payload.
+        if compressed {
+            replyContent[WatchDatabaseMirror.compressedKey] = true
+        }
+        message.reply(.init(identifier: responseId, content: replyContent))
     }
 
     /// Serve one chunk of an in-progress database sync. The buffer is freed once every chunk has

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -644,7 +644,7 @@ final class WatchCommunicatorService {
                 // completes in seconds (each chunk request has a 30s reply ceiling and one timeout fails
                 // the whole sync on the watch), so a buffer still around after this long is abandoned.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 600) { [weak self] in
-                    guard let self, self.databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
+                    guard let self, databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
                     Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
                 }
                 Current.Log

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -515,8 +515,9 @@ final class WatchCommunicatorService {
                 // The user picks the server before seeing entities, so drop the server prefix that
                 // `getInfo` adds to the context line when multiple servers are configured.
                 let serverPrefix = "\(server.info.name) • "
+                let excluded = HAAppEntity.watchExcludedEntityIds(serverId: serverId)
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
+                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains, excludedEntityIds: excluded) }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }

--- a/Sources/Watch/WatchCommunicatorService.swift
+++ b/Sources/Watch/WatchCommunicatorService.swift
@@ -574,6 +574,11 @@ final class WatchCommunicatorService {
     /// Chunk size for the database sync. Comfortably under WatchConnectivity's per-message ceiling.
     private static let mirrorChunkByteSize = 30000
 
+    /// Serial queue the sync-start payload is built on, so the read/encode/compress work never runs
+    /// on the main queue. Serial so overlapping sync requests queue behind each other instead of
+    /// contending for the same SQLite reader.
+    private static let mirrorBuildQueue = DispatchQueue(label: "watch-mirror-build", qos: .userInitiated)
+
     /// Begin a full database sync: snapshot the reference GRDB tables, encode, split into ordered
     /// chunks held in memory, and tell the watch how many chunks/bytes to expect. The watch then pulls
     /// each chunk via `watchDatabaseMirrorChunk`. A single interactive reply here can exceed the size
@@ -590,59 +595,75 @@ final class WatchCommunicatorService {
         let version = message.content[WatchDatabaseMirror.versionKey] as? Int ?? WatchDatabaseMirror.legacyVersion
         WatchMirrorPushCoordinator.peerMirrorVersion = version
         let compressed = version >= WatchDatabaseMirror.fullReferenceVersion
-        let data: Data
-        let digests: [String: String]
-        do {
-            var mirror = try WatchDatabaseMirror.snapshot(version: version)
-            digests = mirror.tableDigests()
-            // Delta sync: a watch that echoes previously-issued digests receives only the tables
-            // that changed since (nil = retain). Watches that send no digests — older builds or a
-            // first sync — get the full snapshot.
-            if let stored = message.content[WatchDatabaseMirror.digestsKey] as? [String: String],
-               !stored.isEmpty {
-                mirror = mirror.omittingTables(matching: stored, currentDigests: digests)
+        let storedDigests = message.content[WatchDatabaseMirror.digestsKey] as? [String: String]
+        // Building the snapshot reads every reference table and then encodes, hashes and compresses
+        // megabytes of rows. On the main queue that competes with everything else the app is doing,
+        // and the watch's reply ceiling expires before the answer lands ("The counterpart did not
+        // reply in time"), so the build runs off-main; only the buffer bookkeeping and the reply
+        // itself hop back. Replying off the main queue would be safe too, but the buffer is
+        // main-queue state.
+        Self.mirrorBuildQueue.async { [weak self] in
+            let data: Data
+            let digests: [String: String]
+            do {
+                var mirror = try WatchDatabaseMirror.snapshot(version: version)
+                digests = mirror.tableDigests()
+                // Delta sync: a watch that echoes previously-issued digests receives only the tables
+                // that changed since (nil = retain). Watches that send no digests — older builds or a
+                // first sync — get the full snapshot.
+                if let storedDigests, !storedDigests.isEmpty {
+                    mirror = mirror.omittingTables(matching: storedDigests, currentDigests: digests)
+                }
+                let encoded = try mirror.encodeForWatch()
+                data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
+            } catch {
+                Current.Log.error("Failed to build watch database mirror: \(error.localizedDescription)")
+                message.reply(.init(identifier: responseId, content: ["error": true]))
+                return
             }
-            let encoded = try mirror.encodeForWatch()
-            data = compressed ? try WatchDatabaseMirror.compress(encoded) : encoded
-        } catch {
-            Current.Log.error("Failed to build watch database mirror: \(error.localizedDescription)")
-            message.reply(.init(identifier: responseId, content: ["error": true]))
-            return
-        }
 
-        let chunkSize = Self.mirrorChunkByteSize
-        var chunks: [Data] = []
-        var offset = 0
-        while offset < data.count {
-            let end = min(offset + chunkSize, data.count)
-            chunks.append(data.subdata(in: offset ..< end))
-            offset = end
-        }
-        if chunks.isEmpty { chunks = [Data()] }
+            let chunkSize = Self.mirrorChunkByteSize
+            var chunks: [Data] = []
+            var offset = 0
+            while offset < data.count {
+                let end = min(offset + chunkSize, data.count)
+                chunks.append(data.subdata(in: offset ..< end))
+                offset = end
+            }
+            if chunks.isEmpty { chunks = [Data()] }
+            let builtChunks = chunks
 
-        let transferId = UUID().uuidString
-        databaseSyncChunks[transferId] = DatabaseSyncTransfer(chunks: chunks)
-        // Backstop for a watch that dies mid-pull and never starts another sync: a healthy pull
-        // completes in seconds (each chunk request has a 30s reply ceiling and one timeout fails the
-        // whole sync on the watch), so a buffer still around after this long is abandoned.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 600) { [weak self] in
-            guard let self, databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
-            Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
+            DispatchQueue.main.async {
+                guard let self else {
+                    message.reply(.init(identifier: responseId, content: ["error": true]))
+                    return
+                }
+                let transferId = UUID().uuidString
+                databaseSyncChunks[transferId] = DatabaseSyncTransfer(chunks: builtChunks)
+                // Backstop for a watch that dies mid-pull and never starts another sync: a healthy pull
+                // completes in seconds (each chunk request has a 30s reply ceiling and one timeout fails
+                // the whole sync on the watch), so a buffer still around after this long is abandoned.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 600) { [weak self] in
+                    guard let self, databaseSyncChunks.removeValue(forKey: transferId) != nil else { return }
+                    Current.Log.info("Expired abandoned watch DB sync buffer \(transferId)")
+                }
+                Current.Log
+                    .info("Watch DB sync start: \(builtChunks.count) chunk(s), \(data.count) bytes, id \(transferId)")
+                var replyContent: [String: Any] = [
+                    "transferId": transferId,
+                    "totalChunks": builtChunks.count,
+                    "totalBytes": data.count,
+                    // The watch stores these after a successful apply and echoes them on the next sync.
+                    WatchDatabaseMirror.digestsKey: digests,
+                ]
+                // Explicit flag rather than inferred from the requested version: a watch that asked for
+                // v2 but is answered by an older phone build gets no flag and decodes the plain payload.
+                if compressed {
+                    replyContent[WatchDatabaseMirror.compressedKey] = true
+                }
+                message.reply(.init(identifier: responseId, content: replyContent))
+            }
         }
-        Current.Log.info("Watch DB sync start: \(chunks.count) chunk(s), \(data.count) bytes, id \(transferId)")
-        var replyContent: [String: Any] = [
-            "transferId": transferId,
-            "totalChunks": chunks.count,
-            "totalBytes": data.count,
-            // The watch stores these after a successful apply and echoes them on the next sync.
-            WatchDatabaseMirror.digestsKey: digests,
-        ]
-        // Explicit flag rather than inferred from the requested version: a watch that asked for v2
-        // but is answered by an older phone build gets no flag and decodes the plain payload.
-        if compressed {
-            replyContent[WatchDatabaseMirror.compressedKey] = true
-        }
-        message.reply(.init(identifier: responseId, content: replyContent))
     }
 
     /// Serve one chunk of an in-progress database sync. The buffer is freed once every chunk has

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -370,11 +370,14 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         Self.performProtectedDatabaseWork(reason: "watch-mirror-apply") {
             do {
                 try mirror.apply()
-                // The push carries the phone's digests in the transfer metadata; storing them keeps
-                // the next interactive delta sync accurate instead of re-fetching everything.
-                if let digests = metadata?[WatchDatabaseMirror.digestsKey] as? [String: String] {
-                    WatchUserDefaults.shared.databaseMirrorDigests = digests
-                }
+                // The push carries the phone's digests in the transfer metadata; storing them for
+                // the tables this push actually carried keeps the next interactive delta sync
+                // accurate instead of re-fetching everything (or wrongly assuming it has data a
+                // delta push omitted).
+                WatchUserDefaults.shared.mergeDatabaseMirrorDigests(
+                    metadata?[WatchDatabaseMirror.digestsKey] as? [String: String],
+                    carrying: mirror.carriedDigestKeys
+                )
                 Current.Log.info("Applied pushed watch database mirror (\(data.count) bytes)")
                 Current.clientEventStore.addEvent(.init(
                     text: "Applied pushed watch database mirror from iPhone (\(data.count) bytes)",

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -341,6 +341,20 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     /// when the watch app was suspended). Mirrors the watch-pull apply path so the watch's cached data
     /// (entities, areas, pipelines, complications) stays fresh without the user opening the app.
     private func applyPushedDatabaseMirror(_ data: Data, metadata: HAWatchConnectivity.Content?) {
+        var data = data
+        // Full-reference (v2) pushes travel compressed; the transfer metadata says so explicitly.
+        if metadata?[WatchDatabaseMirror.compressedKey] as? Bool == true {
+            do {
+                data = try WatchDatabaseMirror.decompress(data)
+            } catch {
+                Current.Log.error("Failed to decompress pushed watch database mirror: \(error)")
+                Current.clientEventStore.addEvent(.init(
+                    text: "Failed to decompress pushed watch database mirror (\(data.count) bytes): \(error)",
+                    type: .database
+                ))
+                return
+            }
+        }
         let mirror: WatchDatabaseMirror
         do {
             mirror = try WatchDatabaseMirror.decodeForWatchThrowing(data)

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -59,7 +59,7 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
                 let entries: [Entry] = (entitiesPerServer[serverId] ?? [])
                     .filter { entity in
                         area.entities.contains(entity.entityId)
-                            && entity.isWatchAreaCompatible(allowedDomains: allowedDomains)
+                            && entity.isWatchCompatible(allowedDomains: allowedDomains)
                     }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                     .compactMap { entity in

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -59,8 +59,7 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
                 let entries: [Entry] = (entitiesPerServer[serverId] ?? [])
                     .filter { entity in
                         area.entities.contains(entity.entityId)
-                            && allowedDomains.contains(entity.domain)
-                            && entity.entityCategory == nil
+                            && entity.isWatchAreaCompatible(allowedDomains: allowedDomains)
                     }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                     .compactMap { entity in

--- a/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
+++ b/Sources/WatchApp/Home/Areas/WatchAreaEntitiesViewModel.swift
@@ -56,10 +56,14 @@ final class WatchAreaEntitiesViewModel: ObservableObject {
             let provider = Current.magicItemProvider()
             provider.loadInformation { entitiesPerServer in
                 let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
+                let excluded = HAAppEntity.watchExcludedEntityIds(serverId: serverId)
                 let entries: [Entry] = (entitiesPerServer[serverId] ?? [])
                     .filter { entity in
                         area.entities.contains(entity.entityId)
-                            && entity.isWatchCompatible(allowedDomains: allowedDomains)
+                            && entity.isWatchCompatible(
+                                allowedDomains: allowedDomains,
+                                excludedEntityIds: excluded
+                            )
                     }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                     .compactMap { entity in

--- a/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
@@ -256,8 +256,9 @@ extension WatchHomeViewModel {
             let groups: [WatchConfigAvailableItems.ServerGroup] = Current.servers.all.map { server in
                 let serverId = server.identifier.rawValue
                 let serverPrefix = "\(server.info.name) • "
+                let excluded = HAAppEntity.watchExcludedEntityIds(serverId: serverId)
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
+                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains, excludedEntityIds: excluded) }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }

--- a/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel+Editing.swift
@@ -257,7 +257,7 @@ extension WatchHomeViewModel {
                 let serverId = server.identifier.rawValue
                 let serverPrefix = "\(server.info.name) • "
                 let candidates: [WatchConfigAvailableItems.Candidate] = (entitiesPerServer[serverId] ?? [])
-                    .filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+                    .filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
                     .compactMap { entity in
                         let item = MagicItem(id: entity.entityId, serverId: serverId, type: .entity)
                         guard let info = magicItemProvider.getInfo(for: item) else { return nil }

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -549,8 +549,12 @@ final class WatchHomeViewModel: ObservableObject {
             }
             do {
                 try mirror.apply()
-                // Only a successfully applied mirror advances the delta-sync baseline.
-                WatchUserDefaults.shared.databaseMirrorDigests = responseDigests
+                // Only a successfully applied mirror advances the delta-sync baseline, and only for
+                // the tables it actually carried — see `mergeDatabaseMirrorDigests`.
+                WatchUserDefaults.shared.mergeDatabaseMirrorDigests(
+                    responseDigests,
+                    carrying: mirror.carriedDigestKeys
+                )
                 Current.Log.info("Applied watch database mirror (\(data.count) bytes)")
                 Current.clientEventStore.addEvent(.init(
                     text: "Apple Watch database sync applied (\(data.count) bytes)",

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -411,7 +411,9 @@ final class WatchHomeViewModel: ObservableObject {
             if !emptyTables.isEmpty {
                 Current.Log
                     .info("Re-requesting mirrored tables that are empty locally: \(emptyTables.sorted())")
-                for key in emptyTables { digests[key] = nil }
+                for key in emptyTables {
+                    digests[key] = nil
+                }
                 WatchUserDefaults.shared.databaseMirrorDigests = digests
             }
             if !digests.isEmpty {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -379,6 +379,9 @@ final class WatchHomeViewModel: ObservableObject {
     /// Digests issued with the sync-start reply; stored as the new baseline only after the mirror
     /// actually applies, so a failed sync keeps requesting the same tables.
     private var syncResponseDigests: [String: String]?
+    /// Whether the sync-start reply flagged the payload as compressed. Trusted over the requested
+    /// version: an older phone ignores the version and serves a plain (uncompressed) payload.
+    private var syncResponseCompressed = false
     /// How many chunk requests may be outstanding at once. Overlapping requests hide the
     /// per-message round-trip latency that made the sync strictly serial (one full round trip per
     /// 30 KB chunk).
@@ -393,8 +396,12 @@ final class WatchHomeViewModel: ObservableObject {
             return
         }
         resetSyncState()
+        // Advertise the highest mirror version this build understands; the phone answers with the
+        // matching snapshot fidelity (an older phone ignores the key and serves the legacy slice).
+        var content: [String: Any] = [
+            WatchDatabaseMirror.versionKey: WatchDatabaseMirror.fullReferenceVersion,
+        ]
         // Echo the digests from the last applied mirror so the phone can omit unchanged tables.
-        var content: [String: Any] = [:]
         if let digests = WatchUserDefaults.shared.databaseMirrorDigests {
             content[WatchDatabaseMirror.digestsKey] = digests
         }
@@ -441,6 +448,7 @@ final class WatchHomeViewModel: ObservableObject {
         syncChunks = [:]
         syncNextIndexToRequest = 0
         syncResponseDigests = message.content[WatchDatabaseMirror.digestsKey] as? [String: String]
+        syncResponseCompressed = message.content[WatchDatabaseMirror.compressedKey] as? Bool ?? false
         Current.clientEventStore.addEvent(.init(
             text: "Apple Watch database sync started (\(totalChunks) chunks)",
             type: .database
@@ -510,9 +518,18 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func finishDatabaseSync() {
         let chunks = syncChunks
-        let data = chunks.keys.sorted().compactMap { chunks[$0] }.reduce(Data(), +)
+        var data = chunks.keys.sorted().compactMap { chunks[$0] }.reduce(Data(), +)
         let responseDigests = syncResponseDigests
+        let isCompressed = syncResponseCompressed
         resetSyncState()
+        if isCompressed {
+            do {
+                data = try WatchDatabaseMirror.decompress(data)
+            } catch {
+                failSync(L10n.Watch.Sync.Error.data, detail: "decompress failed (\(data.count) bytes): \(error)")
+                return
+            }
+        }
         let mirror: WatchDatabaseMirror
         do {
             mirror = try WatchDatabaseMirror.decodeForWatchThrowing(data)
@@ -574,6 +591,7 @@ final class WatchHomeViewModel: ObservableObject {
         syncChunks = [:]
         syncNextIndexToRequest = 0
         syncResponseDigests = nil
+        syncResponseCompressed = false
         syncProgress = nil
     }
 
@@ -660,7 +678,7 @@ final class WatchHomeViewModel: ObservableObject {
         Self.areasModeQueue.async { [weak self] in
             let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
             let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
-                let watchEntities = entities.filter { $0.isWatchAreaCompatible(allowedDomains: allowedDomains) }
+                let watchEntities = entities.filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
                 return Set(watchEntities.map(\.entityId))
             }
             let mode = WatchHomeAreasMode.compute(

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -714,9 +714,13 @@ final class WatchHomeViewModel: ObservableObject {
     private func updateAreasMode(config: WatchConfig, entitiesPerServer: [String: [HAAppEntity]]) {
         Self.areasModeQueue.async { [weak self] in
             let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
-            let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
-                let watchEntities = entities.filter { $0.isWatchCompatible(allowedDomains: allowedDomains) }
-                return Set(watchEntities.map(\.entityId))
+            let watchEntityIdsByServer = entitiesPerServer.reduce(into: [String: Set<String>]()) { result, pair in
+                let (serverId, entities) = pair
+                let excluded = HAAppEntity.watchExcludedEntityIds(serverId: serverId)
+                let watchEntities = entities.filter {
+                    $0.isWatchCompatible(allowedDomains: allowedDomains, excludedEntityIds: excluded)
+                }
+                result[serverId] = Set(watchEntities.map(\.entityId))
             }
             let mode = WatchHomeAreasMode.compute(
                 areas: (try? AppArea.fetchAllAreas()) ?? [],

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -660,7 +660,7 @@ final class WatchHomeViewModel: ObservableObject {
         Self.areasModeQueue.async { [weak self] in
             let allowedDomains = Set(Domain.watchAddable.map(\.rawValue))
             let watchEntityIdsByServer = entitiesPerServer.mapValues { entities in
-                let watchEntities = entities.filter { allowedDomains.contains($0.domain) && $0.entityCategory == nil }
+                let watchEntities = entities.filter { $0.isWatchAreaCompatible(allowedDomains: allowedDomains) }
                 return Set(watchEntities.map(\.entityId))
             }
             let mode = WatchHomeAreasMode.compute(

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -401,9 +401,22 @@ final class WatchHomeViewModel: ObservableObject {
         var content: [String: Any] = [
             WatchDatabaseMirror.versionKey: WatchDatabaseMirror.fullReferenceVersion,
         ]
-        // Echo the digests from the last applied mirror so the phone can omit unchanged tables.
-        if let digests = WatchUserDefaults.shared.databaseMirrorDigests {
-            content[WatchDatabaseMirror.digestsKey] = digests
+        // Echo the digests from the last applied mirror so the phone can omit unchanged tables —
+        // minus any table that is empty here, which the phone would otherwise keep omitting forever
+        // (see `digestKeysForEmptyLocalTables`). Pruning is persisted so the repair sticks even if
+        // this sync fails.
+        if var digests = WatchUserDefaults.shared.databaseMirrorDigests {
+            let emptyTables = WatchDatabaseMirror.digestKeysForEmptyLocalTables()
+                .filter { digests[$0] != nil }
+            if !emptyTables.isEmpty {
+                Current.Log
+                    .info("Re-requesting mirrored tables that are empty locally: \(emptyTables.sorted())")
+                for key in emptyTables { digests[key] = nil }
+                WatchUserDefaults.shared.databaseMirrorDigests = digests
+            }
+            if !digests.isEmpty {
+                content[WatchDatabaseMirror.digestsKey] = digests
+            }
         }
         Communicator.shared.send(.init(
             identifier: InteractiveImmediateMessages.watchDatabaseMirror.rawValue,

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -518,44 +518,62 @@ final class WatchHomeViewModel: ObservableObject {
     @MainActor
     private func finishDatabaseSync() {
         let chunks = syncChunks
-        var data = chunks.keys.sorted().compactMap { chunks[$0] }.reduce(Data(), +)
         let responseDigests = syncResponseDigests
         let isCompressed = syncResponseCompressed
         resetSyncState()
-        if isCompressed {
+        // Assembling, decompressing and decoding the payload — and the apply's full table rewrite —
+        // are real work with the full-reference mirror, so they run off the main actor; only state
+        // updates and the follow-up config pull hop back.
+        Task.detached(priority: .userInitiated) { [weak self] in
+            var data = chunks.keys.sorted().compactMap { chunks[$0] }.reduce(Data(), +)
+            if isCompressed {
+                do {
+                    data = try WatchDatabaseMirror.decompress(data)
+                } catch {
+                    await self?.failSync(
+                        L10n.Watch.Sync.Error.data,
+                        detail: "decompress failed (\(data.count) bytes): \(error)"
+                    )
+                    return
+                }
+            }
+            let mirror: WatchDatabaseMirror
             do {
-                data = try WatchDatabaseMirror.decompress(data)
+                mirror = try WatchDatabaseMirror.decodeForWatchThrowing(data)
             } catch {
-                failSync(L10n.Watch.Sync.Error.data, detail: "decompress failed (\(data.count) bytes): \(error)")
+                await self?.failSync(
+                    L10n.Watch.Sync.Error.data,
+                    detail: "decode failed (\(data.count) bytes): \(error)"
+                )
                 return
             }
+            do {
+                try mirror.apply()
+                // Only a successfully applied mirror advances the delta-sync baseline.
+                WatchUserDefaults.shared.databaseMirrorDigests = responseDigests
+                Current.Log.info("Applied watch database mirror (\(data.count) bytes)")
+                Current.clientEventStore.addEvent(.init(
+                    text: "Apple Watch database sync applied (\(data.count) bytes)",
+                    type: .database
+                ))
+            } catch {
+                await self?.failSync(L10n.Watch.Sync.Error.data, detail: "apply to database failed: \(error)")
+                return
+            }
+            await self?.finishAppliedDatabaseSync(mirror: mirror)
         }
-        let mirror: WatchDatabaseMirror
-        do {
-            mirror = try WatchDatabaseMirror.decodeForWatchThrowing(data)
-        } catch {
-            failSync(L10n.Watch.Sync.Error.data, detail: "decode failed (\(data.count) bytes): \(error)")
-            return
-        }
-        do {
-            try mirror.apply()
-            // Only a successfully applied mirror advances the delta-sync baseline.
-            WatchUserDefaults.shared.databaseMirrorDigests = responseDigests
-            Current.Log.info("Applied watch database mirror (\(data.count) bytes)")
-            Current.clientEventStore.addEvent(.init(
-                text: "Apple Watch database sync applied (\(data.count) bytes)",
-                type: .database
-            ))
-            // The sync also refreshes the servers carried by the mirror (in addition to the dedicated
-            // serversConfigSync exchange kicked off at the start of the reload).
-            WatchServerSync.applyMirroredServers(mirror.servers)
-            // The mirror carries complications too — rebuild widget snapshots now so a reload is another
-            // chance to obtain them if the background context push hasn't delivered them yet.
-            WatchWidgetComplicationSnapshotStore.update()
-        } catch {
-            failSync(L10n.Watch.Sync.Error.data, detail: "apply to database failed: \(error)")
-            return
-        }
+    }
+
+    /// Main-actor tail of a successfully applied mirror: server refresh, widget snapshots and the
+    /// follow-up config pull, all expected on the main thread (matching the pushed-mirror path).
+    @MainActor
+    private func finishAppliedDatabaseSync(mirror: WatchDatabaseMirror) {
+        // The sync also refreshes the servers carried by the mirror (in addition to the dedicated
+        // serversConfigSync exchange kicked off at the start of the reload).
+        WatchServerSync.applyMirroredServers(mirror.servers)
+        // The mirror carries complications too — rebuild widget snapshots now so a reload is another
+        // chance to obtain them if the background context push hasn't delivered them yet.
+        WatchWidgetComplicationSnapshotStore.update()
         // Reference tables are fresh — now pull the watch config and render everything from the DB.
         setLoadingStatus(L10n.Watch.Home.Sync.syncing)
         pullWatchConfig()

--- a/Tests/Shared/Models/EntityRegistry.test.swift
+++ b/Tests/Shared/Models/EntityRegistry.test.swift
@@ -107,4 +107,50 @@ struct AppEntitiesModelNameResolutionTests {
         let namesAfterSecondPass = try await storedNames()
         #expect(namesAfterSecondPass == names)
     }
+
+    /// The registry hidden flag is baked into `HAAppEntity.isHidden` at write time, so consumers
+    /// that never receive the full registry (the watch) can exclude hidden entities locally.
+    @Test("isHidden is copied from the registry at write time")
+    func persistsRegistryHiddenFlag() async throws {
+        let previousDatabase = Current.database
+        let database = try DatabaseQueue(path: ":memory:")
+        try HAppEntityTable().createIfNeeded(database: database)
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        let serverId = "hidden-flag-test"
+        let server = Server.fake(identifier: .init(rawValue: serverId))
+
+        // "light.hidden" is hidden in the registry; "light.visible" has a registry row without the
+        // flag; "light.unregistered" has no registry row at all.
+        try await database.write { db in
+            try EntityRegistryListForDisplay.Entity(serverId: serverId, entityId: "light.hidden", hidden: true)
+                .insert(db)
+            try EntityRegistryListForDisplay.Entity(serverId: serverId, entityId: "light.visible")
+                .insert(db)
+        }
+
+        let entities: Set<HAEntity> = try [
+            makeEntity("light.hidden", friendlyName: "Hidden Light"),
+            makeEntity("light.visible", friendlyName: "Visible Light"),
+            makeEntity("light.unregistered", friendlyName: "Unregistered Light"),
+        ]
+
+        await AppEntitiesModel().updateModel(entities, server: server)
+
+        let rows = try await database.read { db in
+            try HAAppEntity
+                .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
+                .fetchAll(db)
+        }
+        #expect(rows.count == 3)
+        func row(_ entityId: String) throws -> HAAppEntity {
+            try #require(rows.first { $0.entityId == entityId })
+        }
+        #expect(try row("light.hidden").isHidden == true)
+        // Not-hidden and unregistered entities stay `nil`, mirroring how `entityCategory` is baked.
+        #expect(try row("light.visible").isHidden == nil)
+        #expect(try row("light.unregistered").isHidden == nil)
+    }
 }

--- a/Tests/Shared/Models/EntityRegistry.test.swift
+++ b/Tests/Shared/Models/EntityRegistry.test.swift
@@ -148,9 +148,9 @@ struct AppEntitiesModelNameResolutionTests {
         func row(_ entityId: String) throws -> HAAppEntity {
             try #require(rows.first { $0.entityId == entityId })
         }
-        #expect(try row("light.hidden").isHidden == true)
+        try #expect(row("light.hidden").isHidden == true)
         // Not-hidden and unregistered entities stay `nil`, mirroring how `entityCategory` is baked.
-        #expect(try row("light.visible").isHidden == nil)
-        #expect(try row("light.unregistered").isHidden == nil)
+        try #expect(row("light.visible").isHidden == nil)
+        try #expect(row("light.unregistered").isHidden == nil)
     }
 }

--- a/Tests/Shared/Watch/WatchAreaEntry.test.swift
+++ b/Tests/Shared/Watch/WatchAreaEntry.test.swift
@@ -16,10 +16,13 @@ struct WatchAreaEntryTests {
                 try Self.entity(entityId: "camera.garage", domain: "camera").insert(db)
                 // A diagnostic entity is filtered out even though its domain is addable.
                 try Self.entity(entityId: "sensor.uptime", domain: "sensor", entityCategory: 1).insert(db)
+                // A hidden entity is filtered out even though its domain is addable.
+                try Self.entity(entityId: "light.hidden", domain: "light", isHidden: true).insert(db)
 
                 try Self.area(areaId: "living_room", entities: ["light.living_room"]).insert(db)
                 try Self.area(areaId: "garage", entities: ["camera.garage"]).insert(db)
                 try Self.area(areaId: "attic", entities: ["sensor.uptime"]).insert(db)
+                try Self.area(areaId: "basement", entities: ["light.hidden"]).insert(db)
                 try Self.area(areaId: "empty", entities: []).insert(db)
                 // Same entity id on another server: scoping must keep that area out of server 1's list.
                 try Self.area(areaId: "office", serverId: "2", entities: ["light.living_room"]).insert(db)
@@ -59,7 +62,8 @@ struct WatchAreaEntryTests {
         entityId: String,
         domain: String,
         serverId: String = "1",
-        entityCategory: Int? = nil
+        entityCategory: Int? = nil,
+        isHidden: Bool? = nil
     ) -> HAAppEntity {
         .init(
             id: "\(serverId)-\(entityId)",
@@ -69,7 +73,8 @@ struct WatchAreaEntryTests {
             name: entityId,
             icon: nil,
             rawDeviceClass: nil,
-            entityCategory: entityCategory
+            entityCategory: entityCategory,
+            isHidden: isHidden
         )
     }
 

--- a/Tests/Shared/Watch/WatchAreaEntry.test.swift
+++ b/Tests/Shared/Watch/WatchAreaEntry.test.swift
@@ -18,11 +18,28 @@ struct WatchAreaEntryTests {
                 try Self.entity(entityId: "sensor.uptime", domain: "sensor", entityCategory: 1).insert(db)
                 // A hidden entity is filtered out even though its domain is addable.
                 try Self.entity(entityId: "light.hidden", domain: "light", isHidden: true).insert(db)
+                // Rows written before the hidden/category columns shipped carry neither flag. The
+                // registry still knows, and is what the filter has to believe — otherwise a server
+                // whose entities haven't been rewritten keeps offering entities the user hid.
+                try Self.entity(entityId: "light.stale_hidden", domain: "light").insert(db)
+                try Self.entity(entityId: "sensor.stale_diagnostic", domain: "sensor").insert(db)
+                try EntityRegistryListForDisplay.Entity(
+                    serverId: "1",
+                    entityId: "light.stale_hidden",
+                    hidden: true
+                ).insert(db)
+                try EntityRegistryListForDisplay.Entity(
+                    serverId: "1",
+                    entityId: "sensor.stale_diagnostic",
+                    entityCategory: 1
+                ).insert(db)
 
                 try Self.area(areaId: "living_room", entities: ["light.living_room"]).insert(db)
                 try Self.area(areaId: "garage", entities: ["camera.garage"]).insert(db)
                 try Self.area(areaId: "attic", entities: ["sensor.uptime"]).insert(db)
                 try Self.area(areaId: "basement", entities: ["light.hidden"]).insert(db)
+                try Self.area(areaId: "cellar", entities: ["light.stale_hidden"]).insert(db)
+                try Self.area(areaId: "loft", entities: ["sensor.stale_diagnostic"]).insert(db)
                 try Self.area(areaId: "empty", entities: []).insert(db)
                 // Same entity id on another server: scoping must keep that area out of server 1's list.
                 try Self.area(areaId: "office", serverId: "2", entities: ["light.living_room"]).insert(db)
@@ -102,6 +119,7 @@ struct WatchAreaEntryTests {
         let database = try DatabaseQueue(path: ":memory:")
         try AppAreaTable().createIfNeeded(database: database)
         try HAppEntityTable().createIfNeeded(database: database)
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
         Current.database = { database }
         defer { Current.database = previousDatabase }
 

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -122,6 +122,29 @@ struct WatchDatabaseMirrorFullReferenceTests {
         }
     }
 
+    /// Regression: a watch whose tables were wiped kept echoing digests claiming it still held them,
+    /// so the phone omitted those tables on every sync. Nothing ever refilled them, the home screen
+    /// could resolve no names (falling back to entity ids) and each sync carried almost no data.
+    @Test("Digests are reported stale for tables that are empty locally")
+    func emptyLocalTablesInvalidateTheirDigests() throws {
+        try withDatabase { database in
+            // Nothing stored yet: every mirrored table is empty, so no digest may be trusted.
+            #expect(WatchDatabaseMirror.digestKeysForEmptyLocalTables() ==
+                ["entities", "areas", "pipelines", "registry", "devices"])
+
+            try database.write { db in
+                try Self.entity(entityId: "light.kitchen", domain: "light").insert(db)
+                try Self.area(areaId: "kitchen").insert(db)
+            }
+
+            // The tables that now hold rows drop out; the still-empty ones remain stale.
+            let stale = WatchDatabaseMirror.digestKeysForEmptyLocalTables()
+            #expect(!stale.contains("entities"))
+            #expect(!stale.contains("areas"))
+            #expect(stale == ["pipelines", "registry", "devices"])
+        }
+    }
+
     @Test("carriedDigestKeys tracks exactly the tables a payload holds")
     func carriedKeys() {
         let full = WatchDatabaseMirror(

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -57,7 +57,7 @@ struct WatchDatabaseMirrorFullReferenceTests {
         let payload = Data(repeating: 7, count: 200_000)
         let compressed = try WatchDatabaseMirror.compress(payload)
         #expect(compressed.count < payload.count)
-        #expect(try WatchDatabaseMirror.decompress(compressed) == payload)
+        try #expect(WatchDatabaseMirror.decompress(compressed) == payload)
         #expect(throws: (any Error).self) {
             _ = try WatchDatabaseMirror.decompress(Data([0x00, 0x01, 0x02]))
         }

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -1,0 +1,201 @@
+import Foundation
+import GRDB
+@testable import Shared
+import Testing
+
+/// Tests for the full-reference (v2) watch database mirror: the version/compression wire constants,
+/// snapshot fidelity per advertised version, the registry/device table retain-vs-replace semantics,
+/// and payload compression.
+@Suite(.serialized)
+struct WatchDatabaseMirrorFullReferenceTests {
+    @Test("Version and payload keys are stable wire constants")
+    func constants() {
+        #expect(WatchDatabaseMirror.versionKey == "mirrorVersion")
+        #expect(WatchDatabaseMirror.compressedKey == "compressed")
+        #expect(WatchDatabaseMirror.legacyVersion == 1)
+        #expect(WatchDatabaseMirror.fullReferenceVersion == 2)
+    }
+
+    @Test("Registry and devices round-trip: nil retains, empty is authoritative")
+    func retainSemantics() throws {
+        let retain = WatchDatabaseMirror(entities: [], areas: [], pipelines: [])
+        let retainDecoded = try WatchDatabaseMirror.decodeForWatchThrowing(retain.encodeForWatch())
+        #expect(retainDecoded.registry == nil)
+        #expect(retainDecoded.devices == nil)
+
+        let authoritative = WatchDatabaseMirror(entities: [], areas: [], pipelines: [], registry: [], devices: [])
+        let decoded = try WatchDatabaseMirror.decodeForWatchThrowing(authoritative.encodeForWatch())
+        #expect(decoded.registry == [])
+        #expect(decoded.devices == [])
+    }
+
+    @Test("Digests cover registry and devices, and matching digests omit them")
+    func digestsAndOmission() {
+        let mirror = WatchDatabaseMirror(
+            entities: [],
+            areas: [],
+            pipelines: [],
+            registry: [.init(serverId: "s1", entityId: "light.a", hidden: true)],
+            devices: [Self.device(deviceId: "d1")]
+        )
+        let digests = mirror.tableDigests()
+        #expect(digests["registry"] != nil)
+        #expect(digests["devices"] != nil)
+
+        let omitted = mirror.omittingTables(matching: digests, currentDigests: digests)
+        #expect(omitted.registry == nil)
+        #expect(omitted.devices == nil)
+
+        // Digests that don't match keep the tables carried.
+        let carried = mirror.omittingTables(matching: [:], currentDigests: digests)
+        #expect(carried.registry != nil)
+        #expect(carried.devices != nil)
+    }
+
+    @Test("Compression round-trips and rejects garbage")
+    func compression() throws {
+        let payload = Data(repeating: 7, count: 200_000)
+        let compressed = try WatchDatabaseMirror.compress(payload)
+        #expect(compressed.count < payload.count)
+        #expect(try WatchDatabaseMirror.decompress(compressed) == payload)
+        #expect(throws: (any Error).self) {
+            _ = try WatchDatabaseMirror.decompress(Data([0x00, 0x01, 0x02]))
+        }
+    }
+
+    @Test("Legacy snapshot serves the filtered slice; full-reference carries every table row")
+    func snapshotFidelity() throws {
+        try withDatabase { database in
+            try database.write { db in
+                try Self.entity(entityId: "light.visible", domain: "light").insert(db)
+                try Self.entity(entityId: "light.hidden", domain: "light", isHidden: true).insert(db)
+                // A domain the legacy mirror never carries.
+                try Self.entity(entityId: "camera.garage", domain: "camera").insert(db)
+                try EntityRegistryListForDisplay.Entity(serverId: "1", entityId: "light.hidden", hidden: true)
+                    .insert(db)
+                try EntityRegistryListForDisplay.Entity(serverId: "1", entityId: "light.visible").insert(db)
+                try Self.device(deviceId: "d1").insert(db)
+            }
+
+            let legacy = try WatchDatabaseMirror.snapshot()
+            #expect(legacy.entities?.map(\.entityId) == ["light.visible"])
+            #expect(legacy.registry == nil)
+            #expect(legacy.devices == nil)
+            #expect(legacy.tableDigests()["registry"] == nil)
+            #expect(legacy.tableDigests()["devices"] == nil)
+
+            let full = try WatchDatabaseMirror.snapshot(version: WatchDatabaseMirror.fullReferenceVersion)
+            #expect(full.entities?.map(\.entityId).sorted() == ["camera.garage", "light.hidden", "light.visible"])
+            #expect(full.registry?.map(\.entityId).sorted() == ["light.hidden", "light.visible"])
+            #expect(full.devices?.map(\.deviceId) == ["d1"])
+        }
+    }
+
+    @Test("Applying a mirror replaces the registry and device tables; nil retains them")
+    func applySemantics() throws {
+        try withDatabase { database in
+            try database.write { db in
+                try EntityRegistryListForDisplay.Entity(serverId: "1", entityId: "light.old").insert(db)
+                try Self.device(deviceId: "old").insert(db)
+            }
+
+            let mirror = WatchDatabaseMirror(
+                entities: nil,
+                areas: nil,
+                pipelines: nil,
+                registry: [.init(serverId: "1", entityId: "light.new")],
+                devices: [Self.device(deviceId: "new")]
+            )
+            try mirror.apply()
+            let (registryRows, deviceRows) = try database.read { db in
+                try (
+                    EntityRegistryListForDisplay.Entity.fetchAll(db).map(\.entityId),
+                    AppDeviceRegistry.fetchAll(db).map(\.deviceId)
+                )
+            }
+            #expect(registryRows == ["light.new"])
+            #expect(deviceRows == ["new"])
+
+            // A mirror without the tables (delta sync) retains the local rows.
+            try WatchDatabaseMirror(entities: nil, areas: nil, pipelines: nil).apply()
+            let retained = try database.read { db in
+                try AppDeviceRegistry.fetchAll(db).map(\.deviceId)
+            }
+            #expect(retained == ["new"])
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func entity(
+        entityId: String,
+        domain: String,
+        serverId: String = "1",
+        isHidden: Bool? = nil
+    ) -> HAAppEntity {
+        .init(
+            id: "\(serverId)-\(entityId)",
+            entityId: entityId,
+            serverId: serverId,
+            domain: domain,
+            name: entityId,
+            icon: nil,
+            rawDeviceClass: nil,
+            isHidden: isHidden
+        )
+    }
+
+    private static func device(deviceId: String, serverId: String = "1") -> AppDeviceRegistry {
+        .init(
+            serverId: serverId,
+            deviceId: deviceId,
+            areaId: nil,
+            configurationURL: nil,
+            configEntries: nil,
+            configEntriesSubentries: nil,
+            connections: nil,
+            createdAt: nil,
+            disabledBy: nil,
+            entryType: nil,
+            hwVersion: nil,
+            identifiers: nil,
+            labels: nil,
+            manufacturer: nil,
+            model: nil,
+            modelID: nil,
+            modifiedAt: nil,
+            nameByUser: nil,
+            name: nil,
+            primaryConfigEntry: nil,
+            serialNumber: nil,
+            swVersion: nil,
+            viaDeviceID: nil
+        )
+    }
+
+    /// In-memory database with every table `snapshot()`/`apply()` touches, plus a fake server
+    /// manager (`snapshot()` reads `Current.servers.restorableState()`).
+    private func withDatabase(perform work: (DatabaseQueue) throws -> Void) throws {
+        let previousDatabase = Current.database
+        let previousServers = Current.servers
+        let database = try DatabaseQueue(path: ":memory:")
+        let tables: [DatabaseTableProtocol] = [
+            HAppEntityTable(),
+            DisplayEntityRegistryTable(),
+            AppDeviceRegistryTable(),
+            AppAreaTable(),
+            AssistPipelinesTable(),
+        ]
+        for table in tables {
+            try table.createIfNeeded(database: database)
+        }
+        Current.database = { database }
+        Current.servers = FakeServerManager()
+        defer {
+            Current.database = previousDatabase
+            Current.servers = previousServers
+        }
+
+        try work(database)
+    }
+}

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -134,8 +134,15 @@ struct WatchDatabaseMirrorFullReferenceTests {
             complicationConfigs: [],
             servers: Data()
         )
-        #expect(full.carriedDigestKeys == ["entities", "areas", "pipelines", "registry", "devices",
-                                           "complications", "servers"])
+        #expect(full.carriedDigestKeys == [
+            "entities",
+            "areas",
+            "pipelines",
+            "registry",
+            "devices",
+            "complications",
+            "servers",
+        ])
 
         // Delta payloads carry only what changed.
         let delta = WatchDatabaseMirror(entities: nil, areas: [], pipelines: nil)

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -92,6 +92,65 @@ struct WatchDatabaseMirrorFullReferenceTests {
         }
     }
 
+    /// Regression: a phone whose reference tables read back empty (a refresh that fetched nothing, a
+    /// reset, a rebuild in progress) used to send authoritative empty arrays, which deleted every
+    /// mirrored row on the watch and left it unable to resolve any item.
+    @Test("An empty phone table is carried as nil (retain), never as an authoritative wipe")
+    func emptyTablesAreNotAuthoritative() throws {
+        try withDatabase { database in
+            // Areas exist; entities, registry and devices are empty — the state that wiped watches.
+            try database.write { db in
+                try Self.area(areaId: "kitchen").insert(db)
+            }
+
+            for version in [WatchDatabaseMirror.legacyVersion, WatchDatabaseMirror.fullReferenceVersion] {
+                let snapshot = try WatchDatabaseMirror.snapshot(version: version)
+                #expect(snapshot.entities == nil)
+                #expect(snapshot.registry == nil)
+                #expect(snapshot.devices == nil)
+                #expect(snapshot.pipelines == nil)
+                // The table that does have rows is still carried.
+                #expect(snapshot.areas?.map(\.areaId) == ["kitchen"])
+                // A table that isn't carried publishes no digest, so it can never be "matched" and
+                // skipped on a later sync once the phone has rows again.
+                let digests = snapshot.tableDigests()
+                #expect(digests["entities"] == nil)
+                #expect(digests["registry"] == nil)
+                #expect(snapshot.carriedDigestKeys.contains("areas"))
+                #expect(!snapshot.carriedDigestKeys.contains("entities"))
+            }
+        }
+    }
+
+    @Test("carriedDigestKeys tracks exactly the tables a payload holds")
+    func carriedKeys() {
+        let full = WatchDatabaseMirror(
+            entities: [],
+            areas: [],
+            pipelines: [],
+            registry: [],
+            devices: [],
+            complications: [],
+            complicationConfigs: [],
+            servers: Data()
+        )
+        #expect(full.carriedDigestKeys == ["entities", "areas", "pipelines", "registry", "devices",
+                                           "complications", "servers"])
+
+        // Delta payloads carry only what changed.
+        let delta = WatchDatabaseMirror(entities: nil, areas: [], pipelines: nil)
+        #expect(delta.carriedDigestKeys == ["areas"])
+
+        // The complication group needs both halves to count as carried.
+        let halfComplications = WatchDatabaseMirror(
+            entities: nil,
+            areas: nil,
+            pipelines: nil,
+            complications: []
+        )
+        #expect(halfComplications.carriedDigestKeys.isEmpty)
+    }
+
     @Test("Applying a mirror replaces the registry and device tables; nil retains them")
     func applySemantics() throws {
         try withDatabase { database in
@@ -143,6 +202,20 @@ struct WatchDatabaseMirrorFullReferenceTests {
             icon: nil,
             rawDeviceClass: nil,
             isHidden: isHidden
+        )
+    }
+
+    private static func area(areaId: String, serverId: String = "1") -> AppArea {
+        .init(
+            id: "\(serverId)-\(areaId)",
+            serverId: serverId,
+            areaId: areaId,
+            name: areaId.capitalized,
+            aliases: [],
+            picture: nil,
+            icon: nil,
+            sortOrder: nil,
+            entities: []
         )
     }
 

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -129,8 +129,8 @@ struct WatchDatabaseMirrorFullReferenceTests {
     func emptyLocalTablesInvalidateTheirDigests() throws {
         try withDatabase { database in
             // Nothing stored yet: every mirrored table is empty, so no digest may be trusted.
-            #expect(WatchDatabaseMirror.digestKeysForEmptyLocalTables() ==
-                ["entities", "areas", "pipelines", "registry", "devices"])
+            let everyTable: Set<String> = ["entities", "areas", "pipelines", "registry", "devices"]
+            #expect(WatchDatabaseMirror.digestKeysForEmptyLocalTables() == everyTable)
 
             try database.write { db in
                 try Self.entity(entityId: "light.kitchen", domain: "light").insert(db)

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -54,9 +54,10 @@ struct WatchDatabaseMirrorFullReferenceTests {
 
     @Test("Compression round-trips and rejects garbage")
     func compression() throws {
+        // Round-trip correctness is the contract; no size assertion — the codec doesn't guarantee
+        // a smaller output for arbitrary input.
         let payload = Data(repeating: 7, count: 200_000)
         let compressed = try WatchDatabaseMirror.compress(payload)
-        #expect(compressed.count < payload.count)
         try #expect(WatchDatabaseMirror.decompress(compressed) == payload)
         #expect(throws: (any Error).self) {
             _ = try WatchDatabaseMirror.decompress(Data([0x00, 0x01, 0x02]))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes #5400: the watch areas section showed entities hidden in the entity registry (and diagnostic ones on stale data).

- The registry hidden flag is now baked into `HAAppEntity` at write time (like `entityCategory`), and a single shared predicate filters hidden/diagnostic entities in every watch candidate list: area browsing, home-screen areas, and the add flows.
- The watch database mirror gains a v2: watches that advertise it receive every reference table the iPhone maintains (all entities, full entity registry, full device registry, areas, pipelines) instead of a curated slice, so filtering happens at read time like on the iPhone and future registry-derived features need no extra mirroring work. v2 payloads travel LZFSE-compressed; legacy watches keep receiving the exact old payload.

## Screenshots
N/A — Apple Watch data-sync change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Both sync paths (chunked pull and background push) negotiate the version; the phone persists what the paired watch advertised and drops back to legacy if an older watch pairs. Unit tests cover snapshot fidelity per version, retain-vs-replace semantics, digest groups and the compression round-trip.