### PR TITLE
Detect in-flight state using cabin pressure

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		42B18FD72F38CA2300A1537A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 42B18FD62F38CA2300A1537A /* FirebaseMessaging */; };
 		42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */; };
 		42B89EAC2E080494000224A2 /* AppConstants.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B89EAB2E080494000224A2 /* AppConstants.test.swift */; };
+		42D6FE19300F900000D4BEB9 /* CabinPressureMonitor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */; };
 		42BB4C372CD26490003E47FD /* HATypedRequest+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */; };
 		42BB4C382CD26490003E47FD /* HATypedRequest+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */; };
 		42BC36C5300683F700E5EE14 /* JinjaEntityReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */; };
@@ -189,6 +190,10 @@
 		42D14C9D301BC38E0058088E /* CornerComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C9C301BC38E0058088E /* CornerComplicationSnapshot.test.swift */; };
 		42D6FDD3300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD2300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift */; };
 		42D6FDD5300F71F600D4BEB9 /* FlightDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */; };
+		42D6FE11300F900000D4BEB9 /* CabinPressureSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */; };
+		42D6FE13300F900000D4BEB9 /* CabinPressureEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */; };
+		42D6FE15300F900000D4BEB9 /* CabinPressureMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */; };
+		42D6FE17300F900000D4BEB9 /* FlightSpeedProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */; };
 		42D6FDD7300F720600D4BEB9 /* FlightGreetingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */; };
 		42DC44332E1C06E5001046C1 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 42DC44322E1C06E5001046C1 /* WebRTC */; };
 		42DF195130065055003B7FA1 /* JinjaTemplateSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF195030065055003B7FA1 /* JinjaTemplateSuggestion.swift */; };
@@ -649,6 +654,7 @@
 		42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreRestoreLastURL.test.swift; sourceTree = "<group>"; };
 		42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialDesignIconsSFSymbol.test.swift; sourceTree = "<group>"; };
 		42B89EAB2E080494000224A2 /* AppConstants.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.test.swift; sourceTree = "<group>"; };
+		42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureMonitor.test.swift; sourceTree = "<group>"; };
 		42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HATypedRequest+App.swift"; sourceTree = "<group>"; };
 		42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaEntityReference.swift; sourceTree = "<group>"; };
 		42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayAssistDebugSettings.test.swift; sourceTree = "<group>"; };
@@ -663,6 +669,10 @@
 		42D14C9C301BC38E0058088E /* CornerComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerComplicationSnapshot.test.swift; sourceTree = "<group>"; };
 		42D6FDD2300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InFlightWiFiSSIDs.swift; sourceTree = "<group>"; };
 		42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightDetector.swift; sourceTree = "<group>"; };
+		42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureSample.swift; sourceTree = "<group>"; };
+		42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureEvidence.swift; sourceTree = "<group>"; };
+		42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureMonitor.swift; sourceTree = "<group>"; };
+		42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightSpeedProbe.swift; sourceTree = "<group>"; };
 		42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightGreetingManager.swift; sourceTree = "<group>"; };
 		42DF195030065055003B7FA1 /* JinjaTemplateSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaTemplateSuggestion.swift; sourceTree = "<group>"; };
 		42DF195230065071003B7FA1 /* JinjaAutocompleteProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaAutocompleteProvider.swift; sourceTree = "<group>"; };
@@ -2418,6 +2428,10 @@
 				42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */,
 				42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */,
 				424D4160300F75B7001998ED /* GreetingsSettingsView.swift */,
+				42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */,
+				42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */,
+				42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */,
+				42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */,
 			);
 			path = FlightGreetings;
 			sourceTree = "<group>";
@@ -2537,6 +2551,7 @@
 				42EDBB773002FBBE0051FC9B /* Kiosk */,
 				42EDBB663002FBBE0051FC9B /* EntityPicker */,
 				42B89EAB2E080494000224A2 /* AppConstants.test.swift */,
+				42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */,
 				42646B762E0BE6F100F6B367 /* BackgroundTask.test.swift */,
 				42EDBB963002FBBE0051FC9B /* Additions */,
 				42EDBB6B3002FBBE0051FC9B /* Area */,
@@ -4009,6 +4024,10 @@
 				42EDEB12300315A50051FC9B /* HAApplicationShortcutItem.swift in Sources */,
 				42EDEB13300315A50051FC9B /* LifecycleManager.swift in Sources */,
 				42D6FDD5300F71F600D4BEB9 /* FlightDetector.swift in Sources */,
+				42D6FE11300F900000D4BEB9 /* CabinPressureSample.swift in Sources */,
+				42D6FE13300F900000D4BEB9 /* CabinPressureEvidence.swift in Sources */,
+				42D6FE15300F900000D4BEB9 /* CabinPressureMonitor.swift in Sources */,
+				42D6FE17300F900000D4BEB9 /* FlightSpeedProbe.swift in Sources */,
 				FA11C0DE0000000000000101 /* BackgroundRefreshManager.swift in Sources */,
 				42BC36C5300683F700E5EE14 /* JinjaEntityReference.swift in Sources */,
 				42EDEB14300315A50051FC9B /* MainWindowGroupCommands.swift in Sources */,
@@ -4026,6 +4045,7 @@
 				42DF97B2300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift in Sources */,
 				42646B772E0BE6F100F6B367 /* BackgroundTask.test.swift in Sources */,
 				42B89EAC2E080494000224A2 /* AppConstants.test.swift in Sources */,
+				42D6FE19300F900000D4BEB9 /* CabinPressureMonitor.test.swift in Sources */,
 				42165CE0301324980077A903 /* LocationBasedServerSwitcher.test.swift in Sources */,
 				42D14C4E301BAFC80058088E /* RectangularComplicationSnapshot.test.swift in Sources */,
 				119C786725CF845800D41734 /* LocalizedStrings.test.swift in Sources */,

--- a/Sources/App/FlightGreetings/CabinPressureEvidence.swift
+++ b/Sources/App/FlightGreetings/CabinPressureEvidence.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// What recent barometer readings say about the device being inside a pressurized aircraft.
+enum CabinPressureEvidence: Equatable {
+    /// No barometer, no Motion & Fitness access, or not enough readings yet.
+    case insufficientData
+    /// Readings look like ground air: nothing here suggests a flight.
+    case inconclusive
+    /// Pressure is moving at a rate, and for long enough, that only cabin pressurization sustains.
+    case sustainedChange(kpaPerMinute: Double)
+    /// Pressure sits at cabin cruise level and far below the device's own recent ground baseline.
+    case lowPressure(kpa: Double, belowBaselineKpa: Double)
+
+    var indicatesFlight: Bool {
+        switch self {
+        case .insufficientData, .inconclusive:
+            false
+        case .sustainedChange, .lowPressure:
+            true
+        }
+    }
+}

