### PR TITLE
Convert remaining Xcode groups to synchronized folders

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1915,7 +1915,53 @@
 			);
 			target = B657A8FB1CA646EB00121384 /* Tests-App */;
 		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		42FD0000001700510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.capacity-ring.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.custom-text-color.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.full-fraction.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.icon-and-value-no-name.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.icon-only-no-gauge.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.icon-value-name-open.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.long-value.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.no-gauge.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.no-min-max.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.value-and-name-no-icon.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.value-only.png",
+				"__Snapshots__/CircularComplicationSnapshot.test/circularComplicationVariants.zero-fraction.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.custom-text-color.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.full-fraction.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.icon-gauge.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.icon-name-value-gauge.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.icon-only.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.name-only-gauge.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.value-name-gauge.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.value-name-no-gauge.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.value-only.png",
+				"__Snapshots__/CornerComplicationSnapshot.test/cornerComplicationVariants.zero-fraction.png",
+				"__Snapshots__/InlineComplicationSnapshot.test/inlineComplicationVariants.long-line.png",
+				"__Snapshots__/InlineComplicationSnapshot.test/inlineComplicationVariants.name-and-value.png",
+				"__Snapshots__/InlineComplicationSnapshot.test/inlineComplicationVariants.name-only.png",
+				"__Snapshots__/InlineComplicationSnapshot.test/inlineComplicationVariants.value-only.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.all-slots-no-min-max.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.all-slots.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.custom-text-color.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.full-fraction.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.icon-name-gauge.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.long-text.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.no-icon.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.no-name.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.text-only.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.value-as-text.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/rectangularComplicationVariants.zero-fraction.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/renderingModeVariants.accented.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/renderingModeVariants.fullColor.png",
+				"__Snapshots__/RectangularComplicationSnapshot.test/renderingModeVariants.vibrant.png",
+			);
+			target = B657A8FB1CA646EB00121384 /* Tests-App */;
+		};
+	/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		11AF1EC52528FB2300AAE364 /* Entitlements */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Entitlements; sourceTree = "<group>"; };
@@ -1939,7 +1985,7 @@
 		42DF4F00302CACC600589E49 /* Templating */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Templating; sourceTree = "<group>"; };
 		42DF4F03302CACD000589E49 /* ServerSwitching */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ServerSwitching; sourceTree = "<group>"; };
 		42DF4F06302CACD400589E49 /* ServerSwitching */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ServerSwitching; sourceTree = "<group>"; };
-		42DF4F8E302CADA700589E49 /* WatchComplications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WatchComplications; sourceTree = "<group>"; };
+		42DF4F8E302CADA700589E49 /* WatchComplications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000001700510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WatchComplications; sourceTree = "<group>"; };
 		42EDB61A3002FB9A0051FC9B /* Launcher */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42EDBB5E3002FB9B0051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Launcher; sourceTree = "<group>"; };
 		42EDB6203002FB9A0051FC9B /* Improv */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Improv; sourceTree = "<group>"; };
 		42EDB6453002FB9A0051FC9B /* CarPlay */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CarPlay; sourceTree = "<group>"; };

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -90,8 +90,6 @@
 		42145A642DAFD4CC00891E04 /* MaterialDesignIcons+CarPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1DA732B4FF9F8002729BC /* MaterialDesignIcons+CarPlay.swift */; };
 		42145A662F7F4CC000891E04 /* EntityColorAttributesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42145A652F7F4CC000891E04 /* EntityColorAttributesParser.swift */; };
 		42164BB9301320720077A903 /* ComplicationFormula.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42164BB8301320720077A903 /* ComplicationFormula.test.swift */; };
-		42165CDB3013242D0077A903 /* LocationBasedServerSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42165CDA3013242D0077A903 /* LocationBasedServerSwitcher.swift */; };
-		42165CE0301324980077A903 /* LocationBasedServerSwitcher.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42165CDF301324980077A903 /* LocationBasedServerSwitcher.test.swift */; };
 		4237E6392E5333370023B673 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 4237E6382E5333370023B673 /* ZIPFoundation */; };
 		423FB76D2FFFDFDE000CB8FD /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1171506A24DFCDE60065E874 /* WidgetKit.framework */; };
 		423FB76E2FFFDFDE000CB8FD /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46C62BA82D8A3AC5002C0001 /* SwiftUI.framework */; };
