### PR TITLE
Add top gradient behind camera player toolbar before iOS 26

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -84,6 +84,10 @@ struct CameraPlayerView: View {
                         .transition(.opacity)
                     }
                 }
+                // Only the WebRTC player toggles `controlsVisible` inside `withAnimation`; the HLS and
+                // MJPEG ones toggle it bare, so scope the animation here to fade the scrim on every
+                // player type. Matches the curve WebRTC uses for the rest of the controls.
+                .animation(.easeInOut(duration: 0.2), value: isToolbarVisible)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         CloseButton {

--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -27,6 +27,7 @@ struct CameraPlayerView: View {
     @State private var showLoader = true
 
     private let maxTitleTextWidth: CGFloat = 100
+    private let topScrimHeight: CGFloat = 140
 
     enum PlayerType {
         case webRTC
@@ -63,6 +64,26 @@ struct CameraPlayerView: View {
     private var navigationStack: some View {
         NavigationStack {
             content
+                .overlay {
+                    // From iOS 26 the toolbar items get their contrast from Liquid Glass. Earlier
+                    // versions render them bare over the stream, so they can disappear against a
+                    // bright image — a scrim from the top gives them something to sit on. It mirrors
+                    // the bottom gradient behind the talkback controls.
+                    if needsTopScrim, isToolbarVisible {
+                        VStack(spacing: 0) {
+                            LinearGradient(
+                                colors: [.black.opacity(0.6), .clear],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                            .frame(height: topScrimHeight)
+                            Spacer(minLength: 0)
+                        }
+                        .allowsHitTesting(false)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                    }
+                }
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         CloseButton {
@@ -83,6 +104,26 @@ struct CameraPlayerView: View {
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Liquid Glass backs the toolbar items from iOS 26 onwards, so the scrim is only needed before that.
+    private var needsTopScrim: Bool {
+        if #available(iOS 26.0, *) {
+            return false
+        } else {
+            return true
+        }
+    }
+
+    /// Mirrors the navigation bar visibility so the scrim comes and goes with the items it backs. Hiding
+    /// the bar requires `toolbarVisibility`, so before iOS 18 the toolbar — and therefore the scrim —
+    /// stays on screen even while the controls are dimmed.
+    private var isToolbarVisible: Bool {
+        if #available(iOS 18.0, *) {
+            return controlsVisible
+        } else {
+            return true
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The camera player toolbar gets its contrast from Liquid Glass, which only exists from iOS 26. On earlier versions the close button and camera name badge sit bare over the stream and can disappear against a bright image.

This adds a black gradient from the top behind the toolbar on those versions, mirroring the existing bottom gradient behind the talkback controls. On iOS 26 and later nothing changes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The camera player is always dark, so there is no light/dark variant. Screenshots to be added.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The scrim follows the navigation bar visibility. Before iOS 18 the bar cannot be hidden (`toolbarVisibility` is unavailable), so it stays on screen along with the toolbar it backs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5sLGGpkYAK437KA84vgEf)_