--- a/Sources/App/FlightGreetings/CabinPressureMonitor.swift
+++ b/Sources/App/FlightGreetings/CabinPressureMonitor.swift
@@ -180,8 +180,14 @@ final class CabinPressureMonitor {
         for index in 0 ..< bucketCount {
             let start = now.addingTimeInterval(-trendWindow + Double(index) * trendBucket)
             let end = start.addingTimeInterval(trendBucket)
+            // Both ends are inclusive on purpose, so consecutive buckets share the reading on their
+            // boundary: each one then spans a whole minute instead of stopping at the last reading
+            // before it, which would make every bucket read low by one sampling interval.
             let bucket = samples.filter { $0.date >= start && $0.date <= end }
-            guard let first = bucket.first, let last = bucket.last else { continue }
+            // `CMAltimeter` reports on change rather than at a fixed rate, so a minute can arrive
+            // with a single reading. That measures nothing, and recording it as a zero change would
+            // pass it off as a flat minute.
+            guard bucket.count >= 2, let first = bucket.first, let last = bucket.last else { continue }
             changes.append(last.pressureKpa - first.pressureKpa)
         }
 

--- a/Sources/App/FlightGreetings/CabinPressureMonitor.swift
+++ b/Sources/App/FlightGreetings/CabinPressureMonitor.swift
@@ -1,0 +1,195 @@
+import CoreMotion
+import Foundation
+import Shared
+
+/// Watches cabin air pressure to decide whether the device is inside a pressurized aircraft.
+///
+/// This is the only flight signal that survives with neither connectivity nor a GPS fix: the
+/// barometer reads the air in the cabin, so it works in a middle seat with the phone in a pocket.
+/// Airliners hold the cabin between 6,000 and 8,000 ft, which is 75–81 kPa against 101 kPa at sea
+/// level, and they take ten minutes or more to get there.
+///
+/// Readings arrive through `Current.barometerObserver` so the pressure sensor keeps working while
+/// this is running.
+final class CabinPressureMonitor {
+    static let shared = CabinPressureMonitor()
+
+    private static let subscriberID = "cabin-pressure-monitor"
+
+    /// Ground level somewhere on Earth reaches this low — Bogotá sits near 74 kPa — so a reading
+    /// under the ceiling is evidence of a flight only alongside the device's own ground baseline.
+    static let cabinPressureCeilingKpa: Double = 82
+    /// Sea-level ground to cabin cruise is a drop of roughly 23 kPa, and no weather system moves
+    /// pressure by more than about 3 kPa, so this margin can't come from weather or sensor drift.
+    static let baselineDropKpa: Double = 8
+    /// Pressurization moves the cabin by 0.9–1.5 kPa/min for ten minutes or more. Requiring the
+    /// change to repeat across separate minutes is what separates it from an elevator ride, which
+    /// moves as much pressure but only for seconds.
+    static let trendWindow: TimeInterval = 5 * 60
+    static let trendBucket: TimeInterval = 60
+    static let trendBucketMinimumChangeKpa: Double = 0.35
+    static let trendRequiredBuckets = 4
+    /// Past this the device has likely moved to a different elevation, making the baseline unusable.
+    static let baselineValidity: TimeInterval = 48 * 60 * 60
+
+    private static let baselinePressureKey = "cabinPressureGroundBaselineKpa"
+    private static let baselineDateKey = "cabinPressureGroundBaselineDate"
+
+    private let lock = NSLock()
+    private var samples: [CabinPressureSample] = []
+    private var didIndicateFlight = false
+    private var didLogUnavailable = false
+    private var evidenceDidChange: ((CabinPressureEvidence) -> Void)?
+
+    /// What the current window of readings says. `.insufficientData` while nothing is being observed.
+    var evidence: CabinPressureEvidence {
+        lock.lock()
+        let currentSamples = samples
+        lock.unlock()
+        return Self.evidence(samples: currentSamples, baseline: groundBaseline, now: Current.date())
+    }
+
+    var isObserving: Bool {
+        Current.barometerObserver.hasSubscriber(id: Self.subscriberID)
+    }
+
+    /// The highest pressure recently seen while the device had a network, which stands in for "the
+    /// air where this device lives". Nil until one has been recorded.
+    var groundBaseline: CabinPressureSample? {
+        // The two keys are always written together, so the date doubles as the presence check.
+        guard let date = prefs.object(forKey: Self.baselineDateKey) as? Date else { return nil }
+        return CabinPressureSample(date: date, pressureKpa: prefs.double(forKey: Self.baselinePressureKey))
+    }
+
+    /// Starts feeding the rolling window, calling `onEvidenceChange` when the verdict flips between
+    /// suggesting a flight and not.
+    ///
+    /// Does nothing when there is no barometer or Motion & Fitness access hasn't been granted.
+    /// Authorization is only ever checked, never requested, so this cannot raise a permission prompt.
+    func start(onEvidenceChange: @escaping (CabinPressureEvidence) -> Void) {
+        lock.lock()
+        evidenceDidChange = onEvidenceChange
+        lock.unlock()
+
+        guard !isObserving else { return }
+
+        let started = Current.barometerObserver.addSubscriber(id: Self.subscriberID) { [weak self] data, _ in
+            guard let data else { return }
+            self?.record(pressureKpa: data.pressure.doubleValue)
+        }
+        guard !started else { return }
+        // Every foreground pass retries, so log the reason once rather than on each attempt.
+        lock.lock()
+        let shouldLog = !didLogUnavailable
+        didLogUnavailable = true
+        lock.unlock()
+        if shouldLog {
+            Current.Log.info("Cabin pressure monitoring unavailable: no barometer or no motion access")
+        }
+    }
+
+    func stop() {
+        Current.barometerObserver.removeSubscriber(id: Self.subscriberID)
+        lock.lock()
+        samples.removeAll()
+        didIndicateFlight = false
+        evidenceDidChange = nil
+        lock.unlock()
+    }
+
+    private func record(pressureKpa: Double) {
+        let now = Current.date()
+        updateGroundBaselineIfNeeded(pressureKpa: pressureKpa, now: now)
+
+        lock.lock()
+        samples.removeAll { now.timeIntervalSince($0.date) > Self.trendWindow }
+        samples.append(CabinPressureSample(date: now, pressureKpa: pressureKpa))
+        let currentSamples = samples
+        lock.unlock()
+
+        let evidence = Self.evidence(samples: currentSamples, baseline: groundBaseline, now: now)
+
+        lock.lock()
+        // Only the verdict is worth reporting: `sustainedChange` carries a rate that moves with every
+        // reading, and comparing the whole value would fire a callback a second.
+        let flipped = evidence.indicatesFlight != didIndicateFlight
+        didIndicateFlight = evidence.indicatesFlight
+        let notify = flipped ? evidenceDidChange : nil
+        lock.unlock()
+
+        if let notify {
+            Current.Log.info("Cabin pressure evidence changed to \(evidence)")
+            notify(evidence)
+        }
+    }
+
+    private func updateGroundBaselineIfNeeded(pressureKpa: Double, now: Date) {
+        // A reading at or below cabin cruise pressure must never become the baseline: recording one
+        // mid-flight would erase the very drop the low-pressure rule looks for. It also means a
+        // device that lives above the ceiling never gets a baseline, so that rule stays silent there
+        // rather than firing on every reading.
+        guard pressureKpa > Self.cabinPressureCeilingKpa else { return }
+        // With no network the device could be airborne, so the reading isn't trustworthy as ground.
+        guard Current.connectivity.simpleNetworkType() != .noConnection else { return }
+
+        if let existing = groundBaseline,
+           now.timeIntervalSince(existing.date) <= Self.baselineValidity,
+           pressureKpa <= existing.pressureKpa {
+            return
+        }
+
+        prefs.set(pressureKpa, forKey: Self.baselinePressureKey)
+        prefs.set(now, forKey: Self.baselineDateKey)
+    }
+
+    static func evidence(
+        samples: [CabinPressureSample],
+        baseline: CabinPressureSample?,
+        now: Date
+    ) -> CabinPressureEvidence {
+        guard let latest = samples.last else { return .insufficientData }
+
+        if let rate = sustainedChangeKpaPerMinute(in: samples, now: now) {
+            return .sustainedChange(kpaPerMinute: rate)
+        }
+
+        if latest.pressureKpa <= cabinPressureCeilingKpa,
+           let baseline,
+           now.timeIntervalSince(baseline.date) <= baselineValidity,
+           baseline.pressureKpa - latest.pressureKpa >= baselineDropKpa {
+            return .lowPressure(
+                kpa: latest.pressureKpa,
+                belowBaselineKpa: baseline.pressureKpa - latest.pressureKpa
+            )
+        }
+
+        return .inconclusive
+    }
+
+    /// The mean per-minute pressure change, but only when it holds across most of the window rather
+    /// than in one burst. A skyscraper elevator moves 3 kPa in forty seconds and then stops, which
+    /// clears any threshold on total change but fills a single bucket; a cabin fills all of them.
+    static func sustainedChangeKpaPerMinute(in samples: [CabinPressureSample], now: Date) -> Double? {
+        guard let oldest = samples.first,
+              now.timeIntervalSince(oldest.date) >= trendWindow - trendBucket else {
+            return nil
+        }
+
+        let bucketCount = Int(trendWindow / trendBucket)
+        var changes = [Double]()
+        for index in 0 ..< bucketCount {
+            let start = now.addingTimeInterval(-trendWindow + Double(index) * trendBucket)
+            let end = start.addingTimeInterval(trendBucket)
+            let bucket = samples.filter { $0.date >= start && $0.date <= end }
+            guard let first = bucket.first, let last = bucket.last else { continue }
+            changes.append(last.pressureKpa - first.pressureKpa)
+        }
+
+        let rising = changes.filter { $0 >= trendBucketMinimumChangeKpa }
+        let falling = changes.filter { $0 <= -trendBucketMinimumChangeKpa }
+        let dominant = rising.count >= falling.count ? rising : falling
+        guard dominant.count >= trendRequiredBuckets else { return nil }
+
+        return dominant.reduce(0, +) / (Double(dominant.count) * trendBucket / 60)
+    }
+}

--- a/Sources/App/FlightGreetings/CabinPressureSample.swift
+++ b/Sources/App/FlightGreetings/CabinPressureSample.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// One barometer reading, as kept in `CabinPressureMonitor`'s rolling window and as the persisted
+/// ground-pressure baseline.
+struct CabinPressureSample: Equatable {
+    let date: Date
+    let pressureKpa: Double
+}

--- a/Sources/App/FlightGreetings/FlightDetector.swift
+++ b/Sources/App/FlightGreetings/FlightDetector.swift
@@ -1,39 +1,64 @@
 import CoreLocation
 import Foundation
-import PromiseKit
 import Shared
 
 /// Determines whether the user is likely on a plane without requiring connectivity, by matching
-/// known in-flight Wi-Fi SSIDs and, failing that, checking GPS ground speed and altitude.
+/// known in-flight Wi-Fi SSIDs, then cabin air pressure, and finally GPS ground speed and altitude.
 enum FlightDetector {
     /// Ground speed no ground vehicle plausibly sustains (~430 km/h), safely above high-speed trains.
     private static let cruiseSpeed: CLLocationSpeed = 120
     /// Climb/descent combination: fast and high together, excluding driving at high altitude.
     private static let climbAltitude: CLLocationDistance = 4000
     private static let climbSpeed: CLLocationSpeed = 60
-    private static let locationTimeout: TimeInterval = 5
+    /// A device with a working network isn't on a plane whose Wi-Fi we failed to recognize, so a
+    /// warm fix is all it can offer and there is no reason to spend more.
+    private static let onlineLocationTimeout: TimeInterval = 5
+    /// Being offline is itself weak evidence of a flight, and it's also what makes a fix slow: with
+    /// no network there is no assistance data, so a cold GPS start runs to tens of seconds.
+    private static let offlineLocationTimeout: TimeInterval = 45
 
     static func isLikelyFlying() async -> Bool {
         if let ssid = await Current.connectivity.currentWiFiSSID(), InFlightWiFiSSIDs.matches(ssid) {
             Current.Log.info("Flight detected via in-flight Wi-Fi SSID")
             return true
         }
-        return await hasInFlightMotion()
+
+        if cabinPressureIndicatesFlight {
+            return true
+        }
+
+        let timeout = isOffline ? offlineLocationTimeout : onlineLocationTimeout
+        return await hasInFlightMotion(timeout: timeout)
     }
 
-    private static func hasInFlightMotion() async -> Bool {
+    /// Whether the barometer currently reads like a pressurized cabin.
+    ///
+    /// Gated on being offline, which is what keeps the low-pressure rule honest: high ground with bad
+    /// weather can reach cabin cruise pressure, but a device sitting there has a network. A plane
+    /// that does have Wi-Fi is caught by its SSID before this is consulted.
+    static var cabinPressureIndicatesFlight: Bool {
+        guard isOffline else { return false }
+        let evidence = CabinPressureMonitor.shared.evidence
+        guard evidence.indicatesFlight else { return false }
+        Current.Log.info("Flight detected via cabin pressure: \(evidence)")
+        return true
+    }
+
+    private static var isOffline: Bool {
+        Current.connectivity.simpleNetworkType() == .noConnection
+    }
+
+    private static func hasInFlightMotion(timeout: TimeInterval) async -> Bool {
         let authorizationStatus = CLLocationManager().authorizationStatus
         guard authorizationStatus == .authorizedAlways || authorizationStatus == .authorizedWhenInUse else {
             return false
         }
 
-        let location: CLLocation? = await withCheckedContinuation { continuation in
-            CLLocationManager.oneShotLocation(timeout: locationTimeout)
-                .done { continuation.resume(returning: $0) }
-                .catch { _ in continuation.resume(returning: nil) }
+        // No usable fix (common inside a fuselage away from a window) means "unknown", not "not
+        // flying"; the pressure signal above is what covers that case.
+        guard let location = await FlightSpeedProbe.firstFixWithSpeed(timeout: timeout) else {
+            return false
         }
-        // No usable fix (common inside a fuselage away from a window) means "unknown", not "not flying".
-        guard let location, location.speed >= 0 else { return false }
 
         if location.speed >= cruiseSpeed {
             Current.Log.info("Flight detected via ground speed \(location.speed) m/s")

--- a/Sources/App/FlightGreetings/FlightGreetingManager.swift
+++ b/Sources/App/FlightGreetings/FlightGreetingManager.swift
@@ -2,9 +2,10 @@ import Foundation
 import Shared
 import UIKit
 
-/// Coordinates the "have a great flight" greeting: runs flight detection when the app becomes
-/// active or the web view loses connection, shows the greeting toast at most once per flight,
-/// and caches detection results so repeated checks stay cheap.
+/// Coordinates the "have a great flight" greeting: watches cabin pressure while the app is in the
+/// foreground, runs flight detection when the app becomes active or the web view loses connection,
+/// shows the greeting toast at most once per flight, and caches detection results so repeated checks
+/// stay cheap.
 @MainActor
 final class FlightGreetingManager {
     static let shared = FlightGreetingManager()
@@ -15,13 +16,15 @@ final class FlightGreetingManager {
     private static let greetingCooldown: TimeInterval = 6 * 60 * 60
     private static let lastGreetingDateKey = "flightGreetingLastShownDate"
     /// How long a detection result stays valid before a caller triggers a fresh check. A positive
-    /// stays valid for a while (the flight isn't ending soon); a negative retries sooner.
+    /// stays valid for a while (the flight isn't ending soon); a negative retries sooner, but not so
+    /// soon that back-to-back checks keep the GPS running continuously.
     private static let positiveDetectionValidity: TimeInterval = 10 * 60
-    private static let negativeDetectionValidity: TimeInterval = 60
+    private static let negativeDetectionValidity: TimeInterval = 2 * 60
 
     private var cachedDetection: (isFlying: Bool, date: Date)?
     private var detectionTask: Task<Bool, Never>?
     private var didBecomeActiveObserver: NSObjectProtocol?
+    private var didEnterBackgroundObserver: NSObjectProtocol?
 
     func start() {
         guard didBecomeActiveObserver == nil else { return }
@@ -31,7 +34,16 @@ final class FlightGreetingManager {
             queue: .main
         ) { _ in
             Task { @MainActor in
-                FlightGreetingManager.shared.greetIfFlying()
+                FlightGreetingManager.shared.appDidBecomeActive()
+            }
+        }
+        didEnterBackgroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                CabinPressureMonitor.shared.stop()
             }
         }
     }
@@ -43,7 +55,7 @@ final class FlightGreetingManager {
             let validity = cachedDetection.isFlying
                 ? Self.positiveDetectionValidity
                 : Self.negativeDetectionValidity
-            if Date().timeIntervalSince(cachedDetection.date) < validity {
+            if Current.date().timeIntervalSince(cachedDetection.date) < validity {
                 return cachedDetection.isFlying
             }
         }
@@ -53,7 +65,7 @@ final class FlightGreetingManager {
         let task = Task { await FlightDetector.isLikelyFlying() }
         detectionTask = task
         let isFlying = await task.value
-        cachedDetection = (isFlying, Date())
+        cachedDetection = (isFlying, Current.date())
         detectionTask = nil
         return isFlying
     }
@@ -69,7 +81,41 @@ final class FlightGreetingManager {
             title: L10n.FlightGreetings.greeting,
             duration: Self.toastDuration
         )
-        prefs.set(Date(), forKey: Self.lastGreetingDateKey)
+        prefs.set(Current.date(), forKey: Self.lastGreetingDateKey)
+        // The greeting for this flight has been shown, so there is nothing left for the barometer to
+        // tell us until the cooldown expires.
+        CabinPressureMonitor.shared.stop()
+    }
+
+    private func appDidBecomeActive() {
+        startPressureMonitoringIfNeeded()
+        greetIfFlying()
+    }
+
+    /// Keeps the barometer running while the app is in the foreground and a greeting is still
+    /// possible, so a flight can announce itself instead of only being noticed when something happens
+    /// to ask. Detection used to be purely on demand, which meant a single failed check at the moment
+    /// the app opened was the end of it.
+    private func startPressureMonitoringIfNeeded() {
+        // The toast itself needs iOS 18, so below that there is nothing detection could lead to.
+        guard #available(iOS 18, *), Current.settingsStore.flightGreetingsEnabled, canGreet else {
+            CabinPressureMonitor.shared.stop()
+            return
+        }
+        CabinPressureMonitor.shared.start { [weak self] _ in
+            Task { @MainActor in
+                self?.cabinPressureEvidenceDidChange()
+            }
+        }
+    }
+
+    private func cabinPressureEvidenceDidChange() {
+        guard Current.settingsStore.flightGreetingsEnabled, canGreet else { return }
+        guard FlightDetector.cabinPressureIndicatesFlight else { return }
+        // Skip the detection pass the cached positive would otherwise trigger: the barometer has
+        // already answered, and the GPS leg of detection has nothing to add.
+        cachedDetection = (true, Current.date())
+        presentGreetingToastIfAllowed()
     }
 
     private func greetIfFlying() {
@@ -83,6 +129,6 @@ final class FlightGreetingManager {
 
     private var canGreet: Bool {
         guard let lastGreeting = prefs.object(forKey: Self.lastGreetingDateKey) as? Date else { return true }
-        return Date().timeIntervalSince(lastGreeting) >= Self.greetingCooldown
+        return Current.date().timeIntervalSince(lastGreeting) >= Self.greetingCooldown
     }
 }

--- a/Sources/App/FlightGreetings/FlightSpeedProbe.swift
+++ b/Sources/App/FlightGreetings/FlightSpeedProbe.swift
@@ -1,0 +1,75 @@
+import CoreLocation
+import Foundation
+import Shared
+
+/// Waits for the first location fix that carries a usable ground speed, or gives up.
+///
+/// `CLLocationManager.oneShotLocation` can't serve this: it optimizes for positional accuracy and
+/// resolves on the first fix that is accurate and recent, which is frequently a fix whose `speed` is
+/// -1 and therefore useless here. It also seeds itself from the manager's cached location, whose
+/// speed describes wherever the device last was rather than how fast it is moving now.
+///
+/// A cabin has no network to assist the GPS either, so a cold fix there can take a minute. The
+/// caller picks how long to wait.
+///
+/// Unlike `oneShotLocation` this deliberately leaves `Current.isPerformingSingleShotLocationQuery`
+/// alone: raising that flag for the length of a cold fix would stop the zone manager from processing
+/// anything for the whole window, which is a far worse trade than the extra location updates the
+/// app's own manager sees while this runs. The long budget is only ever spent offline, where those
+/// updates can't be delivered anyway.
+@MainActor
+final class FlightSpeedProbe: NSObject, CLLocationManagerDelegate {
+    static func firstFixWithSpeed(timeout: TimeInterval) async -> CLLocation? {
+        await FlightSpeedProbe().run(timeout: timeout)
+    }
+
+    private let locationManager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation?, Never>?
+    private var timeoutWork: DispatchWorkItem?
+    private var selfRetain: FlightSpeedProbe?
+
+    private func run(timeout: TimeInterval) async -> CLLocation? {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            self.selfRetain = self
+
+            locationManager.delegate = self
+            locationManager.desiredAccuracy = kCLLocationAccuracyBest
+            locationManager.startUpdatingLocation()
+
+            // GCD rather than `Task.sleep`: the timeout has to fire even when the Swift concurrency
+            // thread pool is starved, which is the situation it exists to bound.
+            let work = DispatchWorkItem { [weak self] in
+                self?.finish(with: nil)
+            }
+            timeoutWork = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: work)
+        }
+    }
+
+    private func finish(with location: CLLocation?) {
+        guard let continuation else { return }
+        self.continuation = nil
+        timeoutWork?.cancel()
+        timeoutWork = nil
+        locationManager.stopUpdatingLocation()
+        locationManager.delegate = nil
+        selfRetain = nil
+        continuation.resume(returning: location)
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        // A negative speed or speedAccuracy means the fix carries no velocity, which is common on the
+        // first fixes of a cold start; keep waiting for one that does.
+        guard let usable = locations.last(where: { $0.speed >= 0 && $0.speedAccuracy >= 0 }) else { return }
+        Task { @MainActor [weak self] in
+            self?.finish(with: usable)
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Failures are routine while a GPS warms up with no network assistance, so let the timeout
+        // decide rather than giving up on the first one.
+        Current.Log.error("Flight speed probe received a location error: \(error)")
+    }
+}

--- a/Sources/App/FlightGreetings/FlightSpeedProbe.swift
+++ b/Sources/App/FlightGreetings/FlightSpeedProbe.swift
@@ -37,10 +37,12 @@ final class FlightSpeedProbe: NSObject, CLLocationManagerDelegate {
             locationManager.desiredAccuracy = kCLLocationAccuracyBest
             locationManager.startUpdatingLocation()
 
-            // GCD rather than `Task.sleep`: the timeout has to fire even when the Swift concurrency
-            // thread pool is starved, which is the situation it exists to bound.
+            // GCD holds the deadline rather than `Task.sleep`: the timeout has to fire even when the
+            // Swift concurrency thread pool is starved, which is one of the things it exists to bound.
             let work = DispatchWorkItem { [weak self] in
-                self?.finish(with: nil)
+                Task { @MainActor in
+                    self?.finish(with: nil)
+                }
             }
             timeoutWork = work
             DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: work)

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
@@ -32,8 +32,9 @@ extension WebViewController {
     }
 
     /// Swaps the disconnected empty state for the in-flight variant (and greets) when flight
-    /// detection confirms the user is on a plane. Detection is async (Wi-Fi SSID + one-shot GPS),
-    /// so the regular disconnected state shows first and upgrades in place.
+    /// detection confirms the user is on a plane. Detection is async (Wi-Fi SSID, cabin pressure,
+    /// then GPS, which offline can take tens of seconds), so the regular disconnected state shows
+    /// first and upgrades in place.
     private func upgradeEmptyStateForFlightIfNeeded() {
         guard Current.settingsStore.flightGreetingsEnabled,
               emptyStateStyle(for: connectionState) == .disconnected else { return }

--- a/Sources/Shared/API/Webhook/Sensors/BarometerObserver.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BarometerObserver.swift
@@ -1,0 +1,96 @@
+import CoreMotion
+import Foundation
+
+/// Owns the single `CMAltimeter` session behind `Current.barometer` and fans its readings out to
+/// every subscriber.
+///
+/// `CMAltimeter.startRelativeAltitudeUpdates(to:withHandler:)` keeps only one handler per altimeter,
+/// so a second `start` on the same altimeter silently orphans the first caller's handler — the
+/// failure behind issue #5100. Anything that wants pressure readings subscribes here rather than
+/// starting a session of its own, so the pressure sensor and flight detection can read the barometer
+/// at the same time.
+public final class BarometerObserver {
+    private let lock = NSLock()
+    private var subscribers: [String: CMAltitudeHandler] = [:]
+    private var isRunning = false
+    private var cachedPressureKpa: Double?
+
+    public init() {}
+
+    /// The most recent pressure in kilopascals seen by the shared session, or nil when no session is
+    /// running or it hasn't reported yet.
+    public var latestPressureKpa: Double? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedPressureKpa
+    }
+
+    public var isUsable: Bool {
+        Current.barometer.isAvailable() && Current.barometer.isAuthorized()
+    }
+
+    /// Delivers every reading of the shared session to `handler` until `removeSubscriber(id:)`,
+    /// starting the session if it isn't running yet. Adding a subscriber under an id that is already
+    /// registered replaces its handler.
+    ///
+    /// Returns false — registering nothing — when the hardware is missing or motion access hasn't
+    /// been granted. Authorization is deliberately only checked, never requested: subscribing must
+    /// not be able to raise a Motion & Fitness prompt on behalf of a caller that has no business
+    /// asking for one.
+    @discardableResult
+    public func addSubscriber(id: String, handler: @escaping CMAltitudeHandler) -> Bool {
+        guard isUsable else { return false }
+
+        lock.lock()
+        subscribers[id] = handler
+        let shouldStart = !isRunning
+        if shouldStart {
+            isRunning = true
+        }
+        lock.unlock()
+
+        if shouldStart {
+            let queue = OperationQueue()
+            queue.name = "barometer-observer"
+            queue.maxConcurrentOperationCount = 1
+            Current.barometer.startUpdatesOnQueueHandler(queue) { [weak self] data, error in
+                self?.deliver(data: data, error: error)
+            }
+        }
+        return true
+    }
+
+    public func removeSubscriber(id: String) {
+        lock.lock()
+        subscribers[id] = nil
+        let shouldStop = subscribers.isEmpty && isRunning
+        if shouldStop {
+            isRunning = false
+            cachedPressureKpa = nil
+        }
+        lock.unlock()
+
+        if shouldStop {
+            Current.barometer.stopUpdates()
+        }
+    }
+
+    public func hasSubscriber(id: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return subscribers[id] != nil
+    }
+
+    private func deliver(data: CMAltitudeData?, error: Error?) {
+        lock.lock()
+        if let data {
+            cachedPressureKpa = data.pressure.doubleValue
+        }
+        let handlers = Array(subscribers.values)
+        lock.unlock()
+
+        for handler in handlers {
+            handler(data, error)
+        }
+    }
+}

--- a/Sources/Shared/API/Webhook/Sensors/BarometerSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/BarometerSensor.swift
@@ -4,8 +4,8 @@ import PromiseKit
 
 final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
     private let signal: () -> Void
+    private let subscriberID = "barometer-signaler-\(UUID().uuidString)"
     private var lastSignaledPressureKpa: Double?
-    private var observationQueue: OperationQueue?
 
     /// The most recent pressure in kilopascals from CMAltimeter, used by BarometerSensor
     /// to avoid starting a separate one-shot read that would conflict with the signaler's stream.
@@ -19,14 +19,7 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
     override func observe() {
         super.observe()
         guard !isObserving else { return }
-        guard Current.barometer.isAvailable(), Current.barometer.isAuthorized() else { return }
-
-        let queue = OperationQueue()
-        queue.name = "barometer-signaler"
-        queue.maxConcurrentOperationCount = 1
-        observationQueue = queue
-
-        Current.barometer.startUpdatesOnQueueHandler(queue) { [weak self] data, _ in
+        guard Current.barometerObserver.addSubscriber(id: subscriberID, handler: { [weak self] data, _ in
             guard let self, let data else { return }
             let newPressure = data.pressure.doubleValue
             latestPressureKpa = newPressure
@@ -36,7 +29,7 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
             }
             lastSignaledPressureKpa = newPressure
             signal()
-        }
+        }) else { return }
         isObserving = true
 
         #if DEBUG
@@ -47,8 +40,7 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
     override func stopObserving() {
         super.stopObserving()
         guard isObserving else { return }
-        Current.barometer.stopUpdates()
-        observationQueue = nil
+        Current.barometerObserver.removeSubscriber(id: subscriberID)
         lastSignaledPressureKpa = nil
         latestPressureKpa = nil
         isObserving = false
@@ -57,19 +49,13 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
     private let oneShotLock = NSLock()
     private var pendingOneShot: Promise<CMAltitudeData>?
 
-    /// Performs a single relative-altitude read, coalescing concurrent callers onto one
-    /// `CMAltimeter` session.
+    /// Performs a single relative-altitude read, coalescing concurrent callers onto one reading.
     ///
-    /// `CMAltimeter.startRelativeAltitudeUpdates(to:withHandler:)` keeps only a single handler on
-    /// the shared altimeter (`Current.barometer`), so a second concurrent `start` orphans the first
-    /// caller's handler — which then never fires. Because sensor generation waits for *every*
-    /// provider (`when(resolved:)`), that orphaned read leaves the whole payload promise unresolved
-    /// and no `update_sensor_states` webhook is ever sent for that server. In a multi-server setup
-    /// the servers' sweeps are dispatched in list order, so the first (default) server was
-    /// deterministically starved while the last one worked. See issue #5100.
-    ///
-    /// Sharing one in-flight read fixes that, and a timeout guarantees the promise always settles
-    /// even if the hardware never reports (which would otherwise hang the sweep forever).
+    /// Sensor generation waits for *every* provider (`when(resolved:)`), so a read that never
+    /// settles leaves the whole payload promise unresolved and no `update_sensor_states` webhook is
+    /// ever sent for that server (issue #5100). Sharing one in-flight read keeps concurrent
+    /// per-server sweeps down to a single reading, and a timeout guarantees the promise always
+    /// settles even if the hardware never reports.
     func oneShotReading() -> Promise<CMAltitudeData> {
         let lock = oneShotLock
         lock.lock()
@@ -82,10 +68,7 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
         pendingOneShot = promise
         lock.unlock()
 
-        let queue = OperationQueue()
-        queue.name = "barometer-sensor"
-        queue.maxConcurrentOperationCount = 1
-
+        let oneShotID = "barometer-sensor-one-shot-\(UUID().uuidString)"
         var timeoutWork: DispatchWorkItem?
         var resolved = false
         // Called from the altimeter handler and from the timeout; the lock serializes them so the
@@ -101,7 +84,7 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
 
             guard !alreadyResolved else { return }
             timeoutWork?.cancel()
-            Current.barometer.stopUpdates()
+            Current.barometerObserver.removeSubscriber(id: oneShotID)
 
             if let data {
                 seal.fulfill(data)
@@ -114,8 +97,11 @@ final class BarometerSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
         timeoutWork = work
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 5, execute: work)
 
-        Current.barometer.startUpdatesOnQueueHandler(queue) { data, error in
+        guard Current.barometerObserver.addSubscriber(id: oneShotID, handler: { data, error in
             finish(data, error)
+        }) else {
+            finish(nil, BarometerSensor.BarometerError.unavailable)
+            return promise
         }
 
         return promise
@@ -137,12 +123,12 @@ public class BarometerSensor: SensorProvider {
     public func sensors() -> Promise<[WebhookSensor]> {
         let signaler: BarometerSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
 
-        // If the signaler is actively observing, use its cached pressure to avoid
-        // starting a separate one-shot read that would stop the signaler's stream.
+        // If the signaler is actively observing, its cached pressure is already current, so there is
+        // nothing for a one-shot read to add.
         if let cachedKpa = signaler.latestPressureKpa {
             return .value([Self.pressureSensor(fromKpa: cachedKpa)])
         } else if signaler.isObserving {
-            // Signaler started but no data yet — skip rather than racing with a one-shot
+            // Signaler started but no data yet — its first reading is moments away
             return .init(error: BarometerError.noData)
         }
 
@@ -155,8 +141,8 @@ public class BarometerSensor: SensorProvider {
             return .init(error: BarometerError.unavailable)
         }
 
-        // Route through the signaler so concurrent per-server sweeps share a single altimeter
-        // read instead of orphaning each other's handler (see `oneShotReading`, issue #5100).
+        // Route through the signaler so concurrent per-server sweeps share a single reading rather
+        // than each waiting out its own (see `oneShotReading`, issue #5100).
         return signaler.oneShotReading().map { data in
             [Self.pressureSensor(fromKpa: data.pressure.doubleValue)]
         }

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -650,6 +650,10 @@ public class AppEnvironment {
 
     public var barometer = Barometer()
 
+    /// Multiplexes the single altimeter session `Barometer` exposes, so more than one consumer can
+    /// read pressure at a time.
+    public var barometerObserver = BarometerObserver()
+
     public var device = DeviceWrapper()
 
     public var matter = MatterWrapper()

--- a/Tests/App/CabinPressureMonitor.test.swift
+++ b/Tests/App/CabinPressureMonitor.test.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+final class CabinPressureMonitorTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Sustained change
+
+    func testCabinClimbIsASustainedChange() throws {
+        // Pressurization takes the cabin down about 1.2 kPa every minute, minute after minute.
+        let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: -1.2)
+
+        let rate = try XCTUnwrap(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+        XCTAssertEqual(rate, -1.2, accuracy: 0.2)
+    }
+
+    func testCabinDescentIsASustainedChange() throws {
+        let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0.9)
+
+        let rate = try XCTUnwrap(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+        XCTAssertEqual(rate, 0.9, accuracy: 0.2)
+    }
+
+    func testElevatorRideIsNotASustainedChange() {
+        // A skyscraper elevator moves as much pressure as a climb but is over in under a minute, so
+        // it lands in one bucket instead of filling the window.
+        var samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: 0)
+        samples = samples.map { sample in
+            let secondsAgo = now.timeIntervalSince(sample.date)
+            guard secondsAgo <= 160 else { return sample }
+            let progress = min(1, max(0, (160 - secondsAgo) / 40))
+            return CabinPressureSample(date: sample.date, pressureKpa: sample.pressureKpa - 3.5 * progress)
+        }
+
+        XCTAssertNil(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+    }
+
+    func testSteadyPressureIsNotASustainedChange() {
+        let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: 0, noiseKpa: 0.05)
+
+        XCTAssertNil(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+    }
+
+    func testSlowDriftIsNotASustainedChange() {
+        // Weather moves pressure, but nowhere near fast enough to clear the per-minute floor.
+        let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: -0.05)
+
+        XCTAssertNil(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+    }
+
+    func testTooShortAWindowIsNotASustainedChange() {
+        let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: -1.2, spanning: 90)
+
+        XCTAssertNil(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
+    }
+
+    // MARK: - Evidence
+
+    func testNoSamplesIsInsufficientData() {
+        XCTAssertEqual(
+            CabinPressureMonitor.evidence(samples: [], baseline: baseline(kpa: 101.3), now: now),
+            .insufficientData
+        )
+    }
+
+    func testCabinCruisePressureFarBelowBaselineIsLowPressure() {
+        let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0)
+
+        let evidence = CabinPressureMonitor.evidence(
+            samples: samples,
+            baseline: baseline(kpa: 101.3),
+            now: now
+        )
+        guard case let .lowPressure(kpa, belowBaselineKpa) = evidence else {
+            XCTFail("Expected low pressure, got \(evidence)")
+            return
+        }
+        XCTAssertEqual(kpa, 78.0, accuracy: 0.01)
+        XCTAssertEqual(belowBaselineKpa, 23.3, accuracy: 0.01)
+    }
+
+    func testCabinCruisePressureWithoutABaselineIsInconclusive() {
+        // Nothing to compare against, so a device that simply lives high up never reads as flying.
+        let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0)
+
+        XCTAssertEqual(
+            CabinPressureMonitor.evidence(samples: samples, baseline: nil, now: now),
+            .inconclusive
+        )
+    }
+
+    func testStaleBaselineIsIgnored() {
+        let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0)
+        let stale = CabinPressureSample(
+            date: now.addingTimeInterval(-CabinPressureMonitor.baselineValidity - 60),
+            pressureKpa: 101.3
+        )
+
+        XCTAssertEqual(
+            CabinPressureMonitor.evidence(samples: samples, baseline: stale, now: now),
+            .inconclusive
+        )
+    }
+
+    func testHighElevationGroundDoesNotClearTheBaselineDrop() {
+        // Denver sits near 83.5 kPa, so a cabin is only ~5 kPa below its baseline — under the margin.
+        let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0)
+
+        XCTAssertEqual(
+            CabinPressureMonitor.evidence(samples: samples, baseline: baseline(kpa: 83.5), now: now),
+            .inconclusive
+        )
+    }
+
+    func testPressureAboveTheCabinCeilingIsInconclusive() {
+        // 1,100 m of ground elevation is a big drop from a sea-level baseline but is not a cabin.
+        let samples = makeSamples(startPressureKpa: 89.0, kpaPerMinute: 0)
+
+        XCTAssertEqual(
+            CabinPressureMonitor.evidence(samples: samples, baseline: baseline(kpa: 101.3), now: now),
+            .inconclusive
+        )
+    }
+
+    func testSustainedChangeIsReportedWithoutABaseline() {
+        // The climb out of a high-elevation airport never clears the baseline drop, so the trend is
+        // the only thing that can catch it.
+        let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: -1.2)
+
+        let evidence = CabinPressureMonitor.evidence(samples: samples, baseline: nil, now: now)
+        guard case let .sustainedChange(kpaPerMinute) = evidence else {
+            XCTFail("Expected a sustained change, got \(evidence)")
+            return
+        }
+        XCTAssertEqual(kpaPerMinute, -1.2, accuracy: 0.2)
+    }
+
+    func testOnlyPositiveEvidenceIndicatesFlight() {
+        XCTAssertFalse(CabinPressureEvidence.insufficientData.indicatesFlight)
+        XCTAssertFalse(CabinPressureEvidence.inconclusive.indicatesFlight)
+        XCTAssertTrue(CabinPressureEvidence.sustainedChange(kpaPerMinute: -1.2).indicatesFlight)
+        XCTAssertTrue(CabinPressureEvidence.lowPressure(kpa: 78, belowBaselineKpa: 23).indicatesFlight)
+    }
+
+    // MARK: - Helpers
+
+    private func baseline(kpa: Double) -> CabinPressureSample {
+        CabinPressureSample(date: now.addingTimeInterval(-60 * 60), pressureKpa: kpa)
+    }
+
+    /// A window of readings ending at `now`, five seconds apart, changing at a fixed rate.
+    private func makeSamples(
+        startPressureKpa: Double,
+        kpaPerMinute: Double,
+        spanning span: TimeInterval = CabinPressureMonitor.trendWindow,
+        noiseKpa: Double = 0
+    ) -> [CabinPressureSample] {
+        let interval: TimeInterval = 5
+        let count = Int(span / interval)
+        return (0 ... count).map { step in
+            let secondsIn = Double(step) * interval
+            // A deterministic wobble, so a "steady" window still isn't perfectly flat.
+            let noise = noiseKpa * (step.isMultiple(of: 2) ? 1 : -1)
+            return CabinPressureSample(
+                date: now.addingTimeInterval(-span + secondsIn),
+                pressureKpa: startPressureKpa + kpaPerMinute * (secondsIn / 60) + noise
+            )
+        }
+    }
+}

--- a/Tests/App/CabinPressureMonitor.test.swift
+++ b/Tests/App/CabinPressureMonitor.test.swift
@@ -12,15 +12,18 @@ final class CabinPressureMonitorTests: XCTestCase {
         // Pressurization takes the cabin down about 1.2 kPa every minute, minute after minute.
         let samples = makeSamples(startPressureKpa: 101.3, kpaPerMinute: -1.2)
 
+        // The tolerance is tight on purpose: consecutive buckets share the reading on their boundary
+        // so each spans a whole minute, and the reported rate is the real one. Stopping a bucket at
+        // the last reading before its boundary instead would report about -1.1 here.
         let rate = try XCTUnwrap(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
-        XCTAssertEqual(rate, -1.2, accuracy: 0.2)
+        XCTAssertEqual(rate, -1.2, accuracy: 0.01)
     }
 
     func testCabinDescentIsASustainedChange() throws {
         let samples = makeSamples(startPressureKpa: 78.0, kpaPerMinute: 0.9)
 
         let rate = try XCTUnwrap(CabinPressureMonitor.sustainedChangeKpaPerMinute(in: samples, now: now))
-        XCTAssertEqual(rate, 0.9, accuracy: 0.2)
+        XCTAssertEqual(rate, 0.9, accuracy: 0.01)
     }
 
     func testElevatorRideIsNotASustainedChange() {

--- a/Tests/Shared/Sensors/BarometerObserver.test.swift
+++ b/Tests/Shared/Sensors/BarometerObserver.test.swift
@@ -5,9 +5,16 @@ import XCTest
 
 class BarometerObserverTests: XCTestCase {
     private var observer: BarometerObserver!
+    private var originalBarometer: AppEnvironment.Barometer!
+    private var originalObserver: BarometerObserver!
 
     override func setUp() {
         super.setUp()
+
+        // `Current` is global, so the stubs below have to be undone or they leak into every test that
+        // runs after this class and make failures depend on ordering.
+        originalBarometer = Current.barometer
+        originalObserver = Current.barometerObserver
 
         Current.barometer.isAuthorized = { true }
         Current.barometer.isAvailable = { true }
@@ -19,6 +26,10 @@ class BarometerObserverTests: XCTestCase {
 
     override func tearDown() {
         observer = nil
+        Current.barometer = originalBarometer
+        Current.barometerObserver = originalObserver
+        originalBarometer = nil
+        originalObserver = nil
         super.tearDown()
     }
 

--- a/Tests/Shared/Sensors/BarometerObserver.test.swift
+++ b/Tests/Shared/Sensors/BarometerObserver.test.swift
@@ -1,0 +1,148 @@
+import CoreMotion
+import Foundation
+@testable import Shared
+import XCTest
+
+class BarometerObserverTests: XCTestCase {
+    private var observer: BarometerObserver!
+
+    override func setUp() {
+        super.setUp()
+
+        Current.barometer.isAuthorized = { true }
+        Current.barometer.isAvailable = { true }
+        Current.barometer.startUpdatesOnQueueHandler = { _, handler in handler(nil, nil) }
+        Current.barometer.stopUpdates = {}
+
+        observer = BarometerObserver()
+    }
+
+    override func tearDown() {
+        observer = nil
+        super.tearDown()
+    }
+
+    func testFirstSubscriberStartsSessionAndSecondReusesIt() {
+        var startCount = 0
+        Current.barometer.startUpdatesOnQueueHandler = { _, _ in startCount += 1 }
+
+        XCTAssertTrue(observer.addSubscriber(id: "a", handler: { _, _ in }))
+        XCTAssertEqual(startCount, 1)
+
+        XCTAssertTrue(observer.addSubscriber(id: "b", handler: { _, _ in }))
+        XCTAssertEqual(startCount, 1)
+    }
+
+    func testEverySubscriberReceivesEveryReading() {
+        var handler: CMAltitudeHandler?
+        Current.barometer.startUpdatesOnQueueHandler = { _, registered in handler = registered }
+
+        var pressuresA = [Double]()
+        var pressuresB = [Double]()
+        observer.addSubscriber(id: "a", handler: { data, _ in pressuresA.append(data?.pressure.doubleValue ?? 0) })
+        observer.addSubscriber(id: "b", handler: { data, _ in pressuresB.append(data?.pressure.doubleValue ?? 0) })
+
+        handler?(FakeAltitudeData(pressureValue: 101.3), nil)
+        handler?(FakeAltitudeData(pressureValue: 78.5), nil)
+
+        XCTAssertEqual(pressuresA, [101.3, 78.5])
+        XCTAssertEqual(pressuresB, [101.3, 78.5])
+    }
+
+    func testErrorsAreForwardedToSubscribers() {
+        var handler: CMAltitudeHandler?
+        Current.barometer.startUpdatesOnQueueHandler = { _, registered in handler = registered }
+
+        var receivedError: Error?
+        observer.addSubscriber(id: "a", handler: { _, error in receivedError = error })
+
+        handler?(nil, TestError.someError)
+        XCTAssertEqual(receivedError as? TestError, .someError)
+    }
+
+    func testSessionStopsOnlyWhenLastSubscriberLeaves() {
+        var stopCount = 0
+        Current.barometer.stopUpdates = { stopCount += 1 }
+
+        observer.addSubscriber(id: "a", handler: { _, _ in })
+        observer.addSubscriber(id: "b", handler: { _, _ in })
+
+        observer.removeSubscriber(id: "a")
+        XCTAssertEqual(stopCount, 0)
+
+        observer.removeSubscriber(id: "b")
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    func testSessionRestartsAfterAllSubscribersLeft() {
+        var startCount = 0
+        Current.barometer.startUpdatesOnQueueHandler = { _, _ in startCount += 1 }
+
+        observer.addSubscriber(id: "a", handler: { _, _ in })
+        observer.removeSubscriber(id: "a")
+        observer.addSubscriber(id: "a", handler: { _, _ in })
+
+        XCTAssertEqual(startCount, 2)
+    }
+
+    func testLatestPressureIsCachedWhileRunningAndClearedOnStop() {
+        var handler: CMAltitudeHandler?
+        Current.barometer.startUpdatesOnQueueHandler = { _, registered in handler = registered }
+
+        observer.addSubscriber(id: "a", handler: { _, _ in })
+        XCTAssertNil(observer.latestPressureKpa)
+
+        handler?(FakeAltitudeData(pressureValue: 99.5), nil)
+        XCTAssertEqual(observer.latestPressureKpa, 99.5)
+
+        observer.removeSubscriber(id: "a")
+        XCTAssertNil(observer.latestPressureKpa)
+    }
+
+    func testUnauthorizedSubscriptionIsRejectedWithoutStartingASession() {
+        Current.barometer.isAuthorized = { false }
+
+        var startCount = 0
+        Current.barometer.startUpdatesOnQueueHandler = { _, _ in startCount += 1 }
+
+        XCTAssertFalse(observer.addSubscriber(id: "a", handler: { _, _ in }))
+        XCTAssertFalse(observer.hasSubscriber(id: "a"))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    func testUnavailableSubscriptionIsRejectedWithoutStartingASession() {
+        Current.barometer.isAvailable = { false }
+
+        var startCount = 0
+        Current.barometer.startUpdatesOnQueueHandler = { _, _ in startCount += 1 }
+
+        XCTAssertFalse(observer.addSubscriber(id: "a", handler: { _, _ in }))
+        XCTAssertEqual(startCount, 0)
+    }
+
+    private enum TestError: Error {
+        case someError
+    }
+}
+
+private class FakeAltitudeData: CMAltitudeData {
+    private let pressureKpa: NSNumber
+
+    init(pressureValue: Double) {
+        self.pressureKpa = NSNumber(value: pressureValue)
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override var pressure: NSNumber {
+        pressureKpa
+    }
+
+    override var relativeAltitude: NSNumber {
+        NSNumber(value: 0)
+    }
+}

--- a/Tests/Shared/Sensors/BarometerSensor.test.swift
+++ b/Tests/Shared/Sensors/BarometerSensor.test.swift
@@ -34,6 +34,10 @@ class BarometerSensorTests: XCTestCase {
         Current.barometer.isAvailable = { false }
         Current.barometer.startUpdatesOnQueueHandler = { _, handler in handler(nil, nil) }
         Current.barometer.stopUpdates = {}
+
+        // The observer owns the one altimeter session process-wide, so a fresh one per test keeps
+        // subscribers (and therefore the started/stopped state) from leaking between them.
+        Current.barometerObserver = BarometerObserver()
     }
 
     override func tearDown() {

--- a/Tests/Shared/Sensors/BarometerSensor.test.swift
+++ b/Tests/Shared/Sensors/BarometerSensor.test.swift
@@ -11,6 +11,8 @@ class BarometerSensorTests: XCTestCase {
 
     private var request: SensorProviderRequest!
     private var originalSensors: SensorContainer!
+    private var originalBarometer: AppEnvironment.Barometer!
+    private var originalObserver: BarometerObserver!
 
     override func setUp() {
         super.setUp()
@@ -29,6 +31,11 @@ class BarometerSensorTests: XCTestCase {
             serverVersion: Version()
         )
 
+        // `Current` is global, so the stubs below have to be undone in tearDown or they leak into
+        // every test that runs after this class and make failures depend on ordering.
+        originalBarometer = Current.barometer
+        originalObserver = Current.barometerObserver
+
         // start by assuming nothing is enabled/available
         Current.barometer.isAuthorized = { false }
         Current.barometer.isAvailable = { false }
@@ -42,7 +49,11 @@ class BarometerSensorTests: XCTestCase {
 
     override func tearDown() {
         Current.sensors = originalSensors
+        Current.barometer = originalBarometer
+        Current.barometerObserver = originalObserver
         originalSensors = nil
+        originalBarometer = nil
+        originalObserver = nil
         super.tearDown()
     }
 


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
In-flight greetings did not appear on a flight without in-flight Wi-Fi. Without a matching SSID, detection fell back to a 5 second GPS one-shot, which cannot get a fix offline: with no network there is no assistance data, so a cold start takes tens of seconds. The one-shot also resolves on the first positionally accurate fix, which often carries no speed at all, and detection only ran once per app activation.

This adds cabin air pressure as a detection signal, which works with no connectivity and no GPS fix:

- `BarometerObserver` on `Current` multiplexes the single `CMAltimeter` session, so the pressure sensor and flight detection can both read the barometer. The altimeter keeps only one handler, so a second session would silently orphan the first (the cause of #5100).
- `CabinPressureMonitor` runs while the app is in the foreground and reports a flight when either the pressure is at cabin cruise level and well below a stored ground baseline, or it is changing at a rate sustained across several minutes. Both rules require the device to be offline, and the baseline is only recorded above cabin cruise pressure while a network is present, so a high altitude city cannot trigger it or poison the baseline.
- `FlightSpeedProbe` replaces the GPS one-shot here, waiting for the first fix that actually carries a ground speed, with 5 seconds online and 45 seconds offline.
- Detection now also pushes from the barometer instead of only being polled, so a single failed check when the app opens is no longer the end of it.

Motion & Fitness access is required for the barometer. It is only ever checked, never requested, so this cannot raise a permission prompt.

## Screenshots
No visual change: same greeting toast and in-flight empty state, only the detection behind them changed.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Flights departing very high altitude airports stay undetectable by pressure, since the cabin at cruise sits at a higher pressure than the ground there. SSID and GPS still cover those.

Unit tests cover the observer fan-out and session refcounting, and the pressure rules including an elevator ride, weather drift, and a high altitude baseline.