@@ -99,7 +97,6 @@
 		4245DC042EBA7919005E0E04 /* AreasService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4245DC022EBA42C3005E0E04 /* AreasService.swift */; };
 		4245DC052EBA7919005E0E04 /* AreasService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4245DC022EBA42C3005E0E04 /* AreasService.swift */; };
 		424D2D102C89DACE00C610F1 /* HAAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */; };
-		424D4161300F75B7001998ED /* GreetingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424D4160300F75B7001998ED /* GreetingsSettingsView.swift */; };
 		4254C4CA2D103ABB00245021 /* ExternalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254C4C92D103ABB00245021 /* ExternalLink.swift */; };
 		4254C4CB2D103ABB00245021 /* ExternalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254C4C92D103ABB00245021 /* ExternalLink.swift */; };
 		425FBA1E2C9C75A300CB5DBB /* DataWidgetsUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A47D4A2C9AEF10003C597D /* DataWidgetsUpdater.swift */; };
@@ -165,10 +162,8 @@
 		42B18FD72F38CA2300A1537A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 42B18FD62F38CA2300A1537A /* FirebaseMessaging */; };
 		42B7C1A32F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */; };
 		42B89EAC2E080494000224A2 /* AppConstants.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B89EAB2E080494000224A2 /* AppConstants.test.swift */; };
-		42D6FE19300F900000D4BEB9 /* CabinPressureMonitor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */; };
 		42BB4C372CD26490003E47FD /* HATypedRequest+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */; };
 		42BB4C382CD26490003E47FD /* HATypedRequest+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */; };
-		42BC36C5300683F700E5EE14 /* JinjaEntityReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */; };
 		42BC58202FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */; };
 		42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */; };
 		42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */; };
@@ -179,31 +174,13 @@
 		42C60FA62F081DA90071A6F6 /* DeviceClassProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */; };
 		42C60FA72F081DA90071A6F6 /* DeviceClassProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */; };
 		42D14C49301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C48301BAF950058088E /* HAWatchComplications */; };
-		42D14CA1301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14CA0301BAF950058088E /* HAWatchComplications */; };
 		42D14C4B301BAFA10058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C4A301BAFA10058088E /* HAWatchComplications */; };
 		42D14C4D301BAFAC0058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C4C301BAFAC0058088E /* HAWatchComplications */; };
-		42D14C4E301BAFC80058088E /* RectangularComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C46301BAD2E0058088E /* RectangularComplicationSnapshot.test.swift */; };
 		42D14C7B301BBAF50058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C7A301BBAF50058088E /* HAWatchComplications */; };
 		42D14C91301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14C90301BAF950058088E /* HAWatchComplications */; };
-		42D14C99301BC37A0058088E /* CircularComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C98301BC37A0058088E /* CircularComplicationSnapshot.test.swift */; };
-		42D14C9B301BC3840058088E /* InlineComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C9A301BC3840058088E /* InlineComplicationSnapshot.test.swift */; };
-		42D14C9D301BC38E0058088E /* CornerComplicationSnapshot.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D14C9C301BC38E0058088E /* CornerComplicationSnapshot.test.swift */; };
-		42D6FDD3300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD2300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift */; };
-		42D6FDD5300F71F600D4BEB9 /* FlightDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */; };
-		42D6FE11300F900000D4BEB9 /* CabinPressureSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */; };
-		42D6FE13300F900000D4BEB9 /* CabinPressureEvidence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */; };
-		42D6FE15300F900000D4BEB9 /* CabinPressureMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */; };
-		42D6FE17300F900000D4BEB9 /* FlightSpeedProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */; };
-		42D6FDD7300F720600D4BEB9 /* FlightGreetingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */; };
+		42D14CA1301BAF950058088E /* HAWatchComplications in Frameworks */ = {isa = PBXBuildFile; productRef = 42D14CA0301BAF950058088E /* HAWatchComplications */; };
+		42D6FE19300F900000D4BEB9 /* CabinPressureMonitor.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */; };
 		42DC44332E1C06E5001046C1 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 42DC44322E1C06E5001046C1 /* WebRTC */; };
