### PR TITLE
Keep the server registered when logging out

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */; };
 		42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */; };
 		42F1C0133140B00011AABB13 /* TokenManagerAccessTokenRejection.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */; };
+		42F1C0153140B00011AABB15 /* TokenManagerRevocation.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0163140B00011AABB16 /* TokenManagerRevocation.test.swift */; };
 		42F1C0323140B00011AACC02 /* ConnectivityWrapper.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */; };
 		42F384052FB49C9500390AFC /* DebugSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 42F384042FB49C9500390AFC /* DebugSwift */; };
 		42FA000000000000000C0002 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 42FA000000000000000C0001 /* WebRTC */; };
@@ -645,6 +646,7 @@
 		42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAssistantAPIIdentity.test.swift; sourceTree = "<group>"; };
 		42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAPITokenFetchFailure.test.swift; sourceTree = "<group>"; };
 		42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerAccessTokenRejection.test.swift; sourceTree = "<group>"; };
+		42F1C0163140B00011AABB16 /* TokenManagerRevocation.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerRevocation.test.swift; sourceTree = "<group>"; };
 		42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityWrapper.test.swift; sourceTree = "<group>"; };
 		42F1DA732B4FF9F8002729BC /* MaterialDesignIcons+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MaterialDesignIcons+CarPlay.swift"; sourceTree = "<group>"; };
 		42FF5E962E22E5C100BDF5EF /* TodoListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListItem.swift; sourceTree = "<group>"; };
@@ -2667,6 +2669,7 @@
 				42F1C0023140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift */,
 				42F1C0123140B00011AABB12 /* HAAPITokenFetchFailure.test.swift */,
 				42F1C0143140B00011AABB14 /* TokenManagerAccessTokenRejection.test.swift */,
+				42F1C0163140B00011AABB16 /* TokenManagerRevocation.test.swift */,
 				11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */,
 				42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */,
 				480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */,
@@ -4134,6 +4137,7 @@
 				42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */,
 				42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */,
 				42F1C0133140B00011AABB13 /* TokenManagerAccessTokenRejection.test.swift in Sources */,
+				42F1C0153140B00011AABB15 /* TokenManagerRevocation.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,
 				110AA57B25B38C02005061A0 /* ServerAlerter.test.swift in Sources */,
 				1133F5F625F1DBF000AD776F /* CLLocation+Sanitize.test.swift in Sources */,

--- a/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
@@ -125,6 +125,10 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     /// Revokes the current authentication token and informs the web view via a JavaScript callback.
+    ///
+    /// The server itself stays registered: logging out only invalidates the credentials, so the user is
+    /// asked to log in again instead of losing the server and everything configured against it
+    /// (widgets, watch and CarPlay items, sensors, notification registration).
     private func handleRevokeExternalAuth(_ messageBody: [String: Any]) {
         guard let callbackName = messageBody["callback"], let server = webView?.server else { return }
 
@@ -134,24 +138,42 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
             Current.api(for: server)?.tokenManager
                 .revokeToken() ?? .init(error: HomeAssistantAPI.APIError.noAPIAvailable)
         }.done { [weak self, server] _ in
-            Current.servers.remove(identifier: server.identifier)
-            Current.resetAPICache(for: [server.identifier])
             let script = "\(callbackName)(true)"
 
             Current.Log.verbose("Running revoke external auth callback \(script)")
 
             self?.webView?.evaluateJavaScript(script) { _, error in
-                Current.onboardingObservation.needed(.logout)
-
                 if let error {
                     Current.Log.error("Failed calling sign out callback: \(error)")
                 }
 
                 Current.Log.verbose("Successfully informed web client of log out.")
+                self?.requireLogin(for: server)
             }
         }.catch { error in
             Current.Log.error("Failed to revoke token: \(error)")
         }
