### PR TITLE
Rename "Reporting now" to "Last reported" in Focus names

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -542,12 +542,12 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "focus.how_it_works.title" = "How it works?";
 "focus.how_it_works.unpaired.body" = "iOS only runs the filter of the Focus that starts, so add one to every Focus you want reported. A Focus without a filter leaves the previous name in place until a paired Focus starts or all of them end.";
 "focus.how_it_works.unpaired.title" = "Focuses without a filter";
-"focus.names.active" = "Reporting now";
 "focus.names.add" = "Add Focus name";
 "focus.names.add_message" = "Give this Focus a name to report to Home Assistant, such as the name of the Focus itself.";
 "focus.names.empty" = "No Focus names yet.";
 "focus.names.footer" = "Create a name for each Focus you want reported, then pick it in Settings > Focus > Focus Filters.";
 "focus.names.header" = "Focus names";
+"focus.names.last_reported" = "Last reported";
 "focus.names.placeholder" = "Name";
 "focus.permission_missing.body" = "Without it the app cannot tell when every Focus has ended, so the last reported name keeps being sent.";
 "focus.permission_missing.title" = "Focus permission is off";

--- a/Sources/App/Settings/Focus/FocusSettingsView.swift
+++ b/Sources/App/Settings/Focus/FocusSettingsView.swift
@@ -32,7 +32,7 @@ struct FocusSettingsView: View {
                         Text(focusName.name)
                         if focusName.name == viewModel.activeFocusName {
                             Spacer()
-                            Text(L10n.Focus.Names.active)
+                            Text(L10n.Focus.Names.lastReported)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1979,8 +1979,6 @@ public enum L10n {
       }
     }
     public enum Names {
-      /// Reporting now
-      public static var active: String { return L10n.tr("Localizable", "focus.names.active") }
       /// Add Focus name
       public static var add: String { return L10n.tr("Localizable", "focus.names.add") }
       /// Give this Focus a name to report to Home Assistant, such as the name of the Focus itself.
@@ -1991,6 +1989,8 @@ public enum L10n {
       public static var footer: String { return L10n.tr("Localizable", "focus.names.footer") }
       /// Focus names
       public static var header: String { return L10n.tr("Localizable", "focus.names.header") }
+      /// Last reported
+      public static var lastReported: String { return L10n.tr("Localizable", "focus.names.last_reported") }
       /// Name
       public static var placeholder: String { return L10n.tr("Localizable", "focus.names.placeholder") }
     }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
In the Focus names settings screen, the label shown next to the currently reported Focus name now reads "Last reported" instead of "Reporting now".

Uses a new localization key `focus.names.last_reported`. The old `focus.names.active` entry is removed from `en.lproj` and from `Strings.swift`; the translated copies in the other locales stay as they are, since they are managed by Lokalise and are cleaned up by the "Lokalise: Delete Keys" workflow.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
