### PR TITLE
Sync notification snooze actions to the Apple Watch

### DIFF
--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -271,6 +271,7 @@ public enum WatchMirrorPushCoordinator {
         case complicationChanged
         case serversChanged
         case watchConfigChanged
+        case notificationSnoozeActionsChanged
 
         /// Human-readable text used in logs and client events.
         public var logDescription: String {
@@ -279,6 +280,7 @@ public enum WatchMirrorPushCoordinator {
             case .complicationChanged: return "complication changed"
             case .serversChanged: return "servers changed"
             case .watchConfigChanged: return "watch config changed"
+            case .notificationSnoozeActionsChanged: return "notification snooze actions changed"
             }
         }
     }

--- a/Sources/Shared/Notifications/NotificationSnoozeAction.swift
+++ b/Sources/Shared/Notifications/NotificationSnoozeAction.swift
@@ -75,11 +75,22 @@ public extension NotificationSnoozeAction {
         return actions
     }
 
+    /// The Apple Watch builds its notification actions from its own mirrored copy of this table, so
+    /// every mutation here has to reach it — otherwise the watch keeps offering the presets it was
+    /// seeded with while the iPhone shows the edited ones. The push coordinator debounces and
+    /// de-duplicates, so calling this after each individual edit is cheap.
+    private static func scheduleWatchSync() {
+        #if os(iOS)
+        WatchMirrorPushCoordinator.schedule(reason: .notificationSnoozeActionsChanged)
+        #endif
+    }
+
     static func save(_ action: NotificationSnoozeAction) {
         do {
             _ = try Current.database().write { db in
                 try action.insert(db, onConflict: .replace)
             }
+            scheduleWatchSync()
         } catch {
             Current.Log.error("Failed to save notification snooze action: \(error.localizedDescription)")
         }
@@ -90,6 +101,7 @@ public extension NotificationSnoozeAction {
             _ = try Current.database().write { db in
                 try NotificationSnoozeAction.deleteOne(db, key: id)
             }
+            scheduleWatchSync()
         } catch {
             Current.Log.error("Failed to delete notification snooze action: \(error.localizedDescription)")
         }
@@ -110,6 +122,7 @@ public extension NotificationSnoozeAction {
                     )
                 }
             }
+            scheduleWatchSync()
         } catch {
             Current.Log.error("Failed to reorder notification snooze actions: \(error.localizedDescription)")
         }

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -226,6 +226,20 @@ public struct WatchDatabaseMirror: WatchCodable {
         }
     }
 