+    }
+
+    /// Drops the connection the revoked token was driving and surfaces the logged-out state. The
+    /// tokens are dead from the revocation on, so they are marked as such: without that, the app and
+    /// the frontend keep re-sending them, which Home Assistant logs as invalid auth and eventually
+    /// answers with an IP ban.
+    ///
+    /// The model manager is deliberately left subscribed. Its subscriptions are established once at
+    /// launch and never re-established, and they cover every server, so unsubscribing here would kill
+    /// model syncing app-wide until the next launch — for the other servers immediately, and for this
+    /// one even after a successful log in. Disconnecting is enough: HAKit restores the subscriptions
+    /// when re-authentication reconnects.
+    private func requireLogin(for server: Server) {
+        // The web view is put into the logged-out state first: invalidating the token writes to the
+        // server, and the observers watching it re-evaluate which URL should be loaded. They have to
+        // find the log out already recorded, or they navigate straight back into the server.
+        webView?.showLoggedOutState()
+
+        let api = Current.api(for: server)
+        api?.tokenManager.handleTokenRevoked()
+        api?.connection.disconnect()
     }
 
     private func handleLogError(_ messageBody: [String: Any]) {

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateActionButtons.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateActionButtons.swift
@@ -138,7 +138,8 @@ struct WebViewEmptyStateActionButtons: View {
     }
 
     private var showsReauthURLPicker: Bool {
-        guard style == .unauthenticated || style == .recoveredServerNeedingReauthentication else { return false }
+        guard style == .unauthenticated || style == .loggedOut
+            || style == .recoveredServerNeedingReauthentication else { return false }
         return availableReauthURLTypes.count > 1
     }
 
@@ -146,7 +147,7 @@ struct WebViewEmptyStateActionButtons: View {
         switch style {
         case .disconnected, .inFlight:
             retryAction()
-        case .unauthenticated:
+        case .unauthenticated, .loggedOut:
             reauthAction(selectedReauthURLType)
         case .recoveredServerNeedingReauthentication:
             if recoveredServerReauthAction == nil {

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateMessage.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateMessage.swift
@@ -33,7 +33,7 @@ struct WebViewEmptyStateMessage: View {
 
     private var bodyText: String {
         switch style {
-        case .disconnected, .inFlight, .unauthenticated:
+        case .disconnected, .inFlight, .unauthenticated, .loggedOut:
             style.body
         case .recoveredServerNeedingReauthentication:
             L10n.Onboarding.ServerImport.Reauthenticate.message(server.info.name)

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateStyle.swift
@@ -6,6 +6,9 @@ enum WebViewEmptyStateStyle: Equatable {
     /// actions as `.disconnected`, with a friendlier header and greeting.
     case inFlight
     case unauthenticated
+    /// The user signed out from the frontend. Same recovery action as `.unauthenticated`, with copy
+    /// that reads as a deliberate log out rather than an expired session.
+    case loggedOut
     case recoveredServerNeedingReauthentication
 
     enum HeaderAccessory {
@@ -22,6 +25,8 @@ enum WebViewEmptyStateStyle: Equatable {
             L10n.FlightGreetings.EmptyState.title
         case .unauthenticated:
             L10n.Unauthenticated.Message.title
+        case .loggedOut:
+            L10n.WebView.EmptyState.LoggedOut.title
         case .recoveredServerNeedingReauthentication:
             L10n.Onboarding.ServerImport.Reauthenticate.title
         }
@@ -35,6 +40,8 @@ enum WebViewEmptyStateStyle: Equatable {
             L10n.FlightGreetings.EmptyState.body
         case .unauthenticated:
             L10n.Unauthenticated.Message.body
+        case .loggedOut:
+            L10n.WebView.EmptyState.LoggedOut.body
         case .recoveredServerNeedingReauthentication:
             ""
         }
@@ -55,6 +62,8 @@ enum WebViewEmptyStateStyle: Equatable {
             L10n.WebView.EmptyState.retryButton
         case .unauthenticated:
             L10n.WebView.EmptyState.reauthenticateButton
+        case .loggedOut:
+            L10n.WebView.EmptyState.LoggedOut.loginButton
         case .recoveredServerNeedingReauthentication:
             L10n.Onboarding.ServerImport.Reauthenticate.continueButton
         }
@@ -62,7 +71,7 @@ enum WebViewEmptyStateStyle: Equatable {
 
     var secondaryButtonTitle: String {
         switch self {
-        case .disconnected, .inFlight, .unauthenticated, .recoveredServerNeedingReauthentication:
+        case .disconnected, .inFlight, .unauthenticated, .loggedOut, .recoveredServerNeedingReauthentication:
             L10n.WebView.EmptyState.openSettingsButton
         }
     }
@@ -71,7 +80,7 @@ enum WebViewEmptyStateStyle: Equatable {
         switch self {
         case .disconnected, .inFlight:
             .none
-        case .unauthenticated:
+        case .unauthenticated, .loggedOut:
             .settings
         case .recoveredServerNeedingReauthentication:
             .none
@@ -82,7 +91,7 @@ enum WebViewEmptyStateStyle: Equatable {
         switch self {
         case .disconnected, .inFlight:
             .hiddenDismiss
-        case .unauthenticated:
+        case .unauthenticated, .loggedOut:
             .none
         case .recoveredServerNeedingReauthentication:
             .settings
@@ -93,7 +102,7 @@ enum WebViewEmptyStateStyle: Equatable {
         switch self {
         case .disconnected, .inFlight:
             true
-        case .unauthenticated, .recoveredServerNeedingReauthentication:
+        case .unauthenticated, .loggedOut, .recoveredServerNeedingReauthentication:
             false
         }
     }
@@ -104,14 +113,14 @@ enum WebViewEmptyStateStyle: Equatable {
         switch self {
         case .disconnected, .inFlight:
             false
-        case .unauthenticated, .recoveredServerNeedingReauthentication:
+        case .unauthenticated, .loggedOut, .recoveredServerNeedingReauthentication:
             true
         }
     }
 
     var showsServerPicker: Bool {
         switch self {
-        case .disconnected, .inFlight, .unauthenticated, .recoveredServerNeedingReauthentication:
+        case .disconnected, .inFlight, .unauthenticated, .loggedOut, .recoveredServerNeedingReauthentication:
             true
         }
     }
@@ -120,6 +129,8 @@ enum WebViewEmptyStateStyle: Equatable {
         switch self {
         case .disconnected, .inFlight, .unauthenticated:
             L10n.WebView.EmptyState.reauthenticateButton
+        case .loggedOut:
+            L10n.WebView.EmptyState.LoggedOut.loginButton
         case .recoveredServerNeedingReauthentication:
             L10n.Onboarding.ServerImport.Reauthenticate.urlPickerTitle
         }

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateView.swift
@@ -136,6 +136,14 @@ struct WebViewEmptyStateView: View {
     )
 }
 
+#Preview("Logged Out") {
+    WebViewEmptyStatePreview.view(
+        style: .loggedOut,
+        availableReauthURLTypes: [.external],
+        reauthAction: { _ in }
+    )
+}
+
 #Preview("Recovered Server Reauthentication") {
     WebViewEmptyStatePreview.view(
         style: .recoveredServerNeedingReauthentication,

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
@@ -7,11 +7,16 @@ import UIKit
 
 extension WebViewController {
     func emptyStateStyle(for connectionState: FrontEndConnectionState) -> WebViewEmptyStateStyle {
+        // A deliberate log out lands in the same authentication-less state as a revoked token, so it is
+        // resolved first: the copy has to read as "log back in", not "your session expired".
+        if didLogOut {
+            return .loggedOut
+        }
         switch connectionState {
         case .authInvalid:
-            .unauthenticated
+            return .unauthenticated
         case .connected, .loaded, .disconnected, .unknown:
-            .disconnected
+            return .disconnected
         }
     }
 

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
@@ -17,6 +17,19 @@ extension WebViewController: OnboardingStateObserver {
 }
 
 extension WebViewController {
+    /// Puts the web view into the logged-out state after the user signed out from the frontend. The
+    /// server stays registered — only its credentials are gone — so the way back in is logging in
+    /// again, the same flow a revoked token goes through.
+    func showLoggedOutState() {
+        Current.Log.info("User logged out of server \(server.identifier.rawValue), asking to log in again")
+
+        didLogOut = true
+        connectionState = .authInvalid
+        overlayState?.connectionState = .authInvalid
+        load(request: URLRequest(url: URL(string: "about:blank")!))
+        showEmptyState()
+    }
+
     func performReauthentication(using urlType: ConnectionInfo.URLType) {
         let connectionInfo = server.info.connection
 
@@ -87,6 +100,7 @@ extension WebViewController {
             }
         }
 
+        didLogOut = false
         connectionState = .unknown
 
         if let api = Current.api(for: server) {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+ReAuth.swift
@@ -24,6 +24,9 @@ extension WebViewController {
         Current.Log.info("User logged out of server \(server.identifier.rawValue), asking to log in again")
 
         didLogOut = true
+        // The flag only stops attempts that have yet to start; one already running would still
+        // navigate into the server when it resolves the URL it was awaiting.
+        cancelActiveURLLoading()
         connectionState = .authInvalid
         overlayState?.connectionState = .authInvalid
         load(request: URLRequest(url: URL(string: "about:blank")!))

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -67,6 +67,15 @@ extension WebViewController {
     static let loadActiveURLStaleInterval: TimeInterval = 10
 
     @objc func loadActiveURLIfNeeded() {
+        // After a log out the web view deliberately sits on a blank page behind the logged-out empty
+        // state, which every caller here would read as "wrong URL loaded" and correct by navigating
+        // back into the server -- taking the empty state down and re-authenticating the frontend with
+        // the token the user just revoked. Re-authenticating clears the flag and loads the URL again.
+        guard !didLogOut else {
+            Current.Log.info("not loading, logged out of \(server.identifier.rawValue)")
+            return
+        }
+
         // Checked before the stale handling below so a hung attempt is only ever replaced while
         // active, when the fallback load and the fresh attempt can both actually run.
         guard !isAppInBackground() else {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+URLLoading.swift
@@ -90,7 +90,22 @@ extension WebViewController {
         }
     }
 
+    /// Stops an active-URL attempt that is already running. `performLoadActiveURL()` re-checks
+    /// cancellation after every await, so a cancelled attempt cannot navigate once it wakes up.
+    func cancelActiveURLLoading() {
+        loadActiveURLTask?.cancel()
+        loadActiveURLTask = nil
+        loadActiveURLTaskStartDate = nil
+    }
+
     private func continueLoadingActiveURLIfNeeded() {
+        // Re-checked because the cache-clean check above is asynchronous: a log out landing while it
+        // was in flight would otherwise navigate back into the server from this completion.
+        guard !didLogOut else {
+            Current.Log.info("not loading, logged out of \(server.identifier.rawValue)")
+            return
+        }
+
         guard !isAppInBackground() else {
             Current.Log.info("not loading, in background")
             return

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController.swift
@@ -41,6 +41,10 @@ final class WebViewController: UIViewController, WKNavigationDelegate, WKUIDeleg
 
     var connectionState: FrontEndConnectionState = .unknown
 
+    /// Set when the user signed out from the frontend. The server stays registered, so the empty state
+    /// asks for a log in rather than reporting an expired session, until re-authentication succeeds.
+    var didLogOut = false
+
     /// Set by `FrontendView`; lets connection/URL state drive SwiftUI overlays in `HomeAssistantView`
     /// instead of UIKit modals presented from here.
     var overlayState: WebFrontendOverlayState?

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewControllerProtocol.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewControllerProtocol.swift
@@ -17,6 +17,7 @@ protocol WebViewControllerProtocol: AnyObject {
     func dismissControllerAboveOverlayController()
     func updateFrontendConnectionState(state: String)
     func handleExternalAuthFailure(error: Error)
+    func showLoggedOutState()
     func navigateToPath(path: String)
     func showBanner(request: BannerRequest)
     func hideBanner(id: String)

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2470,6 +2470,9 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "web_view.add_to.option.Widget.title" = "Widget";
 "web_view.empty_state.body" = "Please check your connection or try again later. If Home Assistant is restarting it will reconnect after it is back online.";
 "web_view.empty_state.clean_cache_and_reload_button" = "Clean cache and reload";
+"web_view.empty_state.logged_out.body" = "You have been signed out of this server. Log in again to continue using it on this device.";
+"web_view.empty_state.logged_out.login_button" = "Log in";
+"web_view.empty_state.logged_out.title" = "You're logged out";
 "web_view.empty_state.open_settings_button" = "Open App settings";
 "web_view.empty_state.reauthenticate_button" = "Re-authenticate";
 "web_view.empty_state.retry_button" = "Retry";

--- a/Sources/HANetworking/Sources/TokenManager.swift
+++ b/Sources/HANetworking/Sources/TokenManager.swift
@@ -81,6 +81,22 @@ public final class TokenManager: @unchecked Sendable {
         authenticationAPI.revokeToken(tokenInfo: server.info.token)
     }
 
+    /// Call after `revokeToken()` succeeded (the user logged out). Home Assistant drops the refresh
+    /// token and with it every access token minted from it, so both are dead from that moment on;
+    /// remembering the rejection keeps the app from re-sending them while the user logs back in, which
+    /// the server would log as invalid auth and eventually answer with an IP ban.
+    ///
+    /// The expiration is pushed into the past on the same best-effort terms as
+    /// `handleAccessTokenRejected`, so the invalidation outlives this process where it can be written.
+    /// The token strings themselves stay put: clearing them is what `mirrorPlaceholderToken` is, which
+    /// would make the server look like one restored from the keychain mirror.
+    public func handleTokenRevoked() {
+        let revokedToken = server.info.token.accessToken
+        HANetworkingEnvironment.current.log.info("Access token \(revokedToken.hash) was revoked")
+        rejectedAccessTokens.mutate { $0.insert(revokedToken) }
+        server.update { $0.token.expiration = .distantPast }
+    }
+
     public var bearerToken: Promise<(String, Date)> {
         firstly {
             self.currentToken

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -8023,6 +8023,14 @@ public enum L10n {
       public static var retryButton: String { return L10n.tr("Localizable", "web_view.empty_state.retry_button") }
       /// You're disconnected
       public static var title: String { return L10n.tr("Localizable", "web_view.empty_state.title") }
+      public enum LoggedOut {
+        /// You have been signed out of this server. Log in again to continue using it on this device.
+        public static var body: String { return L10n.tr("Localizable", "web_view.empty_state.logged_out.body") }
+        /// Log in
+        public static var loginButton: String { return L10n.tr("Localizable", "web_view.empty_state.logged_out.login_button") }
+        /// You're logged out
+        public static var title: String { return L10n.tr("Localizable", "web_view.empty_state.logged_out.title") }
+      }
     }
     public enum NoUrlAvailable {
       /// 🔐  Due to your security choices, there's no URL that we are allowed to use. 

--- a/Tests/App/WebView/Mocks/MockWebViewController.swift
+++ b/Tests/App/WebView/Mocks/MockWebViewController.swift
@@ -37,6 +37,8 @@ final class MockWebViewController: WebViewControllerProtocol {
     var handleExternalAuthFailureCalled = false
     var lastExternalAuthFailure: Error?
     var handleExternalAuthFailureExpectation: XCTestExpectation?
+    var showLoggedOutStateCalled = false
+    var showLoggedOutStateExpectation: XCTestExpectation?
 
     init() {
         self.webViewExternalMessageHandler = MockWebViewExternalMessageHandler()
@@ -98,6 +100,11 @@ final class MockWebViewController: WebViewControllerProtocol {
         handleExternalAuthFailureCalled = true
         lastExternalAuthFailure = error
         handleExternalAuthFailureExpectation?.fulfill()
+    }
+
+    func showLoggedOutState() {
+        showLoggedOutStateCalled = true
+        showLoggedOutStateExpectation?.fulfill()
     }
 
     func updateImprovEntryView(show: Bool) {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -621,6 +621,33 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
         XCTAssertNil(sut.loadActiveURLTaskStartDate)
     }
 
+    /// The cache-clean check is asynchronous, so a log out can land between the two halves of an
+    /// attempt that already passed the guard on the way in.
+    func testLoadActiveURLDoesNothingWhenLogOutLandsDuringCacheCleanCheck() {
+        let sut = makeSUT()
+        websiteDataStoreHandler.completesFrontendAssetCacheCleanImmediately = false
+        sut.loadActiveURLIfNeeded()
+
+        sut.didLogOut = true
+        websiteDataStoreHandler.invokePendingFrontendAssetCacheCompletion(didClean: true)
+
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
+    func testShowLoggedOutStateCancelsInFlightActiveURLAttempt() {
+        let sut = makeSUT()
+        let inFlight = neverFinishingTask()
+        sut.loadActiveURLTask = inFlight
+        sut.loadActiveURLTaskStartDate = Current.date()
+
+        sut.showLoggedOutState()
+
+        XCTAssertTrue(inFlight.isCancelled)
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
     func testLoadActiveURLResumesOnceLoggedBackIn() {
         let sut = makeSUT()
         sut.didLogOut = true

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -31,6 +31,33 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(style, .disconnected)
     }
 
+    /// A deliberate log out has to read as "log back in", not as the expired session the same
+    /// authentication-less connection state means everywhere else.
+    func testEmptyStateStyleUsesLoggedOutVariantAfterLogOut() {
+        let sut = makeSUT()
+        sut.didLogOut = true
+
+        XCTAssertEqual(sut.emptyStateStyle(for: .authInvalid), .loggedOut)
+        XCTAssertEqual(sut.emptyStateStyle(for: .disconnected), .loggedOut)
+    }
+
+    /// Logging out keeps the server registered, so the way back in is the empty state asking for a
+    /// log in rather than the app switching to another server or dropping this one.
+    func testShowLoggedOutStateKeepsServerAndPublishesLoggedOutEmptyState() {
+        let server = Server.fake()
+        let sut = makeSUT(server: server)
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.showLoggedOutState()
+
+        XCTAssertTrue(sut.didLogOut)
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.emptyState?.style, .loggedOut)
+        XCTAssertEqual(overlayState.emptyState?.server.identifier, server.identifier)
+    }
+
     func testUpdateFrontendConnectionStateDoesNotDowngradeAuthInvalidToDisconnected() {
         let sut = makeSUT()
         sut.connectionState = .authInvalid
@@ -578,6 +605,33 @@ final class WebViewControllerURLLoadingTests: XCTestCase {
         XCTAssertEqual(websiteDataStoreHandler.cleanFrontendAssetCacheIfNeededCallCount, 0)
         XCTAssertNil(sut.loadActiveURLTask)
         XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
+    /// The blank page behind the logged-out empty state reads as the wrong URL, so without this the
+    /// next trigger — a settings sheet closing, the app coming back to the foreground, the token
+    /// update the log out itself writes — would navigate back into the server the user just left.
+    func testLoadActiveURLDoesNothingAfterLogOut() {
+        let sut = makeSUT()
+        sut.didLogOut = true
+
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertEqual(websiteDataStoreHandler.cleanFrontendAssetCacheIfNeededCallCount, 0)
+        XCTAssertNil(sut.loadActiveURLTask)
+        XCTAssertNil(sut.loadActiveURLTaskStartDate)
+    }
+
+    func testLoadActiveURLResumesOnceLoggedBackIn() {
+        let sut = makeSUT()
+        sut.didLogOut = true
+        sut.loadActiveURLIfNeeded()
+
+        sut.didLogOut = false
+        sut.loadActiveURLIfNeeded()
+
+        XCTAssertEqual(websiteDataStoreHandler.cleanFrontendAssetCacheIfNeededCallCount, 1)
+        XCTAssertNotNil(sut.loadActiveURLTask)
+        sut.loadActiveURLTask?.cancel()
     }
 
     func testLoadActiveURLWaitsForFrontendAssetCacheCleanCheckBeforeLoading() async {

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -46,6 +46,8 @@ final class WebViewControllerTests: XCTestCase {
     func testShowLoggedOutStateKeepsServerAndPublishesLoggedOutEmptyState() {
         let server = Server.fake()
         let sut = makeSUT(server: server)
+        // Entering the logged-out state parks the web view on a blank page, so it needs a real one.
+        sut.webView = WKWebView(frame: .zero)
         let overlayState = WebFrontendOverlayState()
         sut.overlayState = overlayState
 

--- a/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
+++ b/Tests/App/WebView/WebViewScriptMessageHandlerTests.swift
@@ -6,6 +6,8 @@ final class WebViewScriptMessageHandlerTests: XCTestCase {
     private var sut: WebViewScriptMessageHandler!
     private var mockWebViewController: MockWebViewController!
     private var mockExternalMessageHandler: MockWebViewExternalMessageHandler!
+    private var originalServers: ServerManager!
+    private var originalCachedApis: [Identifier<Server>: HomeAssistantAPI]!
 
     override func setUp() async throws {
         mockWebViewController = MockWebViewController()
@@ -13,12 +15,16 @@ final class WebViewScriptMessageHandlerTests: XCTestCase {
         mockWebViewController.webViewExternalMessageHandler = mockExternalMessageHandler
         sut = WebViewScriptMessageHandler()
         sut.webView = mockWebViewController
+        originalServers = Current.servers
+        originalCachedApis = Current.cachedApis
     }
 
     override func tearDown() async throws {
         sut = nil
         mockWebViewController = nil
         mockExternalMessageHandler = nil
+        Current.servers = originalServers
+        Current.cachedApis = originalCachedApis
     }
 
     @MainActor func testGetExternalAuthInBackgroundRejectsCallback() {
@@ -64,5 +70,39 @@ final class WebViewScriptMessageHandlerTests: XCTestCase {
 
         XCTAssertTrue(mockExternalMessageHandler.handleExternalMessageCalled)
         XCTAssertEqual(mockExternalMessageHandler.handleExternalMessageParams?["id"] as? Int, 1)
+    }
+
+    /// Logging out only invalidates the credentials: the server has to stay registered so everything
+    /// configured against it survives, with the user asked to log in again.
+    @MainActor func testRevokeExternalAuthKeepsServerAndAsksToLogInAgain() {
+        let server = givenLoggedInServer()
+
+        let calledBack = expectation(description: "sign out callback ran")
+        mockWebViewController.evaluateJavaScriptExpectation = calledBack
+        sut.isAppInBackground = { false }
+
+        sut.handle(messageName: "revokeExternalAuth", messageBody: ["callback": "window.externalBusRevoke"])
+
+        wait(for: [calledBack], timeout: 10)
+        XCTAssertEqual(mockWebViewController.lastEvaluatedJavaScriptScript, "window.externalBusRevoke(true)")
+        mockWebViewController.lastEvaluatedJavaScriptCompletion?(nil, nil)
+
+        XCTAssertEqual(Current.servers.all.map(\.identifier), [server.identifier])
+        XCTAssertNotNil(Current.api(for: server))
+        XCTAssertTrue(mockWebViewController.showLoggedOutStateCalled)
+    }
+
+    /// Points the environment at a single server the mock web view is showing. Its only URL refuses
+    /// connections immediately, so the revoke request fails fast instead of reaching the network.
+    @MainActor private func givenLoggedInServer() -> Server {
+        let servers = FakeServerManager(initial: 0)
+        let server = servers.addFake()
+        server.update { info in
+            info.connection.set(address: URL(string: "http://127.0.0.1:1")!, for: ConnectionInfo.URLType.external)
+        }
+        Current.servers = servers
+        Current.cachedApis = [server.identifier: HomeAssistantAPI(server: server)]
+        mockWebViewController.server = server
+        return server
     }
 }

--- a/Tests/Shared/TokenManagerRevocation.test.swift
+++ b/Tests/Shared/TokenManagerRevocation.test.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import Shared
+import XCTest
+
+class TokenManagerRevocationTests: XCTestCase {
+    /// Logging out revokes the refresh token, and with it every access token minted from it, so the
+    /// stored token must never be handed out again — the app would otherwise keep signing requests
+    /// with it while the user logs back in, which the server logs as invalid auth.
+    func testRevokedTokenIsNotProvidedAgain() {
+        let server = Server.fake(update: { info in
+            info.connection.set(address: nil, for: .external)
+        })
+        let tokenManager = TokenManager(server: server)
+        let revokedToken = server.info.token.accessToken
+
+        tokenManager.handleTokenRevoked()
+
+        let settled = expectation(description: "bearerToken settled")
+        tokenManager.bearerToken.done { token, _ in
+            XCTAssertNotEqual(token, revokedToken)
+            settled.fulfill()
+        }.catch { _ in
+            // Refresh failing (no reachable server in tests) is the acceptable outcome; what matters
+            // is that the revoked token was not fulfilled.
+            settled.fulfill()
+        }
+
+        wait(for: [settled], timeout: 5)
+    }
+
+    /// The expiration is pushed into the past so the invalidation reaches the processes that read the
+    /// store fresh, but the token strings stay: clearing those is what the keychain-mirror placeholder
+    /// is, and it would send the app to the recovered-server import flow at launch instead of the
+    /// logged-out state.
+    func testRevocationInvalidatesExpirationWithoutBlankingTheToken() {
+        let server = Server.fake()
+        let tokenManager = TokenManager(server: server)
+        let token = server.info.token
+
+        tokenManager.handleTokenRevoked()
+
+        XCTAssertEqual(server.info.token.accessToken, token.accessToken)
+        XCTAssertEqual(server.info.token.refreshToken, token.refreshToken)
+        XCTAssertEqual(server.info.token.expiration, .distantPast)
+        XCTAssertFalse(server.info.requiresReauthenticationAfterMirrorRestore)
+    }
+}


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Logging out removed the server from the app and dropped the user on another server, taking everything configured against the removed one with it: widgets, watch and CarPlay items, sensors and the notification registration. Only the credentials are gone on a log out, so the server now stays and the user is asked to log in again.

This is #5440, which never reached `main`: it was stacked on the branch behind #5438, and #5438 was squash-merged first, so its commit ended up on a branch `main` had already left behind.

On top of that, active-URL loading is now suspended while logged out. The web view sits on a blank page behind the empty state, which every loading trigger would otherwise read as the wrong URL and correct by navigating back into the server just left.

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