-		42DF195130065055003B7FA1 /* JinjaTemplateSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF195030065055003B7FA1 /* JinjaTemplateSuggestion.swift */; };
-		42DF195330065071003B7FA1 /* JinjaAutocompleteProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF195230065071003B7FA1 /* JinjaAutocompleteProvider.swift */; };
-		42DF1955300650A9003B7FA1 /* JinjaSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF1954300650A9003B7FA1 /* JinjaSyntaxHighlighter.swift */; };
-		42DF1959300650C7003B7FA1 /* JinjaTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF1958300650C7003B7FA1 /* JinjaTextEditor.swift */; };
-		42DF97B2300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF97B1300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift */; };
-		42DF97B430066D95003B7FA1 /* JinjaTemplateEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF97B330066D95003B7FA1 /* JinjaTemplateEditorSheet.swift */; };
-		42DF97B630066DAE003B7FA1 /* JinjaTemplateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF97B530066DAE003B7FA1 /* JinjaTemplateButton.swift */; };
-		42DF97B83006721A003B7FA1 /* JinjaEntitySuggestionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DF97B73006721A003B7FA1 /* JinjaEntitySuggestionsView.swift */; };
 		42DFE8802EFB23240058DADB /* HAEntity+CarPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */; };
 		42E00D112E1E7487006D140D /* SharedPush in Frameworks */ = {isa = PBXBuildFile; productRef = 42E00D102E1E7487006D140D /* SharedPush */; };
 		42E1C8102FFE4DA3008DAEE5 /* XCGLogger in Frameworks */ = {isa = PBXBuildFile; productRef = 42E1C80F2FFE4DA3008DAEE5 /* XCGLogger */; };
