### PR TITLE
Fix camera stream orientation on iPad

### DIFF
--- a/Sources/App/BarcodeScanner/Camera/BarcodeScannerCamera.swift
+++ b/Sources/App/BarcodeScanner/Camera/BarcodeScannerCamera.swift
@@ -313,16 +313,6 @@ final class BarcodeScannerCamera: NSObject, @unchecked Sendable {
         }
         return orientation
     }
-
-    private func videoOrientationFor(_ deviceOrientation: UIDeviceOrientation) -> AVCaptureVideoOrientation? {
-        switch deviceOrientation {
-        case .portrait: return AVCaptureVideoOrientation.portrait
-        case .portraitUpsideDown: return AVCaptureVideoOrientation.portraitUpsideDown
-        case .landscapeLeft: return AVCaptureVideoOrientation.landscapeRight
-        case .landscapeRight: return AVCaptureVideoOrientation.landscapeLeft
-        default: return nil
-        }
-    }
 }
 
 extension BarcodeScannerCamera: AVCaptureVideoDataOutputSampleBufferDelegate {
@@ -334,7 +324,7 @@ extension BarcodeScannerCamera: AVCaptureVideoDataOutputSampleBufferDelegate {
         guard let pixelBuffer = sampleBuffer.imageBuffer else { return }
 
         if connection.isVideoOrientationSupported,
-           let videoOrientation = videoOrientationFor(deviceOrientation) {
+           let videoOrientation = AVCaptureVideoOrientation(deviceOrientation: deviceOrientation) {
             connection.videoOrientation = videoOrientation
         }
 

--- a/Sources/Shared/Environment/MotionDetectionManager.swift
+++ b/Sources/Shared/Environment/MotionDetectionManager.swift
@@ -124,6 +124,8 @@ public class MotionDetectionManager: NSObject {
     private let processingQueue = DispatchQueue(label: "motion-detection-frames")
     private var isCaptureSessionConfigured = false
     private var captureDevice: AVCaptureDevice?
+    /// Retained so the capture connection can be re-oriented as the device rotates.
+    private var videoOutput: AVCaptureVideoDataOutput?
 
     /// Subsampling step over the Y plane; with VGA input this yields roughly
     /// 80x60 samples per frame, plenty for presence detection.
@@ -154,6 +156,12 @@ public class MotionDetectionManager: NSObject {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(deviceOrientationDidChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
     }
 
     // MARK: - Observers
@@ -164,6 +172,7 @@ public class MotionDetectionManager: NSObject {
         observers.add(observer)
         if wasEmpty {
             wantsRunning = true
+            setGeneratingOrientationNotifications(true)
             startSession()
         }
     }
@@ -172,6 +181,7 @@ public class MotionDetectionManager: NSObject {
         observers.remove(observer)
         if observers.allObjects.isEmpty {
             wantsRunning = false
+            setGeneratingOrientationNotifications(false)
             stopSession()
         }
     }
@@ -232,6 +242,74 @@ public class MotionDetectionManager: NSObject {
     @objc private func applicationDidBecomeActive() {
         if wantsRunning {
             startSession()
+            // Orientation notifications are suspended in the background, so the device
+            // may have been rotated since the session last ran.
+            refreshVideoOrientation()
+        }
+    }
+
+    // MARK: - Orientation
+
+    @objc private func deviceOrientationDidChange() {
+        refreshVideoOrientation()
+    }
+
+    /// `UIDevice.orientationDidChangeNotification` is only posted while orientation
+    /// notifications are being generated; the calls are reference counted, so this is
+    /// balanced against observer registration.
+    private func setGeneratingOrientationNotifications(_ generating: Bool) {
+        DispatchQueue.main.async {
+            if generating {
+                UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+            } else {
+                UIDevice.current.endGeneratingDeviceOrientationNotifications()
+            }
+        }
+    }
+
+    /// Re-reads how the device is being held and applies it to the capture connection.
+    /// Safe to call from any thread.
+    public func refreshVideoOrientation() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let orientation = Self.currentVideoOrientation()
+            sessionQueue.async { [weak self] in
+                self?.apply(videoOrientation: orientation)
+            }
+        }
+    }
+
+    /// How the device is currently held. Prefers the physical device orientation —
+    /// what matters for a camera is which way the room actually is, not whether the
+    /// UI happens to be rotation-locked — and falls back to the screen's rotation
+    /// when the device reports no usable orientation, which is what a flat or
+    /// wall-mounted tablet reports (`.faceUp`, `.faceDown`, `.unknown`).
+    ///
+    /// Must be called on the main thread: it reads UIKit state.
+    private static func currentVideoOrientation() -> AVCaptureVideoOrientation {
+        AVCaptureVideoOrientation(deviceOrientation: UIDevice.current.orientation)
+            ?? AVCaptureVideoOrientation(deviceOrientation: UIScreen.main.orientation)
+            ?? .portrait
+    }
+
+    /// Rotates captured frames so they stay upright. Frames are handed to the MJPEG
+    /// stream exactly as captured, so without this the stream keeps whatever fixed
+    /// orientation the connection defaulted to and comes out rotated or upside down
+    /// on any device that isn't held that way — routinely the case on iPad, which has
+    /// no natural orientation.
+    private func apply(videoOrientation: AVCaptureVideoOrientation) {
+        guard let connection = videoOutput?.connection(with: .video),
+              connection.isVideoOrientationSupported,
+              connection.videoOrientation != videoOrientation else { return }
+
+        connection.videoOrientation = videoOrientation
+        Current.Log.info("Motion detection: capture orientation now \(videoOrientation.rawValue)")
+
+        // Samples from before and after a rotation aren't comparable: a 180° flip
+        // keeps the sample count identical, so the diff would read as a frame full of
+        // motion and trip the sensor.
+        processingQueue.async { [weak self] in
+            self?.previousSamples = nil
         }
     }
 
@@ -264,24 +342,26 @@ public class MotionDetectionManager: NSObject {
             captureSession.sessionPreset = .vga640x480
         }
 
-        let videoOutput = AVCaptureVideoDataOutput()
-        videoOutput.videoSettings = [
+        let output = AVCaptureVideoDataOutput()
+        output.videoSettings = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
         ]
-        videoOutput.alwaysDiscardsLateVideoFrames = true
-        videoOutput.setSampleBufferDelegate(self, queue: processingQueue)
+        output.alwaysDiscardsLateVideoFrames = true
+        output.setSampleBufferDelegate(self, queue: processingQueue)
 
         guard captureSession.canAddInput(deviceInput),
-              captureSession.canAddOutput(videoOutput) else {
+              captureSession.canAddOutput(output) else {
             Current.Log.error("Motion detection: unable to add capture input/output")
             return
         }
 
         captureSession.addInput(deviceInput)
-        captureSession.addOutput(videoOutput)
+        captureSession.addOutput(output)
+        videoOutput = output
 
         isCaptureSessionConfigured = true
         applyFrameRate()
+        refreshVideoOrientation()
     }
 
     /// Applies the capture frame rate: the highest rate among active consumers
@@ -418,6 +498,7 @@ public class MotionDetectionManager {
 
     public func register(observer: MotionDetectionObserver) {}
     public func unregister(observer: MotionDetectionObserver) {}
+    public func refreshVideoOrientation() {}
 }
 
 #endif

--- a/Sources/Shared/Extensions/AVCaptureVideoOrientation+DeviceOrientation.swift
+++ b/Sources/Shared/Extensions/AVCaptureVideoOrientation+DeviceOrientation.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+#if os(iOS)
+import AVFoundation
+import UIKit
+
+public extension AVCaptureVideoOrientation {
+    /// The video orientation that keeps captured frames upright for a device held in
+    /// `deviceOrientation`, or `nil` when the device orientation says nothing about
+    /// which way is up (`.faceUp`, `.faceDown`, `.unknown`).
+    ///
+    /// The two landscape cases swap: `UIDeviceOrientation` names them after which way
+    /// the *device* was rotated, while `AVCaptureVideoOrientation` names them after
+    /// where the resulting *image* has its bottom edge. Rotating the device to the
+    /// left leaves the camera looking out of what it calls the right-hand landscape.
+    init?(deviceOrientation: UIDeviceOrientation) {
+        switch deviceOrientation {
+        case .portrait: self = .portrait
+        case .portraitUpsideDown: self = .portraitUpsideDown
+        case .landscapeLeft: self = .landscapeRight
+        case .landscapeRight: self = .landscapeLeft
+        default: return nil
+        }
+    }
+}
+#endif

--- a/Sources/Shared/Extensions/UIScreen+Orientation.swift
+++ b/Sources/Shared/Extensions/UIScreen+Orientation.swift
@@ -1,7 +1,14 @@
 import Foundation
+
+#if os(iOS)
 import UIKit
 
-extension UIScreen {
+public extension UIScreen {
+    /// The screen's current rotation, expressed as the equivalent device orientation.
+    ///
+    /// Unlike `UIDevice.current.orientation` this is derived from the screen geometry,
+    /// so it stays meaningful when the device itself reports `.faceUp`, `.faceDown` or
+    /// `.unknown` — the usual case for a flat or wall-mounted tablet.
     var orientation: UIDeviceOrientation {
         let point = coordinateSpace.convert(CGPoint.zero, to: fixedCoordinateSpace)
         if point == CGPoint.zero {
@@ -17,3 +24,4 @@ extension UIScreen {
         }
     }
 }
+#endif

--- a/Tests/Shared/CaptureVideoOrientation.test.swift
+++ b/Tests/Shared/CaptureVideoOrientation.test.swift
@@ -1,0 +1,35 @@
+@testable import Shared
+import XCTest
+
+#if os(iOS)
+import AVFoundation
+import UIKit
+
+class CaptureVideoOrientationTests: XCTestCase {
+    // The landscape cases deliberately cross over: rotating the device left aims the
+    // camera out of what AVFoundation calls the right-hand landscape. Getting this
+    // backwards is what makes a stream come out upside down.
+    func testFromDeviceOrientation() {
+        XCTAssertEqual(AVCaptureVideoOrientation(deviceOrientation: .portrait), .portrait)
+        XCTAssertEqual(AVCaptureVideoOrientation(deviceOrientation: .portraitUpsideDown), .portraitUpsideDown)
+        XCTAssertEqual(AVCaptureVideoOrientation(deviceOrientation: .landscapeLeft), .landscapeRight)
+        XCTAssertEqual(AVCaptureVideoOrientation(deviceOrientation: .landscapeRight), .landscapeLeft)
+    }
+
+    /// A flat or wall-mounted tablet reports these, and they say nothing about which
+    /// way is up — callers need to fall back to the screen's rotation.
+    func testDeviceOrientationWithoutAnUpDirection() {
+        XCTAssertNil(AVCaptureVideoOrientation(deviceOrientation: .faceUp))
+        XCTAssertNil(AVCaptureVideoOrientation(deviceOrientation: .faceDown))
+        XCTAssertNil(AVCaptureVideoOrientation(deviceOrientation: .unknown))
+    }
+
+    /// Every device orientation should map to a distinct video orientation — an
+    /// accidental collision would silently leave one rotation broken.
+    func testEveryRotationIsDistinct() {
+        let orientations: [UIDeviceOrientation] = [.portrait, .portraitUpsideDown, .landscapeLeft, .landscapeRight]
+        let mapped = orientations.compactMap(AVCaptureVideoOrientation.init(deviceOrientation:))
+        XCTAssertEqual(Set(mapped.map(\.rawValue)).count, orientations.count)
+    }
+}
+#endif


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The capture connection feeding the MJPEG stream server was never given a video orientation, so frames were encoded in whatever fixed orientation the connection defaulted to. On iPad, which has no natural orientation and is usually mounted in landscape for this sensor, the stream came out rotated or upside down.

The connection's orientation is now set from how the device is actually held, and re-applied when the device rotates and when returning from the background. A flat or wall-mounted tablet reports `.faceUp`/`.faceDown`/`.unknown`, so it falls back to the screen's own rotation.

Rotating also invalidates the motion detector's reference frame — a 180° flip keeps the sample count identical, so diffing across it would read as a frame full of motion and trip the sensor — so the retained samples are dropped when the orientation changes.

The device-to-video orientation mapping moved to a shared, tested extension, replacing the barcode scanner's private copy of the same table.

## Screenshots

N/A — the change affects the streamed image, which is rendered by the MJPEG camera integration rather than by the app.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Best verified on a physical iPad: mount it in each of the four rotations and confirm the stream stays upright in Home Assistant.
