### PR TITLE
Apply the re-authenticated token to the running API

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -624,19 +624,7 @@ struct HomeAssistantStandByView: View {
 
     private func actionButtons(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
         VStack(spacing: DesignSystem.Spaces.one) {
-            Button(action: {
-                switch emptyState.style {
-                case .disconnected, .inFlight:
-                    emptyState.retryAction()
-                case .unauthenticated:
-                    emptyState.reauthAction(selectedReauthURLType)
-                case .recoveredServerNeedingReauthentication:
-                    emptyState.reauthAction(selectedReauthURLType)
-                }
-            }) {
-                Text(emptyState.style.primaryButtonTitle)
-            }
-            .buttonStyle(.primaryButton)
+            styledPrimaryButton(for: emptyState)
             reauthURLHint(for: emptyState)
             if canShowErrorDetailsButton(for: emptyState) {
                 Button(action: {
@@ -658,6 +646,34 @@ struct HomeAssistantStandByView: View {
         .frame(maxWidth: Sizes.maxWidthForLargerScreens)
         .padding(.horizontal, DesignSystem.Spaces.two)
         .padding(.top)
+    }
+
+    /// Re-authentication is on the user, not on the app retrying, so it gets the warning-colored button
+    /// (the frontend's `ha-button variant="warning"`) to read as "action required".
+    @ViewBuilder
+    private func styledPrimaryButton(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
+        if emptyState.style.primaryActionRequiresAttention {
+            primaryButton(for: emptyState)
+                .buttonStyle(.warningButton)
+        } else {
+            primaryButton(for: emptyState)
+                .buttonStyle(.primaryButton)
+        }
+    }
+
+    private func primaryButton(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
+        Button(action: {
+            switch emptyState.style {
+            case .disconnected, .inFlight:
+                emptyState.retryAction()
+            case .unauthenticated:
+                emptyState.reauthAction(selectedReauthURLType)
+            case .recoveredServerNeedingReauthentication:
+                emptyState.reauthAction(selectedReauthURLType)
+            }
+        }) {
+            Text(emptyState.style.primaryButtonTitle)
+        }
     }
 
     @ViewBuilder

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
@@ -98,6 +98,17 @@ enum WebViewEmptyStateStyle: Equatable {
         }
     }
 
+    /// Whether the primary action is something the user has to do for the app to work again (rather than
+    /// a retry it could also perform itself), which the warning-colored button signals.
+    var primaryActionRequiresAttention: Bool {
+        switch self {
+        case .disconnected, .inFlight:
+            false
+        case .unauthenticated, .recoveredServerNeedingReauthentication:
+            true
+        }
+    }
+
     var showsServerPicker: Bool {
         switch self {
         case .disconnected, .inFlight, .unauthenticated, .recoveredServerNeedingReauthentication:

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -114,8 +114,7 @@ struct WebViewEmptyStateView: View {
 
     private var actionButtons: some View {
         VStack(spacing: DesignSystem.Spaces.one) {
-            primaryButton
-                .buttonStyle(.primaryButton)
+            styledPrimaryButton
             reauthURLHint
             if canShowErrorDetailsButton {
                 errorDetailsButton
@@ -243,6 +242,19 @@ struct WebViewEmptyStateView: View {
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, DesignSystem.Spaces.two)
+        }
+    }
+
+    /// Re-authentication is on the user, not on the app retrying, so it gets the warning-colored button
+    /// (the frontend's `ha-button variant="warning"`) to read as "action required".
+    @ViewBuilder
+    private var styledPrimaryButton: some View {
+        if style.primaryActionRequiresAttention {
+            primaryButton
+                .buttonStyle(.warningButton)
+        } else {
+            primaryButton
+                .buttonStyle(.primaryButton)
         }
     }
 

--- a/Sources/App/Onboarding/API/OnboardingAuth.swift
+++ b/Sources/App/Onboarding/API/OnboardingAuth.swift
@@ -45,10 +45,18 @@ class OnboardingAuth {
                 // actually persists to outside-onboarding
                 Current.servers.add(identifier: api.server.identifier, serverInfo: api.server.info)
             }.get { server in
-                // somewhat necessary so it points to the keychain-persisted version
-                api.server = server
-                // not super necessary but prevents making a duplicate connection during this session
-                Current.setCachedApi(api, for: api.server.identifier)
+                // Nothing was persisted yet when `configuredAPI` ran, so the API it returned is built
+                // around a detached, in-memory `Server` — and everything that API created at init
+                // captured that instance: the token manager, the websocket's connection-info and
+                // token closures, the request adapters. Handing `api.server` the keychain-persisted
+                // server cannot reach any of them, so they keep reading the onboarding-time snapshot
+                // for the rest of the session. A later re-authentication then writes its new token to
+                // the persisted server while this API keeps presenting the superseded one, which Home
+                // Assistant answers with `auth: invalid` / 401 until the app is relaunched. Replace it
+                // with an API built on the persisted server, and drop the onboarding connection so the
+                // session doesn't keep two.
+                api.connection.disconnect()
+                Current.setCachedApi(HomeAssistantAPI(server: server), for: server.identifier)
             }.then { server in
                 steps(.complete).map { server }
             }.recover(policy: .allErrors) { [self] error -> Promise<Server> in

--- a/Sources/HADesignSystem/Sources/Colors/Color+Semantic.swift
+++ b/Sources/HADesignSystem/Sources/Colors/Color+Semantic.swift
@@ -6,6 +6,15 @@ import UIKit
 public extension ShapeStyle where Self == Color {
     static var haPrimary: Color { srgb(0x00, 0x9A, 0xC7, opacity: 1) }
 
+    /// The frontend's `--ha-color-fill-warning-loud-resting`: `orange-70` on light, `orange-40` on dark.
+    /// The fill `ha-button variant="warning"` uses, for actions that need the user to step in.
+    static var haWarning: Color {
+        adaptive(
+            light: srgb(0xFF, 0x93, 0x42, opacity: 1),
+            dark: srgb(0x9D, 0x38, 0x00, opacity: 1)
+        )
+    }
+
     static var track: Color { displayP3(0, 0, 0, opacity: 0.12) }
 
     static var onSurface: Color {

--- a/Sources/HADesignSystem/Sources/Styles/HAButtonStyles.swift
+++ b/Sources/HADesignSystem/Sources/Styles/HAButtonStyles.swift
@@ -79,6 +79,44 @@ public struct HAButtonStyle: ButtonStyle {
     }
 }
 
+/// The primary button in the frontend's `warning` variant: same shape, size and white label, filled
+/// with `haWarning` instead of `haPrimary`. For a primary action the user has to take before the app
+/// can carry on, such as re-authenticating a server whose token the server no longer accepts.
+public struct HAWarningButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled: Bool
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .foregroundColor(.white)
+            .haButtonBasicSizing()
+            .padding(.horizontal, HAButtonStylesConstants.horizontalPadding)
+            .background(backgroundColorForState(isEnabled: isEnabled, isPressed: configuration.isPressed))
+            .clipShape(Capsule())
+            .opacity(isEnabled ? 1 : HAButtonStylesConstants.disabledOpacity)
+            .haButtonHoverEffect(isEnabled: isEnabled, isPressed: configuration.isPressed)
+    }
+
+    private func backgroundColorForState(isEnabled: Bool, isPressed: Bool) -> Color {
+        if !isEnabled {
+            return Color.gray
+        }
+
+        if isPressed {
+            return Color.haWarning.opacity(HAButtonStylesConstants.highlightedOpacity)
+        }
+
+        return Color.haWarning
+    }
+}
+
+#Preview {
+    VStack {
+        Button("Warning Button") {}
+            .buttonStyle(.warningButton)
+    }
+}
+
 /// The primary button's shape and size with the quiet colors of `TextButton`: a tinted fill and
 /// `haPrimary` text instead of a solid `haPrimary` background. For actions that should read as a
 /// full-size button without competing with the screen's primary one.
@@ -224,6 +262,12 @@ public struct HALinkButtonStyle: ButtonStyle {
 public extension ButtonStyle where Self == HAButtonStyle {
     static var primaryButton: HAButtonStyle {
         HAButtonStyle()
+    }
+}
+
+public extension ButtonStyle where Self == HAWarningButtonStyle {
+    static var warningButton: HAWarningButtonStyle {
+        HAWarningButtonStyle()
     }
 }
 

--- a/Sources/HANetworking/Sources/TokenManager.swift
+++ b/Sources/HANetworking/Sources/TokenManager.swift
@@ -106,8 +106,10 @@ public final class TokenManager: @unchecked Sendable {
     /// Remembering the rejection makes every future `bearerToken` refuse to hand the token out and go
     /// through a refresh instead: either the refresh mints a working token, or it fails with
     /// 400...403 and the reauthentication-required flow kicks in — in both cases the rejected token is
-    /// never sent again. The expiration is also pushed into the past so processes that share the store
-    /// (the extensions, which read it fresh rather than from a cache) see the invalidation too.
+    /// never sent again. The expiration is also pushed into the past, but only as a best effort: the
+    /// store coalesces a write that changes nothing but the expiration (see `rejectedAccessTokens`), so
+    /// it lands solely where there is no cache to coalesce against — an app extension invalidating a
+    /// token the server just refused, which the other processes then read fresh.
     public func handleAccessTokenRejected(_ rejectedToken: String) {
         // A refresh may have already replaced the token by the time the 401 lands; only the
         // currently stored token must be invalidated, never its fresh successor.

--- a/Sources/HANetworking/Sources/TokenManager.swift
+++ b/Sources/HANetworking/Sources/TokenManager.swift
@@ -1,5 +1,6 @@
 import Alamofire
 import Foundation
+import HAKit
 import PromiseKit
 
 public final class TokenManager: @unchecked Sendable {
@@ -38,6 +39,15 @@ public final class TokenManager: @unchecked Sendable {
     }
 
     private let refreshPromiseCache = RefreshPromiseCache()
+
+    /// Access tokens the server refused while their stored expiration still said they were valid.
+    ///
+    /// Tracked in memory because the persisted invalidation in `handleAccessTokenRejected` cannot be
+    /// relied on: `ServerInfo` equality considers two tokens with the same access/refresh pair equal, so
+    /// the server store drops a write that only pushes a token's expiration into the past as a no-op.
+    /// Without this, every websocket reconnect and every request keeps re-sending a token the server has
+    /// already rejected, which Home Assistant logs as invalid auth and eventually answers with an IP ban.
+    private let rejectedAccessTokens = HAProtected<Set<String>>(value: [])
 
     public init(server: Server) {
         self.authenticationAPI = AuthenticationAPI(server: server)
@@ -93,10 +103,11 @@ public final class TokenManager: @unchecked Sendable {
     /// server was restored from a backup. Without this, every poll re-sends the same rejected token,
     /// which the server logs as invalid auth and eventually answers with an IP ban.
     ///
-    /// Marking the stored token expired makes every future `bearerToken` refuse to hand it out and go
+    /// Remembering the rejection makes every future `bearerToken` refuse to hand the token out and go
     /// through a refresh instead: either the refresh mints a working token, or it fails with
     /// 400...403 and the reauthentication-required flow kicks in — in both cases the rejected token is
-    /// never sent again.
+    /// never sent again. The expiration is also pushed into the past so processes that share the store
+    /// (the extensions, which read it fresh rather than from a cache) see the invalidation too.
     public func handleAccessTokenRejected(_ rejectedToken: String) {
         // A refresh may have already replaced the token by the time the 401 lands; only the
         // currently stored token must be invalidated, never its fresh successor.
@@ -104,6 +115,7 @@ public final class TokenManager: @unchecked Sendable {
         HANetworkingEnvironment.current.log.error(
             "Server rejected access token \(rejectedToken.hash) before its expiration; forcing refresh"
         )
+        rejectedAccessTokens.mutate { $0.insert(rejectedToken) }
         server.update { $0.token.expiration = .distantPast }
     }
 
@@ -130,6 +142,13 @@ public final class TokenManager: @unchecked Sendable {
     private var currentToken: Promise<(String, Date)> {
         Promise<(String, Date)> { seal in
             let tokenInfo = server.info.token
+
+            if rejectedAccessTokens.read({ $0.contains(tokenInfo.accessToken) }) {
+                HANetworkingEnvironment.current.log
+                    .error("Token \(tokenInfo.accessToken.hash) was rejected by the server, refusing to reuse it")
+                seal.reject(TokenError.expired)
+                return
+            }
 
             // Refresh a full minute early (matching `TokenInfo.needsRefresh`) so we never hand back a
             // token that lapses in flight — especially on slow watch/cloud paths where the round trip
@@ -206,8 +225,18 @@ extension TokenManager: Authenticator {
         AuthenticationInterceptor(authenticator: self, credential: server.info.token, refreshWindow: nil)
     }
 
+    /// Signs the request with the token in the store rather than with the credential Alamofire hands
+    /// back.
+    ///
+    /// `AuthenticationInterceptor` keeps the credential it was built with and only replaces it after a
+    /// refresh it drove itself. Re-authentication mints a token through an entirely different path (the
+    /// login web view exchanging a fresh authorization code), so that snapshot outlives it: every
+    /// request the session sends afterwards carries the access token the server already rejected, which
+    /// Home Assistant logs as invalid auth, and since the session lives as long as the cached
+    /// `HomeAssistantAPI`, only relaunching the app stopped it. The store is the single source of truth
+    /// here, the same way `ServerRequestAdapter` resolves the active URL fresh per request.
     public func apply(_ credential: TokenInfo, to urlRequest: inout URLRequest) {
-        urlRequest.headers.add(.authorization(bearerToken: credential.accessToken))
+        urlRequest.headers.add(.authorization(bearerToken: server.info.token.accessToken))
     }
 
     public func refresh(
@@ -237,8 +266,11 @@ extension TokenManager: Authenticator {
         }
     }
 
+    /// Compared against the stored token for the same reason `apply` signs with it: a 401 for a request
+    /// that carried a superseded token has to be retried with the current one instead of being taken as
+    /// a rejection of the token the interceptor still has cached.
     public func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: TokenInfo) -> Bool {
-        let bearerToken = HTTPHeader.authorization(bearerToken: credential.accessToken).value
+        let bearerToken = HTTPHeader.authorization(bearerToken: server.info.token.accessToken).value
         return urlRequest.headers["Authorization"] == bearerToken
     }
 }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -48,7 +48,10 @@ public class HomeAssistantAPI {
     public static let unauthenticatedManager: Alamofire.Session = configureSessionManager()
 
     public let tokenManager: TokenManager
-    public var server: Server
+    /// Fixed for the lifetime of the API: the token manager, the websocket's connection-info and
+    /// token closures and the request adapters all capture this instance at init, so swapping it
+    /// afterwards would only change what this property reports. Build a new API instead.
+    public let server: Server
     public internal(set) var connection: HAConnection
 
     private var rejectedReconnectAttempts = 0

--- a/Tests/Shared/TokenManagerAccessTokenRejection.test.swift
+++ b/Tests/Shared/TokenManagerAccessTokenRejection.test.swift
@@ -1,3 +1,4 @@
+import Alamofire
 import Foundation
 @testable import Shared
 import XCTest
@@ -49,5 +50,71 @@ class TokenManagerAccessTokenRejectionTests: XCTestCase {
         }
 
         wait(for: [settled], timeout: 5)
+    }
+
+    /// The real server store drops a write whose `ServerInfo` compares equal to what it already has,
+    /// and `TokenInfo` equality ignores the expiration — so pushing the expiration into the past does
+    /// not persist. The rejection must hold anyway, or every later request re-sends the rejected token.
+    func testRejectedTokenIsNotProvidedWhenStoreDropsExpirationOnlyWrites() {
+        let server = Self.serverDroppingWritesThatCompareEqual()
+        let tokenManager = TokenManager(server: server)
+        let rejectedToken = server.info.token.accessToken
+
+        tokenManager.handleAccessTokenRejected(rejectedToken)
+        XCTAssertGreaterThan(server.info.token.expiration, Current.date())
+
+        let settled = expectation(description: "bearerToken settled")
+        tokenManager.bearerToken.done { token, _ in
+            XCTAssertNotEqual(token, rejectedToken)
+            settled.fulfill()
+        }.catch { _ in
+            settled.fulfill()
+        }
+
+        wait(for: [settled], timeout: 5)
+    }
+
+    /// Re-authentication stores a brand new token without going through the token manager, so requests
+    /// signed by a session built before it must still carry the new token — otherwise the rejected one
+    /// keeps going out until the app is relaunched.
+    func testInterceptorSignsRequestsWithTheTokenStoredAfterReauthentication() throws {
+        let url = try XCTUnwrap(URL(string: "http://homeassistant.local:8123/api/"))
+        let server = Server.fake()
+        let tokenManager = TokenManager(server: server)
+        let interceptor = tokenManager.authenticationInterceptor
+
+        server.update { info in
+            info.token = .init(
+                accessToken: "ReauthenticatedAccessToken",
+                refreshToken: "ReauthenticatedRefreshToken",
+                expiration: Current.date().addingTimeInterval(3600)
+            )
+        }
+
+        let adapted = expectation(description: "request adapted")
+        interceptor.adapt(URLRequest(url: url), for: Session.default) { result in
+            let authorization = try? result.get().value(forHTTPHeaderField: "Authorization")
+            XCTAssertEqual(authorization, "Bearer ReauthenticatedAccessToken")
+            adapted.fulfill()
+        }
+
+        wait(for: [adapted], timeout: 5)
+    }
+
+    /// A `Server` whose setter behaves like `ServerManagerImpl`'s: a value that compares equal to the
+    /// stored one is discarded, which is what makes an expiration-only update a no-op in the app.
+    private static func serverDroppingWritesThatCompareEqual() -> Server {
+        var stored = ServerInfo.fake()
+        // No reachable URL, so the refresh the rejection forces fails fast instead of hitting the network.
+        stored.connection.set(address: nil, for: .external)
+        return Server(
+            identifier: .init(rawValue: UUID().uuidString),
+            getter: { stored },
+            setter: { newValue in
+                guard newValue != stored else { return false }
+                stored = newValue
+                return true
+            }
+        )
     }
 }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Re-authenticating a server did nothing until the app was force quit: Home Assistant kept answering `auth: invalid` / 401 because the app kept sending the old token.

- The API created during onboarding wraps a detached in-memory `Server`, and its token manager, websocket closures and request adapters capture that instance at init. Re-pointing `api.server` afterwards never reached them, so the new token was ignored for the rest of the session. The persisted server now gets its own API in the cache.
- Alamofire's `AuthenticationInterceptor` signed every request with the credential it snapshotted at init, so REST calls also kept using the superseded token. Requests are now signed with the stored token.
- A rejected access token was invalidated by writing only its expiration, which the server store drops because `ServerInfo` equality ignores it. Rejections are now remembered in memory as well.

The re-authenticate button uses a new warning-colored button style (the frontend's `ha-button variant="warning"`) so it reads as "action required".

## Screenshots

<img width="3642" height="2968" alt="CleanShot 2026-08-17 at 14 15 08@2x" src="https://github.com/user-attachments/assets/3c77cdaa-9493-4cd9-88dd-e1b0a8b95e69" />

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
