### PR TITLE
Fix watch watchdog and suspension crashes

### DIFF
--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -30,6 +30,15 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
         Current.Log.verbose("didFinishLaunching")
 
+        // A background cold launch (background refresh, WCSession delivery) never fires
+        // `applicationDidEnterBackground`, so without this the suspension machinery stays disarmed
+        // and every database access runs unprotected — GRDB work still in flight when the process
+        // freezes was the remaining 0xdead10cc crash cluster. Arming it here routes those accesses
+        // through the expiring-activity protection; a later foreground transition resumes as usual.
+        if WKApplication.shared().applicationState == .background {
+            AppDatabaseSuspension.suspend()
+        }
+
         // Import any legacy Realm data into GRDB before anything reads it
         RealmToGRDBMigration.migrateIfNeeded()
 
@@ -340,10 +349,22 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         }
     }
 
+    /// Serial queue the pushed-mirror decompress + decode runs on: the payload is a full reference
+    /// mirror (hundreds of KB of plist), far too slow for the main queue the blob observation
+    /// arrives on — decoding there at launch was a watchdog-kill crash cluster. Serial so burst
+    /// deliveries decode in arrival order.
+    private static let pushedMirrorQueue = DispatchQueue(label: "pushed-mirror-decode", qos: .utility)
+
     /// Apply a reference database mirror the iPhone pushed proactively over `transferFile` (arrives even
     /// when the watch app was suspended). Mirrors the watch-pull apply path so the watch's cached data
     /// (entities, areas, pipelines, complications) stays fresh without the user opening the app.
     private func applyPushedDatabaseMirror(_ data: Data, metadata: HAWatchConnectivity.Content?) {
+        Self.pushedMirrorQueue.async { [weak self] in
+            self?.decodeAndApplyPushedDatabaseMirror(data, metadata: metadata)
+        }
+    }
+
+    private func decodeAndApplyPushedDatabaseMirror(_ data: Data, metadata: HAWatchConnectivity.Content?) {
         var data = data
         // Full-reference (v2) pushes travel compressed; the transfer metadata says so explicitly.
         if metadata?[WatchDatabaseMirror.compressedKey] as? Bool == true {
@@ -381,6 +402,12 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                     metadata?[WatchDatabaseMirror.digestsKey] as? [String: String],
                     carrying: mirror.carriedDigestKeys
                 )
+                // The mirror also carries the servers. Applied here, inside the protected window,
+                // for two reasons: restoring writes the Keychain mirror back through GRDB, and doing
+                // it from the main-queue completion below blocked the main thread behind the burst
+                // of mirror writes (the watch's watchdog-kill crash cluster) against a database the
+                // expired activity may already have re-suspended.
+                WatchServerSync.applyMirroredServersAndWait(mirror.servers)
                 Current.Log.info("Applied pushed watch database mirror (\(data.count) bytes)")
                 Current.clientEventStore.addEvent(.init(
                     text: "Applied pushed watch database mirror from iPhone (\(data.count) bytes)",
@@ -398,8 +425,6 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                 return false
             }
         } completion: { [weak self] in
-            // The mirror also carries the servers; keep them in step with the reference tables.
-            WatchServerSync.applyMirroredServers(mirror.servers)
             // Rebuild complication snapshots and let the home screen re-render from the fresh data.
             WatchWidgetComplicationSnapshotStore.update()
             NotificationCenter.default.post(name: WatchComplicationConfig.didChangeNotification, object: nil)

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -583,8 +583,8 @@ final class WatchHomeViewModel: ObservableObject {
         }
     }
 
-    /// Main-actor tail of a successfully applied mirror: server refresh, widget snapshots and the
-    /// follow-up config pull, all expected on the main thread (matching the pushed-mirror path).
+    /// Main-actor tail of a successfully applied mirror: kick off the server refresh (applied on
+    /// its own queue), widget snapshots and the follow-up config pull.
     @MainActor
     private func finishAppliedDatabaseSync(mirror: WatchDatabaseMirror) {
         // The sync also refreshes the servers carried by the mirror (in addition to the dedicated

--- a/Sources/WatchApp/WatchServerSync.swift
+++ b/Sources/WatchApp/WatchServerSync.swift
@@ -5,6 +5,12 @@ import Shared
 /// Home refresh button and the Settings screens. The phone replies to `serversConfigSync` with the
 /// encoded servers and any client certificate bundles inline; both are applied to the local Keychain.
 enum WatchServerSync {
+    /// Serial queue every server-state apply runs on. Restoring servers reads the Keychain and the
+    /// GRDB mirror and writes both back per server — far too slow for the main thread (the watchdog
+    /// killed the app waiting on the database queue behind burst mirror writes) — and serializing
+    /// here keeps concurrent applies from racing `restoreState`.
+    private static let applyQueue = DispatchQueue(label: "watch-server-sync-apply", qos: .utility)
+
     static func request() {
         guard Communicator.shared.currentReachability == .immediatelyReachable else {
             Current.Log.info("[Watch] Skipping server sync, iPhone not immediately reachable")
@@ -13,7 +19,7 @@ enum WatchServerSync {
         Communicator.shared.send(.init(
             identifier: InteractiveImmediateMessages.serversConfigSync.rawValue,
             reply: { message in
-                DispatchQueue.main.async {
+                applyQueue.async {
                     apply(message)
                 }
             }
@@ -37,20 +43,30 @@ enum WatchServerSync {
     /// (which delivers the bundles inline) as soon as the phone is reachable.
     static func applyMirroredServers(_ data: Data?) {
         guard let data else { return }
+        applyQueue.async { applyMirroredServersNow(data) }
+    }
+
+    /// Synchronous variant for a caller that must have the servers applied before it returns —
+    /// the pushed-mirror path runs inside an expiring background activity, and work dispatched
+    /// past its end would hit a re-suspended database.
+    static func applyMirroredServersAndWait(_ data: Data?) {
+        guard let data else { return }
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        applyQueue.sync { applyMirroredServersNow(data) }
+    }
+
+    private static func applyMirroredServersNow(_ data: Data) {
         applyServersState(data)
-        // Keychain lookups (SecItemCopyMatching) are too slow for the main thread this runs on, so
-        // check off-main; pushed mirrors also often arrive while the phone isn't immediately
-        // reachable, so the follow-up request waits for reachability instead of being dropped.
-        let servers = Current.servers.all
-        DispatchQueue.global(qos: .utility).async {
-            let missingCertificate = servers.contains { server in
-                guard let certificate = server.info.connection.clientCertificate else { return false }
-                return !ClientCertificateManager.shared.hasIdentity(for: certificate)
-            }
-            guard missingCertificate else { return }
-            Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
-            DispatchQueue.main.async { requestWhenReachable() }
+        // Already off-main here, so the Keychain lookups (SecItemCopyMatching) can run inline.
+        // Pushed mirrors also often arrive while the phone isn't immediately reachable, so the
+        // follow-up request waits for reachability instead of being dropped.
+        let missingCertificate = Current.servers.all.contains { server in
+            guard let certificate = server.info.connection.clientCertificate else { return false }
+            return !ClientCertificateManager.shared.hasIdentity(for: certificate)
         }
+        guard missingCertificate else { return }
+        Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
+        DispatchQueue.main.async { requestWhenReachable() }
     }
 
     /// One-shot reachability observation guarding the deferred certificate request. Main-thread only.
@@ -108,6 +124,9 @@ enum WatchServerSync {
         }.map(\.identifier)
         Current.resetAPICache(for: affected)
 
-        NotificationCenter.default.post(name: .clientCertificatesImported, object: nil)
+        // Posted on main: WatchServerDetailView receives this straight into SwiftUI state.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .clientCertificatesImported, object: nil)
+        }
     }
 }

--- a/Sources/WatchApp/WatchServerSync.swift
+++ b/Sources/WatchApp/WatchServerSync.swift
@@ -52,6 +52,7 @@ enum WatchServerSync {
     static func applyMirroredServersAndWait(_ data: Data?) {
         guard let data else { return }
         dispatchPrecondition(condition: .notOnQueue(.main))
+        dispatchPrecondition(condition: .notOnQueue(applyQueue))
         applyQueue.sync { applyMirroredServersNow(data) }
     }
 


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes the watch app's top crash clusters, all system terminations around the pushed database mirror:

- Server state from a mirror is now applied on a serial background queue instead of the main queue. Restoring servers reads the Keychain and GRDB and blocked the main thread behind burst mirror writes until the watchdog killed the app.
- Pushed mirrors are decompressed and decoded off the main queue; the payload is a full reference mirror and decoding it on the main queue at launch also hit the watchdog.
- The pushed-mirror path applies servers inside the protected database window, so the writes can't land on a re-suspended database.
- Background cold launches (background refresh, WCSession deliveries) never fire `applicationDidEnterBackground`, leaving database suspension disarmed and accesses exposed to 0xdead10cc when the process froze. Suspension is now armed at launch when starting directly into the background.

## Screenshots
Not a user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
