### PR TITLE
Persist server info to the Keychain off the calling thread

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		423FB76D2FFFDFDE000CB8FD /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1171506A24DFCDE60065E874 /* WidgetKit.framework */; };
 		423FB76E2FFFDFDE000CB8FD /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46C62BA82D8A3AC5002C0001 /* SwiftUI.framework */; };
 		423FB77D2FFFDFDF000CB8FD /* Extensions-WatchWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 423FB76C2FFFDFDE000CB8FD /* Extensions-WatchWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		424169A3303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424169A2303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift */; };
 		4245DC042EBA7919005E0E04 /* AreasService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4245DC022EBA42C3005E0E04 /* AreasService.swift */; };
 		4245DC052EBA7919005E0E04 /* AreasService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4245DC022EBA42C3005E0E04 /* AreasService.swift */; };
 		424D2D102C89DACE00C610F1 /* HAAppEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */; };
@@ -613,6 +614,7 @@
 		42164BB8301320720077A903 /* ComplicationFormula.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFormula.test.swift; sourceTree = "<group>"; };
 		4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIconColorProvider.swift; sourceTree = "<group>"; };
 		423FB76C2FFFDFDE000CB8FD /* Extensions-WatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Extensions-WatchWidgets.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		424169A2303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteBehindServerManagerKeychain.test.swift; sourceTree = "<group>"; };
 		4245DC022EBA42C3005E0E04 /* AreasService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreasService.swift; sourceTree = "<group>"; };
 		424D2D0F2C89DACE00C610F1 /* HAAppEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HAAppEntity.swift; sourceTree = "<group>"; };
 		4254C4C92D103ABB00245021 /* ExternalLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalLink.swift; sourceTree = "<group>"; };
@@ -2700,6 +2702,7 @@
 				B90B4A989089C3375C55AF75 /* CallServiceResponse.test.swift */,
 				42EDBC3C3002FBE40051FC9B /* Watch */,
 				42164BB8301320720077A903 /* ComplicationFormula.test.swift */,
+				424169A2303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -4149,6 +4152,7 @@
 				1130A5782751BDD900640E38 /* ServerManager.test.swift in Sources */,
 				42F1C0013140B00011AABB01 /* HomeAssistantAPIIdentity.test.swift in Sources */,
 				42F1C0113140B00011AABB11 /* HAAPITokenFetchFailure.test.swift in Sources */,
+				424169A3303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift in Sources */,
 				42F1C0133140B00011AABB13 /* TokenManagerAccessTokenRejection.test.swift in Sources */,
 				42F1C0153140B00011AABB15 /* TokenManagerRevocation.test.swift in Sources */,
 				1104FCCF253275CF00B8BE34 /* WatchBackgroundRefreshScheduler.test.swift in Sources */,

