### PR TITLE
Link the Focus name sensor to its configuration screen

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1860,6 +1860,7 @@ Importing replaces every category listed on this screen, including app settings.
 "settings_details.widgets.reload_all.title" = "Reload all widgets";
 "settings_sensors.body" = "Decide which of your device sensors you want to share with Home Assistant.";
 "settings_sensors.detail.attributes" = "Attributes";
+"settings_sensors.detail.configure_focus_names" = "Configure Focus names";
 "settings_sensors.detail.device_class" = "Device Class";
 "settings_sensors.detail.enabled" = "Enabled";
 "settings_sensors.detail.icon" = "Icon";

--- a/Sources/App/Settings/Sensors/Details/SensorDetailView.swift
+++ b/Sources/App/Settings/Sensors/Details/SensorDetailView.swift
@@ -1,3 +1,4 @@
+import SFSafeSymbols
 import Shared
 import SwiftUI
 
@@ -27,6 +28,16 @@ struct SensorDetailView: View {
                 }
                 if let icon = viewModel.icon {
                     SensorDetailLabelRowView(attribute: L10n.SettingsSensors.Detail.icon, value: icon)
+                }
+            }
+
+            if viewModel.showsFocusConfiguration {
+                Section {
+                    NavigationLink {
+                        FocusSettingsView()
+                    } label: {
+                        Label(L10n.SettingsSensors.Detail.configureFocusNames, systemSymbol: .gearshape)
+                    }
                 }
             }
 

--- a/Sources/App/Settings/Sensors/Details/SensorDetailViewModel.swift
+++ b/Sources/App/Settings/Sensors/Details/SensorDetailViewModel.swift
@@ -55,6 +55,12 @@ class SensorDetailViewModel: ObservableObject, SensorObserver {
             }
     }
 
+    /// The Focus name sensor reports the names the user manages in Focus settings, so its detail
+    /// links straight there instead of leaving them to find the screen on their own.
+    var showsFocusConfiguration: Bool {
+        sensor.UniqueID == WebhookSensorId.focusName.rawValue
+    }
+
     func setEnabled(_ enabled: Bool) {
         Current.sensors.setEnabled(enabled, for: sensor)
         isEnabled = enabled

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6110,6 +6110,8 @@ public enum L10n {
     public enum Detail {
       /// Attributes
       public static var attributes: String { return L10n.tr("Localizable", "settings_sensors.detail.attributes") }
+      /// Configure Focus names
+      public static var configureFocusNames: String { return L10n.tr("Localizable", "settings_sensors.detail.configure_focus_names") }
       /// Device Class
       public static var deviceClass: String { return L10n.tr("Localizable", "settings_sensors.detail.device_class") }
       /// Enabled


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The `focus_name` sensor reports the names managed in Settings > Focus, but its detail screen gave no way to get there.

Adds a "Configure Focus names" row to that sensor's detail screen, which opens the Focus settings screen. It only shows for the Focus name sensor; every other sensor detail is unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
To be added.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Follows on from #5441 and #5445.


---
_Generated by [Claude Code](https://claude.ai/code/session_016xrC1wgcBVMYTMaMzDhMBP)_