### PR TITLE
Remove extra top spacing in entity deeplink sheet

### DIFF
--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -66,6 +66,15 @@ struct DeeplinkView: View {
                     }
                 }
             }
+            .modify { view in
+                if #available(iOS 17.0, *) {
+                    view
+                        .listSectionSpacing(.zero)
+                        .contentMargins(.top, 0)
+                } else {
+                    view
+                }
+            }
             .safeAreaInset(edge: .bottom) {
                 Button {
                     viewModel.copyToClipboard()
@@ -91,6 +100,11 @@ struct DeeplinkView: View {
     }
 }
 
+@available(iOS 17.0, *)
 #Preview {
-    DeeplinkView(viewModel: DeeplinkViewModel(entityId: "light.mesa_de_jantar", serverName: "Home"))
+    Color.clear
+        .sheet(isPresented: .constant(true)) {
+            DeeplinkView(viewModel: DeeplinkViewModel(entityId: "light.mesa_de_jantar", serverName: "Home"))
+                .presentationDetents([.medium, .large])
+        }
 }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The entity deeplink sheet had extra spacing above the header, pushing the content down. This removes the list top content margin and the section spacing so the header sits right below the navigation bar.

The preview was also updated to render the view inside a sheet, which is how it is actually presented.

## Screenshots

N/A

## Link to pull request in Documentation repository

Documentation: N/A

## Any other notes

N/A
