### PR TITLE
Fix legacy watch complication rendering

### DIFF
--- a/Sources/Shared/API/Models/LegacyComplicationRender.swift
+++ b/Sources/Shared/API/Models/LegacyComplicationRender.swift
@@ -6,8 +6,9 @@ import Foundation
 /// The legacy model stores a free-form blob of per-template text areas, and ClockKit laid each
 /// template out its own way. WidgetKit's four accessory families have one shared layout instead, so
 /// the areas have to collapse onto it: they are read in the order the template declares them (which
-/// is the order they appeared on the face), a row's second column folds onto the first, and the
-/// result maps title → value → bottom text.
+/// is the order they appeared on the face), a gauge's end labels peel off to `minLabel` / `maxLabel`,
+/// a row's second column folds onto the first, and the rest maps title → value → bottom text — or
+/// value → title for the families that lead with their content (see `ContentLed`).
 ///
 /// This is deliberately pure and lives in `Shared` — the watch turns it into a complication snapshot,
 /// but the mapping itself is testable without a watch.
@@ -34,6 +35,30 @@ public struct LegacyComplicationRender: Equatable {
     public let iconName: String?
     /// Hex color for the icon.
     public let iconColor: String?
+    /// The label for the low end of the gauge — the template's Leading area — or nil when it has none.
+    public let minLabel: String?
+    /// The label for the high end of the gauge — the template's Trailing area.
+    public let maxLabel: String?
+    /// The same areas mapped onto the families that lead with their content (see `ContentLed`).
+    public let contentLed: ContentLed
+
+    /// The corner and circular families' two text positions, which run the other way round to the rest.
+    ///
+    /// The rectangular and modular templates open with a `Header` — a label above the content — so
+    /// their areas collapse onto title → value in declaration order. The corner and circular templates
+    /// have no header: they lead with the content itself and caption it afterwards. Circular stacks its
+    /// value above its name, and WidgetKit draws an `accessoryCorner` widget's own content on the
+    /// *outside* of the curve with its `widgetLabel` on the *inside* — which is where ClockKit's
+    /// `outerTextProvider` drew too. So for those two the first area is the value and the second is the
+    /// title, the opposite way round from the header-led templates.
+    public struct ContentLed: Equatable {
+        /// The complication's own content: the template's first text area.
+        public let value: String
+        /// The caption: the template's second text area.
+        public let title: String
+        /// Hex color for `value`, or nil to use the face's default.
+        public let textColor: String?
+    }
 
     public init(complication: WatchComplication) {
         let data = complication.Data
@@ -41,19 +66,26 @@ public struct LegacyComplicationRender: Equatable {
         self.iconName = icon?["icon"]
         self.iconColor = icon?["icon_color"]
 
-        let lines = Self.lines(from: complication)
+        let areas = Self.areas(from: complication)
+        self.minLabel = areas.first { $0.area == .Leading }?.text
+        self.maxLabel = areas.first { $0.area == .Trailing }?.text
+
+        let lines = Self.lines(from: areas)
         // Fall back to the complication's own name only when it has nothing else to show, so an
-        // image-only template (e.g. "Simple Image") stays image-only.
-        let resolved: [(text: String, color: String?)] = lines.isEmpty && iconName == nil
+        // image-only template (e.g. "Simple Image") stays image-only. Gated on the areas rather than
+        // the body lines: a gauge template whose only filled areas are its end labels still has the
+        // gauge to show, and would otherwise start captioning itself with the complication's name.
+        let resolved: [(text: String, color: String?)] = areas.isEmpty && iconName == nil
             ? [(complication.displayName, nil)]
             : lines
 
         self.title = resolved.count > 1 ? resolved[0].text : ""
         self.value = resolved.count > 1 ? resolved[1].text : (resolved.first?.text ?? "")
         self.bottomText = resolved.dropFirst(2).map(\.text).joined(separator: " ")
-        // Inline draws no icon, so an image-only template has nothing of the user's left to show
-        // there and would otherwise render as the app's own name.
-        let joined = resolved.map(\.text).joined(separator: " ")
+        // Inline draws neither icon nor gauge, so its single line carries every area — the gauge's end
+        // labels included, since they have nowhere else to go there. An image-only template has nothing
+        // of the user's left to show and would otherwise render as the app's own name.
+        let joined = areas.map(\.text).joined(separator: " ")
         self.inlineText = joined.isEmpty ? complication.displayName : joined
 
         // ClockKit only ever painted the picked colors on the full-color "graphic" families; it tinted
@@ -67,40 +99,56 @@ public struct LegacyComplicationRender: Equatable {
         }
         self.textColor = graphicOnly(resolved.count > 1 ? resolved[1].color : resolved.first?.color)
         self.bottomTextColor = graphicOnly(resolved.dropFirst(2).first?.color)
+        self.contentLed = ContentLed(
+            value: resolved.first?.text ?? "",
+            title: resolved.count > 1 ? resolved[1].text : "",
+            textColor: graphicOnly(resolved.first?.color)
+        )
 
         self.fraction = Self.fraction(from: data)
         self.tint = Self.tint(from: data)
         self.gaugeStyle = Self.gaugeStyle(from: data)
     }
 
+    private typealias ResolvedArea = (area: ComplicationTextAreas, text: String, color: String?)
+
     /// The template's text areas in declaration order, each resolved to its server-rendered value
-    /// (falling back to the configured text, which is what a non-template area stores) and paired
-    /// with the color picked for it. Empty areas drop out, and a row's second column folds onto the
-    /// first so the columns and table templates keep reading as rows.
+    /// (falling back to the configured text, which is what a non-template area stores) and paired with
+    /// the area it came from and the color picked for it. Empty areas drop out.
     ///
     /// Walking `Template.textAreas` is what lets the areas no fixed key list mentioned — Outer, Inner,
     /// Leading, Trailing, Bottom and the third table row — render at all.
-    private static func lines(from complication: WatchComplication) -> [(text: String, color: String?)] {
+    private static func areas(from complication: WatchComplication) -> [ResolvedArea] {
         let configured = complication.Data["textAreas"] as? [String: [String: Any]] ?? [:]
         let rendered = renderedTextAreas(from: complication.Data)
 
-        var lines: [(text: String, color: String?)] = []
-        var lastArea: ComplicationTextAreas?
-        for area in complication.Template.textAreas {
+        return complication.Template.textAreas.compactMap { area -> ResolvedArea? in
             let raw = configured[area.slug] ?? [:]
             let text = rendered[area.slug] ?? (raw["text"] as? String ?? "")
-            guard !text.isEmpty else { continue }
+            guard !text.isEmpty else { return nil }
+            return (area: area, text: text, color: raw["color"] as? String)
+        }
+    }
 
+    /// The body lines the text slots are filled from: the areas that carry text, with a row's second
+    /// column folded onto the first so the columns and table templates keep reading as rows.
+    ///
+    /// The gauge's end labels are not body text — they label the two ends of the gauge — so they are
+    /// left out here and reach the face as `minLabel` / `maxLabel` instead.
+    private static func lines(from areas: [ResolvedArea]) -> [(text: String, color: String?)] {
+        var lines: [(text: String, color: String?)] = []
+        var lastArea: ComplicationTextAreas?
+        for entry in areas where !entry.area.isGaugeEndLabel {
             // Only fold a second column onto the line its own first column just emitted: when that
             // first column is empty it drops out above, and the second column would otherwise land on
             // the previous row's line.
-            if let firstColumn = area.firstColumnOfSameRow, firstColumn == lastArea,
+            if let firstColumn = entry.area.firstColumnOfSameRow, firstColumn == lastArea,
                let previous = lines.popLast() {
-                lines.append((previous.text + "  " + text, previous.color))
+                lines.append((previous.text + "  " + entry.text, previous.color))
             } else {
-                lines.append((text, raw["color"] as? String))
+                lines.append((entry.text, entry.color))
             }
-            lastArea = area
+            lastArea = entry.area
         }
         return lines
     }

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -244,7 +244,7 @@ public extension HomeAssistantAPI {
             HomeAssistantAPI.syncWatchContext()
             #else
             // in case the user updated just the complication's metadata, force a refresh
-            WebhookResponseUpdateComplications.updateComplications()
+            NotificationCenter.default.post(name: WatchComplication.didChangeNotification, object: nil)
             #endif
 
             return .value(())

--- a/Sources/Shared/API/Webhook/Networking/WebhookResponseUpdateComplications.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookResponseUpdateComplications.swift
@@ -2,9 +2,6 @@ import Foundation
 import GRDB
 import PromiseKit
 import UserNotifications
-#if os(watchOS)
-import ClockKit
-#endif
 
 extension WebhookResponseIdentifier {
     static var updateComplications: Self { .init(rawValue: "updateComplications") }
@@ -81,7 +78,11 @@ struct WebhookResponseUpdateComplications: WebhookResponseHandler {
             }
         }.done {
             #if os(watchOS)
-            Self.updateComplications()
+            // The face renders from the WidgetKit snapshots in the app group, not from these rows, so
+            // announce the write and let the watch app rebuild them (see
+            // `ExtensionDelegate.observeLegacyComplicationRenders`). Reloading ClockKit here — which is
+            // what this used to do — updates nothing: the watch left ClockKit behind in #5036.
+            NotificationCenter.default.post(name: WatchComplication.didChangeNotification, object: nil)
             #else
             HomeAssistantAPI.syncWatchContext()
             // Current watch builds only read complications from the database mirror (the context
@@ -95,16 +96,4 @@ struct WebhookResponseUpdateComplications: WebhookResponseHandler {
             return Guarantee.value(WebhookResponseHandlerResult.default)
         }
     }
-
-    #if os(watchOS)
-    static func updateComplications() {
-        let server = CLKComplicationServer.sharedInstance()
-
-        server.activeComplications?.forEach {
-            server.reloadTimeline(for: $0)
-        }
-
-        server.reloadComplicationDescriptors()
-    }
-    #endif
 }

--- a/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
+++ b/Sources/Shared/Common/Extensions/CLKComplication+Strings.swift
@@ -1549,6 +1549,17 @@ public enum ComplicationTextAreas: String, CaseIterable {
         }
     }
 
+    /// Whether the area labels one end of the template's gauge rather than carrying body text. Every
+    /// ClockKit template that declares Leading and Trailing is a gauge template, and drew them at the
+    /// two ends of the gauge — so they belong to the modern gauge's min / max labels, not to a text
+    /// slot, where they would read as the complication's value or name.
+    public var isGaugeEndLabel: Bool {
+        switch self {
+        case .Leading, .Trailing: return true
+        default: return false
+        }
+    }
+
     public var slug: String {
         var cleanLocation = rawValue
         cleanLocation = cleanLocation.replacingOccurrences(of: " ", with: "")

--- a/Sources/WatchApp/Complication/ComplicationStateFetcher.swift
+++ b/Sources/WatchApp/Complication/ComplicationStateFetcher.swift
@@ -134,7 +134,14 @@ enum ComplicationStateFetcher {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(HomeAssistantAPI.userAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["template": template])
-        guard let data = await data(for: request, server: server, token: token).data else { return nil }
-        return String(data: data, encoding: .utf8)
+        guard let data = await data(for: request, server: server, token: token).data,
+              let rendered = String(data: data, encoding: .utf8),
+              !rendered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            // An empty body is not a render. Reporting one as successful marks the complication live
+            // and writes a blank value over the last-known snapshot, so a template the server couldn't
+            // render blanks the face instead of leaving its previous value up.
+            return nil
+        }
+        return rendered
     }
 }

--- a/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot.swift
+++ b/Sources/WatchApp/Complication/WatchWidgetComplicationSnapshot.swift
@@ -339,6 +339,8 @@ struct WatchWidgetComplicationSnapshot: Codable, Equatable {
             showName: !render.title.isEmpty,
             showIcon: iconData != nil,
             gaugeStyle: render.gaugeStyle,
+            minLabel: render.minLabel,
+            maxLabel: render.maxLabel,
             textColor: render.textColor,
             bottomTextColor: render.bottomTextColor,
             title: render.title,
@@ -351,6 +353,25 @@ struct WatchWidgetComplicationSnapshot: Codable, Equatable {
         var inlineOptions = options
         inlineOptions.title = render.inlineText
         inlineOptions.showName = !render.inlineText.isEmpty
+        // The corner and circular families lead with the complication's content and caption it after,
+        // rather than heading it with a label, so their two areas land the other way round (see
+        // `LegacyComplicationRender.ContentLed`).
+        let contentLedOptions = PerFamily(
+            fraction: render.fraction,
+            tint: render.tint,
+            showValue: !render.contentLed.value.isEmpty,
+            showName: !render.contentLed.title.isEmpty,
+            showIcon: iconData != nil,
+            gaugeStyle: render.gaugeStyle,
+            minLabel: render.minLabel,
+            maxLabel: render.maxLabel,
+            textColor: render.contentLed.textColor,
+            bottomTextColor: render.bottomTextColor,
+            title: render.contentLed.title,
+            value: render.contentLed.value,
+            bottomText: render.bottomText,
+            showBottomText: !render.bottomText.isEmpty
+        )
 
         self.init(
             id: complication.identifier,
@@ -366,9 +387,9 @@ struct WatchWidgetComplicationSnapshot: Codable, Equatable {
             // Spelled out rather than aliased to `Family`: `WatchComplication.Family` is the legacy
             // ClockKit family, and the two reading alike in one initializer invites a mix-up.
             perFamily: [
-                WatchComplicationConfig.Family.circular.rawValue: options,
+                WatchComplicationConfig.Family.circular.rawValue: contentLedOptions,
                 WatchComplicationConfig.Family.rectangular.rawValue: options,
-                WatchComplicationConfig.Family.corner.rawValue: options,
+                WatchComplicationConfig.Family.corner.rawValue: contentLedOptions,
                 WatchComplicationConfig.Family.inline.rawValue: inlineOptions,
             ],
             menuName: complication.displayName

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -15,6 +15,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     fileprivate var watchConnectivityWatchdogTimer: Timer?
 
     private var immediateCommunicatorService: ImmediateCommunicatorService?
+    /// Held for the app's lifetime — see `observeLegacyComplicationRenders`.
+    private var legacyComplicationRenderToken: NSObjectProtocol?
 
     override init() {
         (self.watchConnectivityBackgroundPromise, self.watchConnectivityBackgroundSeal) = Guarantee<Void>.pending()
@@ -46,6 +48,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
         setupWatchCommunicator()
         WatchWidgetComplicationSnapshotStore.update()
+        observeLegacyComplicationRenders()
 
         // Re-apply any watch-local "Always use" URL choices to the persisted servers (their
         // connection info doesn't carry the override across launches/syncs).
@@ -403,6 +406,20 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
             // The mirror is now the only complication delivery path, so it also reloads the ClockKit
             // timelines (previously done when the application context arrived).
             self?.updateComplications()
+        }
+    }
+
+    /// Rebuild the WidgetKit snapshots whenever freshly rendered legacy complication templates land in
+    /// the database. `WebhookResponseUpdateComplications` writes them from `Shared`, which can't reach
+    /// the snapshot store in this target, so it announces the write and this picks it up — without it
+    /// the new text sits in the database until the next periodic refresh happens to rebuild.
+    private func observeLegacyComplicationRenders() {
+        legacyComplicationRenderToken = NotificationCenter.default.addObserver(
+            forName: WatchComplication.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            WatchWidgetComplicationSnapshotStore.update()
         }
     }
 

--- a/Sources/WatchWidgets/Complications/CornerComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CornerComplicationView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 import WidgetKit
 
-/// Corner complication: the value (or the icon, when enabled) curved along the outside of the corner
-/// via `widgetCurvesContent`, with the name carried on the inside of the curve by the bezel label —
-/// alongside the gauge when a value exists (matching the system UV Index / Battery complications).
+/// Corner complication: the complication's own content sits in the corner — the value curved along the
+/// outside of the corner via `widgetCurvesContent`, or stacked under the icon when it has one — with the
+/// name carried on the inside of the curve by the bezel label, alongside the gauge when a value exists
+/// (matching the system UV Index / Battery complications).
 @available(watchOS 10.0, *)
 struct CornerComplicationView: View {
     let complication: WatchWidgetComplicationSnapshot?
@@ -15,34 +16,69 @@ struct CornerComplicationView: View {
                 // Built-ins (Home Assistant / Assist): the icon alone fills the corner, matching
                 // the circular family — no arc text and no bezel label.
                 ComplicationIconView(complication: complication)
+            } else if hasBezelContent(complication) {
+                cornerContent(complication)
+                    .widgetLabel { bezelLabel(complication) }
             } else {
-                Group {
-                    if showsIconInCorner(complication), let iconImage = complication.iconImage {
-                        // The icon sits in the corner un-curved; curving a raster image collapses it.
-                        iconImage.renderingMode(.template).resizable().scaledToFit().widgetAccentable()
-                    } else {
-                        // Curve the value/name along the outer edge of the corner; the system lays
-                        // the widget label on the inside of the same curve.
-                        Text(cornerText(complication))
-                            .minimumScaleFactor(0.5)
-                            .lineLimit(1)
-                            .widgetCurvesContent()
-                    }
-                }
-                .widgetLabel { bezelLabel(complication) }
+                // An empty bezel label isn't free: the system still lays the curve out and shrinks the
+                // corner content to make room for a label that draws nothing.
+                cornerContent(complication)
             }
         } else {
             Text(WatchWidgetConstants.appName)
         }
     }
 
-    /// Whether the icon takes the corner, leaving the value/name to ride the arc.
+    /// What sits in the corner itself.
+    ///
+    /// The complication's own text stays here whether or not it also has an icon. ClockKit's
+    /// "Text Image" corner drew the glyph and the text together, and the shared preview
+    /// (`CornerComplicationContentView`) still models it that way, so this is the layout the in-app
+    /// editor shows too. Handing the whole corner to the icon instead demotes the text onto the bezel,
+    /// where the system re-typesets it small and rotates it glyph by glyph along the arc — which
+    /// destroys any text whose cells have to abut, such as the block-element bar graphs people build
+    /// rain sparklines from.
+    @ViewBuilder
+    private func cornerContent(_ complication: WatchWidgetComplicationSnapshot) -> some View {
+        let text = cornerText(complication)
+        if showsIconInCorner(complication), let iconImage = complication.iconImage {
+            // Un-curved: curving a raster image collapses it, so the icon (and any text under it) lay
+            // out flat and the system fits the pair into the corner.
+            VStack(spacing: 0) {
+                iconImage.renderingMode(.template).resizable().scaledToFit().widgetAccentable()
+                if !text.isEmpty {
+                    // The text is sized first and the resizable icon takes what's left, so a long
+                    // value can't be squeezed out of the corner by the glyph above it.
+                    cornerLabel(text, complication).layoutPriority(1)
+                }
+            }
+        } else {
+            // Nothing but text: curve it along the outer edge of the corner, the way the system's own
+            // text-only corner complications do.
+            cornerLabel(text.isEmpty ? WatchWidgetConstants.appName : text, complication)
+                .widgetCurvesContent()
+        }
+    }
+
+    /// The corner's own text, honoring the complication's configured color the way the circular and
+    /// rectangular families do, and shrinking rather than cropping when it doesn't fit.
+    private func cornerLabel(
+        _ text: String,
+        _ complication: WatchWidgetComplicationSnapshot
+    ) -> some View {
+        Text(text)
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+            .foregroundStyle(complication.textColor(for: family) ?? .primary)
+    }
+
+    /// Whether the icon takes the top of the corner, with the text tucked under it.
     private func showsIconInCorner(_ complication: WatchWidgetComplicationSnapshot) -> Bool {
         complication.showsIcon(for: family) && complication.iconImage != nil
     }
 
-    /// The flat corner shows the value slot, falling back to the title slot (then the app name)
-    /// when the value is hidden or empty.
+    /// The complication's own text: the value slot, falling back to the title slot when the value is
+    /// hidden or empty. Empty when it has neither — an icon-only complication shows just its glyph.
     private func cornerText(_ complication: WatchWidgetComplicationSnapshot) -> String {
         if complication.showsValue(for: family), !complication.valueText(for: family).isEmpty {
             return complication.valueText(for: family)
@@ -50,7 +86,12 @@ struct CornerComplicationView: View {
         if complication.showsName(for: family), !complication.titleText(for: family).isEmpty {
             return complication.titleText(for: family)
         }
-        return WatchWidgetConstants.appName
+        return ""
+    }
+
+    /// Whether the bezel has anything to draw, so an all-empty label is left off entirely.
+    private func hasBezelContent(_ complication: WatchWidgetComplicationSnapshot) -> Bool {
+        complication.fraction(for: family) != nil || !arcText(complication).isEmpty
     }
 
     /// The curved bezel carries the arc text — as the gauge's label when a fraction exists, otherwise
@@ -64,21 +105,19 @@ struct CornerComplicationView: View {
             .tint(complication.tintColor(for: family))
         } else {
             Text(arcText(complication))
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
         }
     }
 
-    /// What rides the arc. When the icon fills the corner, the value slot goes on the arc (falling
-    /// back to the title). Otherwise the value occupies the corner and the title rides the arc —
-    /// but only then, so the arc never duplicates whatever the corner is already showing.
+    /// What rides the arc: whatever the corner isn't already showing. The corner leads with the value,
+    /// so the arc carries the name — never a second copy of the text already in the corner, and nothing
+    /// at all for a complication whose corner is its icon alone.
     private func arcText(_ complication: WatchWidgetComplicationSnapshot) -> String {
-        if showsIconInCorner(complication) {
-            if complication.showsValue(for: family), !complication.valueText(for: family).isEmpty {
-                return complication.valueText(for: family)
-            }
-            return complication.showsName(for: family) ? complication.titleText(for: family) : ""
-        }
-        guard complication.showsValue(for: family), !complication.valueText(for: family).isEmpty else { return "" }
-        return complication.showsName(for: family) ? complication.titleText(for: family) : ""
+        let corner = cornerText(complication)
+        guard !corner.isEmpty, complication.showsName(for: family) else { return "" }
+        let title = complication.titleText(for: family)
+        return title == corner ? "" : title
     }
 }
 
@@ -176,6 +215,19 @@ struct CornerComplicationView: View {
         date: .now,
         family: .accessoryCorner,
         complication: .previewSample(showValue: false, showName: false, includeIcon: true)
+    )
+}
+
+/// The long-standing rain-sparkline recipe: an icon plus a block-element bar graph, which only reads as
+/// a graph while its cells stay flat and abutting.
+@available(watchOS 10.0, *)
+#Preview("Icon + block-element sparkline", as: .accessoryCorner) {
+    WatchWidgets()
+} timeline: {
+    WatchWidgetEntry(
+        date: .now,
+        family: .accessoryCorner,
+        complication: .previewSample(title: "▁▂▃▄▅▆▇█", fraction: nil, showName: false, includeIcon: true)
     )
 }
 #endif

--- a/Tests/Shared/Watch/LegacyComplicationRender.test.swift
+++ b/Tests/Shared/Watch/LegacyComplicationRender.test.swift
@@ -76,6 +76,144 @@ struct LegacyComplicationRenderTests {
         #expect(render.value == "inner")
     }
 
+    // MARK: - Content-led families (corner and circular)
+
+    /// The corner and circular templates have no `Header`: they lead with the content and caption it
+    /// after. WidgetKit draws an `accessoryCorner` widget's own content on the outside of the curve and
+    /// its `widgetLabel` on the inside — where ClockKit's `outerTextProvider` drew too — and the
+    /// circular face stacks its value above its name. So the first area has to be the value there,
+    /// the opposite of the label-then-content reading above.
+    @Test func contentLedKeepsTheFirstAreaAsTheValue() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerStackText,
+            textAreas: ["Inner": ("inner", "#00FF00FF"), "Outer": ("outer", "#268BD2FF")]
+        ))
+
+        #expect(render.contentLed.value == "outer")
+        #expect(render.contentLed.title == "inner")
+        // The color follows the text it was picked for, so it swaps with it.
+        #expect(render.contentLed.textColor == "#268BD2FF")
+    }
+
+    /// The circular open gauge's Center area is its big number and Bottom is the caption under it —
+    /// not the other way round, which would read the subtext as the value.
+    @Test func circularOpenGaugeLeadsWithItsCenterArea() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularOpenGaugeSimpleText,
+            textAreas: ["Center": ("21.5°", "#268BD2FF"), "Bottom": ("now", "#FFFFFFFF")]
+        ))
+
+        #expect(render.contentLed.value == "21.5°")
+        #expect(render.contentLed.title == "now")
+    }
+
+    /// The long-standing rain-sparkline recipe: a single Center area rendering a block-element bar
+    /// graph, plus an icon. The graph is the complication's whole content, so it belongs in the corner
+    /// itself — demoting it to the bezel re-typesets it small and rotates it glyph by glyph, which is
+    /// exactly what a bar graph can't survive.
+    @Test func contentLedSingleAreaIsTheContent() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerTextImage,
+            textAreas: ["Center": ("{{ states('sensor.rain') }}", "#268BD2FF")],
+            rendered: ["textArea,Center": "▁▂▃▄▅▆▇█"],
+            extra: ["icon": ["icon": "weather_rainy", "icon_color": "#FFFFFFFF"]]
+        ))
+
+        #expect(render.contentLed.value == "▁▂▃▄▅▆▇█")
+        #expect(render.contentLed.title.isEmpty)
+        #expect(render.iconName == "weather_rainy")
+    }
+
+    /// An image-only template fills neither position, so the face can leave the bezel label off instead
+    /// of drawing an empty one.
+    @Test func contentLedWithoutTextFillsNeitherPosition() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerCircularImage,
+            extra: ["icon": ["icon": "ab_testing", "icon_color": "#30D158FF"]]
+        ))
+
+        #expect(render.contentLed.value.isEmpty)
+        #expect(render.contentLed.title.isEmpty)
+    }
+
+    // MARK: - Gauge end labels
+
+    /// Leading and Trailing label the two ends of the gauge — they are not body text. Reading them as
+    /// text slots made the gauge's minimum the complication's value and dropped the maximum entirely.
+    @Test func gaugeEndLabelsGoToTheGaugeNotTheTextSlots() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularOpenGaugeRangeText,
+            textAreas: [
+                "Center": ("21.5", "#AA00FFFF"),
+                "Leading": ("16", "#268BD2FF"),
+                "Trailing": ("30", "#DC322FFF"),
+            ],
+            extra: ["gauge": ["gauge": "0.5", "gauge_type": "open", "gauge_color": "#268BD2FF"]]
+        ))
+
+        #expect(render.minLabel == "16")
+        #expect(render.maxLabel == "30")
+        // The value is the Center area, and neither end label captions it.
+        #expect(render.contentLed.value == "21.5")
+        #expect(render.contentLed.title.isEmpty)
+        #expect(render.bottomText.isEmpty)
+    }
+
+    /// The corner gauge variant leads with its Outer area, with Leading / Trailing going to the gauge.
+    @Test func cornerGaugeTextLeadsWithItsOuterArea() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerGaugeText,
+            textAreas: [
+                "Outer": ("21.5°", "#FFFFFFFF"),
+                "Leading": ("16", "#FFFFFFFF"),
+                "Trailing": ("30", "#FFFFFFFF"),
+            ]
+        ))
+
+        #expect(render.contentLed.value == "21.5°")
+        #expect(render.contentLed.title.isEmpty)
+        #expect(render.minLabel == "16")
+        #expect(render.maxLabel == "30")
+    }
+
+    /// A gauge template whose only filled areas are its end labels still has the gauge to show, so it
+    /// must not fall through to captioning itself with the complication's name.
+    @Test func gaugeEndLabelsAloneAreNotAnEmptyComplication() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCorner,
+            template: .GraphicCornerGaugeImage,
+            textAreas: ["Leading": ("16", "#FFFFFFFF"), "Trailing": ("30", "#FFFFFFFF")]
+        ))
+
+        #expect(render.minLabel == "16")
+        #expect(render.maxLabel == "30")
+        #expect(render.value.isEmpty)
+        #expect(render.contentLed.value.isEmpty)
+        #expect(render.inlineText == "16 30")
+    }
+
+    /// Inline draws no gauge, so its one line still has to carry the end labels — they have nowhere
+    /// else to go there.
+    @Test func inlineStillCarriesTheGaugeEndLabels() {
+        let render = LegacyComplicationRender(complication: complication(
+            family: .graphicCircular,
+            template: .GraphicCircularOpenGaugeRangeText,
+            textAreas: [
+                "Center": ("21.5", "#FFFFFFFF"),
+                "Leading": ("16", "#FFFFFFFF"),
+                "Trailing": ("30", "#FFFFFFFF"),
+            ]
+        ))
+
+        #expect(render.inlineText == "21.5 16 30")
+    }
+
     /// Outer / Inner / Leading / Trailing / Bottom and the third table row used to be unreachable:
     /// the renderer looked up a fixed list of area names that never mentioned them.
     @Test func areasOutsideTheOldKeyListRender() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Legacy (ClockKit-era) complications lose their content on the WidgetKit face. Reported against the long-standing rain sparkline recipe: a Graphic Corner "Text Image" complication with an icon and a block-element bar graph, which renders as the icon alone.

