### PR TITLE
Open more info dialog when tapping sensors widget

### DIFF
--- a/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Sensor/WidgetSensorsAppIntentTimelineProvider.swift
@@ -120,7 +120,9 @@ struct WidgetSensorsAppIntentTimelineProvider: AppIntentTimelineProvider {
             key: sensor.displayString,
             value: state.value,
             unitOfMeasurement: state.unitOfMeasurement,
-            icon: sensor.icon ?? Domain(entityId: sensor.entityId)?.icon().name
+            icon: sensor.icon ?? Domain(entityId: sensor.entityId)?.icon().name,
+            entityId: sensor.entityId,
+            serverId: sensor.serverId
         )
     }
 
@@ -151,6 +153,10 @@ struct WidgetSensorsEntry: TimelineEntry {
         var value: String
         var unitOfMeasurement: String?
         var icon: String?
+        /// Placeholder and gallery samples have no real entity behind them, so they carry no
+        /// identifiers and the tile falls back to a non-navigating interaction.
+        var entityId: String?
+        var serverId: String?
     }
 }
 

--- a/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
+++ b/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
@@ -21,7 +21,7 @@ struct WidgetSensors: Widget {
                         id: sensor.id,
                         title: appendUnitOfMeasurementToValue(sensor: sensor),
                         subtitle: sensor.key,
-                        interactionType: .appIntent(.refresh),
+                        interactionType: interactionType(for: sensor),
                         icon: MaterialDesignIcons(
                             serversideValueNamed: sensor.icon ?? "",
                             fallback: .dotsGridIcon
@@ -41,6 +41,17 @@ struct WidgetSensors: Widget {
 
     private func appendUnitOfMeasurementToValue(sensor: WidgetSensorsEntry.SensorData) -> String {
         "\(sensor.value) \(sensor.unitOfMeasurement ?? "")"
+    }
+
+    /// Tapping a sensor opens the app on that entity's more info dialog, matching the behavior of the
+    /// other entity based widgets. Placeholder and gallery entries have no entity to open, so they keep
+    /// the refresh interaction.
+    private func interactionType(for sensor: WidgetSensorsEntry.SensorData) -> WidgetInteractionType {
+        guard let entityId = sensor.entityId, let serverId = sensor.serverId,
+              let url = AppConstants.openEntityDeeplinkURL(entityId: entityId, serverId: serverId) else {
+            return .appIntent(.refresh)
+        }
+        return .widgetURL(url)
     }
 }
 


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Tapping a tile in the sensors widget only refreshed the widget timeline, it never opened the app. Sensor tiles now use the same deep link the other entity based widgets use, so a tap opens the app on that entity's more info dialog.

Fixes #4737

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change, only the tap behavior changed.

## Link to pull request in Documentation repository
Documentation: N/A

## Any other notes
Placeholder and widget gallery tiles have no entity behind them, so they keep the previous refresh interaction.