@@ -633,13 +610,10 @@
 		421125C62F51DE9200971BAD /* StatePrecision.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePrecision.test.swift; sourceTree = "<group>"; };
 		42145A652F7F4CC000891E04 /* EntityColorAttributesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityColorAttributesParser.swift; sourceTree = "<group>"; };
 		42164BB8301320720077A903 /* ComplicationFormula.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFormula.test.swift; sourceTree = "<group>"; };
-		42165CDA3013242D0077A903 /* LocationBasedServerSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationBasedServerSwitcher.swift; sourceTree = "<group>"; };
-		42165CDF301324980077A903 /* LocationBasedServerSwitcher.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationBasedServerSwitcher.test.swift; sourceTree = "<group>"; };
 		4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIconColorProvider.swift; sourceTree = "<group>"; };
 		423FB76C2FFFDFDE000CB8FD /* Extensions-WatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Extensions-WatchWidgets.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4245DC022EBA42C3005E0E04 /* AreasService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreasService.swift; sourceTree = "<group>"; };
 		424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAppEntity.swift; sourceTree = "<group>"; };
-		424D4160300F75B7001998ED /* GreetingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreetingsSettingsView.swift; sourceTree = "<group>"; };
 		4254C4C92D103ABB00245021 /* ExternalLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalLink.swift; sourceTree = "<group>"; };
 		425573E42B58380D00145217 /* CarPlay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CarPlay.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/iOSSupport/System/Library/Frameworks/CarPlay.framework; sourceTree = DEVELOPER_DIR; };
 		42646B762E0BE6F100F6B367 /* BackgroundTask.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.test.swift; sourceTree = "<group>"; };
@@ -654,34 +628,14 @@
 		42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreRestoreLastURL.test.swift; sourceTree = "<group>"; };
 		42B7C1A22F78D10000E4F3AB /* MaterialDesignIconsSFSymbol.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaterialDesignIconsSFSymbol.test.swift; sourceTree = "<group>"; };
 		42B89EAB2E080494000224A2 /* AppConstants.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.test.swift; sourceTree = "<group>"; };
-		42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureMonitor.test.swift; sourceTree = "<group>"; };
 		42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HATypedRequest+App.swift"; sourceTree = "<group>"; };
-		42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaEntityReference.swift; sourceTree = "<group>"; };
 		42BC581F2FAA501E0080EE09 /* CarPlayAssistDebugSettings.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayAssistDebugSettings.test.swift; sourceTree = "<group>"; };
 		42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimateControlState.test.swift; sourceTree = "<group>"; };
 		42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VacuumCapabilities.test.swift; sourceTree = "<group>"; };
 		42C11A0631AC500011AABB06 /* VacuumAreaMapping.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VacuumAreaMapping.test.swift; sourceTree = "<group>"; };
 		42C60FA52F081DA90071A6F6 /* DeviceClassProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceClassProvider.swift; sourceTree = "<group>"; };
-		42D14C46301BAD2E0058088E /* RectangularComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangularComplicationSnapshot.test.swift; sourceTree = "<group>"; };
 		42D14C6D301BB6330058088E /* HomeAssistant-WatchAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "HomeAssistant-WatchAppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		42D14C98301BC37A0058088E /* CircularComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularComplicationSnapshot.test.swift; sourceTree = "<group>"; };
-		42D14C9A301BC3840058088E /* InlineComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineComplicationSnapshot.test.swift; sourceTree = "<group>"; };
-		42D14C9C301BC38E0058088E /* CornerComplicationSnapshot.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerComplicationSnapshot.test.swift; sourceTree = "<group>"; };
-		42D6FDD2300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InFlightWiFiSSIDs.swift; sourceTree = "<group>"; };
-		42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightDetector.swift; sourceTree = "<group>"; };
-		42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureSample.swift; sourceTree = "<group>"; };
-		42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureEvidence.swift; sourceTree = "<group>"; };
-		42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureMonitor.swift; sourceTree = "<group>"; };
-		42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightSpeedProbe.swift; sourceTree = "<group>"; };
-		42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightGreetingManager.swift; sourceTree = "<group>"; };
-		42DF195030065055003B7FA1 /* JinjaTemplateSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaTemplateSuggestion.swift; sourceTree = "<group>"; };
-		42DF195230065071003B7FA1 /* JinjaAutocompleteProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaAutocompleteProvider.swift; sourceTree = "<group>"; };
-		42DF1954300650A9003B7FA1 /* JinjaSyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaSyntaxHighlighter.swift; sourceTree = "<group>"; };
-		42DF1958300650C7003B7FA1 /* JinjaTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaTextEditor.swift; sourceTree = "<group>"; };
-		42DF97B1300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaAutocompleteProvider.test.swift; sourceTree = "<group>"; };
-		42DF97B330066D95003B7FA1 /* JinjaTemplateEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaTemplateEditorSheet.swift; sourceTree = "<group>"; };
-		42DF97B530066DAE003B7FA1 /* JinjaTemplateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaTemplateButton.swift; sourceTree = "<group>"; };
-		42DF97B73006721A003B7FA1 /* JinjaEntitySuggestionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JinjaEntitySuggestionsView.swift; sourceTree = "<group>"; };
+		42D6FE18300F900000D4BEB9 /* CabinPressureMonitor.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CabinPressureMonitor.test.swift; sourceTree = "<group>"; };
 		42EDE940300315A50051FC9B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		42EDE941300315A50051FC9B /* HAApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAApp.swift; sourceTree = "<group>"; };
 		42EDE942300315A50051FC9B /* HAApplicationShortcutItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAApplicationShortcutItem.swift; sourceTree = "<group>"; };
@@ -1980,6 +1934,12 @@
 		42CA28AC2B101D320093B31A /* DesignSystem */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000000D00510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DesignSystem; sourceTree = "<group>"; };
 		42D14C6E301BB6330058088E /* WatchAppTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WatchAppTests; sourceTree = "<group>"; };
 		42D3E49F2C5BCCF600444BE6 /* Watch */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Watch; sourceTree = "<group>"; };
