### PR TITLE
Make entities searchable in Spotlight

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -135,6 +135,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupUIApplicationShortcutItems()
         migrateIfNeeded()
         RemindersSyncManager.shared.start()
+        if #available(iOS 18.0, *) {
+            SpotlightEntityIndexer.shared.start()
+        }
 
         return true
     }

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -1,4 +1,5 @@
 import CallbackURLKit
+import CoreSpotlight
 import Foundation
 import PromiseKit
 import SafariServices
@@ -238,6 +239,11 @@ class IncomingURLHandler {
     func handle(userActivity: NSUserActivity) -> Bool {
         Current.Log.info(userActivity)
 
+        if userActivity.activityType == CSSearchableItemActionType,
+           let identifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
+            return handleSpotlightEntity(identifier: identifier)
+        }
+
         switch Current.tags.handle(userActivity: userActivity) {
         case let .handled(type):
             showTagReadConfirmation(type: type)
@@ -256,6 +262,21 @@ class IncomingURLHandler {
                 return false
             }
         }
+    }
+
+    /// Opens the entity a tapped Spotlight result stands for. `ShowEntityDetailsAppIntent` handles this
+    /// for the system, so this is the fallback for when the tap arrives as a user activity instead. The
+    /// identifier is the indexed entity's id, which is what the local database keys its rows by.
+    private func handleSpotlightEntity(identifier: String) -> Bool {
+        guard let entity = HAAppEntity.entity(uniqueId: identifier),
+              let url = AppConstants.openEntityDestinationURL(
+                  entityId: entity.entityId,
+                  serverId: entity.serverId
+              ) else {
+            Current.Log.error("Can't route Spotlight entity \(identifier)")
+            return false
+        }
+        return handle(url: url)
     }
 
     func handle(shortcutItem: UIApplicationShortcutItem) -> Promise<Void> {

--- a/Sources/App/HAApp.swift
+++ b/Sources/App/HAApp.swift
@@ -1,3 +1,4 @@
+import CoreSpotlight
 import PromiseKit
 import Shared
 import SwiftUI
@@ -14,6 +15,7 @@ struct HAApp: App {
                 .toastOverlay()
                 .onOpenURL { handleIncoming(url: $0) }
                 .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { handleIncoming(userActivity: $0) }
+                .onContinueUserActivity(CSSearchableItemActionType) { handleIncoming(userActivity: $0) }
                 // SwiftUI copy of the launch screen; hides the system-splash → first-screen hand-off by
                 // morphing the splash logo into the first screen's logo before fading out.
                 .overlay { LaunchSplashOverlayView(state: .shared) }

--- a/Sources/App/Resources/Info.plist
+++ b/Sources/App/Resources/Info.plist
@@ -133,6 +133,7 @@
 	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
+		<string>com.apple.corespotlightitem</string>
 		<string>INSendMessageIntent</string>
 		<string>ReloadWidgetsAppIntent</string>
 		<string>ScriptAppIntent</string>

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -147,6 +147,8 @@
 "app_intents.server.title" = "Server";
 "app_intents.show_confirmation_dialog.description" = "Shows confirmation notification after executed";
 "app_intents.show_confirmation_dialog.title" = "Confirmation notification";
+"app_intents.show_entity_details.parameter.entity" = "Entity";
+"app_intents.show_entity_details.title" = "Show Entity Details";
 "app_intents.state.target" = "Target state";
 "app_intents.state.toggle" = "Toggle";
 "app_intents.switch.title" = "Switch";

--- a/Sources/App/Utilities/Spotlight/HAAppEntityAppIntentEntity+IndexedEntity.swift
+++ b/Sources/App/Utilities/Spotlight/HAAppEntityAppIntentEntity+IndexedEntity.swift
@@ -1,0 +1,51 @@
+import AppIntents
+import CoreSpotlight
+import Foundation
+import Shared
+
+@available(iOS 18.0, *)
+extension HAAppEntityAppIntentEntity: IndexedEntity {
+    /// Augments what App Intents derives from `displayRepresentation` with everything a person might
+    /// type, and with the context line, which a search result needs as `contentDescription`: Spotlight
+    /// renders that as the second row and does not fall back to the display representation's subtitle.
+    var attributeSet: CSSearchableItemAttributeSet {
+        let attributes = defaultAttributeSet
+        attributes.contentDescription = subtitle
+        attributes.keywords = searchKeywords
+        attributes.alternateNames = contextualNames
+        attributes.thumbnailData = SpotlightEntityIconRenderer.thumbnailData(iconName: iconName)
+        return attributes
+    }
+
+    /// Terms that should find the entity even though they aren't part of its name: its context, its
+    /// domain, and the entity id both as written and spelled out (`cover.cortina_sala` also matches
+    /// "cortina sala").
+    private var searchKeywords: [String] {
+        Self.deduplicated([
+            areaName,
+            deviceName,
+            floorName,
+            serverName,
+            Domain(entityId: entityId)?.localizedDescription,
+            entityId,
+            entityId.replacingOccurrences(of: ".", with: " ").replacingOccurrences(of: "_", with: " "),
+        ])
+    }
+
+    /// The name paired with each piece of its context, in both orders, so a query that mixes the two —
+    /// "Light living room" for a "Light" in the living room — matches a single field with the same
+    /// weight as the name alone, rather than relying on Spotlight to combine name and keyword hits.
+    private var contextualNames: [String] {
+        Self.deduplicated([areaName, deviceName, floorName, serverName])
+            .flatMap { ["\(displayString) \($0)", "\($0) \(displayString)"] }
+    }
+
+    /// Drops empty and repeated terms (a device named after its area is common) while keeping the most
+    /// specific ones first, since Spotlight treats earlier entries as more relevant.
+    private static func deduplicated(_ terms: [String?]) -> [String] {
+        var seen = Set<String>()
+        return terms
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+    }
+}

--- a/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
+++ b/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
@@ -1,0 +1,34 @@
+import AppIntents
+import Foundation
+import Shared
+
+/// Opens an entity's more-info dialog in the frontend (or the native player, for cameras).
+///
+/// Spotlight runs this intent when someone taps one of the indexed entities, which is why it exists
+/// separately from the widget control's `OpenEntityAppIntent`: only an `OpenIntent` with a `target`
+/// parameter is picked up for that.
+@available(macOS 13.0, *)
+struct ShowEntityDetailsAppIntent: OpenIntent {
+    static var title: LocalizedStringResource = .init(
+        "app_intents.show_entity_details.title",
+        defaultValue: "Show Entity Details"
+    )
+
+    @Parameter(
+        title: .init("app_intents.show_entity_details.parameter.entity", defaultValue: "Entity")
+    )
+    var target: HAAppEntityAppIntentEntity
+
+    func perform() async throws -> some IntentResult {
+        guard let url = AppConstants.openEntityDestinationURL(
+            entityId: target.entityId,
+            serverId: target.serverId
+        ) else {
+            return .result()
+        }
+        await MainActor.run {
+            URLOpener.shared.open(url, options: [:], completionHandler: nil)
+        }
+        return .result()
+    }
+}

--- a/Sources/App/Utilities/Spotlight/SpotlightEntityIconRenderer.swift
+++ b/Sources/App/Utilities/Spotlight/SpotlightEntityIconRenderer.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Shared
+import UIKit
+
+/// Renders the Material Design icon an entity resolves to as PNG data for its Spotlight result.
+///
+/// Drawn in Home Assistant blue rather than black so the glyph stays visible in both light and dark
+/// appearances (Spotlight shows the thumbnail as-is), and memoized by icon name because the same few
+/// glyphs repeat across thousands of entities.
+enum SpotlightEntityIconRenderer {
+    static func thumbnailData(iconName: String) -> Data? {
+        let key = iconName as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached as Data
+        }
+
+        MaterialDesignIcons.register()
+        let icon = MaterialDesignIcons(serversideValueNamed: iconName, fallback: .dotsGridIcon)
+        let imageRect = CGRect(origin: .zero, size: size).insetBy(dx: 12, dy: 12)
+        let data = UIGraphicsImageRenderer(size: size).pngData { _ in
+            icon
+                .image(ofSize: imageRect.size, color: AppConstants.lighterTintColor)
+                .draw(in: imageRect)
+        }
+
+        cache.setObject(data as NSData, forKey: key)
+        return data
+    }
+
+    private static let size = CGSize(width: 128, height: 128)
+    private static let cache = NSCache<NSString, NSData>()
+}

--- a/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
+++ b/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
@@ -114,8 +114,12 @@ final class SpotlightEntityIndexer: ServerObserver {
     }
 
     /// The entities worth searching for, in a stable order, paired with a signature of everything the
-    /// index displays. `nil` when the database can't be read, so a failed read never empties the index
-    /// — an empty snapshot legitimately means "no servers" and does clear it.
+    /// index carries. The server name is part of that signature even when it stays out of the displayed
+    /// subtitle, because it is always indexed as a search term, so renaming a single server still
+    /// rewrites the index.
+    ///
+    /// `nil` when the database can't be read, so a failed read never empties the index — an empty
+    /// snapshot legitimately means "no servers" and does clear it.
     ///
     /// Hidden entities are excluded (as everywhere else in the app) and so are config/diagnostic ones,
     /// which would otherwise bury the entities people search for under firmware versions and signal
@@ -133,7 +137,7 @@ final class SpotlightEntityIndexer: ServerObserver {
         }
 
         var entities: [HAAppEntityAppIntentEntity] = []
-        var signatureLines: [String] = []
+        var signatureLines = ["serverContext=\(includesServerContext)"]
 
         for server in servers {
             let serverId = server.identifier.rawValue
@@ -164,7 +168,7 @@ final class SpotlightEntityIndexer: ServerObserver {
                     indexed.areaName ?? "",
                     indexed.deviceName ?? "",
                     indexed.floorName ?? "",
-                    includesServerContext ? indexed.serverName : "",
+                    indexed.serverName,
                     indexed.iconName,
                 ].joined(separator: "|"))
             }

