### PR TITLE
Hide unavailable sources from energy widget

### DIFF
--- a/Sources/Extensions/Widgets/Energy/WidgetEnergyMediumView.swift
+++ b/Sources/Extensions/Widgets/Energy/WidgetEnergyMediumView.swift
@@ -8,29 +8,22 @@ struct WidgetEnergyMediumView: View {
     let entry: WidgetEnergyEntry
 
     var body: some View {
+        // Only the series the server actually reports: a blank figure beside a real one reads as a
+        // broken series rather than as one this home simply doesn't have. Placeholders come back
+        // when nothing is reported at all, so a period that has only just begun keeps the layout's
+        // shape instead of collapsing to a bare chart. Totals rather than live power: these families
+        // summarise the whole period, and the gallery placeholder entry carries live power too.
+        let metrics = WidgetEnergyMetric.metricsOrPlaceholders(for: entry, figure: .totals)
         VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
-            // Every series the source preference asks for keeps its slot even before the server has
-            // reported anything for the period: the figure blanks out, the layout doesn't move.
             HStack(alignment: .top, spacing: DesignSystem.Spaces.one) {
-                if entry.source.showsSolar {
+                ForEach(metrics) { metric in
                     WidgetEnergyStatView(
-                        icon: .solarPowerIcon,
-                        value: entry.solarGenerated.map(WidgetEnergyStyle.energy) ?? WidgetEnergyStyle.emptyValue,
-                        unit: WidgetEnergyStyle.energyUnit,
-                        label: L10n.Widgets.Energy.solar,
-                        direction: WidgetEnergyStyle.direction(ofTotal: entry.solarGenerated),
-                        color: entry.solarGenerated == nil ? WidgetEnergyStyle.secondaryText : WidgetEnergyStyle.solar
-                    )
-                }
-
-                if entry.source.showsGrid {
-                    WidgetEnergyStatView(
-                        icon: .transmissionTowerIcon,
-                        value: entry.gridNet.map(WidgetEnergyStyle.energy) ?? WidgetEnergyStyle.emptyValue,
-                        unit: WidgetEnergyStyle.energyUnit,
-                        label: L10n.Widgets.Energy.electricityTotal,
-                        direction: WidgetEnergyStyle.direction(ofTotal: entry.gridNet),
-                        color: entry.gridNet == nil ? WidgetEnergyStyle.secondaryText : WidgetEnergyStyle.consumption
+                        icon: metric.icon,
+                        value: metric.value,
+                        unit: metric.unit,
+                        label: metric.kind.totalLabel,
+                        direction: metric.direction,
+                        color: metric.color
                     )
                 }
 
@@ -105,6 +98,21 @@ struct WidgetEnergyMediumView: View {
             return WidgetEnergyEntry.ChartPoint(
                 date: dayStart.addingTimeInterval(h * 3600),
                 grid: 0.25 + 0.8 * exp(-pow(h - 7, 2) / 4) + 1.0 * exp(-pow(h - 20, 2) / 6),
+                solar: h >= 6 && h <= 18 ? 1.6 * sin((h - 6) / 12 * .pi) : 0
+            )
+        }
+    )
+    // A home with solar but no grid statistics: the grid figure is dropped, not blanked.
+    WidgetEnergyEntry(
+        period: .today,
+        isConfigured: true,
+        solarGenerated: 40.3,
+        chartPoints: (0 ..< 24).map { hour in
+            let h = Double(hour)
+            let dayStart = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+            return WidgetEnergyEntry.ChartPoint(
+                date: dayStart.addingTimeInterval(h * 3600),
+                grid: 0,
                 solar: h >= 6 && h <= 18 ? 1.6 * sin((h - 6) / 12 * .pi) : 0
             )
         }

--- a/Sources/Extensions/Widgets/Energy/WidgetEnergyMetric.swift
+++ b/Sources/Extensions/Widgets/Energy/WidgetEnergyMetric.swift
@@ -5,8 +5,9 @@ import SwiftUI
 /// A single energy figure resolved from an entry, ready to render. Prefers live instantaneous power
 /// (W) when power sensors are configured, otherwise falls back to the period's energy totals (kWh).
 ///
-/// Shared by the compact layouts — the small card and the lock screen accessories — so they all
-/// derive the same numbers from an entry.
+/// Shared by every home screen and lock screen layout, so they all derive the same numbers from an
+/// entry — and drop the same series when the server doesn't report one. The wide cards ask for
+/// `Figure.totals`, which pins them to the period's energy regardless of live power.
 @available(iOS 17, *)
 struct WidgetEnergyMetric: Identifiable, Equatable {
     /// Which energy series the figure describes. Carries the presentation that never varies with
@@ -29,6 +30,15 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
             }
         }
 
+        /// Caption for the layouts wide enough to spell out what the figure covers. They summarise a
+        /// whole period, so the grid figure is that period's electricity total rather than "Grid".
+        var totalLabel: String {
+            switch self {
+            case .solar: L10n.Widgets.Energy.solar
+            case .grid: L10n.Widgets.Energy.electricityTotal
+            }
+        }
+
         var color: Color {
             switch self {
             case .solar: WidgetEnergyStyle.solar
@@ -44,6 +54,15 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
             case .grid: .boltFill
             }
         }
+    }
+
+    /// Which figure a metric reports. The wide layouts summarise a window, so they ask for the
+    /// period's totals even when the entry also carries live power — the gallery placeholder does.
+    enum Figure {
+        /// Live instantaneous power (W) when power sensors report it, the period's totals otherwise.
+        case livePowerOrTotals
+        /// The period's energy totals (kWh), whatever live power the entry carries.
+        case totals
     }
 
     let kind: Kind
@@ -84,19 +103,26 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
 
     /// The series the entry's source preference asks for, in headline order (solar first), skipping
     /// any the server doesn't report.
-    static func metrics(for entry: WidgetEnergyEntry) -> [WidgetEnergyMetric] {
+    static func metrics(
+        for entry: WidgetEnergyEntry,
+        figure: Figure = .livePowerOrTotals
+    ) -> [WidgetEnergyMetric] {
         [
-            entry.source.showsSolar ? solar(for: entry) : nil,
-            entry.source.showsGrid ? grid(for: entry) : nil,
+            entry.source.showsSolar ? solar(for: entry, figure: figure) : nil,
+            entry.source.showsGrid ? grid(for: entry, figure: figure) : nil,
         ].compactMap { $0 }
     }
 
     /// The same series as `metrics(for:)`, but never empty: when the server has nothing to report for
     /// the period yet — early in the day, typically — the series the source preference asks for come
-    /// back as blank stand-ins, so the layout keeps its shape instead of collapsing to a lone
-    /// "no energy data" line.
-    static func metricsOrPlaceholders(for entry: WidgetEnergyEntry) -> [WidgetEnergyMetric] {
-        let metrics = metrics(for: entry)
+    /// back as blank stand-ins, so the layout keeps its shape instead of collapsing. A series is only
+    /// ever blanked alongside every other one: a stand-in next to a real figure would read as a
+    /// broken series rather than as one this home doesn't have.
+    static func metricsOrPlaceholders(
+        for entry: WidgetEnergyEntry,
+        figure: Figure = .livePowerOrTotals
+    ) -> [WidgetEnergyMetric] {
+        let metrics = metrics(for: entry, figure: figure)
         guard metrics.isEmpty else { return metrics }
         return [
             entry.source.showsSolar ? placeholder(kind: .solar) : nil,
@@ -114,8 +140,8 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
         )
     }
 
-    static func solar(for entry: WidgetEnergyEntry) -> WidgetEnergyMetric? {
-        if let watts = entry.livePowerSolar {
+    static func solar(for entry: WidgetEnergyEntry, figure: Figure = .livePowerOrTotals) -> WidgetEnergyMetric? {
+        if figure == .livePowerOrTotals, let watts = entry.livePowerSolar {
             let power = WidgetEnergyStyle.power(watts)
             return .init(kind: .solar, value: power.value, unit: power.unit, direction: .up)
         }
@@ -124,14 +150,14 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
                 kind: .solar,
                 value: WidgetEnergyStyle.energy(kWh),
                 unit: WidgetEnergyStyle.energyUnit,
-                direction: .up
+                direction: WidgetEnergyStyle.direction(ofTotal: kWh)
             )
         }
         return nil
     }
 
-    static func grid(for entry: WidgetEnergyEntry) -> WidgetEnergyMetric? {
-        if let watts = entry.livePowerGrid {
+    static func grid(for entry: WidgetEnergyEntry, figure: Figure = .livePowerOrTotals) -> WidgetEnergyMetric? {
+        if figure == .livePowerOrTotals, let watts = entry.livePowerGrid {
             // Live grid power is net: positive is drawn from the grid, negative is returned to it.
             let power = WidgetEnergyStyle.power(watts)
             return .init(kind: .grid, value: power.value, unit: power.unit, direction: watts > 0 ? .down : .up)
@@ -141,7 +167,7 @@ struct WidgetEnergyMetric: Identifiable, Equatable {
                 kind: .grid,
                 value: WidgetEnergyStyle.energy(net),
                 unit: WidgetEnergyStyle.energyUnit,
-                direction: net >= 0 ? .up : .down
+                direction: WidgetEnergyStyle.direction(ofTotal: net)
             )
         }
         return nil

--- a/Tests/Widgets/WidgetEnergyMetricTests.swift
+++ b/Tests/Widgets/WidgetEnergyMetricTests.swift
@@ -88,4 +88,40 @@ struct WidgetEnergyMetricTests {
         #expect(metrics.map(\.kind) == [.solar])
         #expect(metrics[0].value != WidgetEnergyStyle.emptyValue)
     }
+
+    @available(iOS 17, *)
+    @Test func totalsIgnoreLivePower() {
+        let entry = WidgetEnergyEntry(
+            isConfigured: true,
+            gridConsumed: 6.2,
+            gridReturned: 10.5,
+            solarGenerated: 12.4,
+            livePowerGrid: 250,
+            livePowerSolar: 1450
+        )
+        let metrics = WidgetEnergyMetric.metrics(for: entry, figure: .totals)
+
+        #expect(metrics.map(\.kind) == [.solar, .grid])
+        #expect(metrics.allSatisfy { $0.unit == WidgetEnergyStyle.energyUnit })
+    }
+
+    /// The case the wide layouts hit on a home with solar but no grid statistics: the grid figure is
+    /// dropped rather than shown as a blank beside a real solar total. Live grid power doesn't
+    /// resurrect it — these layouts summarise the period.
+    @available(iOS 17, *)
+    @Test func totalsDropSeriesTheServerDoesNotReport() {
+        let entry = WidgetEnergyEntry(isConfigured: true, solarGenerated: 40.3, livePowerGrid: 250)
+
+        #expect(WidgetEnergyMetric.metrics(for: entry, figure: .totals).map(\.kind) == [.solar])
+        #expect(WidgetEnergyMetric.metricsOrPlaceholders(for: entry, figure: .totals).map(\.kind) == [.solar])
+    }
+
+    @available(iOS 17, *)
+    @Test func totalsStillStandInForEverySeriesWhenThereIsNoData() {
+        let entry = WidgetEnergyEntry(isConfigured: true, livePowerGrid: 250, livePowerSolar: 1450)
+        let metrics = WidgetEnergyMetric.metricsOrPlaceholders(for: entry, figure: .totals)
+
+        #expect(metrics.map(\.kind) == [.solar, .grid])
+        #expect(metrics.allSatisfy { $0.value == WidgetEnergyStyle.emptyValue })
+    }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The medium and large energy widgets always drew both the solar and the grid figure, so a home that only has one of them configured showed a permanent `— kWh` next to the real value.

They now follow the rule the small and lock screen layouts already used: a series the server does not report is dropped. Blanks only come back when nothing at all is reported, so a period that has just started still keeps the card's shape.

## Screenshots
With solar configured but no grid statistics, the widget used to show `↑ 40.3 kWh` for solar and an empty `— kWh` "Electricity total" beside it. Now only the solar figure is drawn. Widgets with both series configured are unchanged, and the existing snapshot tests still match.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant# N/A — bug fix, no documented behaviour changes.

## Any other notes
Tests added in `WidgetEnergyMetricTests` for the dropped-series and no-data-at-all cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L2P8rf4jw2qt6FDzguZLWM)_