### PR TITLE
Clear the reported Focus name once every Focus has ended

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
@@ -51,14 +51,16 @@ final class FocusNameSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
 ///
 /// The user creates the names in the app's Focus settings and pairs each one with a Focus in
 /// Settings › Focus › Focus Filters; activating that Focus runs our filter, which stores the paired
-/// name for this sensor to send.
+/// name for this sensor to send. `FocusStatusWrapper` clears that name again when the Focus status
+/// says every Focus ended, so a name only sticks around while some Focus is running.
 final class FocusNameSensor: SensorProvider {
     public enum FocusNameError: Error, Equatable {
         /// No Focus name has been created, so there is nothing this sensor could ever report.
         case unconfigured
     }
 
-    /// Reported while iOS says no Focus is running.
+    /// Reported while iOS says no Focus is running. The stored name is normally already cleared by
+    /// then; this also covers the window before that clear lands, and reads taken without one.
     static let notFocusedState = "Not focused"
     /// Reported while a Focus is running that no Focus Filter has named — either the user hasn't
     /// paired that Focus yet, or the Focus status permission is missing so we can't tell.

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -77,6 +77,14 @@ public class FocusStatusWrapper {
     public func update(fromReceived status: INFocusStatus?) {
         precondition(Current.isAppExtension)
         lastStatus = status.flatMap { Status(focusStatus: $0) }
+
+        // A Focus Filter only runs when a Focus starts, so nothing ever tells us the name it
+        // reported has gone stale. This is the moment we learn every Focus ended, so drop it here
+        // rather than leave the last name sitting in the app group.
+        if lastStatus?.isFocused == false {
+            Current.focusFilter.setActiveFocusName(nil)
+        }
+
         trigger.value = Current.date()
     }
 

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -1,4 +1,5 @@
 import GRDB
+import Intents
 import PromiseKit
 @testable import Shared
 import XCTest
@@ -22,6 +23,7 @@ class FocusNameSensorTests: XCTestCase {
         try clearFocusNames()
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
+        Current.isAppExtension = false
         try super.tearDownWithError()
     }
 
@@ -98,5 +100,43 @@ class FocusNameSensorTests: XCTestCase {
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, "Sleep")
         XCTAssertNil(sensors[0].Attributes?["Is focused"])
+    }
+
+    /// The Focus Filter only runs when a Focus starts, so a received status saying nothing is
+    /// running is the only signal that the reported name is stale.
+    func testReceivedStatusClearsTheNameWhenEveryFocusEnded() throws {
+        Current.isAppExtension = true
+        var storedName: String? = "Work"
+        Current.focusFilter.activeFocusName = { storedName }
+        Current.focusFilter.setActiveFocusName = { storedName = $0 }
+
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
+
+        XCTAssertNil(storedName)
+    }
+
+    func testReceivedStatusKeepsTheNameWhileAFocusRuns() throws {
+        Current.isAppExtension = true
+        var storedName: String? = "Work"
+        Current.focusFilter.activeFocusName = { storedName }
+        Current.focusFilter.setActiveFocusName = { storedName = $0 }
+
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: true))
+
+        XCTAssertEqual(storedName, "Work")
+    }
+
+    /// iOS sends an unknown focus state when the permission is there but it won't say; that is not
+    /// the same as "no Focus is running", so the name has to survive it.
+    func testReceivedStatusKeepsTheNameWhenFocusStateIsUnknown() throws {
+        Current.isAppExtension = true
+        var storedName: String? = "Work"
+        Current.focusFilter.activeFocusName = { storedName }
+        Current.focusFilter.setActiveFocusName = { storedName = $0 }
+
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: nil))
+        Current.focusStatus.update(fromReceived: nil)
+
+        XCTAssertEqual(storedName, "Work")
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Follow-up to #5441.

A Focus Filter only runs when a Focus starts, so the name it stored had no expiry and stayed in the app group after the Focus was over. The boolean `focus` sensor already learns that moment, so `FocusStatusWrapper` now drops the name when a received status says nothing is running.

The `focus_name` sensor still reports `Not focused` on its own, which covers the window before the clear lands and reads taken without it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
An unknown focus state, or no status at all, keeps the name: that is not the same as "no Focus is running". Covered by the three new tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_016xrC1wgcBVMYTMaMzDhMBP)_