### PR TITLE
Keep distribution build artifacts when the Apple upload fails

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -49,37 +49,38 @@ jobs:
           EMERGE_BASE_SHA: ${{ github.event.before }}
 
       - name: Dump Version Information
+        if: ${{ !cancelled() }}
         run: cat Configuration/Version.xcconfig
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload iOS IPA"
-        if: success() && matrix.kind == 'ios'
+        if: ${{ !cancelled() && matrix.kind == 'ios' }}
         with:
           name: ios-app-store.ipa
           path: build/ios/Home Assistant.ipa
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload iOS dSYMs"
-        if: success() && matrix.kind == 'ios'
+        if: ${{ !cancelled() && matrix.kind == 'ios' }}
         with:
           name: ios.dSYM.zip
           path: build/ios/Home Assistant.app.dSYM.zip
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload Mac Developer ID App"
-        if: success() && matrix.kind == 'mac'
+        if: ${{ !cancelled() && matrix.kind == 'mac' }}
         with:
           name: mac-developer-id.zip
           path: build/macos/home-assistant-mac.zip
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload Mac App Store Package"
-        if: success() && matrix.kind == 'mac'
+        if: ${{ !cancelled() && matrix.kind == 'mac' }}
         with:
           name: mac-app-store.pkg
           path: build/macos/Home Assistant.pkg
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload Mac dSYMs"
-        if: success() && matrix.kind == 'mac'
+        if: ${{ !cancelled() && matrix.kind == 'mac' }}
         with:
           name: mac.dSYM.zip
           path: build/macos/Home Assistant.app.dSYM.zip

--- a/fastlane/lanes/build_utils.rb
+++ b/fastlane/lanes/build_utils.rb
@@ -36,8 +36,9 @@ end
 def report_upload_limit_reached(type:)
   store = type == 'osx' ? 'Mac App Store' : 'App Store'
   message = "#{store} upload failed: Apple daily upload limit reached (error 90382). " \
-            'The app built, notarized and stapled fine; this is an App Store Connect ' \
-            'per-app daily quota, not a build failure. Wait ~24h for the reset, then re-run.'
+            'The app built and signed fine; this is an App Store Connect per-app daily ' \
+            'quota, not a build failure. The binary is kept as a workflow artifact, so ' \
+            'upload that once the quota resets instead of re-running the build.'
 
   UI.error(message)
   puts "::error title=#{store} upload limit reached (90382)::#{message}"
@@ -50,9 +51,10 @@ def upload_limit_summary(store, type)
     '',
     "Apple returned **error 90382 (\"Upload limit reached\")** for the `#{type}` package.",
     '',
-    '- The app **built, notarized and stapled successfully**, so this is not a build or code failure.',
+    '- The app **built and signed successfully**, so this is not a build or code failure.',
     '- App Store Connect enforces a **per-app daily upload quota**, which has now been exhausted.',
-    "- **Action:** wait ~24h for Apple's window to reset, then re-run. Re-running sooner hits the same limit."
+    '- The signed binary is kept as a **workflow artifact**, so it does not need to be rebuilt.',
+    '- **Action:** wait ~24h for the quota to reset, then upload that artifact with Transporter.'
   ].join("\n")
 end
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Distribute workflow uploaded the built binaries only on `success()`, so when the App Store upload failed the signed artifacts were thrown away.

That is what happened in [run 32164404224](https://github.com/home-assistant/iOS/actions/runs/32164404224): the iOS app built and signed fine, but Apple rejected the upload with error 90382 (per-app daily upload quota). The re-run spent another 40 minutes building and hit the same limit, because the quota only resets after ~24h.

Now the artifacts are uploaded whenever the job is not cancelled, and the 90382 job summary points at the retained binary instead of asking for a re-run.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A, CI only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The upload-limit message also no longer claims the app was "notarized and stapled", which is only true for the macOS lane.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B91qFA6Y13vK4xGxWyb4vC)_