+    /// The user's snooze presets, in the order the watch renders them.
+    ///
+    /// Read in its own transaction (GRDB serializes reads, so it can't nest inside `snapshot()`'s).
+    /// Not run through `retainingIfEmpty` — these are the user's own settings, so "none left" is a
+    /// real choice that must reach the watch — but a *failed* read still yields `nil`, keeping the
+    /// "only a successful read is authoritative" rule the complication tables follow.
+    private static func snoozeActionsSnapshot() -> [NotificationSnoozeAction]? {
+        try? Current.database().read { db in
+            try NotificationSnoozeAction
+                .order(Column(DatabaseTables.NotificationSnoozeAction.sortOrder.rawValue))
+                .fetchAll(db)
+        }
+    }
+
     /// Read the current reference tables from the local GRDB (called on the phone). Pass the mirror
     /// version the receiving watch advertised; the default serves the legacy slice (see the type doc).
     public static func snapshot(version: Int = legacyVersion) throws -> WatchDatabaseMirror {
@@ -254,15 +268,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         // Deterministic order keeps the encoded payload — and therefore the delta-sync digests —
         // stable across snapshots of unchanged data.
         registry.sort { ($0.serverId, $0.entityId) < ($1.serverId, $1.entityId) }
-        // Read in its own transaction (GRDB serializes reads, so this can't nest inside the one
-        // below). Not run through `retainingIfEmpty` — these are the user's own settings, so "none
-        // left" is a real choice that must reach the watch — but a *failed* read still carries `nil`,
-        // keeping the "only a successful read is authoritative" rule the complication tables follow.
-        let snoozeActions = try? Current.database().read { db in
-            try NotificationSnoozeAction
-                .order(Column(DatabaseTables.NotificationSnoozeAction.sortOrder.rawValue))
-                .fetchAll(db)
-        }
+        let snoozeActions = snoozeActionsSnapshot()
         // Resolved outside the GRDB read: servers live in their own store, not the database.
         let servers = Current.servers.restorableState()
 
@@ -356,7 +362,7 @@ public struct WatchDatabaseMirror: WatchCodable {
                 "registry": EntityRegistryListForDisplay.Entity.fetchCount(db),
                 "devices": AppDeviceRegistry.fetchCount(db),
                 "pipelines": AssistPipelines.fetchCount(db),
-                "snoozeActions": NotificationSnoozeAction.fetchCount(db),
+                "notificationSnoozeActions": NotificationSnoozeAction.fetchCount(db),
             ]
         }) ?? [:]
         let rows = counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }.joined(separator: " ")

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -342,6 +342,7 @@ public struct WatchDatabaseMirror: WatchCodable {
     public func apply() throws {
         try Current.database().write { db in
             try applyReferenceTables(in: db)
+            try applySettingsTables(in: db)
             try applyComplicationTables(in: db, includeRegistryRows: true)
         }
         logApplyOutcome()
@@ -405,6 +406,11 @@ public struct WatchDatabaseMirror: WatchCodable {
                 try device.insert(db)
             }
         }
+    }
+
+    /// The user's own settings that travel on the mirror, as opposed to the server-derived reference
+    /// tables above. Same present-is-authoritative / absent-means-retain contract.
+    private func applySettingsTables(in db: Database) throws {
         // The watch seeds this table with the same defaults the phone does, so a replace (rather than
         // an upsert) is what lets a preset the user *removed* on the phone disappear from the watch.
         if let notificationSnoozeActions {

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -68,6 +68,17 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// without carrying the whole registry. Encoded under the pre-rename `complicationEntities` key
     /// so payloads stay compatible across builds.
     public var registryEntities: [EntityRegistryListForDisplay.Entity]
+    /// The user's notification snooze presets, so the watch's long-look offers the same quick actions
+    /// the iPhone does. The watch builds its actions from its *own* copy of this table at presentation
+    /// time (`UNNotificationContent.userInfoActions`), so without this the watch was stuck forever on
+    /// the 5/15/60 defaults its database seeds at creation.
+    ///
+    /// Unlike the reference tables above, an empty array is authoritative here: "the user disabled or
+    /// deleted every preset" is a state worth propagating, and the phone only ever reads this table
+    /// from its own settings (never from a server refresh that can transiently read back empty).
+    /// `nil` still means "not carried" — a delta sync, or a payload from a build that predates this
+    /// field — and the watch retains what it has.
+    public var notificationSnoozeActions: [NotificationSnoozeAction]?
     /// The phone's servers (`ServerManager.restorableState()` encoding), so every sync — the chunked
     /// pull and the proactive background push — also refreshes the watch's servers *in addition to*
     /// the on-demand `serversConfigSync` interactive exchange (which additionally carries the mTLS
@@ -84,6 +95,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         complications: [WatchComplication]? = nil,
         complicationConfigs: [WatchComplicationConfig]? = nil,
         registryEntities: [EntityRegistryListForDisplay.Entity] = [],
+        notificationSnoozeActions: [NotificationSnoozeAction]? = nil,
         servers: Data? = nil
     ) {
         self.entities = entities
@@ -94,11 +106,13 @@ public struct WatchDatabaseMirror: WatchCodable {
         self.complications = complications
         self.complicationConfigs = complicationConfigs
         self.registryEntities = registryEntities
+        self.notificationSnoozeActions = notificationSnoozeActions
         self.servers = servers
     }
 
     private enum CodingKeys: String, CodingKey {
         case entities, areas, pipelines, registry, devices, complications, complicationConfigs, servers
+        case notificationSnoozeActions
         case registryEntities = "complicationEntities"
     }
 
@@ -127,6 +141,10 @@ public struct WatchDatabaseMirror: WatchCodable {
             [EntityRegistryListForDisplay.Entity].self,
             forKey: .registryEntities
         )).flatMap { $0 } ?? []
+        self.notificationSnoozeActions = (try? container.decodeIfPresent(
+            [NotificationSnoozeAction].self,
+            forKey: .notificationSnoozeActions
+        )).flatMap { $0 }
         self.servers = (try? container.decodeIfPresent(Data.self, forKey: .servers)).flatMap { $0 }
     }
 
@@ -166,6 +184,7 @@ public struct WatchDatabaseMirror: WatchCodable {
         if registry != nil { keys.insert("registry") }
         if devices != nil { keys.insert("devices") }
         if complications != nil, complicationConfigs != nil { keys.insert("complications") }
+        if notificationSnoozeActions != nil { keys.insert("notificationSnoozeActions") }
         if servers != nil { keys.insert("servers") }
         return keys
     }
