### PR TITLE
Limit Focus name sensor and Focus settings to TestFlight

### DIFF
--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -206,7 +206,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
         switch self {
         case .liveActivities:
             return Self.canShowLiveActivities
-        case .remindersSync:
+        case .remindersSync, .focus:
             // Labs feature, limited to TestFlight builds while it matures.
             return Current.isTestFlight
         case .macToolbar:

--- a/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
@@ -53,10 +53,15 @@ final class FocusNameSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
 /// Settings › Focus › Focus Filters; activating that Focus runs our filter, which stores the paired
 /// name for this sensor to send. `FocusStatusWrapper` clears that name again when the Focus status
 /// says every Focus ended, so a name only sticks around while some Focus is running.
+///
+/// Labs feature, limited to TestFlight builds while it matures, matching the Focus settings screen
+/// where the names are created.
 final class FocusNameSensor: SensorProvider {
     public enum FocusNameError: Error, Equatable {
         /// No Focus name has been created, so there is nothing this sensor could ever report.
         case unconfigured
+        /// Labs feature, limited to TestFlight builds while it matures.
+        case unavailable
     }
 
     /// Reported while iOS says no Focus is running. The stored name is normally already cleared by
@@ -72,6 +77,10 @@ final class FocusNameSensor: SensorProvider {
     }
 
     func sensors() -> Promise<[WebhookSensor]> {
+        guard Current.isTestFlight else {
+            return .init(error: FocusNameError.unavailable)
+        }
+
         let activeName = Current.focusFilter.activeFocusName()
 
         guard activeName != nil || !FocusName.all().isEmpty else {

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -17,6 +17,7 @@ class FocusNameSensorTests: XCTestCase {
         try clearFocusNames()
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
+        Current.isTestFlight = true
     }
 
     override func tearDownWithError() throws {
@@ -24,6 +25,7 @@ class FocusNameSensorTests: XCTestCase {
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
         Current.isAppExtension = false
+        Current.isTestFlight = true
         try super.tearDownWithError()
     }
 
@@ -51,6 +53,17 @@ class FocusNameSensorTests: XCTestCase {
         let promise = FocusNameSensor(request: request).sensors()
         XCTAssertThrowsError(try hang(promise)) { error in
             XCTAssertEqual(error as? FocusNameSensor.FocusNameError, .unconfigured)
+        }
+    }
+
+    func testUnavailableOutsideTestFlight() throws {
+        Current.isTestFlight = false
+        FocusName(name: "Work").save()
+        setUpDependencies(activeFocusName: "Work", isFocused: true)
+
+        let promise = FocusNameSensor(request: request).sensors()
+        XCTAssertThrowsError(try hang(promise)) { error in
+            XCTAssertEqual(error as? FocusNameSensor.FocusNameError, .unavailable)
         }
     }
 

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -17,6 +17,9 @@ class FocusNameSensorTests: XCTestCase {
         try clearFocusNames()
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
+
+        let previousIsTestFlight = Current.isTestFlight
+        addTeardownBlock { Current.isTestFlight = previousIsTestFlight }
         Current.isTestFlight = true
     }
 
@@ -25,7 +28,6 @@ class FocusNameSensorTests: XCTestCase {
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
         Current.isAppExtension = false
-        Current.isTestFlight = true
         try super.tearDownWithError()
     }
 


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Gates the Focus name feature to TestFlight builds while it matures, matching how Reminders sync is handled:

- `FocusNameSensor` reports nothing outside TestFlight, so the sensor no longer appears in the sensors list.
- The Focus entry point in Settings is hidden outside TestFlight, so Focus names cannot be configured there.

## Screenshots
No new UI, the existing Focus screen is only hidden outside TestFlight.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`Current.isTestFlight` is `true` in debug builds, so behaviour is unchanged while developing.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jCFZp3ZGLJ7vY9ssBgLCf)_