+		42DF4EE5302CACB600589E49 /* FlightGreetings */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FlightGreetings; sourceTree = "<group>"; };
+		42DF4EF6302CACC200589E49 /* Templating */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Templating; sourceTree = "<group>"; };
+		42DF4F00302CACC600589E49 /* Templating */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Templating; sourceTree = "<group>"; };
+		42DF4F03302CACD000589E49 /* ServerSwitching */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ServerSwitching; sourceTree = "<group>"; };
+		42DF4F06302CACD400589E49 /* ServerSwitching */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ServerSwitching; sourceTree = "<group>"; };
+		42DF4F8E302CADA700589E49 /* WatchComplications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WatchComplications; sourceTree = "<group>"; };
 		42EDB61A3002FB9A0051FC9B /* Launcher */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42EDBB5E3002FB9B0051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Launcher; sourceTree = "<group>"; };
 		42EDB6203002FB9A0051FC9B /* Improv */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Improv; sourceTree = "<group>"; };
 		42EDB6453002FB9A0051FC9B /* CarPlay */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CarPlay; sourceTree = "<group>"; };
@@ -2363,7 +2323,7 @@
 				B657A8FF1CA646EB00121384 /* App */,
 				D03D894320E0BC1800D4F28D /* Shared */,
 				B657A90A1CA646EB00121384 /* UI */,
-				42D14C45301BAD2E0058088E /* WatchComplications */,
+				42DF4F8E302CADA700589E49 /* WatchComplications */,
 				42D14C6E301BB6330058088E /* WatchAppTests */,
 			);
 			path = Tests;
@@ -2394,71 +2354,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		42165CD93013242D0077A903 /* ServerSwitching */ = {
-			isa = PBXGroup;
-			children = (
-				42165CDA3013242D0077A903 /* LocationBasedServerSwitcher.swift */,
-			);
-			path = ServerSwitching;
-			sourceTree = "<group>";
-		};
-		42165CDE301324980077A903 /* ServerSwitching */ = {
-			isa = PBXGroup;
-			children = (
-				42165CDF301324980077A903 /* LocationBasedServerSwitcher.test.swift */,
-			);
-			path = ServerSwitching;
-			sourceTree = "<group>";
-		};
-		42D14C45301BAD2E0058088E /* WatchComplications */ = {
-			isa = PBXGroup;
-			children = (
-				42D14C46301BAD2E0058088E /* RectangularComplicationSnapshot.test.swift */,
-				42D14C98301BC37A0058088E /* CircularComplicationSnapshot.test.swift */,
-				42D14C9A301BC3840058088E /* InlineComplicationSnapshot.test.swift */,
-				42D14C9C301BC38E0058088E /* CornerComplicationSnapshot.test.swift */,
-			);
-			path = WatchComplications;
-			sourceTree = "<group>";
-		};
-		42D6FDD1300F71E800D4BEB9 /* FlightGreetings */ = {
-			isa = PBXGroup;
-			children = (
-				42D6FDD2300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift */,
-				42D6FDD4300F71F600D4BEB9 /* FlightDetector.swift */,
-				42D6FDD6300F720600D4BEB9 /* FlightGreetingManager.swift */,
-				424D4160300F75B7001998ED /* GreetingsSettingsView.swift */,
-				42D6FE10300F900000D4BEB9 /* CabinPressureSample.swift */,
-				42D6FE12300F900000D4BEB9 /* CabinPressureEvidence.swift */,
-				42D6FE14300F900000D4BEB9 /* CabinPressureMonitor.swift */,
-				42D6FE16300F900000D4BEB9 /* FlightSpeedProbe.swift */,
-			);
-			path = FlightGreetings;
-			sourceTree = "<group>";
-		};
-		42DF194F30065055003B7FA1 /* Templating */ = {
-			isa = PBXGroup;
-			children = (
-				42DF195030065055003B7FA1 /* JinjaTemplateSuggestion.swift */,
-				42DF195230065071003B7FA1 /* JinjaAutocompleteProvider.swift */,
-				42DF1954300650A9003B7FA1 /* JinjaSyntaxHighlighter.swift */,
-				42DF1958300650C7003B7FA1 /* JinjaTextEditor.swift */,
-				42DF97B330066D95003B7FA1 /* JinjaTemplateEditorSheet.swift */,
-				42DF97B530066DAE003B7FA1 /* JinjaTemplateButton.swift */,
-				42DF97B73006721A003B7FA1 /* JinjaEntitySuggestionsView.swift */,
-				42BC36C4300683F700E5EE14 /* JinjaEntityReference.swift */,
-			);
-			path = Templating;
-			sourceTree = "<group>";
-		};
-		42DF97B0300669B9003B7FA1 /* Templating */ = {
-			isa = PBXGroup;
-			children = (
-				42DF97B1300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift */,
-			);
-			path = Templating;
-			sourceTree = "<group>";
-		};
 		42EDE945300315A50051FC9B /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -2486,9 +2381,9 @@
 				42EDE943300315A50051FC9B /* LifecycleManager.swift */,
 				FA11C0DE0000000000000100 /* BackgroundRefreshManager.swift */,
 				42EDE944300315A50051FC9B /* MainWindowGroupCommands.swift */,
