### PR TITLE
Fix toast window forcing the status bar to stay visible

### DIFF
--- a/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
+++ b/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
@@ -68,6 +68,7 @@ private struct ToastWindowInstaller: UIViewRepresentable {
 
             let hostingController = ToastHostingController(rootView: ToastWindowContent())
             hostingController.view.backgroundColor = .clear
+            hostingController.statusBarHiddenWhenIdle = statusBarHidden(in: windowScene)
 
             let toastWindow = ToastWindow(windowScene: windowScene)
             toastWindow.rootViewController = hostingController
@@ -88,9 +89,7 @@ private struct ToastWindowInstaller: UIViewRepresentable {
 
             guard !presenting else {
                 isPresenting = true
-                // Read while the toast window is still off screen, so it reflects what the app itself wants.
-                let statusBarHidden = windowScene?.statusBarManager?.isStatusBarHidden ?? false
-                hostingController?.statusBarHiddenWhenIdle = statusBarHidden
+                hostingController?.statusBarHiddenWhenIdle = statusBarHidden(in: windowScene)
                 toastWindow?.isHidden = false
                 hostingController?.setNeedsStatusBarAppearanceUpdate()
                 return
@@ -104,6 +103,11 @@ private struct ToastWindowInstaller: UIViewRepresentable {
             }
             self.hideWorkItem = hideWorkItem
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.hideDelay, execute: hideWorkItem)
+        }
+
+        /// Read while the toast window is off screen, so it reflects what the app itself wants.
+        private func statusBarHidden(in windowScene: UIWindowScene?) -> Bool {
+            windowScene?.statusBarManager?.isStatusBarHidden ?? false
         }
     }
 

--- a/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
+++ b/Sources/Shared/Toast/DynamicIslandToast/ToastView.swift
@@ -17,17 +17,22 @@ public extension View {
 
 @available(iOS 18, *)
 private struct ToastOverlayModifier: ViewModifier {
+    @ObservedObject private var presenter = ToastPresenter.shared
+
     func body(content: Content) -> some View {
         content
-            .background(ToastWindowInstaller())
+            .background(ToastWindowInstaller(isPresenting: presenter.toast != nil))
     }
 }
 
 @available(iOS 18, *)
 private struct ToastWindowInstaller: UIViewRepresentable {
+    let isPresenting: Bool
+
     func makeUIView(context: Context) -> UIView {
         let view = UIView(frame: .zero)
         view.isUserInteractionEnabled = false
+        context.coordinator.setPresenting(isPresenting)
         DispatchQueue.main.async {
             context.coordinator.attach(to: view.window?.windowScene)
         }
@@ -35,6 +40,7 @@ private struct ToastWindowInstaller: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.setPresenting(isPresenting)
         DispatchQueue.main.async {
             context.coordinator.attach(to: uiView.window?.windowScene)
         }
@@ -45,8 +51,14 @@ private struct ToastWindowInstaller: UIViewRepresentable {
     }
 
     final class Coordinator {
+        /// Long enough for `ToastView`'s dismissal animation to play out before the window goes away.
+        private static let hideDelay: TimeInterval = 0.6
+
         private weak var windowScene: UIWindowScene?
         private var toastWindow: ToastWindow?
+        private var hostingController: ToastHostingController?
+        private var isPresenting = false
+        private var hideWorkItem: DispatchWorkItem?
 
         func attach(to windowScene: UIWindowScene?) {
             guard let windowScene else { return }
@@ -54,16 +66,54 @@ private struct ToastWindowInstaller: UIViewRepresentable {
 
             self.windowScene = windowScene
 
-            let hostingController = UIHostingController(rootView: ToastWindowContent())
+            let hostingController = ToastHostingController(rootView: ToastWindowContent())
             hostingController.view.backgroundColor = .clear
 
             let toastWindow = ToastWindow(windowScene: windowScene)
             toastWindow.rootViewController = hostingController
             toastWindow.windowLevel = .alert + 1
             toastWindow.backgroundColor = .clear
-            toastWindow.isHidden = false
+            toastWindow.isHidden = !isPresenting
 
+            self.hostingController = hostingController
             self.toastWindow = toastWindow
+        }
+
+        /// The topmost visible window owns status-bar appearance for the whole scene, so this one exists
+        /// only while a toast does: left visible it would override kiosk mode's "hide status bar" and the
+        /// full-screen setting with its own status-bar preference.
+        func setPresenting(_ presenting: Bool) {
+            hideWorkItem?.cancel()
+            hideWorkItem = nil
+
+            guard !presenting else {
+                isPresenting = true
+                // Read while the toast window is still off screen, so it reflects what the app itself wants.
+                let statusBarHidden = windowScene?.statusBarManager?.isStatusBarHidden ?? false
+                hostingController?.statusBarHiddenWhenIdle = statusBarHidden
+                toastWindow?.isHidden = false
+                hostingController?.setNeedsStatusBarAppearanceUpdate()
+                return
+            }
+
+            guard isPresenting else { return }
+
+            let hideWorkItem = DispatchWorkItem { [weak self] in
+                self?.isPresenting = false
+                self?.toastWindow?.isHidden = true
+            }
+            self.hideWorkItem = hideWorkItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.hideDelay, execute: hideWorkItem)
+        }
+    }
+
+    /// On iPhone the toast is drawn over the status bar / Dynamic Island, so it hides the status bar while
+    /// it shows. On iPad it sits below the status bar and leaves it exactly as the app had it.
+    private final class ToastHostingController: UIHostingController<ToastWindowContent> {
+        var statusBarHiddenWhenIdle = false
+
+        override var prefersStatusBarHidden: Bool {
+            UIDevice.current.userInterfaceIdiom == .phone ? true : statusBarHiddenWhenIdle
         }
     }
 }
@@ -82,7 +132,6 @@ private struct ToastWindowContent: View {
     var body: some View {
         ToastView(toast: presenter.toast, isExpanded: presenter.toast != nil)
             .allowsHitTesting(false)
-            .statusBarHidden(presenter.toast != nil)
     }
 }
 

--- a/Sources/Shared/Toast/ToastPresenter.swift
+++ b/Sources/Shared/Toast/ToastPresenter.swift
@@ -2,7 +2,7 @@ import SFSafeSymbols
 import SwiftUI
 
 /// Holds the currently presented toast and drives auto-dismissal. Pure state — the toast is rendered
-/// by the SwiftUI `toastOverlay()` modifier attached at the app root, with no UIKit window involved.
+/// by the SwiftUI `toastOverlay()` modifier attached at the app root.
 ///
 /// Example:
 /// ```swift


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The toast lives in its own window above the app's, and the topmost visible window owns status-bar appearance for the whole scene. Since that window was always on screen, its status-bar preference overrode kiosk mode's "Hide status bar" and the full screen setting on iOS 18+.

The toast window is now only visible while a toast is. On iPhone it still hides the status bar while showing, on iPad it keeps the status bar exactly as the app had it.

Follow up to #5321.

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
