### PR TITLE
Share the empty state views between both screens

### DIFF
--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -4,13 +4,10 @@ import SwiftUI
 import UIKit
 
 struct HomeAssistantStandByView: View {
-    static let dismissTapThreshold = 5
     static let logoDismissTapThreshold = 10
 
-    private static let headerAccessorySize = CGSize(width: 44, height: 44)
+    private static let connectionTypeIndicatorSize = CGSize(width: 44, height: 44)
     static let loadingLogoResourceName = "home-assistant-logo-loading"
-    private static let emptyStateLogoSize = CGSize(width: 80, height: 80)
-    private static let reauthenticationIconSize: CGFloat = 56
     private static let serverPillHeight: CGFloat = 44
     private static let connectionTypeToastID = "home-assistant-stand-by-connection-type"
     static let serverSelectionTransitionID = "home-assistant-stand-by-server-selection"
@@ -28,11 +25,6 @@ struct HomeAssistantStandByView: View {
     private let delayedSettingsButtonDelay: Duration
     private let cleanCacheButtonDelay: Duration
 
-    @State private var selectedReauthURLType: ConnectionInfo.URLType
-    @State private var showURLPicker = false
-    @State private var isPerformingPrimaryAction = false
-    @State private var errorMessage: String?
-    @State private var dismissTapCount = 0
     @State private var logoDismissTapCount = 0
     @State private var showsEmptyStateContent = false
     @State private var showsDelayedSettingsButton = false
@@ -73,7 +65,7 @@ struct HomeAssistantStandByView: View {
         // While loading, the logo mirrors the splash logo exactly (size and full-screen-centered
         // position) so the launch-screen → splash → stand-by hand-off is a pure crossfade with no
         // movement; the logo only moves (to the top, smaller) for the empty/error state.
-        showsEmptyState ? Self.emptyStateLogoSize : LaunchSplashOverlayView.Constants.splashLogoSize
+        showsEmptyState ? WebViewEmptyStateIcon.logoSize : LaunchSplashOverlayView.Constants.splashLogoSize
     }
 
     private func contentOffset(safeAreaInsets: EdgeInsets) -> CGFloat {
@@ -107,7 +99,6 @@ struct HomeAssistantStandByView: View {
         self.onCleanCacheAndReload = onCleanCacheAndReload
         self.delayedSettingsButtonDelay = delayedSettingsButtonDelay
         self.cleanCacheButtonDelay = cleanCacheButtonDelay
-        self._selectedReauthURLType = State(initialValue: emptyState?.availableReauthURLTypes.first ?? .external)
         self._showsAnimatedLogo = State(initialValue: emptyState == nil)
     }
 
@@ -151,7 +142,14 @@ struct HomeAssistantStandByView: View {
         VStack(spacing: DesignSystem.Spaces.three) {
             iconView
             if let emptyState {
-                emptyStateBody(for: emptyState)
+                WebViewEmptyStateMessage(
+                    style: emptyState.style,
+                    server: server,
+                    complementaryMessageAction: openSettings
+                )
+                .opacity(contentOpacity)
+                .transition(.opacity)
+                Spacer()
             }
         }
         .padding(.horizontal, DesignSystem.Spaces.three)
@@ -192,32 +190,37 @@ struct HomeAssistantStandByView: View {
         }
         .safeAreaInset(edge: .top) {
             if let emptyState {
-                header(for: emptyState)
-                    .opacity(contentOpacity)
+                WebViewEmptyStateHeader(
+                    style: emptyState.style,
+                    server: server,
+                    isLoading: isLoading,
+                    showsServerSelection: emptyState.style.showsServerPicker
+                        && Current.servers.all.count > 1
+                        && !Current.isCatalyst,
+                    showsErrorDetailsButton: canShowErrorDetailsButton(for: emptyState),
+                    settingsAction: emptyState.settingsAction,
+                    serverSelectionAction: selectServer,
+                    dismissAction: emptyState.dismissAction
+                )
+                .opacity(contentOpacity)
             }
         }
         .safeAreaInset(edge: .bottom) {
             if let emptyState {
-                actionButtons(for: emptyState)
-                    .opacity(contentOpacity)
+                WebViewEmptyStateActionButtons(
+                    style: emptyState.style,
+                    availableReauthURLTypes: emptyState.availableReauthURLTypes,
+                    showsErrorDetailsButton: canShowErrorDetailsButton(for: emptyState),
+                    retryAction: emptyState.retryAction,
+                    settingsAction: emptyState.settingsAction,
+                    errorDetailsAction: emptyState.errorDetailsAction,
+                    reauthAction: emptyState.reauthAction
+                )
+                .opacity(contentOpacity)
             } else if showsCleanCacheAndReloadButton {
                 cleanCacheButton
                     .transition(.opacity)
             }
-        }
-        .alert(L10n.errorLabel, isPresented: .init(
-            get: { errorMessage != nil },
-            set: { newValue in
-                if !newValue {
-                    errorMessage = nil
-                }
-            }
-        )) {
-            Button(L10n.okLabel, role: .cancel) {
-                errorMessage = nil
-            }
-        } message: {
-            Text(errorMessage ?? "")
         }
         .animation(DesignSystem.Animation.default, value: standByContentOpacity)
         .animation(DesignSystem.Animation.default, value: showsEmptyState)
@@ -229,9 +232,6 @@ struct HomeAssistantStandByView: View {
         }
         .onChange(of: emptyState != nil, perform: handleEmptyStateChange)
         .task(id: showsEmptyState, restoreAnimatedLogoIfNeeded)
-        .onChange(of: emptyState?.availableReauthURLTypes ?? []) { availableReauthURLTypes in
-            selectedReauthURLType = availableReauthURLTypes.first ?? .external
-        }
         .onReceive(
             NotificationCenter.default
                 .publisher(for: Current.connectivity.connectivityDidChangeNotification())
@@ -331,20 +331,6 @@ struct HomeAssistantStandByView: View {
     }
 
     @ViewBuilder
-    private func emptyStateBody(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        VStack(spacing: DesignSystem.Spaces.one) {
-            Text(emptyState.style.title)
-                .font(.title2)
-                .fontWeight(.semibold)
-            bodyText(for: emptyState)
-            bodyComplementaryText(for: emptyState)
-        }
-        .opacity(contentOpacity)
-        .transition(.opacity)
-        Spacer()
-    }
-
-    @ViewBuilder
     private var currentServerPill: some View {
         if #available(iOS 26.0, *) {
             GlassEffectContainer {
@@ -414,7 +400,10 @@ struct HomeAssistantStandByView: View {
                 .modify { view in
                     if #available(iOS 26.0, *) {
                         view
-                            .frame(width: Self.headerAccessorySize.width, height: Self.headerAccessorySize.height)
+                            .frame(
+                                width: Self.connectionTypeIndicatorSize.width,
+                                height: Self.connectionTypeIndicatorSize.height
+                            )
                             .glassEffect(.regular.interactive(), in: .circle)
                             .contentShape(Circle())
                     } else {
@@ -480,37 +469,26 @@ struct HomeAssistantStandByView: View {
         }
     }
 
-    @ViewBuilder
     private var iconView: some View {
-        Group {
-            if emptyState?.style == .recoveredServerNeedingReauthentication {
-                Image(systemSymbol: .key)
-                    .font(.system(size: Self.reauthenticationIconSize))
-                    .foregroundStyle(Color.haPrimary)
-            } else {
-                ZStack(alignment: .bottomTrailing) {
-                    // Keep the static logo behind the animated SVG while loading: the launch-splash
-                    // hero morphs into a pixel-identical `Image(.logo)` (matched geometry), and it
-                    // also fills any frame before the WKWebView paints. The animated SVG sits on top
-                    // once loaded, and is swapped out for the static logo around the empty-state
-                    // move since the webview can't track animated frame changes.
-                    Image(.logo)
-                        .resizable()
-                        .scaledToFit()
-                    // Hidden via opacity (never removed) with animation explicitly disabled, so the
-                    // swap to the static logo is always instantaneous — a conditional removal would
-                    // inherit the surrounding empty-state animation and fade out mid-move.
-                    AnimatedSVGView(resourceName: Self.loadingLogoResourceName)
-                        .opacity(showsAnimatedLogo ? 1 : 0)
-                        .animation(nil, value: showsAnimatedLogo)
-                        // Decorative duplicate of the static logo; its webview is already
-                        // non-interactive, this also keeps it out of VoiceOver.
-                        .accessibilityHidden(true)
-                    if case .inFlight = emptyState?.style {
-                        inFlightIcon
-                            .offset(x: 15, y: 15)
-                    }
-                }
+        ZStack(alignment: .bottomTrailing) {
+            // Keep the static logo behind the animated SVG while loading: the launch-splash
+            // hero morphs into a pixel-identical `Image(.logo)` (matched geometry), and it
+            // also fills any frame before the WKWebView paints. The animated SVG sits on top
+            // once loaded, and is swapped out for the static logo around the empty-state
+            // move since the webview can't track animated frame changes.
+            WebViewEmptyStateIcon(style: emptyState?.style, size: logoSize)
+            // Hidden via opacity (never removed) with animation explicitly disabled, so the
+            // swap to the static logo is always instantaneous — a conditional removal would
+            // inherit the surrounding empty-state animation and fade out mid-move.
+            AnimatedSVGView(resourceName: Self.loadingLogoResourceName)
+                .opacity(showsAnimatedLogo ? 1 : 0)
+                .animation(nil, value: showsAnimatedLogo)
+                // Decorative duplicate of the static logo; its webview is already
+                // non-interactive, this also keeps it out of VoiceOver.
+                .accessibilityHidden(true)
+            if case .inFlight = emptyState?.style {
+                inFlightIcon
+                    .offset(x: 15, y: 15)
             }
         }
         .frame(width: logoSize.width, height: logoSize.height)
@@ -537,179 +515,6 @@ struct HomeAssistantStandByView: View {
             }
     }
 
-    private func header(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        HStack {
-            headerAccessory(resolvedLeadingHeaderAccessory(for: emptyState))
-            Spacer()
-            serverSelection(for: emptyState)
-            Spacer()
-            headerAccessory(emptyState.style.trailingHeaderAccessory)
-        }
-        .padding()
-    }
-
-    @ViewBuilder
-    private func headerAccessory(_ accessory: WebViewEmptyStateStyle.HeaderAccessory) -> some View {
-        switch accessory {
-        case .none:
-            Color.clear
-                .frame(width: Self.headerAccessorySize.width, height: Self.headerAccessorySize.height)
-        case .settings:
-            ModalReusableButton(
-                icon: .sfSymbol(.gearshape),
-                action: {
-                    emptyState?.settingsAction()
-                }
-            )
-            .accessibilityLabel(L10n.WebView.EmptyState.openSettingsButton)
-        case .hiddenDismiss:
-            Color.clear
-                .frame(width: Self.headerAccessorySize.width, height: Self.headerAccessorySize.height)
-                .overlay {
-                    if isLoading {
-                        ProgressView()
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture(perform: registerDismissTap)
-                .accessibilityHidden(true)
-        }
-    }
-
-    @ViewBuilder
-    private func serverSelection(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        if emptyState.style.showsServerPicker, Current.servers.all.count > 1, !Current.isCatalyst {
-            ServerPickerView(server: server, onSelect: selectServer)
-                .background(Color(uiColor: .secondarySystemBackground))
-                .clipShape(Capsule())
-        }
-    }
-
-    @ViewBuilder
-    private func bodyText(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        switch emptyState.style {
-        case .disconnected, .inFlight, .unauthenticated:
-            Text(emptyState.style.body)
-                .font(.callout)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DesignSystem.Spaces.two)
-        case .recoveredServerNeedingReauthentication:
-            Text(L10n.Onboarding.ServerImport.Reauthenticate.message(server.info.name))
-                .font(.callout)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DesignSystem.Spaces.two)
-        }
-    }
-
-    @ViewBuilder
-    private func bodyComplementaryText(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        switch emptyState.style {
-        case .inFlight:
-            if let text = emptyState.style.complementaryMessage {
-                Button(action: openSettings) {
-                    Text(text)
-                        .font(.caption2.italic())
-                        .foregroundColor(.haPrimary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, DesignSystem.Spaces.two)
-                }
-                .buttonStyle(.plain)
-            }
-        default:
-            EmptyView()
-        }
-    }
-
-    private func actionButtons(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        VStack(spacing: DesignSystem.Spaces.one) {
-            styledPrimaryButton(for: emptyState)
-            reauthURLHint(for: emptyState)
-            if canShowErrorDetailsButton(for: emptyState) {
-                Button(action: {
-                    emptyState.errorDetailsAction()
-                }) {
-                    Text(L10n.ConnectionError.MoreDetailsSection.title)
-                }
-                .buttonStyle(.secondaryButton)
-            }
-            if emptyState.style.showsSecondarySettingsButton, !canShowErrorDetailsButton(for: emptyState) {
-                Button(action: {
-                    emptyState.settingsAction()
-                }) {
-                    Text(emptyState.style.secondaryButtonTitle)
-                }
-                .buttonStyle(.secondaryButton)
-            }
-        }
-        .frame(maxWidth: Sizes.maxWidthForLargerScreens)
-        .padding(.horizontal, DesignSystem.Spaces.two)
-        .padding(.top)
-    }
-
-    /// Re-authentication is on the user, not on the app retrying, so it gets the warning-colored button
-    /// (the frontend's `ha-button variant="warning"`) to read as "action required".
-    @ViewBuilder
-    private func styledPrimaryButton(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        if emptyState.style.primaryActionRequiresAttention {
-            primaryButton(for: emptyState)
-                .buttonStyle(.warningButton)
-        } else {
-            primaryButton(for: emptyState)
-                .buttonStyle(.primaryButton)
-        }
-    }
-
-    private func primaryButton(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        Button(action: {
-            switch emptyState.style {
-            case .disconnected, .inFlight:
-                emptyState.retryAction()
-            case .unauthenticated:
-                emptyState.reauthAction(selectedReauthURLType)
-            case .recoveredServerNeedingReauthentication:
-                emptyState.reauthAction(selectedReauthURLType)
-            }
-        }) {
-            Text(emptyState.style.primaryButtonTitle)
-        }
-    }
-
-    @ViewBuilder
-    private func reauthURLHint(for emptyState: WebFrontendOverlayState.EmptyStateContent) -> some View {
-        if emptyState.style == .unauthenticated, emptyState.availableReauthURLTypes.count > 1 {
-            Button {
-                showURLPicker = true
-            } label: {
-                HStack(spacing: 4) {
-                    Text(selectedReauthURLType.description)
-                    Image(systemSymbol: .chevronUpChevronDown)
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-            .confirmationDialog(
-                emptyState.style.urlPickerTitle,
-                isPresented: $showURLPicker,
-                titleVisibility: .visible
-            ) {
-                ForEach(emptyState.availableReauthURLTypes, id: \.self) { urlType in
-                    Button(urlType.description) {
-                        selectedReauthURLType = urlType
-                    }
-                }
-            }
-        }
-    }
-
-    private func registerDismissTap() {
-        dismissTapCount += 1
-        guard dismissTapCount >= Self.dismissTapThreshold else { return }
-        dismissTapCount = 0
-        emptyState?.dismissAction()
-    }
-
     // Debug escape hatch while the loader is stuck; empty-state mode already has its own hidden dismiss accessory.
     private func registerLogoDismissTap() {
         guard emptyState == nil, let onLogoDismiss else { return }
@@ -728,16 +533,6 @@ struct HomeAssistantStandByView: View {
     private func openSettings() {
         Current.sceneManager.appCoordinator.done { coordinator in
             coordinator.showSettings()
-        }
-    }
-
-    private func resolvedLeadingHeaderAccessory(
-        for emptyState: WebFrontendOverlayState.EmptyStateContent
-    ) -> WebViewEmptyStateStyle.HeaderAccessory {
-        if emptyState.style.showsSecondarySettingsButton, canShowErrorDetailsButton(for: emptyState) {
-            .settings
-        } else {
-            emptyState.style.leadingHeaderAccessory
         }
     }
 

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateActionButtons.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateActionButtons.swift
@@ -1,0 +1,229 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Bottom action stack of the connection/re-authentication empty state, shared by
+/// `HomeAssistantStandByView` and `WebViewEmptyStateView`: primary action, re-authentication URL hint
+/// and either the error details or the secondary settings button.
+struct WebViewEmptyStateActionButtons: View {
+    let style: WebViewEmptyStateStyle
+    let availableReauthURLTypes: [ConnectionInfo.URLType]
+    let showsErrorDetailsButton: Bool
+    let retryAction: () -> Void
+    let settingsAction: () -> Void
+    let errorDetailsAction: () -> Void
+    let reauthAction: (ConnectionInfo.URLType) -> Void
+    /// Recovered-server re-authentication reports its outcome back, so the primary button can show
+    /// progress while the login flow runs and surface a failure as an alert. Without it the recovered
+    /// style falls back to `reauthAction`.
+    let recoveredServerReauthAction: ((
+        ConnectionInfo.URLType,
+        @escaping (Swift.Result<Void, Error>) -> Void
+    ) -> Void)?
+
+    @State private var selectedReauthURLType: ConnectionInfo.URLType
+    @State private var showURLPicker = false
+    @State private var isPerformingPrimaryAction = false
+    @State private var errorMessage: String?
+
+    init(
+        style: WebViewEmptyStateStyle,
+        availableReauthURLTypes: [ConnectionInfo.URLType],
+        showsErrorDetailsButton: Bool = false,
+        retryAction: @escaping () -> Void,
+        settingsAction: @escaping () -> Void,
+        errorDetailsAction: @escaping () -> Void,
+        reauthAction: @escaping (ConnectionInfo.URLType) -> Void,
+        recoveredServerReauthAction: ((
+            ConnectionInfo.URLType,
+            @escaping (Swift.Result<Void, Error>) -> Void
+        ) -> Void)? = nil
+    ) {
+        self.style = style
+        self.availableReauthURLTypes = availableReauthURLTypes
+        self.showsErrorDetailsButton = showsErrorDetailsButton
+        self.retryAction = retryAction
+        self.settingsAction = settingsAction
+        self.errorDetailsAction = errorDetailsAction
+        self.reauthAction = reauthAction
+        self.recoveredServerReauthAction = recoveredServerReauthAction
+        self._selectedReauthURLType = State(initialValue: availableReauthURLTypes.first ?? .external)
+    }
+
+    var body: some View {
+        VStack(spacing: DesignSystem.Spaces.one) {
+            styledPrimaryButton
+            if showsReauthURLPicker {
+                Button {
+                    showURLPicker = true
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(selectedReauthURLType.description)
+                        Image(systemSymbol: .chevronUpChevronDown)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .confirmationDialog(
+                    style.urlPickerTitle,
+                    isPresented: $showURLPicker,
+                    titleVisibility: .visible
+                ) {
+                    ForEach(availableReauthURLTypes, id: \.self) { urlType in
+                        Button(urlType.description) {
+                            selectedReauthURLType = urlType
+                        }
+                    }
+                }
+            }
+            if showsErrorDetailsButton {
+                Button(action: errorDetailsAction) {
+                    Text(L10n.ConnectionError.MoreDetailsSection.title)
+                }
+                .buttonStyle(.secondaryButton)
+            }
+            if style.showsSecondarySettingsButton, !showsErrorDetailsButton {
+                Button(action: settingsAction) {
+                    Text(style.secondaryButtonTitle)
+                }
+                .buttonStyle(.secondaryButton)
+            }
+        }
+        .frame(maxWidth: Sizes.maxWidthForLargerScreens)
+        .padding(.horizontal, DesignSystem.Spaces.two)
+        .padding(.top)
+        .onChange(of: availableReauthURLTypes) { newValue in
+            selectedReauthURLType = newValue.first ?? .external
+        }
+        .alert(L10n.errorLabel, isPresented: .init(
+            get: { errorMessage != nil },
+            set: { newValue in
+                if !newValue {
+                    errorMessage = nil
+                }
+            }
+        )) {
+            Button(L10n.okLabel, role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    /// Re-authentication is on the user, not on the app retrying, so it gets the warning-colored button
+    /// (the frontend's `ha-button variant="warning"`) to read as "action required".
+    @ViewBuilder
+    private var styledPrimaryButton: some View {
+        if style.primaryActionRequiresAttention {
+            primaryButton
+                .buttonStyle(.warningButton)
+        } else {
+            primaryButton
+                .buttonStyle(.primaryButton)
+        }
+    }
+
+    private var primaryButton: some View {
+        Button(action: performPrimaryAction) {
+            if isPerformingPrimaryAction {
+                ProgressView()
+                    .tint(.white)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Text(style.primaryButtonTitle)
+            }
+        }
+        .disabled(isPerformingPrimaryAction)
+    }
+
+    private var showsReauthURLPicker: Bool {
+        guard style == .unauthenticated || style == .recoveredServerNeedingReauthentication else { return false }
+        return availableReauthURLTypes.count > 1
+    }
+
+    private func performPrimaryAction() {
+        switch style {
+        case .disconnected, .inFlight:
+            retryAction()
+        case .unauthenticated:
+            reauthAction(selectedReauthURLType)
+        case .recoveredServerNeedingReauthentication:
+            if recoveredServerReauthAction == nil {
+                reauthAction(selectedReauthURLType)
+            } else {
+                beginRecoveredServerReauthentication()
+            }
+        }
+    }
+
+    private func beginRecoveredServerReauthentication() {
+        guard !isPerformingPrimaryAction, let recoveredServerReauthAction else { return }
+        isPerformingPrimaryAction = true
+        errorMessage = nil
+
+        recoveredServerReauthAction(selectedReauthURLType) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    isPerformingPrimaryAction = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}
+
+#Preview("Disconnected") {
+    WebViewEmptyStateActionButtons(
+        style: .disconnected,
+        availableReauthURLTypes: [],
+        retryAction: {},
+        settingsAction: {},
+        errorDetailsAction: {},
+        reauthAction: { _ in }
+    )
+}
+
+#Preview("Disconnected With Error Details") {
+    WebViewEmptyStateActionButtons(
+        style: .disconnected,
+        availableReauthURLTypes: [],
+        showsErrorDetailsButton: true,
+        retryAction: {},
+        settingsAction: {},
+        errorDetailsAction: {},
+        reauthAction: { _ in }
+    )
+}
+
+#Preview("Unauthenticated Multiple URLs") {
+    WebViewEmptyStateActionButtons(
+        style: .unauthenticated,
+        availableReauthURLTypes: [.remoteUI, .external, .internal],
+        retryAction: {},
+        settingsAction: {},
+        errorDetailsAction: {},
+        reauthAction: { _ in }
+    )
+}
+
+#Preview("Recovered Reauthentication Failure") {
+    WebViewEmptyStateActionButtons(
+        style: .recoveredServerNeedingReauthentication,
+        availableReauthURLTypes: [.remoteUI, .external],
+        retryAction: {},
+        settingsAction: {},
+        errorDetailsAction: {},
+        reauthAction: { _ in },
+        recoveredServerReauthAction: { _, completion in
+            completion(.failure(NSError(
+                domain: "Preview",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Reauthentication failed."]
+            )))
+        }
+    )
+}

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateHeader.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateHeader.swift
@@ -1,0 +1,162 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Top row of the connection/re-authentication empty state, shared by `HomeAssistantStandByView` and
+/// `WebViewEmptyStateView`: the style's accessories around the server selection.
+struct WebViewEmptyStateHeader: View {
+    static let accessorySize = CGSize(width: 44, height: 44)
+    static let dismissTapThreshold = 5
+
+    let style: WebViewEmptyStateStyle
+    let server: Server
+    let isLoading: Bool
+    let showsServerSelection: Bool
+    /// When the action buttons show the error details button in place of the secondary settings button,
+    /// settings moves up into the leading accessory.
+    let showsErrorDetailsButton: Bool
+    let settingsAction: () -> Void
+    let serverSelectionAction: (Server) -> Void
+    let dismissAction: () -> Void
+
+    var body: some View {
+        HStack {
+            Accessory(
+                accessory: leadingAccessory,
+                isLoading: isLoading,
+                settingsAction: settingsAction,
+                dismissAction: dismissAction
+            )
+            Spacer()
+            if showsServerSelection {
+                if Current.isCatalyst {
+                    Menu {
+                        ForEach(Current.servers.all, id: \.identifier) { availableServer in
+                            Button {
+                                serverSelectionAction(availableServer)
+                            } label: {
+                                Label(availableServer.info.name, systemSymbol: symbol(for: availableServer))
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: DesignSystem.Spaces.one) {
+                            Image(systemSymbol: .serverRack)
+                                .foregroundStyle(Color.haPrimary)
+                            Text(server.info.name)
+                                .font(.callout)
+                                .lineLimit(1)
+                            Image(systemSymbol: .chevronUpChevronDown)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, DesignSystem.Spaces.two)
+                        .padding(.vertical, DesignSystem.Spaces.one)
+                        .background(Color(uiColor: .secondarySystemBackground))
+                        .clipShape(.capsule)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    ServerPickerView(server: server, onSelect: serverSelectionAction)
+                        // Using .secondarySystemBackground to visually distinguish the server selection view
+                        .background(Color(uiColor: .secondarySystemBackground))
+                        .clipShape(Capsule())
+                }
+            }
+            Spacer()
+            Accessory(
+                accessory: style.trailingHeaderAccessory,
+                isLoading: isLoading,
+                settingsAction: settingsAction,
+                dismissAction: dismissAction
+            )
+        }
+        .padding()
+    }
+
+    private var leadingAccessory: WebViewEmptyStateStyle.HeaderAccessory {
+        if style.showsSecondarySettingsButton, showsErrorDetailsButton {
+            .settings
+        } else {
+            style.leadingHeaderAccessory
+        }
+    }
+
+    private func symbol(for availableServer: Server) -> SFSymbol {
+        availableServer.identifier == server.identifier ? .checkmark : .serverRack
+    }
+
+    private struct Accessory: View {
+        private static let size = WebViewEmptyStateHeader.accessorySize
+
+        let accessory: WebViewEmptyStateStyle.HeaderAccessory
+        let isLoading: Bool
+        let settingsAction: () -> Void
+        let dismissAction: () -> Void
+
+        @State private var dismissTapCount = 0
+
+        var body: some View {
+            switch accessory {
+            case .none:
+                Color.clear
+                    .frame(width: Self.size.width, height: Self.size.height)
+            case .settings:
+                ModalReusableButton(
+                    icon: .sfSymbol(.gearshape),
+                    action: settingsAction
+                )
+                .accessibilityLabel(L10n.WebView.EmptyState.openSettingsButton)
+            case .hiddenDismiss:
+                Color.clear
+                    .frame(width: Self.size.width, height: Self.size.height)
+                    .overlay {
+                        if isLoading {
+                            ProgressView()
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: registerDismissTap)
+                    .accessibilityHidden(true)
+            }
+        }
+
+        private func registerDismissTap() {
+            dismissTapCount += 1
+            guard dismissTapCount >= WebViewEmptyStateHeader.dismissTapThreshold else { return }
+            dismissTapCount = 0
+            dismissAction()
+        }
+    }
+}
+
+#Preview("Disconnected") {
+    VStack {
+        WebViewEmptyStateHeader(
+            style: .disconnected,
+            server: ServerFixture.standard,
+            isLoading: true,
+            showsServerSelection: true,
+            showsErrorDetailsButton: false,
+            settingsAction: {},
+            serverSelectionAction: { _ in },
+            dismissAction: {}
+        )
+        Spacer()
+    }
+}
+
+#Preview("Recovered Reauthentication") {
+    VStack {
+        WebViewEmptyStateHeader(
+            style: .recoveredServerNeedingReauthentication,
+            server: ServerFixture.standard,
+            isLoading: false,
+            showsServerSelection: false,
+            showsErrorDetailsButton: false,
+            settingsAction: {},
+            serverSelectionAction: { _ in },
+            dismissAction: {}
+        )
+        Spacer()
+    }
+}

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateIcon.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateIcon.swift
@@ -1,0 +1,34 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// Icon of the connection/re-authentication empty state, shared by `HomeAssistantStandByView` and
+/// `WebViewEmptyStateView`. A `nil` style is the stand-by loader, which shows the same logo.
+struct WebViewEmptyStateIcon: View {
+    static let logoSize = CGSize(width: 80, height: 80)
+    static let reauthenticationIconSize: CGFloat = 56
+
+    let style: WebViewEmptyStateStyle?
+    var size: CGSize = WebViewEmptyStateIcon.logoSize
+
+    var body: some View {
+        if style == .recoveredServerNeedingReauthentication {
+            Image(systemSymbol: .key)
+                .font(.system(size: Self.reauthenticationIconSize))
+                .foregroundStyle(Color.haPrimary)
+        } else {
+            Image(.logo)
+                .resizable()
+                .scaledToFit()
+                .frame(width: size.width, height: size.height)
+        }
+    }
+}
+
+#Preview("Logo") {
+    WebViewEmptyStateIcon(style: .disconnected)
+}
+
+#Preview("Re-authentication Key") {
+    WebViewEmptyStateIcon(style: .recoveredServerNeedingReauthentication)
+}

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateMessage.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateMessage.swift
@@ -1,0 +1,66 @@
+import Shared
+import SwiftUI
+
+/// Title, body and complementary hint of the connection/re-authentication empty state, shared by
+/// `HomeAssistantStandByView` and `WebViewEmptyStateView`.
+struct WebViewEmptyStateMessage: View {
+    let style: WebViewEmptyStateStyle
+    let server: Server
+    let complementaryMessageAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: DesignSystem.Spaces.one) {
+            Text(style.title)
+                .font(.title2)
+                .fontWeight(.semibold)
+            Text(bodyText)
+                .font(.callout)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, DesignSystem.Spaces.two)
+            if let complementaryMessage = style.complementaryMessage {
+                Button(action: complementaryMessageAction) {
+                    Text(complementaryMessage)
+                        .font(.caption2.italic())
+                        .foregroundColor(.haPrimary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, DesignSystem.Spaces.two)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var bodyText: String {
+        switch style {
+        case .disconnected, .inFlight, .unauthenticated:
+            style.body
+        case .recoveredServerNeedingReauthentication:
+            L10n.Onboarding.ServerImport.Reauthenticate.message(server.info.name)
+        }
+    }
+}
+
+#Preview("Disconnected") {
+    WebViewEmptyStateMessage(
+        style: .disconnected,
+        server: ServerFixture.standard,
+        complementaryMessageAction: {}
+    )
+}
+
+#Preview("In-flight") {
+    WebViewEmptyStateMessage(
+        style: .inFlight,
+        server: ServerFixture.standard,
+        complementaryMessageAction: {}
+    )
+}
+
+#Preview("Recovered Reauthentication") {
+    WebViewEmptyStateMessage(
+        style: .recoveredServerNeedingReauthentication,
+        server: ServerFixture.standard,
+        complementaryMessageAction: {}
+    )
+}

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -1,18 +1,10 @@
-import SFSafeSymbols
 import Shared
 import SwiftUI
 
+/// Full-screen connection/re-authentication empty state, used by the recovered-server re-authentication
+/// flow. The web view path renders the same content (`WebViewEmptyStateHeader`, `WebViewEmptyStateIcon`,
+/// `WebViewEmptyStateMessage`, `WebViewEmptyStateActionButtons`) inside `HomeAssistantStandByView`.
 struct WebViewEmptyStateView: View {
-    static let dismissTapThreshold = 5
-
-    @State private var selectedReauthURLType: ConnectionInfo.URLType
-    @State private var showURLPicker = false
-    @State private var isPerformingPrimaryAction = false
-    @State private var errorMessage: String?
-    @State private var dismissTapCount = 0
-
-    private let headerAccessorySize = CGSize(width: 44, height: 44)
-
     let style: WebViewEmptyStateStyle
     let server: Server
     let isLoading: Bool
@@ -48,7 +40,6 @@ struct WebViewEmptyStateView: View {
         self.isLoading = isLoading
         self.showsErrorDetailsButton = showsErrorDetailsButton
         self.availableReauthURLTypes = availableReauthURLTypes
-        self._selectedReauthURLType = State(initialValue: availableReauthURLTypes.first ?? .external)
         self.retryAction = retryAction
         self.settingsAction = settingsAction
         self.errorDetailsAction = errorDetailsAction
@@ -59,263 +50,42 @@ struct WebViewEmptyStateView: View {
     }
 
     var body: some View {
-        content
-            .safeAreaInset(edge: .top, content: {
-                header
-            })
-            .safeAreaInset(edge: .bottom, content: {
-                actionButtons
-            })
-            .alert(L10n.errorLabel, isPresented: .init(
-                get: { errorMessage != nil },
-                set: { newValue in
-                    if !newValue {
-                        errorMessage = nil
-                    }
-                }
-            )) {
-                Button(L10n.okLabel, role: .cancel) {
-                    errorMessage = nil
-                }
-            } message: {
-                Text(errorMessage ?? "")
-            }
-    }
-
-    private var header: some View {
-        HStack {
-            headerAccessory(resolvedLeadingHeaderAccessory)
-
-            Spacer()
-            serverSelection
-            Spacer()
-
-            headerAccessory(style.trailingHeaderAccessory)
-        }
-        .padding()
-    }
-
-    private var content: some View {
         VStack(spacing: DesignSystem.Spaces.three) {
-            iconView
-            VStack(spacing: DesignSystem.Spaces.one) {
-                Text(style.title)
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                bodyText
-            }
+            WebViewEmptyStateIcon(style: style)
+            WebViewEmptyStateMessage(
+                style: style,
+                server: server,
+                complementaryMessageAction: { settingsAction?() }
+            )
             Spacer()
         }
         .padding(.horizontal, DesignSystem.Spaces.three)
         .padding(.top, DesignSystem.Spaces.five)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(uiColor: .systemBackground))
-    }
-
-    private var actionButtons: some View {
-        VStack(spacing: DesignSystem.Spaces.one) {
-            styledPrimaryButton
-            reauthURLHint
-            if canShowErrorDetailsButton {
-                errorDetailsButton
-                    .buttonStyle(.secondaryButton)
-            }
-            if style.showsSecondarySettingsButton, !canShowErrorDetailsButton {
-                secondaryButton
-                    .buttonStyle(.secondaryButton)
-            }
-        }
-        .frame(maxWidth: Sizes.maxWidthForLargerScreens)
-        .padding(.horizontal, DesignSystem.Spaces.two)
-        .padding(.top)
-    }
-
-    @ViewBuilder
-    private var serverSelection: some View {
-        if style.showsServerPicker, Current.servers.all.count > 1 {
-            if Current.isCatalyst {
-                macServerSelection
-            } else {
-                ServerPickerView(server: server, onSelect: serverSelectionAction)
-                    // Using .secondarySystemBackground to visually distinguish the server selection view
-                    .background(Color(uiColor: .secondarySystemBackground))
-                    .clipShape(Capsule())
-            }
-        }
-    }
-
-    private var macServerSelection: some View {
-        Menu {
-            ForEach(Current.servers.all, id: \.identifier) { availableServer in
-                Button {
-                    selectServer(availableServer)
-                } label: {
-                    Label(
-                        availableServer.info.name,
-                        systemSymbol: availableServer.identifier == server.identifier ? .checkmark : .serverRack
-                    )
-                }
-            }
-        } label: {
-            HStack(spacing: DesignSystem.Spaces.one) {
-                Image(systemSymbol: .serverRack)
-                    .foregroundStyle(Color.haPrimary)
-
-                Text(server.info.name)
-                    .font(.callout)
-                    .lineLimit(1)
-
-                Image(systemSymbol: .chevronUpChevronDown)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, DesignSystem.Spaces.two)
-            .padding(.vertical, DesignSystem.Spaces.one)
-            .background(Color(uiColor: .secondarySystemBackground))
-            .clipShape(.capsule)
-        }
-        .buttonStyle(.plain)
-    }
-
-    @ViewBuilder
-    private func headerAccessory(_ accessory: WebViewEmptyStateStyle.HeaderAccessory) -> some View {
-        switch accessory {
-        case .none:
-            Color.clear
-                .frame(width: headerAccessorySize.width, height: headerAccessorySize.height)
-        case .settings:
-            ModalReusableButton(
-                icon: .sfSymbol(.gearshape),
-                action: {
-                    settingsAction?()
-                }
+        .safeAreaInset(edge: .top) {
+            WebViewEmptyStateHeader(
+                style: style,
+                server: server,
+                isLoading: isLoading,
+                showsServerSelection: style.showsServerPicker && Current.servers.all.count > 1,
+                showsErrorDetailsButton: canShowErrorDetailsButton,
+                settingsAction: { settingsAction?() },
+                serverSelectionAction: selectServer,
+                dismissAction: { dismissAction?() }
             )
-            .accessibilityLabel(L10n.WebView.EmptyState.openSettingsButton)
-        case .hiddenDismiss:
-            Color.clear
-                .frame(width: headerAccessorySize.width, height: headerAccessorySize.height)
-                .overlay {
-                    if isLoading {
-                        ProgressView()
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture(perform: registerDismissTap)
-                .accessibilityHidden(true)
         }
-    }
-
-    private func registerDismissTap() {
-        dismissTapCount += 1
-        guard dismissTapCount >= Self.dismissTapThreshold else { return }
-        dismissTapCount = 0
-        dismissAction?()
-    }
-
-    @ViewBuilder
-    private var iconView: some View {
-        switch style {
-        case .disconnected, .inFlight, .unauthenticated:
-            Image(.logo)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 80, height: 80)
-        case .recoveredServerNeedingReauthentication:
-            Image(systemSymbol: .key)
-                .font(.system(size: 56))
-                .foregroundStyle(Color.haPrimary)
-        }
-    }
-
-    @ViewBuilder
-    private var bodyText: some View {
-        switch style {
-        case .disconnected, .inFlight, .unauthenticated:
-            Text(style.body)
-                .font(.callout)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DesignSystem.Spaces.two)
-        case .recoveredServerNeedingReauthentication:
-            Text(L10n.Onboarding.ServerImport.Reauthenticate.message(server.info.name))
-                .font(.callout)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DesignSystem.Spaces.two)
-        }
-    }
-
-    /// Re-authentication is on the user, not on the app retrying, so it gets the warning-colored button
-    /// (the frontend's `ha-button variant="warning"`) to read as "action required".
-    @ViewBuilder
-    private var styledPrimaryButton: some View {
-        if style.primaryActionRequiresAttention {
-            primaryButton
-                .buttonStyle(.warningButton)
-        } else {
-            primaryButton
-                .buttonStyle(.primaryButton)
-        }
-    }
-
-    private var primaryButton: some View {
-        Button(action: {
-            switch style {
-            case .disconnected, .inFlight:
-                retryAction?()
-            case .unauthenticated:
-                reauthAction?(selectedReauthURLType)
-            case .recoveredServerNeedingReauthentication:
-                beginRecoveredServerReauthentication()
-            }
-        }) {
-            if style == .recoveredServerNeedingReauthentication, isPerformingPrimaryAction {
-                ProgressView()
-                    .tint(.white)
-                    .frame(maxWidth: .infinity)
-            } else {
-                Text(style.primaryButtonTitle)
-            }
-        }
-        .disabled(style == .recoveredServerNeedingReauthentication && isPerformingPrimaryAction)
-    }
-
-    @ViewBuilder
-    private var reauthURLHint: some View {
-        if style == .unauthenticated || style == .recoveredServerNeedingReauthentication,
-           availableReauthURLTypes.count > 1 {
-            Button {
-                showURLPicker = true
-            } label: {
-                HStack(spacing: 4) {
-                    Text(selectedReauthURLType.description)
-                    Image(systemSymbol: .chevronUpChevronDown)
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-            .confirmationDialog(
-                style.urlPickerTitle,
-                isPresented: $showURLPicker,
-                titleVisibility: .visible
-            ) {
-                ForEach(availableReauthURLTypes, id: \.self) { urlType in
-                    Button(urlType.description) {
-                        selectedReauthURLType = urlType
-                    }
-                }
-            }
-        }
-    }
-
-    private var secondaryButton: some View {
-        Button(action: {
-            switch style {
-            case .disconnected, .inFlight, .unauthenticated, .recoveredServerNeedingReauthentication:
-                settingsAction?()
-            }
-        }) {
-            Text(style.secondaryButtonTitle)
+        .safeAreaInset(edge: .bottom) {
+            WebViewEmptyStateActionButtons(
+                style: style,
+                availableReauthURLTypes: availableReauthURLTypes,
+                showsErrorDetailsButton: canShowErrorDetailsButton,
+                retryAction: { retryAction?() },
+                settingsAction: { settingsAction?() },
+                errorDetailsAction: { errorDetailsAction?() },
+                reauthAction: { reauthAction?($0) },
+                recoveredServerReauthAction: recoveredServerReauthAction
+            )
         }
     }
 
@@ -329,41 +99,6 @@ struct WebViewEmptyStateView: View {
         } else {
             Current.sceneManager.appCoordinator.done { coordinator in
                 coordinator.activate(server: server)
-            }
-        }
-    }
-
-    private var resolvedLeadingHeaderAccessory: WebViewEmptyStateStyle.HeaderAccessory {
-        if style.showsSecondarySettingsButton, canShowErrorDetailsButton {
-            .settings
-        } else {
-            style.leadingHeaderAccessory
-        }
-    }
-
-    private var errorDetailsButton: some View {
-        Button(action: {
-            errorDetailsAction?()
-        }) {
-            Text(L10n.ConnectionError.MoreDetailsSection.title)
-        }
-    }
-
-    private func beginRecoveredServerReauthentication() {
-        guard !isPerformingPrimaryAction else { return }
-        guard let recoveredServerReauthAction else { return }
-        isPerformingPrimaryAction = true
-        errorMessage = nil
-
-        recoveredServerReauthAction(selectedReauthURLType) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success:
-                    break
-                case let .failure(error):
-                    isPerformingPrimaryAction = false
-                    errorMessage = error.localizedDescription
-                }
             }
         }
     }

--- a/Sources/App/Frontend/WebView/WebFrontendOverlayState.swift
+++ b/Sources/App/Frontend/WebView/WebFrontendOverlayState.swift
@@ -23,8 +23,9 @@ final class WebFrontendOverlayState: ObservableObject {
     /// Catalyst (where the native status-bar view handles it).
     @Published var statusBarColor: UIColor?
 
-    /// Data + actions to render `WebViewEmptyStateView` as a SwiftUI overlay. Built by `WebViewController`,
-    /// which owns the connection state and the actions (retry / settings / error details / re-auth).
+    /// Data + actions to render the empty state as a SwiftUI overlay in `HomeAssistantStandByView`. Built by
+    /// `WebViewController`, which owns the connection state and the actions (retry / settings / error
+    /// details / re-auth).
     struct EmptyStateContent {
         let style: WebViewEmptyStateStyle
         let server: Server


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The connection/re-authentication empty state was written twice. `HomeAssistantStandByView` renders it in the web view, `WebViewEmptyStateView` in the recovered-server re-authentication screen, so changing one copy left the other untouched.

Both screens now render the same views:

- `WebViewEmptyStateIcon`
- `WebViewEmptyStateMessage`
- `WebViewEmptyStateHeader`
- `WebViewEmptyStateActionButtons`

The stand-by view keeps its loader (animated logo, server pill, delayed settings and clean cache buttons) and the re-authentication screen keeps its progress and error handling.

## Screenshots

No visual change, both screens render what they rendered before.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Based on #5437, so the warning-colored re-authenticate button from that PR now comes from the shared action buttons instead of being written in both views.