- **Corner, icon steals the content.** When a complication has an icon, the icon took the whole corner and the complication's own text was pushed onto the bezel label, which re-typesets it small and rotates it glyph by glyph along the arc. ClockKit drew the glyph and the text together in the corner, as does the shared preview view the editor shows, so the text now stays in the corner under the icon.
- **Corner and circular read their text areas backwards.** Those templates lead with their content and caption it after, unlike the rectangular ones that open with a header, so collapsing every template onto title → value put their two areas the wrong way round.
- **Leading and Trailing are gauge end labels.** Reading them as body text made the gauge's minimum the complication's value and dropped the maximum entirely. They now feed the gauge's min/max labels, which the circular and rectangular views already draw. Inline still carries them in its single line, since it draws no gauge.
- **Freshly rendered legacy text never reached the face.** On watchOS the render response reloaded ClockKit, so new text sat in the database until some later periodic refresh rebuilt the snapshots.
- **An empty template response counted as a successful render**, marking the complication live and blanking it over its last known value.

Also on the corner: the bezel label is left off when it has nothing to draw, its text scales to fit instead of cropping, the configured text color is honored as the other families already do, and the arc no longer repeats the corner's text or drops the title when an icon is present.

Covered by new unit tests over the legacy area mapping, plus a preview for the sparkline case.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not included — this changes watch face layout and wants a check on a real watch rather than a simulator shot. The icon + text corner stack applies to every corner complication with both, not only the legacy ones.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Anyone who worked around the corner swap by exchanging the Inner and Outer text areas in their complication should swap them back after this.
