### PR TITLE
Sync zone monitored regions off the main thread

### DIFF
--- a/Sources/App/ZoneManager/ZoneManager.swift
+++ b/Sources/App/ZoneManager/ZoneManager.swift
@@ -13,17 +13,24 @@ class ZoneManager {
     private(set) var zones: [AppZone]
 
     private var observationToken: AnyDatabaseCancellable?
+    private let syncExecutor: (@escaping () -> Void) -> Void
+
+    private static let regionSyncQueue = DispatchQueue(label: "zone-manager-region-sync", qos: .utility)
 
     init(
         locationManager: CLLocationManager = .init(),
         collector: ZoneManagerCollector = ZoneManagerCollectorImpl(),
         processor: ZoneManagerProcessor = ZoneManagerProcessorImpl(),
-        regionFilter: ZoneManagerRegionFilter = ZoneManagerRegionFilterImpl()
+        regionFilter: ZoneManagerRegionFilter = ZoneManagerRegionFilterImpl(),
+        syncExecutor: @escaping (@escaping () -> Void) -> Void = { work in
+            ZoneManager.regionSyncQueue.async(execute: work)
+        }
     ) {
         self.locationManager = locationManager
         self.collector = collector
         self.processor = processor
         self.regionFilter = regionFilter
+        self.syncExecutor = syncExecutor
         self.zones = AppZone.trackedZones()
 
         self.collector.delegate = self
@@ -177,6 +184,15 @@ class ZoneManager {
     }
 
     private func sync(zones: AnyCollection<AppZone>) {
+        syncExecutor { [weak self] in
+            self?.syncNow(zones: zones)
+        }
+    }
+
+    /// Runs on the sync executor: `monitoredRegions` and `location` perform synchronous XPC to
+    /// locationd, which hangs the main thread when the daemon is slow to reply (this was the app's
+    /// top field hang), so they must be read off the main thread.
+    private func syncNow(zones: AnyCollection<AppZone>) {
         let currentRegions = locationManager.monitoredRegions
         let desiredRegions = regionFilter.regions(
             from: zones,
@@ -196,30 +212,35 @@ class ZoneManager {
         let needsRemoval = actual.subtracting(expected)
         let needsAddition = expected.subtracting(actual)
 
-        // process removals before additions
-        // this is important because the system is focused on identifier
-        for region in needsRemoval.map(\.region) {
-            Current.clientEventStore.addEvent(ClientEvent(
-                text: "Ending monitoring \(region.identifier)",
-                type: .locationUpdate,
-                payload: [
-                    "region": String(describing: region),
-                ]
-            ))
-            locationManager.stopMonitoring(for: region)
-        }
+        // Applied on the main thread because the collector (and its ignore-next-state bookkeeping)
+        // is only ever touched from there; synchronously, so the next queued sync's reads observe
+        // these mutations and can't re-add the same regions.
+        Self.runOnMain { [self] in
+            // process removals before additions
+            // this is important because the system is focused on identifier
+            for region in needsRemoval.map(\.region) {
+                Current.clientEventStore.addEvent(ClientEvent(
+                    text: "Ending monitoring \(region.identifier)",
+                    type: .locationUpdate,
+                    payload: [
+                        "region": String(describing: region),
+                    ]
+                ))
+                locationManager.stopMonitoring(for: region)
+            }
 
-        for region in needsAddition.map(\.region) {
-            Current.clientEventStore.addEvent(ClientEvent(
-                text: "Initially monitoring \(region.identifier)",
-                type: .locationUpdate,
-                payload: [
-                    "region": String(describing: region),
-                ]
-            ))
+            for region in needsAddition.map(\.region) {
+                Current.clientEventStore.addEvent(ClientEvent(
+                    text: "Initially monitoring \(region.identifier)",
+                    type: .locationUpdate,
+                    payload: [
+                        "region": String(describing: region),
+                    ]
+                ))
 
-            collector.ignoreNextState(for: region)
-            locationManager.startMonitoring(for: region)
+                collector.ignoreNextState(for: region)
+                locationManager.startMonitoring(for: region)
+            }
         }
 
         let counts = (
@@ -237,6 +258,14 @@ class ZoneManager {
                 "ended \(needsRemoval.count)",
             ]
             return info.joined(separator: ", ")
+        }
+    }
+
+    private static func runOnMain(_ work: () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
         }
     }
 }

--- a/Tests/App/ZoneManager/FakeCLLocationManager.swift
+++ b/Tests/App/ZoneManager/FakeCLLocationManager.swift
@@ -7,12 +7,16 @@ class FakeCLLocationManager: CLLocationManager {
     var isMonitoringSigLocChanges = false
     var overrideMonitoredRegions = Set<CLRegion>()
     var requestedRegions = [CLRegion]()
+    var monitoredRegionsReadsWereOnMainThread = [Bool]()
+    var startMonitoringCallsWereOnMainThread = [Bool]()
 
     override var monitoredRegions: Set<CLRegion> {
-        overrideMonitoredRegions
+        monitoredRegionsReadsWereOnMainThread.append(Thread.isMainThread)
+        return overrideMonitoredRegions
     }
 
     override func startMonitoring(for region: CLRegion) {
+        startMonitoringCallsWereOnMainThread.append(Thread.isMainThread)
         startMonitoringRegions.append(region)
         overrideMonitoredRegions.insert(region)
     }

--- a/Tests/App/ZoneManager/ZoneManager.test.swift
+++ b/Tests/App/ZoneManager/ZoneManager.test.swift
@@ -85,12 +85,15 @@ class ZoneManagerTests: XCTestCase {
         super.tearDown()
     }
 
-    private func newZoneManager() -> ZoneManager {
+    private func newZoneManager(
+        syncExecutor: @escaping (@escaping () -> Void) -> Void = { $0() }
+    ) -> ZoneManager {
         ZoneManager(
             locationManager: locationManager,
             collector: collector,
             processor: processor,
-            regionFilter: regionFilter
+            regionFilter: regionFilter,
+            syncExecutor: syncExecutor
         )
     }
 
@@ -316,6 +319,62 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertEqual(regionFilter.lastAskedZones.flatMap { Set($0) }, Set(zones))
     }
 
+    func testSyncReadsRegionsOffMainThreadAndAppliesOnMainThread() throws {
+        _ = try addedZones([
+            AppZone(
+                entityId: "home",
+                serverIdentifier: apis[0].server.identifier.rawValue,
+                latitude: 37.1234,
+                longitude: -122.4567,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])
+
+        let syncQueue = DispatchQueue(label: "zone-manager-test-sync")
+        let manager = newZoneManager(syncExecutor: { work in
+            syncQueue.async(execute: work)
+        })
+
+        // poll a property only the fake writes, so the wait itself doesn't
+        // record main-thread reads of monitoredRegions
+        waitForZoneSync { [locationManager] in
+            !locationManager!.startMonitoringRegions.isEmpty
+        }
+
+        XCTAssertFalse(locationManager.monitoredRegionsReadsWereOnMainThread.isEmpty)
+        XCTAssertFalse(locationManager.monitoredRegionsReadsWereOnMainThread.contains(true))
+        XCTAssertFalse(locationManager.startMonitoringCallsWereOnMainThread.isEmpty)
+        XCTAssertFalse(locationManager.startMonitoringCallsWereOnMainThread.contains(false))
+        XCTAssertFalse(collector.ignoreNextStateCallsWereOnMainThread.contains(false))
+
+        withExtendedLifetime(manager) { /* silences unused variable */ }
+    }
+
+    func testSyncUsesInjectedExecutor() throws {
+        _ = try addedZones([
+            AppZone(
+                entityId: "home",
+                serverIdentifier: apis[0].server.identifier.rawValue,
+                latitude: 37.1234,
+                longitude: -122.4567,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])
+
+        var executions = 0
+        let manager = newZoneManager(syncExecutor: { work in
+            executions += 1
+            work()
+        })
+
+        XCTAssertEqual(executions, 1)
+        XCTAssertFalse(locationManager.startMonitoringRegions.isEmpty)
+
+        withExtendedLifetime(manager) { /* silences unused variable */ }
+    }
+
     func testBasicStartup() {
         let manager = newZoneManager()
         XCTAssertTrue(locationManager.isMonitoringSigLocChanges)
@@ -531,8 +590,10 @@ private class FakeCollector: NSObject, ZoneManagerCollector {
     var delegate: ZoneManagerCollectorDelegate?
 
     var ignoringNextStates = Set<CLRegion>()
+    var ignoreNextStateCallsWereOnMainThread = [Bool]()
 
     func ignoreNextState(for region: CLRegion) {
+        ignoreNextStateCallsWereOnMainThread.append(Thread.isMainThread)
         ignoringNextStates.insert(region)
     }
 }

--- a/Tests/App/ZoneManager/ZoneManager.test.swift
+++ b/Tests/App/ZoneManager/ZoneManager.test.swift
@@ -346,6 +346,10 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertFalse(locationManager.monitoredRegionsReadsWereOnMainThread.contains(true))
         XCTAssertFalse(locationManager.startMonitoringCallsWereOnMainThread.isEmpty)
         XCTAssertFalse(locationManager.startMonitoringCallsWereOnMainThread.contains(false))
+        XCTAssertEqual(
+            collector.ignoreNextStateCallsWereOnMainThread.count,
+            locationManager.startMonitoringCallsWereOnMainThread.count
+        )
         XCTAssertFalse(collector.ignoreNextStateCallsWereOnMainThread.contains(false))
 
         withExtendedLifetime(manager) { /* silences unused variable */ }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes the app's top field hang (35% of reported hangs in 2026.7.3): `ZoneManager.sync(zones:)` read `CLLocationManager.monitoredRegions` and `.location` on the main thread. Both perform synchronous XPC to locationd and block the main thread for seconds when the daemon is slow to reply.

- Region syncs now run on a serial background queue: the locationd reads and the region diff happen off the main thread.
- The resulting mutations (start/stop monitoring, collector bookkeeping, client events) are still applied on the main thread, synchronously, so consecutive syncs stay ordered.
- The executor is injectable for tests; new tests cover that reads happen off the main thread and mutations on it.

## Screenshots
Not a user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes