### PR TITLE
Notify the user when a Live Activity push token can't reach Home Assistant

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -859,6 +859,8 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "live_activity.sync.done" = "Synced";
 "live_activity.sync.footer" = "Reports running Live Activities to Home Assistant and releases tokens for any that have ended. Runs automatically when the app opens.";
 "live_activity.title" = "Live Activities";
+"live_activity.token_unreachable.body" = "Home Assistant couldn't be reached to register this Live Activity, so it won't receive updates. Check the server's connection security level in the companion app settings, and if you rely on your internal URL make sure location permission is set to “Always”.";
+"live_activity.token_unreachable.title" = "Live Activity won't update";
 "location_change_notification.app_shortcut.body" = "Location updated via App Shortcut";
 "location_change_notification.background_fetch.body" = "Current location delivery triggered via background fetch";
 "location_change_notification.beacon_region_enter.body" = "%@ entered via iBeacon";

--- a/Sources/HANetworking/Sources/Server.swift
+++ b/Sources/HANetworking/Sources/Server.swift
@@ -372,6 +372,17 @@ public extension Server {
         }
         return url
     }
+
+    /// Returns the webhook url evaluated against the most recently known network information,
+    /// without refreshing it first. Only for callers that already refreshed, or that cannot await —
+    /// prefer the async `webhookURL()`.
+    func webhookURLUsingLastKnownNetworkState() -> URL? {
+        var url: URL?
+        update { info in
+            url = info.connection.evaluateWebhookURL()
+        }
+        return url
+    }
 }
 
 #if !os(watchOS)

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -571,11 +571,10 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     /// location permission isn't "Always") makes the webhook fail with `noActiveURL`, so the token
     /// never reaches Core.
     static func serversWithResolvableWebhookURL(_ servers: [Server]) async -> [Server] {
-        var reachable: [Server] = []
-        for server in servers where await server.webhookURL() != nil {
-            reachable.append(server)
-        }
-        return reachable
+        // Refresh once for the whole set: `Server.webhookURL()` refreshes on every call, so asking it
+        // per server would repeat the same SSID lookup for each configured server.
+        await Current.connectivity.refreshNetworkInformation()
+        return servers.filter { $0.webhookURLUsingLastKnownNetworkState() != nil }
     }
 
     /// Tell the user, through an ordinary local notification, that this Live Activity won't receive

--- a/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
+++ b/Sources/Shared/LiveActivity/LiveActivityRegistry.swift
@@ -79,6 +79,10 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     /// Confirmed, running Live Activities keyed by tag.
     private var entries: [String: Entry] = [:]
 
+    /// Tags we already warned the user about being unable to report a push token for. Keeps a
+    /// retried token report (ActivityKit re-issues tokens) from re-alerting for the same activity.
+    private var unreachableWarnedTags: Set<String> = []
+
     // MARK: - Init
 
     public init() {}
@@ -123,6 +127,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
     private func remove(id: String) -> Entry? {
         let entry = entries.removeValue(forKey: id)
         entry?.observationTask.cancel()
+        unreachableWarnedTags.remove(id)
         return entry
     }
 
@@ -510,6 +515,16 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             Current.Log.warning("LiveActivityRegistry: no servers configured, skipping token report for tag \(tag)")
             return
         }
+        let reachableServers = await Self.serversWithResolvableWebhookURL(targetServers)
+        guard !reachableServers.isEmpty else {
+            // Without a token Core can never push an update, so the activity would sit on the Lock
+            // Screen frozen on its opening state with nothing explaining why. Tell the user instead.
+            Current.Log.error(
+                "LiveActivityRegistry: no active URL for any target server, cannot report token for tag \(tag)"
+            )
+            notifyTokenReportUnreachable(tag: tag)
+            return
+        }
         let expiresAt = Current.date()
             .addingTimeInterval(Self.pushTokenTimeToLive)
             .timeIntervalSince1970.rounded(.down)
