### PR TITLE
Don't switch server by location when opening from a deep link

### DIFF
--- a/Sources/App/HAApp.swift
+++ b/Sources/App/HAApp.swift
@@ -60,11 +60,17 @@ struct HAApp: App {
     /// Routes deep links (`homeassistant://…`) and universal / NFC web links into `IncomingURLHandler` once
     /// the app coordinator is available — replacing the deleted `WebViewSceneDelegate`'s
     /// `scene(_:openURLContexts:)` / `scene(_:continue:)` under the SwiftUI lifecycle.
+    @MainActor
     private func handleIncoming(url: URL) {
+        // Synchronously, before waiting on the coordinator: the link names where to land, so
+        // location-based home switching must not fire for the activation it is opening.
+        LocationBasedServerSwitcher.shared.deepLinkWillOpen()
         Current.sceneManager.appCoordinator.done { IncomingURLHandler(coordinator: $0).handle(url: url) }
     }
 
+    @MainActor
     private func handleIncoming(userActivity: NSUserActivity) {
+        LocationBasedServerSwitcher.shared.deepLinkWillOpen()
         Current.sceneManager.appCoordinator.done {
             IncomingURLHandler(coordinator: $0).handle(userActivity: userActivity)
         }

--- a/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
+++ b/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
@@ -30,10 +30,14 @@ final class LocationBasedServerSwitcher {
     /// user who manually switched away stays put until they leave the home, come back to the app
     /// after `matchMemoryLifetime` in the background, or relaunch it.
     private var lastMatchedServerIdentifier: Identifier<Server>?
-    /// Set while a deep link is opening the app: the link picked the destination, so the evaluation
-    /// this activation would run is skipped. Cleared when the app next goes to the background, so a
-    /// link handled while already active never suppresses a later return from the background.
+    /// Set while a deep link is opening the app: the link picked the destination, so the activation
+    /// it is bringing on skips its evaluation. Only ever set with an activation still ahead, so it
+    /// is consumed by that activation rather than lingering into a later one.
     private var skipNextEvaluation = false
+
+    /// The app's activation state, telling a link that is opening the app from one handled while it
+    /// is already up. Replaceable in tests.
+    var applicationStateGetter: () -> UIApplication.State = { UIApplication.shared.applicationState }
 
     /// Whether an evaluation is in flight. Non-private for tests.
     var isEvaluating: Bool { evaluationTask != nil }
@@ -56,6 +60,7 @@ final class LocationBasedServerSwitcher {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.enteredBackgroundDate = Date()
+                // Backstop: the app is down, so no activation is pending to consume a skip.
                 self?.skipNextEvaluation = false
             }
         }
@@ -71,9 +76,12 @@ final class LocationBasedServerSwitcher {
         // `locationTimeout` for a fix — so drop its result rather than let it switch on top.
         evaluationTask?.cancel()
         evaluationTask = nil
-        // On a cold launch the link arrives before the activation notification, so also skip the
-        // evaluation that activation is about to start.
-        skipNextEvaluation = true
+        // Only a link that is opening the app still has an activation ahead of it, and on that
+        // ordering (cold launch) the link lands before `didBecomeActive`, so the evaluation it is
+        // about to start has to be skipped too. Once the app is active that notification has been
+        // and gone — cancelling above is then the whole job, and a flag left set here would swallow
+        // the next, unrelated activation instead.
+        skipNextEvaluation = applicationStateGetter() != .active
     }
 
     func evaluate() {

--- a/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
+++ b/Sources/App/ServerSwitching/LocationBasedServerSwitcher.swift
@@ -11,7 +11,8 @@ import UIKit
 /// only, one check per activation, no background monitoring. A match is applied once per visit, so
 /// manually switching away isn't undone by quick app switches. The manual choice expires after the
 /// app stays in the background for a while (or is relaunched), so reopening later lands on the
-/// server for the home the user is at.
+/// server for the home the user is at. A deep link opening the app names its own destination, so
+/// switching stands down for that activation — see `deepLinkWillOpen()`.
 @MainActor
 final class LocationBasedServerSwitcher {
     static let shared = LocationBasedServerSwitcher()
@@ -29,6 +30,13 @@ final class LocationBasedServerSwitcher {
     /// user who manually switched away stays put until they leave the home, come back to the app
     /// after `matchMemoryLifetime` in the background, or relaunch it.
     private var lastMatchedServerIdentifier: Identifier<Server>?
+    /// Set while a deep link is opening the app: the link picked the destination, so the evaluation
+    /// this activation would run is skipped. Cleared when the app next goes to the background, so a
+    /// link handled while already active never suppresses a later return from the background.
+    private var skipNextEvaluation = false
+
+    /// Whether an evaluation is in flight. Non-private for tests.
+    var isEvaluating: Bool { evaluationTask != nil }
 
     func start() {
         guard didBecomeActiveObserver == nil else { return }
@@ -48,11 +56,31 @@ final class LocationBasedServerSwitcher {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.enteredBackgroundDate = Date()
+                self?.skipNextEvaluation = false
             }
         }
     }
 
+    /// Stands switching down for the activation a deep link is opening. Deep links (`homeassistant://`
+    /// URLs, universal links, NFC tags, widget and App Intent taps) carry their own destination —
+    /// often an explicit server — and location-based switching landing afterwards would replace what
+    /// the link asked for. Call this synchronously as the link arrives, before the work that resolves
+    /// its destination, so it lands whichever side of `didBecomeActive` the link is delivered on.
+    func deepLinkWillOpen() {
+        // An evaluation already running would finish after the link opens — it waits up to
+        // `locationTimeout` for a fix — so drop its result rather than let it switch on top.
+        evaluationTask?.cancel()
+        evaluationTask = nil
+        // On a cold launch the link arrives before the activation notification, so also skip the
+        // evaluation that activation is about to start.
+        skipNextEvaluation = true
+    }
+
     func evaluate() {
+        guard !skipNextEvaluation else {
+            skipNextEvaluation = false
+            return
+        }
         guard Current.settingsStore.locationBasedServerSwitching,
               // Kiosk mode pins the app to its configured server.
               !Current.kioskSettings.enabled,
@@ -69,6 +97,7 @@ final class LocationBasedServerSwitcher {
         evaluationTask = Task { [weak self] in
             // The Wi-Fi check works even without a location fix (and resolves faster than one).
             let ssid = await Current.connectivity.currentWiFiSSID()
+            guard !Task.isCancelled else { return }
 
             var location: CLLocation?
             let authorizationStatus = CLLocationManager().authorizationStatus
@@ -79,7 +108,9 @@ final class LocationBasedServerSwitcher {
                         .catch { _ in continuation.resume(returning: nil) }
                 }
             }
-            guard let self else { return }
+            // A cancelled task leaves `evaluationTask` alone: whoever cancelled it already cleared
+            // the slot, and a later activation may have started a new evaluation in it.
+            guard let self, !Task.isCancelled else { return }
             evaluationTask = nil
             guard ssid != nil || location != nil else { return }
             apply(location: location, currentSSID: ssid)

--- a/Tests/App/ServerSwitching/LocationBasedServerSwitcher.test.swift
+++ b/Tests/App/ServerSwitching/LocationBasedServerSwitcher.test.swift
@@ -3,6 +3,7 @@ import Foundation
 import GRDB
 @testable import HomeAssistant
 @testable import Shared
+import UIKit
 import XCTest
 
 final class LocationBasedServerSwitcherTests: XCTestCase {
@@ -277,17 +278,31 @@ final class LocationBasedServerSwitcherTests: XCTestCase {
     }
 
     @MainActor
-    func testDeepLinkSkipsTheEvaluationForThatActivation() {
+    private func makeSwitcher(applicationState: UIApplication.State) -> LocationBasedServerSwitcher {
+        let switcher = LocationBasedServerSwitcher()
+        switcher.applicationStateGetter = { applicationState }
+        return switcher
+    }
+
+    @MainActor
+    func testDeepLinkSkipsTheEvaluationOfTheActivationItOpens() {
         let previousSetting = Current.settingsStore.locationBasedServerSwitching
         defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
         Current.settingsStore.locationBasedServerSwitching = true
 
-        let switcher = LocationBasedServerSwitcher()
-        // The link arrives before the activation that it triggered (cold launch ordering).
+        // Cold launch ordering: the link lands while the app is still coming up, before the
+        // activation it triggered.
+        let switcher = makeSwitcher(applicationState: .background)
         switcher.deepLinkWillOpen()
         switcher.evaluate()
 
         XCTAssertFalse(switcher.isEvaluating)
+
+        // The activation after that one is an ordinary return to the app, so switching runs again.
+        switcher.evaluate()
+        XCTAssertTrue(switcher.isEvaluating)
+        // Leave no evaluation running past the test.
+        switcher.deepLinkWillOpen()
     }
 
     @MainActor
@@ -296,30 +311,18 @@ final class LocationBasedServerSwitcherTests: XCTestCase {
         defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
         Current.settingsStore.locationBasedServerSwitching = true
 
-        let switcher = LocationBasedServerSwitcher()
         // The activation lands first and the link follows while the location fix is still pending.
+        let switcher = makeSwitcher(applicationState: .active)
         switcher.evaluate()
         XCTAssertTrue(switcher.isEvaluating)
 
         switcher.deepLinkWillOpen()
-
         XCTAssertFalse(switcher.isEvaluating)
-    }
 
-    @MainActor
-    func testSuppressionAppliesOnlyToTheDeepLinkedActivation() {
-        let previousSetting = Current.settingsStore.locationBasedServerSwitching
-        defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
-        Current.settingsStore.locationBasedServerSwitching = true
-
-        let switcher = LocationBasedServerSwitcher()
-        switcher.deepLinkWillOpen()
-        switcher.evaluate()
-
-        // The next activation is an ordinary return to the app, so switching runs again.
+        // This activation's evaluation is already spent, so nothing is left to skip: the next
+        // return to the app must evaluate rather than inherit the link's suppression.
         switcher.evaluate()
         XCTAssertTrue(switcher.isEvaluating)
-        // Leave no evaluation running past the test.
         switcher.deepLinkWillOpen()
     }
 

--- a/Tests/App/ServerSwitching/LocationBasedServerSwitcher.test.swift
+++ b/Tests/App/ServerSwitching/LocationBasedServerSwitcher.test.swift
@@ -276,6 +276,53 @@ final class LocationBasedServerSwitcherTests: XCTestCase {
         XCTAssertEqual(closest.server.identifier, server1.identifier)
     }
 
+    @MainActor
+    func testDeepLinkSkipsTheEvaluationForThatActivation() {
+        let previousSetting = Current.settingsStore.locationBasedServerSwitching
+        defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
+        Current.settingsStore.locationBasedServerSwitching = true
+
+        let switcher = LocationBasedServerSwitcher()
+        // The link arrives before the activation that it triggered (cold launch ordering).
+        switcher.deepLinkWillOpen()
+        switcher.evaluate()
+
+        XCTAssertFalse(switcher.isEvaluating)
+    }
+
+    @MainActor
+    func testDeepLinkCancelsAnEvaluationAlreadyInFlight() {
+        let previousSetting = Current.settingsStore.locationBasedServerSwitching
+        defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
+        Current.settingsStore.locationBasedServerSwitching = true
+
+        let switcher = LocationBasedServerSwitcher()
+        // The activation lands first and the link follows while the location fix is still pending.
+        switcher.evaluate()
+        XCTAssertTrue(switcher.isEvaluating)
+
+        switcher.deepLinkWillOpen()
+
+        XCTAssertFalse(switcher.isEvaluating)
+    }
+
+    @MainActor
+    func testSuppressionAppliesOnlyToTheDeepLinkedActivation() {
+        let previousSetting = Current.settingsStore.locationBasedServerSwitching
+        defer { Current.settingsStore.locationBasedServerSwitching = previousSetting }
+        Current.settingsStore.locationBasedServerSwitching = true
+
+        let switcher = LocationBasedServerSwitcher()
+        switcher.deepLinkWillOpen()
+        switcher.evaluate()
+
+        // The next activation is an ordinary return to the app, so switching runs again.
+        switcher.evaluate()
+        XCTAssertTrue(switcher.isEvaluating)
+        // Leave no evaluation running past the test.
+        switcher.deepLinkWillOpen()
+    }
+
     func testClosestServerIsNilWithoutZonesOrNetworkMatch() {
         XCTAssertNil(LocationBasedServerSwitcher.closestServer(
             to: location(at: home1),


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Opening the app through a deep link could land on the wrong server. The link opens its destination right away, while location-based server switching runs on every `didBecomeActive` and waits up to 5s for a location fix — so the switch applied afterwards, replacing the server the link asked for.

Deep links now stand switching down for the activation they open: an evaluation already in flight is cancelled, and the one the activation is about to start is skipped. That covers the URL arriving either before or after `didBecomeActive`. Only an activation that is still ahead gets skipped, so a normal return to the app still switches as before.

## Screenshots

N/A, no UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes

Notification taps and home screen quick actions open destinations the same way but go through different entry points, so they are not covered here.