--- a/Sources/HANetworking/Sources/ServerManager.swift
+++ b/Sources/HANetworking/Sources/ServerManager.swift
@@ -131,7 +131,9 @@ public final class ServerManagerImpl: ServerManager {
     /// + GRDB mirror store. The designated initializer takes them explicitly (used by tests to inject fakes).
     public convenience init() {
         self.init(
-            keychain: Keychain(service: ServerManagerImpl.service),
+            // Write-behind so saving server info (e.g. during token refresh on the main thread)
+            // never blocks on securityd's synchronous XPC, which was a top field hang.
+            keychain: WriteBehindServerManagerKeychain(upstream: Keychain(service: ServerManagerImpl.service)),
             historicKeychain: Keychain(service: HANetworkingEnvironment.current.bundleID),
             mirrorStore: ServerManagerGRDBMirrorStore()
         )

--- a/Sources/HANetworking/Sources/WriteBehindServerManagerKeychain.swift
+++ b/Sources/HANetworking/Sources/WriteBehindServerManagerKeychain.swift
@@ -1,0 +1,136 @@
+import Foundation
+import HAKit
+
+/// Decorates a `ServerManagerKeychain` so writes return immediately: values are kept in an
+/// in-memory overlay and flushed to the wrapped Keychain on a serial background executor.
+///
+/// `SecItemUpdate`/`SecItemDelete` perform synchronous XPC to securityd, which can take seconds
+/// when the daemon is busy (e.g. right after unlock); saving server info during token refresh on
+/// the main thread was one of the app's top field hangs. Reads consult the overlay first, so
+/// read-after-write stays consistent even in processes that bypass the in-memory server cache
+/// (app extensions, where caching is restricted).
+public final class WriteBehindServerManagerKeychain: ServerManagerKeychain {
+    private enum PendingWrite: Equatable {
+        case set(Data)
+        case remove
+    }
+
+    private struct Overlay {
+        // Masks the wrapped keychain's existing entries until the queued removeAll flushes.
+        var maskingRemoveAll = false
+        // Each write gets a generation so a flush only clears the overlay entry it actually
+        // persisted; a newer write for the same key stays visible until its own flush runs.
+        var generation: UInt64 = 0
+        var writes = [String: (generation: UInt64, write: PendingWrite)]()
+
+        mutating func append(_ write: PendingWrite, key: String) {
+            generation += 1
+            writes[key] = (generation, write)
+        }
+    }
+
+    private let upstream: ServerManagerKeychain
+    private let overlay = HAProtected<Overlay>(value: .init())
+    private let flushExecutor: (@escaping () -> Void) -> Void
+
+    private static let flushQueue = DispatchQueue(label: "server-keychain-write-behind", qos: .utility)
+
+    public init(
+        upstream: ServerManagerKeychain,
+        flushExecutor: ((@escaping () -> Void) -> Void)? = nil
+    ) {
+        self.upstream = upstream
+        self.flushExecutor = flushExecutor ?? { work in Self.flushQueue.async(execute: work) }
+    }
+
+    public func set(_ value: Data, key: String) throws {
+        overlay.mutate { overlay in
+            overlay.append(.set(value), key: key)
+        }
+        flushExecutor { [self] in
+            flush(key: key)
+        }
+    }
+
+    public func remove(_ key: String) throws {
+        overlay.mutate { overlay in
+            overlay.append(.remove, key: key)
+        }
+        flushExecutor { [self] in
+            flush(key: key)
+        }
+    }
+
+    public func removeAll() throws {
+        overlay.mutate { overlay in
+            overlay.maskingRemoveAll = true
+            overlay.writes = [:]
+        }
+        flushExecutor { [self] in
+            do {
+                try upstream.removeAll()
+            } catch {
+                HANetworkingEnvironment.current.log.error("failed to flush keychain removeAll: \(error)")
+            }
+            overlay.mutate { overlay in
+                overlay.maskingRemoveAll = false
+            }
+        }
+    }
+
+    public func getData(_ key: String) throws -> Data? {
+        enum Overlaid {
+            case value(Data?)
+            case upstream
+        }
+
+        let overlaid = overlay.read { overlay -> Overlaid in
+            switch overlay.writes[key]?.write {
+            case let .set(data): return .value(data)
+            case .remove: return .value(nil)
+            case nil: return overlay.maskingRemoveAll ? .value(nil) : .upstream
+            }
+        }
+
+        switch overlaid {
+        case let .value(data): return data
+        case .upstream: return try upstream.getData(key)
+        }
+    }
+
+    public func allKeys() -> [String] {
+        let (snapshot, upstreamMasked) = overlay.read { ($0.writes, $0.maskingRemoveAll) }
+
+        var keys = Set(upstreamMasked ? [] : upstream.allKeys())
+        for (key, pending) in snapshot {
+            switch pending.write {
+            case .set: keys.insert(key)
+            case .remove: keys.remove(key)
+            }
+        }
+        return Array(keys)
+    }
+
+    private func flush(key: String) {
+        // Take the newest pending write for the key; earlier queued flushes for the same key
+        // become no-ops, so a rapid set/set or set/remove sequence lands only its final state.
+        guard let pending = overlay.read({ $0.writes[key] }) else { return }
+
+        do {
+            switch pending.write {
+            case let .set(data): try upstream.set(data, key: key)
+            case .remove: try upstream.remove(key)
+            }
+        } catch {
+            HANetworkingEnvironment.current.log.error("failed to flush keychain write for \(key): \(error)")
+        }
+
+        // Only clear the entry that was just persisted: a write that raced in during the
+        // upstream call must stay visible to readers until its own flush lands.
+        overlay.mutate { overlay in
+            if overlay.writes[key]?.generation == pending.generation {
+                overlay.writes[key] = nil
+            }
+        }
+    }
+}

--- a/Sources/HANetworking/Sources/WriteBehindServerManagerKeychain.swift
+++ b/Sources/HANetworking/Sources/WriteBehindServerManagerKeychain.swift
@@ -122,7 +122,10 @@ public final class WriteBehindServerManagerKeychain: ServerManagerKeychain {
             case .remove: try upstream.remove(key)
             }
         } catch {
+            // Keep the pending write on failure so readers still see it and the next flush
+            // for this key retries it.
             HANetworkingEnvironment.current.log.error("failed to flush keychain write for \(key): \(error)")
+            return
         }
 
         // Only clear the entry that was just persisted: a write that raced in during the

--- a/Tests/Shared/WriteBehindServerManagerKeychain.test.swift
+++ b/Tests/Shared/WriteBehindServerManagerKeychain.test.swift
@@ -114,6 +114,33 @@ class WriteBehindServerManagerKeychainTests: XCTestCase {
         XCTAssertEqual(Set(keychain.allKeys()), Set(["key1", "key3"]))
     }
 
+    func testFailedFlushKeepsPendingWriteAndRetriesOnNextFlush() throws {
+        let failingUpstream = FailingSetServerManagerKeychain()
+        var queued = [() -> Void]()
+        let keychain = WriteBehindServerManagerKeychain(upstream: failingUpstream, flushExecutor: { queued.append($0) })
+
+        let first = Data("first".utf8)
+        try keychain.set(first, key: "key1")
+
+        failingUpstream.failSets = true
+        let flushes = queued
+        queued = []
+        flushes.forEach { $0() }
+
+        // the write failed to persist but must stay visible to readers
+        XCTAssertEqual(try keychain.getData("key1"), first)
+        XCTAssertEqual(keychain.allKeys(), ["key1"])
+        XCTAssertNil(try failingUpstream.wrapped.getData("key1"))
+
+        failingUpstream.failSets = false
+        let second = Data("second".utf8)
+        try keychain.set(second, key: "key1")
+        queued.forEach { $0() }
+
+        XCTAssertEqual(try failingUpstream.wrapped.getData("key1"), second)
+        XCTAssertEqual(try keychain.getData("key1"), second)
+    }
+
     func testDefaultExecutorFlushesWithoutBlockingCaller() throws {
         let defaultKeychain = WriteBehindServerManagerKeychain(upstream: upstream)
         let value = Data("server".utf8)
@@ -129,5 +156,35 @@ class WriteBehindServerManagerKeychainTests: XCTestCase {
             evaluatedWith: nil
         )
         wait(for: [flushed], timeout: 10)
+    }
+}
+
+private class FailingSetServerManagerKeychain: ServerManagerKeychain {
+    let wrapped = FakeServerManagerKeychain()
+    var failSets = false
+
+    struct SetError: Error {}
+
+    func set(_ value: Data, key: String) throws {
+        if failSets {
+            throw SetError()
+        }
+        try wrapped.set(value, key: key)
+    }
+
+    func removeAll() throws {
+        try wrapped.removeAll()
+    }
+
+    func allKeys() -> [String] {
+        wrapped.allKeys()
+    }
+
+    func getData(_ key: String) throws -> Data? {
+        try wrapped.getData(key)
+    }
+
+    func remove(_ key: String) throws {
+        try wrapped.remove(key)
     }
 }