@@ -521,7 +536,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
                 "expires_at": expiresAt,
             ]
         )
-        for server in targetServers {
+        for server in reachableServers {
             // Background session: the OS owns this upload and keeps retrying it (up to its 2 h
             // resource timeout) across connectivity changes even if the app is suspended or
             // terminated — so a momentary drop, or losing foreground time, doesn't lose the token.
@@ -529,6 +544,7 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             // starts, so it should not be best-effort like sendEphemeral.
             Current.webhooks.sendPassive(server: server, request: request).cauterize()
         }
+        unreachableWarnedTags.remove(tag)
         rememberReportedTokenTag(tag)
     }
 
@@ -548,6 +564,31 @@ public actor LiveActivityRegistry: LiveActivityRegistryProtocol {
             Current.Log.warning("LiveActivityRegistry: no server matches the activity origin; reporting token to all")
         }
         return allServers
+    }
+
+    /// The subset of `servers` whose webhook URL resolves right now. A server with no usable URL
+    /// (connection security level rules it out, or the internal URL can't be picked because
+    /// location permission isn't "Always") makes the webhook fail with `noActiveURL`, so the token
+    /// never reaches Core.
+    static func serversWithResolvableWebhookURL(_ servers: [Server]) async -> [Server] {
+        var reachable: [Server] = []
+        for server in servers where await server.webhookURL() != nil {
+            reachable.append(server)
+        }
+        return reachable
+    }
+
+    /// Tell the user, through an ordinary local notification, that this Live Activity won't receive
+    /// updates. Sent at most once per tag while the process lives; a later successful token report
+    /// clears the tag so a recurrence warns again.
+    private func notifyTokenReportUnreachable(tag: String) {
+        guard unreachableWarnedTags.insert(tag).inserted else { return }
+        Current.notificationDispatcher.send(.init(
+            id: .liveActivityTokenUnreachable,
+            title: L10n.LiveActivity.TokenUnreachable.title,
+            body: L10n.LiveActivity.TokenUnreachable.body,
+            sound: .default
+        ))
     }
 
     /// Notify HA servers that the Live Activity was dismissed or ended externally.

--- a/Sources/Shared/Notifications/NotificationIdentifier.swift
+++ b/Sources/Shared/Notifications/NotificationIdentifier.swift
@@ -8,6 +8,7 @@ public enum NotificationIdentifier: String {
     case intentActivateFailed
     case intentPressFailed
     case serverUnreachable
+    case liveActivityTokenUnreachable
 
     // Debug
     case debug

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2869,6 +2869,12 @@ public enum L10n {
       /// Reports running Live Activities to Home Assistant and releases tokens for any that have ended. Runs automatically when the app opens.
       public static var footer: String { return L10n.tr("Localizable", "live_activity.sync.footer") }
     }
+    public enum TokenUnreachable {
+      /// Home Assistant couldn't be reached to register this Live Activity, so it won't receive updates. Check the server's connection security level in the companion app settings, and if you rely on your internal URL make sure location permission is set to “Always”.
+      public static var body: String { return L10n.tr("Localizable", "live_activity.token_unreachable.body") }
+      /// Live Activity won't update
+      public static var title: String { return L10n.tr("Localizable", "live_activity.token_unreachable.title") }
+    }
   }
 
   public enum LocationChangeNotification {

--- a/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
+++ b/Tests/Shared/LiveActivity/HandlerLiveActivityTests.swift
@@ -464,4 +464,71 @@ final class LiveActivityRegistryChronometerAnchorTests: XCTestCase {
     }
 }
 
+// MARK: - LiveActivityRegistry token reachability
+
+/// A push token only reaches Core over the webhook, so a server whose URL can't be resolved right
+/// now (connection security level rules the internal URL out, or location permission isn't "Always" so
+/// the SSID is unknown) must be filtered out and reported to the user instead of failing silently.
+@available(iOS 17.2, *)
+final class LiveActivityRegistryTokenReachabilityTests: XCTestCase {
+    private var previousCurrentNetworkState: (() async -> NetworkState)!
+    private var previousLastKnownNetworkState: (() -> NetworkState)!
+    private var previousRefreshNetworkInformation: (() async -> Void)!
+
+    override func setUp() {
+        super.setUp()
+        previousCurrentNetworkState = Current.connectivity.currentNetworkState
+        previousLastKnownNetworkState = Current.connectivity.lastKnownNetworkState
+        previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
+        // No SSID: the device can't tell it is on the internal network.
+        let state = NetworkState()
+        Current.connectivity.currentNetworkState = { state }
+        Current.connectivity.lastKnownNetworkState = { state }
+        Current.connectivity.refreshNetworkInformation = {}
+    }
+
+    override func tearDown() {
+        Current.connectivity.currentNetworkState = previousCurrentNetworkState
+        Current.connectivity.lastKnownNetworkState = previousLastKnownNetworkState
+        Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
+        super.tearDown()
+    }
+
+    /// An http-only internal URL under the most secure level, off the internal network, resolves to
+    /// no URL at all — the token can't be delivered.
+    private func serverWithoutResolvableURL() -> Server {
+        Server.fake(identifier: "unreachable") { info in
+            info.connection.set(address: nil, for: .external)
+            info.connection.set(address: URL(string: "http://homeassistant.local:8123")!, for: .internal)
+            info.connection.connectionAccessSecurityLevel = .mostSecure
+        }
+    }
+
+    func testServersWithResolvableWebhookURL_dropsServerWithNoActiveURL() async {
+        let reachable = Server.fake(identifier: "reachable")
+        let servers = await LiveActivityRegistry.serversWithResolvableWebhookURL([
+            reachable,
+            serverWithoutResolvableURL(),
+        ])
+        XCTAssertEqual(servers.map(\.identifier), ["reachable"])
+    }
+
+    func testServersWithResolvableWebhookURL_allUnreachable_returnsEmpty() async {
+        let servers = await LiveActivityRegistry.serversWithResolvableWebhookURL([serverWithoutResolvableURL()])
+        XCTAssertTrue(servers.isEmpty)
+    }
+
+    /// A cloudhook still works without an active URL, so such a server must not be filtered out.
+    func testServersWithResolvableWebhookURL_keepsServerWithCloudhookOnly() async {
+        let server = Server.fake(identifier: "cloudhook") { info in
+            info.connection.set(address: nil, for: .external)
+            info.connection.set(address: URL(string: "http://homeassistant.local:8123")!, for: .internal)
+            info.connection.connectionAccessSecurityLevel = .mostSecure
+            info.connection.cloudhookURL = URL(string: "https://hooks.nabu.casa/abc")!
+        }
+        let servers = await LiveActivityRegistry.serversWithResolvableWebhookURL([server])
+        XCTAssertEqual(servers.map(\.identifier), ["cloudhook"])
+    }
+}
+
 #endif


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When a Live Activity starts, its push token is reported to Home Assistant over the webhook. If the server has no usable URL at that moment (connection security level rules the internal URL out, or location permission isn't "Always" so the SSID is unknown), the report fails and the Live Activity stays frozen on its opening state with nothing explaining why.

The token report now checks the webhook URL resolves first, and when no target server has one it sends a normal local notification telling the user the Live Activity won't update and what to check.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — a standard system notification banner, no custom UI.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The check uses `webhookURL()` rather than `activeURL()`: a cloudhook still works when there is no active URL, so gating on `activeURL` would have wrongly warned for cloud-only servers. `webhookURL() == nil` is exactly the condition `WebhookManager` reports as `noActiveURL`.

Warnings are de-duplicated per tag so a re-issued token doesn't re-alert, and cleared on a successful report or when the activity ends.
