### PR TITLE
Always show a title for camera picker items

### DIFF
--- a/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraPlayerView.swift
@@ -130,9 +130,19 @@ struct CameraPlayerView: View {
         }
     }
 
+    /// Entities can reach the picker without a usable name — an empty `friendly_name` upstream, or no
+    /// cached entity at all — and a menu row with no title is unpickable, so fall back to a generic
+    /// localized "Camera" rather than rendering blank.
+    private func displayName(_ name: String?) -> String {
+        guard let name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return L10n.CameraPlayer.defaultCameraName
+        }
+        return name
+    }
+
     @ViewBuilder
     private var nameBadge: some View {
-        if let name, controlsVisible {
+        if controlsVisible {
             Menu {
                 ForEach(cameras) { camera in
                     Button {
@@ -145,7 +155,7 @@ struct CameraPlayerView: View {
                         } else {
                             Image(systemSymbol: .videoFill)
                         }
-                        Text(camera.name)
+                        Text(displayName(camera.name))
                         if let subtitle = cameraSubtitles[camera.entityId], !subtitle.isEmpty {
                             Text(subtitle)
                         }
@@ -154,7 +164,7 @@ struct CameraPlayerView: View {
             } label: {
                 HStack(spacing: DesignSystem.Spaces.one) {
                     VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
-                        Text(name)
+                        Text(displayName(name))
                             .font(DesignSystem.Font.caption.bold())
                             .foregroundStyle(.primary)
                             .frame(maxWidth: maxTitleTextWidth, alignment: .leading)

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -212,6 +212,7 @@
 "camera_list.title" = "Cameras";
 "camera_list.unavailable.message" = "Camera streaming is not available on Mac.";
 "camera_list.unavailable.title" = "Not Available on Mac";
+"camera_player.default_camera_name" = "Camera";
 "camera_player.errors.no_stream_available" = "No stream available";
 "camera_player.errors.unable_to_connect_to_server" = "Unable to connect to Home Assistant";
 "camera_player.errors.unknown" = "Unknown error";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -855,6 +855,8 @@ public enum L10n {
   }
 
   public enum CameraPlayer {
+    /// Camera
+    public static var defaultCameraName: String { return L10n.tr("Localizable", "camera_player.default_camera_name") }
     public enum Errors {
       /// No stream available
       public static var noStreamAvailable: String { return L10n.tr("Localizable", "camera_player.errors.no_stream_available") }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Camera entities can reach the camera player's picker without a usable display name, which rendered a blank menu row that was impossible to identify or pick. Picker rows now fall back to a localized "Camera" when the entity name is missing or empty. The badge that opens the picker uses the same fallback, so it no longer disappears when the current camera has no name.

## Screenshots

N/A

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Adds the `camera_player.default_camera_name` string to `en.lproj/Localizable.strings` and its generated `L10n` accessor.