--- a/Tests/Shared/WriteBehindServerManagerKeychain.test.swift
+++ b/Tests/Shared/WriteBehindServerManagerKeychain.test.swift
@@ -1,0 +1,133 @@
+@testable import Shared
+import XCTest
+
+class WriteBehindServerManagerKeychainTests: XCTestCase {
+    private var upstream: FakeServerManagerKeychain!
+    private var queuedFlushes: [() -> Void]!
+    private var keychain: WriteBehindServerManagerKeychain!
+
+    override func setUp() {
+        super.setUp()
+
+        upstream = FakeServerManagerKeychain()
+        queuedFlushes = []
+        keychain = WriteBehindServerManagerKeychain(upstream: upstream, flushExecutor: { [weak self] work in
+            self?.queuedFlushes.append(work)
+        })
+    }
+
+    private func runQueuedFlushes() {
+        let flushes = queuedFlushes ?? []
+        queuedFlushes = []
+        for flush in flushes {
+            flush()
+        }
+    }
+
+    func testSetIsVisibleImmediatelyAndFlushedLater() throws {
+        let value = Data("server".utf8)
+
+        try keychain.set(value, key: "key1")
+
+        XCTAssertEqual(try keychain.getData("key1"), value)
+        XCTAssertEqual(keychain.allKeys(), ["key1"])
+        XCTAssertNil(try upstream.getData("key1"))
+
+        runQueuedFlushes()
+
+        XCTAssertEqual(try upstream.getData("key1"), value)
+        XCTAssertEqual(try keychain.getData("key1"), value)
+    }
+
+    func testRemoveIsVisibleImmediatelyAndFlushedLater() throws {
+        try upstream.set(Data("server".utf8), key: "key1")
+
+        try keychain.remove("key1")
+
+        XCTAssertNil(try keychain.getData("key1"))
+        XCTAssertTrue(keychain.allKeys().isEmpty)
+        XCTAssertNotNil(try upstream.getData("key1"))
+
+        runQueuedFlushes()
+
+        XCTAssertNil(try upstream.getData("key1"))
+        XCTAssertNil(try keychain.getData("key1"))
+    }
+
+    func testLatestWriteWinsWhenFlushesCoalesce() throws {
+        let first = Data("first".utf8)
+        let second = Data("second".utf8)
+
+        try keychain.set(first, key: "key1")
+        try keychain.set(second, key: "key1")
+
+        XCTAssertEqual(try keychain.getData("key1"), second)
+
+        runQueuedFlushes()
+
+        XCTAssertEqual(try upstream.getData("key1"), second)
+        XCTAssertEqual(try keychain.getData("key1"), second)
+    }
+
+    func testSetThenRemoveEndsRemoved() throws {
+        try keychain.set(Data("server".utf8), key: "key1")
+        try keychain.remove("key1")
+
+        XCTAssertNil(try keychain.getData("key1"))
+
+        runQueuedFlushes()
+
+        XCTAssertNil(try upstream.getData("key1"))
+        XCTAssertNil(try keychain.getData("key1"))
+        XCTAssertTrue(keychain.allKeys().isEmpty)
+    }
+
+    func testRemoveAllMasksUpstreamUntilFlushed() throws {
+        try upstream.set(Data("one".utf8), key: "key1")
+        try upstream.set(Data("two".utf8), key: "key2")
+
+        try keychain.removeAll()
+
+        XCTAssertNil(try keychain.getData("key1"))
+        XCTAssertNil(try keychain.getData("key2"))
+        XCTAssertTrue(keychain.allKeys().isEmpty)
+
+        // a write after removeAll must survive it
+        let replacement = Data("three".utf8)
+        try keychain.set(replacement, key: "key3")
+        XCTAssertEqual(try keychain.getData("key3"), replacement)
+        XCTAssertEqual(keychain.allKeys(), ["key3"])
+
+        runQueuedFlushes()
+
+        XCTAssertEqual(upstream.allKeys(), ["key3"])
+        XCTAssertEqual(try keychain.getData("key3"), replacement)
+    }
+
+    func testAllKeysMergesPendingWrites() throws {
+        try upstream.set(Data("one".utf8), key: "key1")
+        try upstream.set(Data("two".utf8), key: "key2")
+
+        try keychain.set(Data("three".utf8), key: "key3")
+        try keychain.remove("key2")
+
+        XCTAssertEqual(Set(keychain.allKeys()), Set(["key1", "key3"]))
+    }
+
+    func testDefaultExecutorFlushesWithoutBlockingCaller() throws {
+        let defaultKeychain = WriteBehindServerManagerKeychain(upstream: upstream)
+        let value = Data("server".utf8)
+
+        try defaultKeychain.set(value, key: "key1")
+
+        XCTAssertEqual(try defaultKeychain.getData("key1"), value)
+
+        let flushed = expectation(
+            for: NSPredicate(block: { [upstream] _, _ in
+                (try? upstream?.getData("key1")) == value
+            }),
+            evaluatedWith: nil
+        )
+        wait(for: [flushed], timeout: 10)
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes a field hang (8% of reported hangs in 2026.7.3): saving `Server.info` — for example during token refresh on the main queue — wrote to the Keychain synchronously. `SecItemUpdate` performs synchronous XPC to securityd and can block for seconds when the daemon is busy (e.g. right after unlock), and the write also happened while holding the server cache lock.

- Adds `WriteBehindServerManagerKeychain`, a decorator that keeps writes in an in-memory overlay and flushes them to the real Keychain on a serial background queue.
- Reads consult the overlay first, so read-after-write stays consistent even in app extensions, where the server cache is bypassed.
- Coalesces rapid successive writes to the same key and keeps `removeAll` ordering correct.
- The flush executor is injectable; new tests cover visibility, coalescing, removal masking, and the asynchronous default.

## Screenshots
Not a user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
If the process dies before a flush lands, the Keychain keeps the previous value; for the token-refresh path this is recoverable (the refresh token is unchanged and the app refreshes again), and the GRDB mirror snapshot still provides its existing fallback.