@@ -235,6 +254,15 @@ public struct WatchDatabaseMirror: WatchCodable {
         // Deterministic order keeps the encoded payload — and therefore the delta-sync digests —
         // stable across snapshots of unchanged data.
         registry.sort { ($0.serverId, $0.entityId) < ($1.serverId, $1.entityId) }
+        // Read in its own transaction (GRDB serializes reads, so this can't nest inside the one
+        // below). Not run through `retainingIfEmpty` — these are the user's own settings, so "none
+        // left" is a real choice that must reach the watch — but a *failed* read still carries `nil`,
+        // keeping the "only a successful read is authoritative" rule the complication tables follow.
+        let snoozeActions = try? Current.database().read { db in
+            try NotificationSnoozeAction
+                .order(Column(DatabaseTables.NotificationSnoozeAction.sortOrder.rawValue))
+                .fetchAll(db)
+        }
         // Resolved outside the GRDB read: servers live in their own store, not the database.
         let servers = Current.servers.restorableState()
 
@@ -280,6 +308,7 @@ public struct WatchDatabaseMirror: WatchCodable {
                 complications: complications,
                 complicationConfigs: configs,
                 registryEntities: registry,
+                notificationSnoozeActions: snoozeActions,
                 servers: servers
             )
         }
@@ -327,6 +356,7 @@ public struct WatchDatabaseMirror: WatchCodable {
                 "registry": EntityRegistryListForDisplay.Entity.fetchCount(db),
                 "devices": AppDeviceRegistry.fetchCount(db),
                 "pipelines": AssistPipelines.fetchCount(db),
+                "snoozeActions": NotificationSnoozeAction.fetchCount(db),
             ]
         }) ?? [:]
         let rows = counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }.joined(separator: " ")
@@ -367,6 +397,14 @@ public struct WatchDatabaseMirror: WatchCodable {
             try AppDeviceRegistry.deleteAll(db)
             for device in devices {
                 try device.insert(db)
+            }
+        }
+        // The watch seeds this table with the same defaults the phone does, so a replace (rather than
+        // an upsert) is what lets a preset the user *removed* on the phone disappear from the watch.
+        if let notificationSnoozeActions {
+            try NotificationSnoozeAction.deleteAll(db)
+            for action in notificationSnoozeActions {
+                try action.insert(db)
             }
         }
     }
@@ -426,6 +464,9 @@ public struct WatchDatabaseMirror: WatchCodable {
            let entitiesData = try? encoder.encode(registryEntities) {
             digests["complications"] = Self.digest(of: [complicationsData, configsData, entitiesData])
         }
+        if let notificationSnoozeActions, let data = try? encoder.encode(notificationSnoozeActions) {
+            digests["notificationSnoozeActions"] = Self.digest(of: [data])
+        }
         if let servers {
             digests["servers"] = Self.digest(of: [servers])
         }
@@ -461,6 +502,7 @@ public struct WatchDatabaseMirror: WatchCodable {
             copy.complicationConfigs = nil
             copy.registryEntities = []
         }
+        if matches("notificationSnoozeActions") { copy.notificationSnoozeActions = nil }
         if matches("servers") { copy.servers = nil }
         return copy
     }

--- a/Tests/Shared/Watch/WatchComplicationSync.test.swift
+++ b/Tests/Shared/Watch/WatchComplicationSync.test.swift
@@ -24,11 +24,16 @@ struct WatchComplicationSyncTests {
     func reasons() {
         #expect(Set(WatchMirrorPushCoordinator.Reason.allCases.map(\.rawValue)) == [
             "databaseUpdated", "complicationChanged", "serversChanged", "watchConfigChanged",
+            "notificationSnoozeActionsChanged",
         ])
         #expect(WatchMirrorPushCoordinator.Reason.databaseUpdated.logDescription == "database updated")
         #expect(WatchMirrorPushCoordinator.Reason.complicationChanged.logDescription == "complication changed")
         #expect(WatchMirrorPushCoordinator.Reason.serversChanged.logDescription == "servers changed")
         #expect(WatchMirrorPushCoordinator.Reason.watchConfigChanged.logDescription == "watch config changed")
+        #expect(
+            WatchMirrorPushCoordinator.Reason.notificationSnoozeActionsChanged.logDescription
+                == "notification snooze actions changed"
+        )
     }
     #endif
 

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -215,7 +215,71 @@ struct WatchDatabaseMirrorFullReferenceTests {
         }
     }
 