-				42DF194F30065055003B7FA1 /* Templating */,
-				42D6FDD1300F71E800D4BEB9 /* FlightGreetings */,
-				42165CD93013242D0077A903 /* ServerSwitching */,
+				42DF4EF6302CACC200589E49 /* Templating */,
+				42DF4EE5302CACB600589E49 /* FlightGreetings */,
+				42DF4F03302CACD000589E49 /* ServerSwitching */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2576,8 +2471,8 @@
 				42EDBBCD3002FBC90051FC9B /* WebView */,
 				42EDBBB63002FBC90051FC9B /* Widgets */,
 				42EDBBAD3002FBC90051FC9B /* ZoneManager */,
-				42DF97B0300669B9003B7FA1 /* Templating */,
-				42165CDE301324980077A903 /* ServerSwitching */,
+				42DF4F00302CACC600589E49 /* Templating */,
+				42DF4F06302CACD400589E49 /* ServerSwitching */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -3010,6 +2905,9 @@
 			);
 			fileSystemSynchronizedGroups = (
 				4283E0D53004DCF4004D1061 /* Resources */,
+				42DF4EE5302CACB600589E49 /* FlightGreetings */,
+				42DF4EF6302CACC200589E49 /* Templating */,
+				42DF4F03302CACD000589E49 /* ServerSwitching */,
 				42EDB6203002FB9A0051FC9B /* Improv */,
 				42EDB6453002FB9A0051FC9B /* CarPlay */,
 				42EDB66D3002FB9A0051FC9B /* Thread */,
@@ -3071,6 +2969,9 @@
 				428626002DA5CC8400D58D13 /* DesignSystem */,
 				42B980DA2DC2567F00BC5C08 /* Settings */,
 				42D3E49F2C5BCCF600444BE6 /* Watch */,
+				42DF4F00302CACC600589E49 /* Templating */,
+				42DF4F06302CACD400589E49 /* ServerSwitching */,
+				42DF4F8E302CADA700589E49 /* WatchComplications */,
 				42EDBB633002FBA70051FC9B /* Mocks */,
 				42EDBB663002FBBE0051FC9B /* EntityPicker */,
 				42EDBB6B3002FBBE0051FC9B /* Area */,
@@ -4012,29 +3913,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				42165CDB3013242D0077A903 /* LocationBasedServerSwitcher.swift in Sources */,
 				42EDEB10300315A50051FC9B /* AppDelegate.swift in Sources */,
 				42EDEB11300315A50051FC9B /* HAApp.swift in Sources */,
-				42DF1959300650C7003B7FA1 /* JinjaTextEditor.swift in Sources */,
-				42DF195330065071003B7FA1 /* JinjaAutocompleteProvider.swift in Sources */,
-				42DF195130065055003B7FA1 /* JinjaTemplateSuggestion.swift in Sources */,
-				42DF1955300650A9003B7FA1 /* JinjaSyntaxHighlighter.swift in Sources */,
-				42D6FDD7300F720600D4BEB9 /* FlightGreetingManager.swift in Sources */,
-				42D6FDD3300F71E800D4BEB9 /* InFlightWiFiSSIDs.swift in Sources */,
 				42EDEB12300315A50051FC9B /* HAApplicationShortcutItem.swift in Sources */,
 				42EDEB13300315A50051FC9B /* LifecycleManager.swift in Sources */,
-				42D6FDD5300F71F600D4BEB9 /* FlightDetector.swift in Sources */,
-				42D6FE11300F900000D4BEB9 /* CabinPressureSample.swift in Sources */,
-				42D6FE13300F900000D4BEB9 /* CabinPressureEvidence.swift in Sources */,
-				42D6FE15300F900000D4BEB9 /* CabinPressureMonitor.swift in Sources */,
-				42D6FE17300F900000D4BEB9 /* FlightSpeedProbe.swift in Sources */,
 				FA11C0DE0000000000000101 /* BackgroundRefreshManager.swift in Sources */,
-				42BC36C5300683F700E5EE14 /* JinjaEntityReference.swift in Sources */,
 				42EDEB14300315A50051FC9B /* MainWindowGroupCommands.swift in Sources */,
-				424D4161300F75B7001998ED /* GreetingsSettingsView.swift in Sources */,
-				42DF97B83006721A003B7FA1 /* JinjaEntitySuggestionsView.swift in Sources */,
-				42DF97B630066DAE003B7FA1 /* JinjaTemplateButton.swift in Sources */,
-				42DF97B430066D95003B7FA1 /* JinjaTemplateEditorSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4042,16 +3926,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				42DF97B2300669B9003B7FA1 /* JinjaAutocompleteProvider.test.swift in Sources */,
 				42646B772E0BE6F100F6B367 /* BackgroundTask.test.swift in Sources */,
 				42B89EAC2E080494000224A2 /* AppConstants.test.swift in Sources */,
 				42D6FE19300F900000D4BEB9 /* CabinPressureMonitor.test.swift in Sources */,
-				42165CE0301324980077A903 /* LocationBasedServerSwitcher.test.swift in Sources */,
-				42D14C4E301BAFC80058088E /* RectangularComplicationSnapshot.test.swift in Sources */,
 				119C786725CF845800D41734 /* LocalizedStrings.test.swift in Sources */,
-				42D14C99301BC37A0058088E /* CircularComplicationSnapshot.test.swift in Sources */,
-				42D14C9D301BC38E0058088E /* CornerComplicationSnapshot.test.swift in Sources */,
-				42D14C9B301BC3840058088E /* InlineComplicationSnapshot.test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6054,11 +5932,6 @@
 			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
 			productName = HAWatchComplications;
 		};
-		42D14CA0301BAF950058088E /* HAWatchComplications */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
-			productName = HAWatchComplications;
-		};
 		42D14C4A301BAFA10058088E /* HAWatchComplications */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
@@ -6075,6 +5948,11 @@
 			productName = HAWatchComplications;
 		};
 		42D14C90301BAF950058088E /* HAWatchComplications */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
+			productName = HAWatchComplications;
+		};
+		42D14CA0301BAF950058088E /* HAWatchComplications */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 42D14C47301BAF720058088E /* XCLocalSwiftPackageReference "Sources/HAWatchComplications" */;
 			productName = HAWatchComplications;


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Converts the last six legacy Xcode groups into synchronized folders: `FlightGreetings`, `Templating` and `ServerSwitching` under `Sources/App`, `Templating` and `ServerSwitching` under `Tests/App`, and `Tests/WatchComplications`. Files added to these directories are now picked up automatically instead of needing a manual project entry.

No source changes, target membership is unchanged.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The remaining groups can't be converted: `Configuration` (its xcconfigs are used as base configuration references), the virtual `Frameworks`/`Products` groups, and the `Sources/App`, `Sources/Shared`, `Tests/App`, `Tests/Shared` and `Tests/UI` directories, which hold loose files next to folders that are already synchronized.