--- a/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
+++ b/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
@@ -1,0 +1,204 @@
+import AppIntents
+import CoreSpotlight
+import CryptoKit
+import Foundation
+import Shared
+
+/// Publishes the entities cached in the local database to Spotlight, so searching the system for an
+/// entity's name (or its area, device or server) finds it and opens its more-info dialog.
+///
+/// The index is rebuilt from the database rather than kept in sync incrementally: a full snapshot is
+/// cheap to derive, and comparing its signature against the last indexed one means a refresh that
+/// changed nothing costs a single hash instead of thousands of Spotlight writes.
+@available(iOS 18.0, *)
+@MainActor
+final class SpotlightEntityIndexer: ServerObserver {
+    static let shared = SpotlightEntityIndexer()
+
+    private enum Constants {
+        static let indexName = "HomeAssistantEntities"
+        static let stateKey = "spotlightEntityIndexState"
+        static let batchSize = 500
+        static let coalescingDelay: Duration = .seconds(2)
+        /// Bump this when the attributes written per entity change, so a build that indexes the same
+        /// entities differently still rewrites the index instead of matching the stored signature.
+        static let formatVersion = 3
+    }
+
+    /// What the index currently holds: the signature of the snapshot that produced it, and the ids it
+    /// contains, so entities that disappear from the database can be removed from Spotlight too.
+    private struct IndexState: Codable {
+        let signature: String
+        let entityIds: [String]
+    }
+
+    private struct Snapshot {
+        let entities: [HAAppEntityAppIntentEntity]
+        let signature: String
+    }
+
+    private let index = CSSearchableIndex(name: Constants.indexName)
+    private let defaults = UserDefaults(suiteName: AppConstants.AppGroupID)
+    private var databaseObserver: NSObjectProtocol?
+    private var reindexTask: Task<Void, Never>?
+
+    private init() {}
+
+    func start() {
+        guard databaseObserver == nil else { return }
+
+        databaseObserver = NotificationCenter.default.addObserver(
+            forName: .appDatabaseUpdaterDidFinishRoutine,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.scheduleReindex(reason: "database updated")
+            }
+        }
+        Current.servers.add(observer: self)
+        scheduleReindex(reason: "app launch")
+    }
+
+    nonisolated func serversDidChange(_ serverManager: ServerManager) {
+        Task { @MainActor [weak self] in
+            self?.scheduleReindex(reason: "servers changed")
+        }
+    }
+
+    /// One notification arrives per server, and a database refresh touches every server in turn, so
+    /// the work is deferred briefly and the pending task replaced to collapse a burst into one pass.
+    private func scheduleReindex(reason: String) {
+        reindexTask?.cancel()
+        reindexTask = Task { [weak self] in
+            try? await Task.sleep(for: Constants.coalescingDelay)
+            guard !Task.isCancelled else { return }
+            await self?.reindex(reason: reason)
+        }
+    }
+
+    private func reindex(reason: String) async {
+        let snapshot = await Task.detached(priority: .utility) { Self.makeSnapshot() }.value
+        guard let snapshot else { return }
+
+        let previousState = loadState()
+        guard snapshot.signature != previousState?.signature else {
+            Current.Log.verbose("Spotlight entity index already up to date (\(reason))")
+            return
+        }
+
+        let indexedIds = snapshot.entities.map(\.id)
+        let staleIds = Set(previousState?.entityIds ?? []).subtracting(indexedIds)
+
+        do {
+            if !staleIds.isEmpty {
+                try await index.deleteAppEntities(
+                    identifiedBy: Array(staleIds),
+                    ofType: HAAppEntityAppIntentEntity.self
+                )
+            }
+            for batch in stride(from: 0, to: snapshot.entities.count, by: Constants.batchSize) {
+                // A newer pass supersedes this one; leaving the state unsaved makes it redo the work.
+                guard !Task.isCancelled else { return }
+                let upperBound = min(batch + Constants.batchSize, snapshot.entities.count)
+                try await index.indexAppEntities(Array(snapshot.entities[batch ..< upperBound]))
+            }
+            save(IndexState(signature: snapshot.signature, entityIds: indexedIds))
+            Current.Log
+                .info(
+                    "Spotlight entity index updated (\(reason)): \(indexedIds.count) entities, \(staleIds.count) removed"
+                )
+        } catch {
+            Current.Log.error("Failed to update Spotlight entity index: \(error.localizedDescription)")
+        }
+    }
+
+    /// The entities worth searching for, in a stable order, paired with a signature of everything the
+    /// index displays. `nil` when the database can't be read, so a failed read never empties the index
+    /// — an empty snapshot legitimately means "no servers" and does clear it.
+    ///
+    /// Hidden entities are excluded (as everywhere else in the app) and so are config/diagnostic ones,
+    /// which would otherwise bury the entities people search for under firmware versions and signal
+    /// strengths.
+    private nonisolated static func makeSnapshot() -> Snapshot? {
+        let servers = Current.servers.all.sorted { $0.identifier.rawValue < $1.identifier.rawValue }
+        let includesServerContext = servers.count > 1
+
+        let allEntities: [HAAppEntity]
+        do {
+            allEntities = try HAAppEntity.config()
+        } catch {
+            Current.Log.error("Failed to read entities for Spotlight index: \(error.localizedDescription)")
+            return nil
+        }
+
+        var entities: [HAAppEntityAppIntentEntity] = []
+        var signatureLines: [String] = []
+
+        for server in servers {
+            let serverId = server.identifier.rawValue
+            let serverEntities = allEntities
+                .filter { $0.serverId == serverId && $0.entityCategory == nil }
+                .sorted { $0.id < $1.id }
+            let areasMap = serverEntities.areasMap(for: serverId)
+            let devicesMap = serverEntities.devicesMap(for: serverId)
+            let floorNamesMap = serverEntities.floorNamesMap(for: serverId)
+
+            for entity in serverEntities {
+                let indexed = HAAppEntityAppIntentEntity(
+                    id: entity.id,
+                    entityId: entity.entityId,
+                    serverId: serverId,
+                    serverName: server.info.name,
+                    areaName: areasMap[entity.entityId]?.name,
+                    deviceName: devicesMap[entity.entityId]?.name,
+                    floorName: floorNamesMap[entity.entityId],
+                    displayString: entity.name,
+                    iconName: iconName(for: entity),
+                    includesServerContext: includesServerContext
+                )
+                entities.append(indexed)
+                signatureLines.append([
+                    indexed.id,
+                    indexed.displayString,
+                    indexed.areaName ?? "",
+                    indexed.deviceName ?? "",
+                    indexed.floorName ?? "",
+                    includesServerContext ? indexed.serverName : "",
+                    indexed.iconName,
+                ].joined(separator: "|"))
+            }
+        }
+
+        return Snapshot(entities: entities, signature: signature(for: signatureLines))
+    }
+
+    /// The same precedence the entity pickers use: the entity's own icon, then the frontend default
+    /// resolved from the backend `entity_component` map, then the domain fallback.
+    private nonisolated static func iconName(for entity: HAAppEntity) -> String {
+        if let icon = entity.icon, !icon.isEmpty {
+            return icon
+        }
+        if let resolvedIcon = entity.resolvedIcon, !resolvedIcon.isEmpty {
+            return resolvedIcon
+        }
+        return Domain(rawValue: entity.domain)?.icon(deviceClass: entity.rawDeviceClass).name
+            ?? MaterialDesignIcons.dotsGridIcon.name
+    }
+
+    private nonisolated static func signature(for lines: [String]) -> String {
+        let payload = (["v\(Constants.formatVersion)"] + lines).joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(payload.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func loadState() -> IndexState? {
+        guard let data = defaults?.data(forKey: Constants.stateKey) else { return nil }
+        return try? JSONDecoder().decode(IndexState.self, from: data)
+    }
+
+    private func save(_ state: IndexState) {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        defaults?.set(data, forKey: Constants.stateKey)
+    }
+}

--- a/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenEntity/OpenEntityAppIntent.swift
+++ b/Sources/Extensions/Widgets/Controls/OpenEntity/ControlOpenEntity/OpenEntityAppIntent.swift
@@ -21,15 +21,10 @@ struct OpenEntityAppIntent: AppIntent {
     func perform() async throws -> some IntentResult {
         guard let entity else { return .result() }
         #if !WIDGET_EXTENSION
-        if Domain(entityId: entity.entityId) == .camera, let url = AppConstants.openCameraDeeplinkURL(
+        if let url = AppConstants.openEntityDestinationURL(
             entityId: entity.entityId,
             serverId: entity.serverId
         ) {
-            DispatchQueue.main.async {
-                URLOpener.shared.open(url, options: [:], completionHandler: nil)
-            }
-        } else if let url =
-            AppConstants.openEntityDeeplinkURL(entityId: entity.entityId, serverId: entity.serverId) {
             DispatchQueue.main.async {
                 URLOpener.shared.open(url, options: [:], completionHandler: nil)
             }

--- a/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
+++ b/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
@@ -19,10 +19,31 @@ struct HAAppEntityAppIntentEntity: AppEntity, EntityContextRepresentable {
     var floorName: String?
     var displayString: String
     var iconName: String
+    /// Whether the server name leads the context line. Only the Spotlight index sets this, and only
+    /// when more than one server is configured: its results stand alone, while every picker already
+    /// groups entities under a per-server section.
+    var includesServerContext: Bool
+
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
-            subtitle: contextSubtitle.map { LocalizedStringResource(stringLiteral: $0) }
+            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
+        )
+    }
+
+    /// The `Server • Floor • Area • Device` line shown under the entity name.
+    var subtitle: String? {
+        guard includesServerContext else {
+            return contextSubtitle
+        }
+        return EntityContextSubtitle.make(
+            serverName: serverName,
+            floorName: floorName,
+            areaName: areaName,
+            deviceName: deviceName,
+            entityName: displayString,
+            entityId: entityId,
+            domain: Domain(entityId: entityId)
         )
     }
 
@@ -35,7 +56,8 @@ struct HAAppEntityAppIntentEntity: AppEntity, EntityContextRepresentable {
         deviceName: String? = nil,
         floorName: String? = nil,
         displayString: String,
-        iconName: String
+        iconName: String,
+        includesServerContext: Bool = false
     ) {
         self.id = id
         self.entityId = entityId
@@ -46,6 +68,7 @@ struct HAAppEntityAppIntentEntity: AppEntity, EntityContextRepresentable {
         self.floorName = floorName
         self.displayString = displayString
         self.iconName = iconName
+        self.includesServerContext = includesServerContext
     }
 }
 

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -175,6 +175,15 @@ public enum AppConstants {
         return components.url
     }
 
+    /// Where tapping an entity lands: the native camera player for cameras, the frontend's more-info
+    /// dialog for everything else.
+    public static func openEntityDestinationURL(entityId: String, serverId: String) -> URL? {
+        if Domain(entityId: entityId) == .camera {
+            return openCameraDeeplinkURL(entityId: entityId, serverId: serverId)
+        }
+        return openEntityDeeplinkURL(entityId: entityId, serverId: serverId)
+    }
+
     public static func openCameraDeeplinkURL(entityId: String, serverId: String) -> URL? {
         URL(
             string: "\(AppConstants.deeplinkURL.absoluteString)camera/?entityId=\(entityId)&serverId=\(serverId)&\(AppConstants.QueryItems.isComingFromAppIntent.rawValue)=true"

--- a/Sources/Shared/HAAppEntity.swift
+++ b/Sources/Shared/HAAppEntity.swift
@@ -107,6 +107,18 @@ public extension HAAppEntity {
         return Set(compatible.map(\.entityId))
     }
 
+    /// The entity a `ServerEntity.uniqueId` names, without needing to know which server it belongs to.
+    static func entity(uniqueId: String) -> HAAppEntity? {
+        do {
+            return try Current.database().read { db in
+                try HAAppEntity.fetchOne(db, id: uniqueId)
+            }
+        } catch {
+            Current.Log.error("Error fetching entity \(uniqueId): \(error)")
+        }
+        return nil
+    }
+
     static func entity(id: String, serverId: String) -> HAAppEntity? {
         do {
             return try Current.database().read { db in

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -397,6 +397,24 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "app_intents.fire_event.event_name.title") }
       }
     }
+    public enum FocusFilter {
+      /// Reports the Focus name you pick to Home Assistant while this Focus is on.
+      public static var description: String { return L10n.tr("Localizable", "app_intents.focus_filter.description") }
+      /// Report Focus name
+      public static var title: String { return L10n.tr("Localizable", "app_intents.focus_filter.title") }
+      public enum Display {
+        /// No Focus name picked
+        public static var `none`: String { return L10n.tr("Localizable", "app_intents.focus_filter.display.none") }
+      }
+      public enum Entity {
+        /// Focus name
+        public static var name: String { return L10n.tr("Localizable", "app_intents.focus_filter.entity.name") }
+      }
+      public enum FocusName {
+        /// Focus name
+        public static var title: String { return L10n.tr("Localizable", "app_intents.focus_filter.focus_name.title") }
+      }
+    }
     public enum GetCameraSnapshot {
       /// Get a single still frame from a camera
       public static var description: String { return L10n.tr("Localizable", "app_intents.get_camera_snapshot.description") }
@@ -606,6 +624,14 @@ public enum L10n {
       public static var description: String { return L10n.tr("Localizable", "app_intents.show_confirmation_dialog.description") }
       /// Confirmation notification
       public static var title: String { return L10n.tr("Localizable", "app_intents.show_confirmation_dialog.title") }
+    }
+    public enum ShowEntityDetails {
+      /// Show Entity Details
+      public static var title: String { return L10n.tr("Localizable", "app_intents.show_entity_details.title") }
+      public enum Parameter {
+        /// Entity
+        public static var entity: String { return L10n.tr("Localizable", "app_intents.show_entity_details.parameter.entity") }
+      }
     }
     public enum State {
       /// Target state


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The entities cached locally are only searchable inside the app, so finding one means opening the app first.

Adds them to Spotlight: searching the system for an entity, its area, its device or its entity id finds it, results show the usual `Area • Device` context (with the server name when more than one is configured), and tapping one opens that entity's more-info dialog (the camera player, for cameras).

The index is rebuilt from the database whenever a refresh finishes or the server list changes, and skipped when nothing changed.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
To be added.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Requires iOS 18: indexing app entities in Spotlight (`IndexedEntity`) is not available before that. Older versions are unaffected.
