### PR TITLE
Read location permission and cached location off the main thread

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+Onboarding.swift
@@ -25,7 +25,7 @@ extension WebViewController {
             return
         }
 
-        if Current.location.permissionStatus == .notDetermined, connection.hasNonHTTPSURLOptions {
+        if Current.location.permissionStatus() == .notDetermined, connection.hasNonHTTPSURLOptions {
             Current.Log.verbose("User has not decided location permission yet")
             showOnboardingPermissions(steps: OnboardingPermissionsNavigationViewModel.StepID.updateLocationPermission)
         } else if connection.connectionAccessSecurityLevel == .undefined {

--- a/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
+++ b/Sources/App/Onboarding/Steps/Permissions/OnboardingPermissionsNavigationViewModel.swift
@@ -230,7 +230,7 @@ final class OnboardingPermissionsNavigationViewModel: NSObject, ObservableObject
     /// - Note: Opens settings if denied/restricted, grants immediately if already authorized,
     ///         or requests permission if not determined
     private func requestLocationPermission() {
-        switch Current.location.permissionStatus {
+        switch Current.location.permissionStatus() {
         case .denied, .restricted:
             guard locationPermissionContext != .lessSecureLocalConnection else {
                 applyLocationPermissionNeeds()

--- a/Sources/Shared/API/Webhook/Sensors/LocationPermissionSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/LocationPermissionSensor.swift
@@ -9,10 +9,18 @@ public class LocationPermissionSensor: SensorProvider {
     }
 
     public func sensors() -> Promise<[WebhookSensor]> {
-        let sensor = WebhookSensor(name: "Location permission", uniqueID: WebhookSensorId.locationPermission.rawValue)
-        sensor.State = CLLocationManager().authorizationStatus.description
-        sensor.Icon = "mdi:\(MaterialDesignIcons.mapIcon.name)"
-        return .value([sensor])
+        // Sensor updates run on the main queue and reading the authorization status performs
+        // synchronous XPC to locationd, which hangs the main thread when the daemon is slow
+        // (field hang), so read it on a background queue.
+        DispatchQueue.global(qos: .userInitiated).async(.promise) {
+            let sensor = WebhookSensor(
+                name: "Location permission",
+                uniqueID: WebhookSensorId.locationPermission.rawValue
+            )
+            sensor.State = Current.location.permissionStatus().description
+            sensor.Icon = "mdi:\(MaterialDesignIcons.mapIcon.name)"
+            return [sensor]
+        }
     }
 }
 

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -678,7 +678,9 @@ public class AppEnvironment {
             CLLocationManager.oneShotLocation(timeout: $0.oneShotTimeout(maximum: $1))
         }
 
-        public var permissionStatus: CLAuthorizationStatus {
+        /// `authorizationStatus` performs synchronous XPC to locationd and can block for
+        /// seconds; avoid calling this on the main thread.
+        public var permissionStatus: () -> CLAuthorizationStatus = {
             CLLocationManager().authorizationStatus
         }
     }

--- a/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
+++ b/Sources/Shared/Location/CLLocationManager+OneShotLocation.swift
@@ -188,7 +188,8 @@ final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
 
     init(
         locationManager: CLLocationManager,
-        timeout: Guarantee<Void>
+        timeout: Guarantee<Void>,
+        cachedLocationExecutor: ((@escaping () -> Void) -> Void)? = nil
     ) {
         precondition(Thread.isMainThread)
 
@@ -220,11 +221,33 @@ final class OneShotLocationProxy: NSObject, CLLocationManagerDelegate {
             self?.checkPotentialLocations(outOfTime: true)
         }
 
-        if let cachedLocation = locationManager.location {
-            let authorization: CLAccuracyAuthorization = locationManager.accuracyAuthorization
-            let potentialLocation = PotentialLocation(location: cachedLocation, accuracyAuthorization: authorization)
-            potentialLocations.append(potentialLocation)
+        // Reading `location`/`accuracyAuthorization` performs synchronous XPC to locationd and
+        // hangs the main thread when the daemon is slow (field hang), so seed the cached
+        // location from a background queue and hop back to the main thread to record it.
+        let executor = cachedLocationExecutor ?? { work in
+            DispatchQueue.global(qos: .userInitiated).async(execute: work)
         }
+        executor { [weak self] in
+            guard let cachedLocation = locationManager.location else { return }
+            let authorization: CLAccuracyAuthorization = locationManager.accuracyAuthorization
+            if Thread.isMainThread {
+                self?.seed(cachedLocation: cachedLocation, accuracyAuthorization: authorization)
+            } else {
+                DispatchQueue.main.async {
+                    self?.seed(cachedLocation: cachedLocation, accuracyAuthorization: authorization)
+                }
+            }
+        }
+    }
+
+    private func seed(cachedLocation: CLLocation, accuracyAuthorization: CLAccuracyAuthorization) {
+        precondition(Thread.isMainThread)
+
+        guard !promise.isResolved else { return }
+        potentialLocations.append(PotentialLocation(
+            location: cachedLocation,
+            accuracyAuthorization: accuracyAuthorization
+        ))
     }
 
     private func checkPotentialLocations(outOfTime: Bool) {

--- a/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
+++ b/Tests/Shared/CLLocationManager+OneShotLocationTests.swift
@@ -25,7 +25,8 @@ class OneShotLocationTests: XCTestCase {
         let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         timeoutSeal(())
@@ -38,7 +39,8 @@ class OneShotLocationTests: XCTestCase {
         let (timeoutPromise, _) = Guarantee<Void>.pending()
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         let clError = CLError(.deferredAccuracyTooLow)
@@ -52,7 +54,8 @@ class OneShotLocationTests: XCTestCase {
         let (timeoutPromise, _) = Guarantee<Void>.pending()
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         enum SomeError: Error {
@@ -71,7 +74,8 @@ class OneShotLocationTests: XCTestCase {
         locationManager.cachedLocation = cachedLocation
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         timeoutSeal(())
@@ -84,10 +88,53 @@ class OneShotLocationTests: XCTestCase {
         locationManager.cachedLocation = cachedLocation
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didFailWithError: CLError(.deferredAccuracyTooLow))
+        XCTAssertEqual(try hang(promise), cachedLocation)
+    }
+
+    func testCachedLocationIsNotReadUntilExecutorRuns() {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        locationManager.cachedLocation = CLLocation(latitude: 123, longitude: -123)
+
+        var queuedWork = [() -> Void]()
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { queuedWork.append($0) }
+        ).promise
+
+        XCTAssertEqual(queuedWork.count, 1)
+
+        // the cached location was never seeded, so timing out must fail
+        timeoutSeal(())
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? OneShotError, OneShotError.outOfTime)
+        }
+    }
+
+    func testCachedLocationSeededFromBackgroundThread() throws {
+        let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
+        let cachedLocation = CLLocation(latitude: 123, longitude: -123)
+        locationManager.cachedLocation = cachedLocation
+
+        var queuedWork = [() -> Void]()
+        let promise = OneShotLocationProxy(
+            locationManager: locationManager,
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { queuedWork.append($0) }
+        ).promise
+
+        // run the seed read off the main thread like the default executor does; it hops back
+        // to the main queue, so it lands before the timeout sealed below
+        DispatchQueue(label: "one-shot-test-seed").sync {
+            queuedWork.forEach { $0() }
+        }
+
+        timeoutSeal(())
         XCTAssertEqual(try hang(promise), cachedLocation)
     }
 
@@ -110,7 +157,8 @@ class OneShotLocationTests: XCTestCase {
         locationManager.cachedLocation = cachedLocation
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
@@ -128,7 +176,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
@@ -146,7 +195,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [newLocation])
@@ -172,7 +222,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1, location2])
@@ -197,7 +248,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location2, location1])
@@ -229,7 +281,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
@@ -270,7 +323,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
@@ -314,7 +368,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
@@ -344,7 +399,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1])
@@ -374,7 +430,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1])
@@ -407,7 +464,8 @@ class OneShotLocationTests: XCTestCase {
 
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1])
@@ -477,7 +535,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [
@@ -523,7 +582,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1, location2])
@@ -549,7 +609,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1, location2])
@@ -568,7 +629,8 @@ class OneShotLocationTests: XCTestCase {
         )
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: [location1])
@@ -685,7 +747,8 @@ class OneShotLocationTests: XCTestCase {
         let (timeoutPromise, timeoutSeal) = Guarantee<Void>.pending()
         let promise = OneShotLocationProxy(
             locationManager: locationManager,
-            timeout: timeoutPromise
+            timeout: timeoutPromise,
+            cachedLocationExecutor: { $0() }
         ).promise
 
         locationManager.delegate?.locationManager?(locationManager, didUpdateLocations: locations)

--- a/Tests/Shared/Sensors/LocationPermissionSensor.test.swift
+++ b/Tests/Shared/Sensors/LocationPermissionSensor.test.swift
@@ -12,8 +12,16 @@ class LocationPermissionSensorTests: XCTestCase {
         serverVersion: Version()
     )
 
+    private var previousPermissionStatus: (() -> CLAuthorizationStatus)!
+
+    override func setUp() {
+        super.setUp()
+
+        previousPermissionStatus = Current.location.permissionStatus
+    }
+
     override func tearDown() {
-        Current.location.permissionStatus = { CLLocationManager().authorizationStatus }
+        Current.location.permissionStatus = previousPermissionStatus
 
         super.tearDown()
     }
@@ -36,15 +44,22 @@ class LocationPermissionSensorTests: XCTestCase {
     }
 
     func testStatusIsReadOffTheMainThread() throws {
+        let lock = NSLock()
         var readOnMainThread: Bool?
         Current.location.permissionStatus = {
+            lock.lock()
             readOnMainThread = Thread.isMainThread
+            lock.unlock()
             return .notDetermined
         }
 
         let sensors = try hang(LocationPermissionSensor(request: request).sensors())
 
         XCTAssertEqual(sensors[0].State as? String, "Not determined")
-        XCTAssertEqual(readOnMainThread, false)
+
+        lock.lock()
+        let wasReadOnMainThread = readOnMainThread
+        lock.unlock()
+        XCTAssertEqual(wasReadOnMainThread, false)
     }
 }