+    /// Regression: snooze presets edited on the iPhone never reached the Apple Watch, which builds its
+    /// notification actions from its own copy of this table and so stayed on the seeded 5/15/60.
+    @Test("Snooze presets are mirrored, and an empty set is authoritative rather than retained")
+    func snoozeActionsAreMirrored() throws {
+        try withDatabase { database in
+            // The table seeds 5/15/60; replace it with an edited set, as the settings screen would.
+            try database.write { db in
+                try NotificationSnoozeAction.deleteAll(db)
+                try NotificationSnoozeAction(id: "a", minutes: 30, sortOrder: 1).insert(db)
+                try NotificationSnoozeAction(id: "b", minutes: 10, isEnabled: false, sortOrder: 0).insert(db)
+            }
+
+            for version in [WatchDatabaseMirror.legacyVersion, WatchDatabaseMirror.fullReferenceVersion] {
+                let snapshot = try WatchDatabaseMirror.snapshot(version: version)
+                // Carried in the sort order the watch renders them in.
+                #expect(snapshot.notificationSnoozeActions?.map(\.minutes) == [10, 30])
+                #expect(snapshot.notificationSnoozeActions?.map(\.isEnabled) == [false, true])
+                #expect(snapshot.carriedDigestKeys.contains("notificationSnoozeActions"))
+                #expect(snapshot.tableDigests()["notificationSnoozeActions"] != nil)
+            }
+
+            // Round-trips over the wire, and matching digests omit it from the next delta sync.
+            let snapshot = try WatchDatabaseMirror.snapshot()
+            let decoded = try WatchDatabaseMirror.decodeForWatchThrowing(snapshot.encodeForWatch())
+            #expect(decoded.notificationSnoozeActions?.map(\.minutes) == [10, 30])
+            let digests = snapshot.tableDigests()
+            #expect(snapshot.omittingTables(matching: digests, currentDigests: digests)
+                .notificationSnoozeActions == nil)
+            #expect(snapshot.omittingTables(matching: [:], currentDigests: digests)
+                .notificationSnoozeActions != nil)
+
+            // Applying replaces the local presets outright, so one removed on the phone disappears.
+            try decoded.apply()
+            let applied = try Self.storedMinutes(in: database)
+            #expect(applied == [10, 30])
+
+            // Deleting every preset on the phone is a real choice: it must propagate, not be retained.
+            try database.write { db in try NotificationSnoozeAction.deleteAll(db) }
+            let emptied = try WatchDatabaseMirror.snapshot()
+            #expect(emptied.notificationSnoozeActions == [])
+            try emptied.apply()
+            let afterWipe = try Self.storedMinutes(in: database)
+            #expect(afterWipe.isEmpty)
+
+            // A delta payload that doesn't carry the table retains whatever the watch holds.
+            try database.write { db in
+                try NotificationSnoozeAction(id: "c", minutes: 45, sortOrder: 0).insert(db)
+            }
+            try WatchDatabaseMirror(entities: nil, areas: nil, pipelines: nil).apply()
+            let retained = try Self.storedMinutes(in: database)
+            #expect(retained == [45])
+        }
+    }
+
     // MARK: - Fixtures
+
+    /// The locally stored snooze presets, in the order the watch would render them.
+    private static func storedMinutes(in database: DatabaseQueue) throws -> [Int] {
+        try database.read { db in
+            try NotificationSnoozeAction
+                .order(Column(DatabaseTables.NotificationSnoozeAction.sortOrder.rawValue))
+                .fetchAll(db)
+                .map(\.minutes)
+        }
+    }
 
     private static func entity(
         entityId: String,
@@ -289,6 +353,7 @@ struct WatchDatabaseMirrorFullReferenceTests {
             AppDeviceRegistryTable(),
             AppAreaTable(),
             AssistPipelinesTable(),
+            NotificationSnoozeActionTable(),
         ]
         for table in tables {
             try table.createIfNeeded(database: database)

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -241,10 +241,10 @@ struct WatchDatabaseMirrorFullReferenceTests {
             let decoded = try WatchDatabaseMirror.decodeForWatchThrowing(snapshot.encodeForWatch())
             #expect(decoded.notificationSnoozeActions?.map(\.minutes) == [10, 30])
             let digests = snapshot.tableDigests()
-            #expect(snapshot.omittingTables(matching: digests, currentDigests: digests)
-                .notificationSnoozeActions == nil)
-            #expect(snapshot.omittingTables(matching: [:], currentDigests: digests)
-                .notificationSnoozeActions != nil)
+            let omitted = snapshot.omittingTables(matching: digests, currentDigests: digests)
+            #expect(omitted.notificationSnoozeActions == nil)
+            let carried = snapshot.omittingTables(matching: [:], currentDigests: digests)
+            #expect(carried.notificationSnoozeActions != nil)
 
             // Applying replaces the local presets outright, so one removed on the phone disappears.
             try decoded.apply()


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Snooze actions configured on the iPhone were not showing up on the Apple Watch.

The watch builds its notification actions from its own copy of the `notificationSnoozeAction` table, but the database mirror never carried that table, so the watch was stuck on the 5/15/60 defaults seeded at database creation.

`WatchDatabaseMirror` now carries the snooze actions (snapshot, digest, apply and delta-sync bookkeeping), and editing them in Settings schedules a mirror push so the change reaches the watch right away.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — no UI changes, the watch now shows the presets already configured on the iPhone.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
An empty set is treated as authoritative (deleting every preset on the phone propagates to the watch), while a failed read carries `nil` so the watch retains what it already has.
