### PR TITLE
Clarify the server picker prompt for deep links

### DIFF
--- a/Sources/App/Container/AppContainerCoordinator.swift
+++ b/Sources/App/Container/AppContainerCoordinator.swift
@@ -110,7 +110,7 @@ final class AppContainerCoordinator: AppCoordinator {
         }
     }
 
-    func selectServer(prompt: String?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void) {
+    func selectServer(prompt: ServerSelectPrompt?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void) {
         // The picker is the Settings sheet at its medium detent, so anything already presented (Settings
         // itself, What's New, …) would swallow it — clear the screen first. Presenting is deferred by a
         // runloop hop so a sheet that was just torn down can't swallow the one replacing it.
@@ -218,7 +218,7 @@ final class AppContainerCoordinator: AppCoordinator {
                 isComingFromAppIntent: isComingFromAppIntent
             )
         } else if servers.count > 1 {
-            selectServer(prompt: skipConfirm ? nil : from.message(with: openUrlRaw)) {
+            selectServer(prompt: skipConfirm ? nil : from.serverSelectPrompt(with: openUrlRaw)) {
                 [weak self] server in
                 self?.open(
                     from: from,

--- a/Sources/App/Container/AppSettingsPresenter.swift
+++ b/Sources/App/Container/AppSettingsPresenter.swift
@@ -21,7 +21,7 @@ final class AppSettingsPresenter: ObservableObject {
     /// A pending "pick a server" request (deep link, notification, gesture, empty state). `onSelect` runs when
     /// the user activates a server from the compact sheet, and is dropped when the sheet goes away instead.
     struct ServerSelectionRequest {
-        let prompt: String?
+        let prompt: ServerSelectPrompt?
         /// Only the stand-by view has something for the sheet to zoom out of; every other entry point gets the
         /// regular slide-up.
         let zoomsFromStandBy: Bool

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -43,7 +43,9 @@
 "alerts.navigation_error.message" = "This page cannot be displayed because it's outside your Home Assistant server or the page was not found.";
 "alerts.navigation_error.title" = "Navigation Error";
 "alerts.open_url_from_deep_link.message" = "Tap server to open (%@) deep link URL?";
+"alerts.open_url_from_deep_link.select_server" = "Choose which server should open this link";
 "alerts.open_url_from_notification.message" = "Open URL (%@) found in notification?";
+"alerts.open_url_from_notification.select_server" = "Choose which server should open this notification link";
 "alerts.open_url_from_notification.title" = "Open URL?";
 "alerts.prompt.cancel" = "Cancel";
 "alerts.prompt.ok" = "OK";

--- a/Sources/App/Scenes/SceneManager.swift
+++ b/Sources/App/Scenes/SceneManager.swift
@@ -34,6 +34,17 @@ enum OpenSource {
         case .deeplink: return L10n.Alerts.OpenUrlFromDeepLink.message(urlString)
         }
     }
+
+    /// The copy shown above the server picker when the URL arrived without a server to open it on. The URL
+    /// stays out of the sentence so the picker can show it as a pill.
+    func serverSelectPrompt(with urlString: String) -> ServerSelectPrompt {
+        switch self {
+        case .notification:
+            return ServerSelectPrompt(message: L10n.Alerts.OpenUrlFromNotification.selectServer, link: urlString)
+        case .deeplink:
+            return ServerSelectPrompt(message: L10n.Alerts.OpenUrlFromDeepLink.selectServer, link: urlString)
+        }
+    }
 }
 
 protocol AppCoordinator: AnyObject {
@@ -53,7 +64,7 @@ protocol AppCoordinator: AnyObject {
     /// Asks the user which server an action applies to, using the Settings sheet's compact server picker.
     /// `zoomsFromStandBy` is only set by the stand-by view's server pill, the one entry point the sheet has
     /// something to zoom out of; everywhere else the sheet slides up as usual.
-    func selectServer(prompt: String?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void)
+    func selectServer(prompt: ServerSelectPrompt?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void)
     func presentInvitation(url: URL?)
     func setup()
     func open(
@@ -87,7 +98,7 @@ extension AppCoordinator {
     }
 
     /// The picker as every entry point but the stand-by pill wants it: sliding up, not zooming.
-    func selectServer(prompt: String?, completion: @escaping (Server) -> Void) {
+    func selectServer(prompt: ServerSelectPrompt?, completion: @escaping (Server) -> Void) {
         selectServer(prompt: prompt, zoomsFromStandBy: false, completion: completion)
     }
 

--- a/Sources/App/Servers/ServerSelectPrompt.swift
+++ b/Sources/App/Servers/ServerSelectPrompt.swift
@@ -1,0 +1,14 @@
+/// The explanation shown above the servers in `ServerSelectionListView`, for the flows that need the user to
+/// pick a server before something can happen (a server-less deep link, a notification URL).
+///
+/// `link` travels separately from `message` so the picker can render it as its own pill instead of
+/// interpolating a raw URL into a sentence.
+struct ServerSelectPrompt {
+    let message: String
+    let link: String?
+
+    init(message: String, link: String? = nil) {
+        self.message = message
+        self.link = link
+    }
+}

--- a/Sources/App/Servers/ServerSelectionListView.swift
+++ b/Sources/App/Servers/ServerSelectionListView.swift
@@ -9,7 +9,7 @@ struct ServerSelectionListView: View {
     @StateObject private var observer = ServersObserver()
     @State private var activeServerIdentifier: Identifier<Server>?
 
-    let prompt: String?
+    let prompt: ServerSelectPrompt?
     let selectAction: (Server) -> Void
     let expandAction: () -> Void
 
@@ -50,15 +50,26 @@ struct ServerSelectionListView: View {
         .onAppear(perform: updateActiveServer)
     }
 
-    private func promptSection(_ prompt: String) -> some View {
+    private func promptSection(_ prompt: ServerSelectPrompt) -> some View {
         Section {
-            Text(prompt)
-                .font(.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .multilineTextAlignment(.leading)
-                .padding(.horizontal)
-                .listRowBackground(Color.clear)
-                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+            VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
+                Text(prompt.message)
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
+                if let link = prompt.link {
+                    Text(link)
+                        .font(.system(.footnote, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .padding(.vertical, DesignSystem.Spaces.one)
+                        .padding(.horizontal, DesignSystem.Spaces.two)
+                        .background(Color(uiColor: .secondarySystemBackground), in: Capsule())
+                }
+            }
+            .padding(.horizontal)
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
         }
     }
 
@@ -92,5 +103,12 @@ struct ServerSelectionListView: View {
 }
 
 #Preview("Servers with prompt") {
-    ServerSelectionListView(prompt: "Are you sure?", selectAction: { _ in }, expandAction: {})
+    ServerSelectionListView(
+        prompt: ServerSelectPrompt(
+            message: L10n.Alerts.OpenUrlFromDeepLink.selectServer,
+            link: "/?more-info-entity-id=light.living_room_lamp"
+        ),
+        selectAction: { _ in },
+        expandAction: {}
+    )
 }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -230,12 +230,16 @@ public enum L10n {
       public static func message(_ p1: Any) -> String {
         return L10n.tr("Localizable", "alerts.open_url_from_deep_link.message", String(describing: p1))
       }
+      /// Choose which server should open this link
+      public static var selectServer: String { return L10n.tr("Localizable", "alerts.open_url_from_deep_link.select_server") }
     }
     public enum OpenUrlFromNotification {
       /// Open URL (%@) found in notification?
       public static func message(_ p1: Any) -> String {
         return L10n.tr("Localizable", "alerts.open_url_from_notification.message", String(describing: p1))
       }
+      /// Choose which server should open this notification link
+      public static var selectServer: String { return L10n.tr("Localizable", "alerts.open_url_from_notification.select_server") }
       /// Open URL?
       public static var title: String { return L10n.tr("Localizable", "alerts.open_url_from_notification.title") }
     }

--- a/Tests/App/WebView/Mocks/MockAppCoordinator.swift
+++ b/Tests/App/WebView/Mocks/MockAppCoordinator.swift
@@ -41,7 +41,7 @@ final class MockAppCoordinator: AppCoordinator {
         activatedServers.append(server)
     }
 
-    func selectServer(prompt: String?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void) {}
+    func selectServer(prompt: ServerSelectPrompt?, zoomsFromStandBy: Bool, completion: @escaping (Server) -> Void) {}
     func presentInvitation(url: URL?) {}
     func setup() {}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The server picker's prompt used to read "Tap server to open (/?more-info-entity-id=light.x) deep link URL?", with the raw URL stuffed into the sentence. New copy explains the choice, and the URL is shown underneath in a pill, like the NFC tag approval sheet does.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Based on #5418. The notification prompt gets the same treatment, since it shares the picker.