--- a/Tests/Shared/Sensors/LocationPermissionSensor.test.swift
+++ b/Tests/Shared/Sensors/LocationPermissionSensor.test.swift
@@ -1,0 +1,50 @@
+import CoreLocation
+import Foundation
+import PromiseKit
+@testable import Shared
+import XCTest
+
+class LocationPermissionSensorTests: XCTestCase {
+    private var request: SensorProviderRequest = .init(
+        reason: .trigger("unit-test"),
+        dependencies: .init(),
+        location: nil,
+        serverVersion: Version()
+    )
+
+    override func tearDown() {
+        Current.location.permissionStatus = { CLLocationManager().authorizationStatus }
+
+        super.tearDown()
+    }
+
+    func testSensorReportsInjectedStatus() throws {
+        Current.location.permissionStatus = { .authorizedAlways }
+
+        let sensors = try hang(LocationPermissionSensor(request: request).sensors())
+
+        XCTAssertEqual(sensors.count, 1)
+        XCTAssertEqual(sensors[0].UniqueID, WebhookSensorId.locationPermission.rawValue)
+        XCTAssertEqual(sensors[0].Name, "Location permission")
+        XCTAssertEqual(sensors[0].State as? String, "Authorized Always")
+        XCTAssertEqual(sensors[0].Icon, "mdi:map")
+
+        Current.location.permissionStatus = { .denied }
+
+        let updated = try hang(LocationPermissionSensor(request: request).sensors())
+        XCTAssertEqual(updated[0].State as? String, "Denied")
+    }
+
+    func testStatusIsReadOffTheMainThread() throws {
+        var readOnMainThread: Bool?
+        Current.location.permissionStatus = {
+            readOnMainThread = Thread.isMainThread
+            return .notDetermined
+        }
+
+        let sensors = try hang(LocationPermissionSensor(request: request).sensors())
+
+        XCTAssertEqual(sensors[0].State as? String, "Not determined")
+        XCTAssertEqual(readOnMainThread, false)
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes two field hangs (9% each of reported hangs in 2026.7.3), both `CLLocationManager` properties that perform synchronous XPC to locationd and were read on the main thread:

- The Location permission sensor read `authorizationStatus` on the main queue during every sensor update. The read now happens on a background queue, through a new injectable `Current.location.permissionStatus` seam.
- `OneShotLocationProxy` read the cached `location` (and `accuracyAuthorization`) synchronously in its main-thread initializer during zone event processing. The cached-location seed is now read on a background queue and hops back to the main thread to be recorded; the executor is injectable for tests.

New tests cover the sensor states via the environment seam, that the status read happens off the main thread, and that the cached-location seed is deferred to the executor and still wins over the timeout.

## Screenshots
Not a user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes