### PR TITLE
Document TestFlight feature gating in AI agent instructions

### DIFF
--- a/.agents/skills/ha-ios-architecture/SKILL.md
+++ b/.agents/skills/ha-ios-architecture/SKILL.md
@@ -103,6 +103,10 @@ Current.servers = FakeServerManager()
 
 **Never assign to `Current.*` properties outside of test code.** This is enforced by a custom SwiftLint rule that will fail CI. In production code, only _read_ from `Current`.
 
+### Beta-Only Features
+
+`Current.isTestFlight` is the only supported way to limit a feature to beta builds — no bespoke flags, build settings, or `#if` branches. Every gate must be paired with a draft PR that removes it; see the `ha-ios-workflow-ci` skill for the procedure.
+
 ## Additional Resources
 
 - [Home Assistant Developer Docs (Apple)](https://developers.home-assistant.io/docs/apple/)

--- a/.agents/skills/ha-ios-workflow-ci/SKILL.md
+++ b/.agents/skills/ha-ios-workflow-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ha-ios-workflow-ci
-description: The end-to-end change workflow and CI gates. Use when preparing a change for commit, understanding the order of lint/autocorrect/test steps, or knowing what GitHub Actions checks before a PR can merge.
+description: The end-to-end change workflow, TestFlight feature gating, and CI gates. Use when preparing a change for commit, understanding the order of lint/autocorrect/test steps, gating a feature behind TestFlight with `Current.isTestFlight`, or knowing what GitHub Actions checks before a PR can merge.
 ---
 
 # Workflow & Continuous Integration
@@ -13,6 +13,36 @@ description: The end-to-end change workflow and CI gates. Use when preparing a c
 4. **Run autocorrect**: `bundle exec fastlane autocorrect` (see the `ha-ios-code-style` skill)
 5. **Run tests**: `bundle exec fastlane test` (see the `ha-ios-testing` skill)
 6. **Commit** your changes
+
+## TestFlight-Gated Features
+
+A feature that is not ready for every user yet may ship to beta testers only. Two rules govern this, and both are mandatory.
+
+### 1. `Current.isTestFlight` is the only gate
+
+```swift
+case .remindersSync:
+    // Labs feature, limited to TestFlight builds while it matures.
+    return Current.isTestFlight
+```
+
+- Gate on `Current.isTestFlight` (defined in `Sources/Shared/Environment/Environment.swift`) and nothing else. Do not invent a feature-flag type, add a build setting, an `#if` branch, an `Info.plist` key, or a hidden setting to accomplish the same thing.
+- Read `Current.isTestFlight`; never assign to it outside tests (see the `ha-ios-architecture` skill for the `Current` rules, and the `ha-ios-testing` skill for overriding it in tests).
+- Keep the gate at the smallest edge that hides the feature — one availability check, menu entry, or settings row — rather than scattering the condition through the implementation. Removing the gate should be a small, obvious diff.
+- Add a short comment next to the gate saying why the feature is beta-only, as in the example above.
+
+### 2. Every gate ships with a parallel draft PR that removes it
+
+Whenever a change puts a feature behind `Current.isTestFlight`, a second, parallel **draft** PR must exist that removes that gate:
+
+- Branch it off the gating PR's branch, so its diff is exactly the gate removal and nothing else.
+- Title it so its purpose is obvious, e.g. `Ungate <feature> from TestFlight`, and mark it as a draft — it is merged only once the feature is ready for general release.
+- Link the two PRs to each other in their descriptions.
+- When the gating PR changes during review, update the ungating PR to match, so it stays mergeable.
+
+The point is that graduating a feature out of beta is a one-click merge instead of an archaeology exercise: an unpaired gate tends to outlive the reason it was added.
+
+> Per the [AI policy](../../../AI_POLICY.md), agents do not open PRs autonomously. Prepare the ungating branch and hand both PRs to a human to review and submit.
 
 ## Continuous Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ These apply to every change, even if you don't load the matching skill:
 - **One type per file**: each `struct`/`class`/`enum` lives in its own file named after the type — never stack multiple top-level types (especially SwiftUI `View` structs) in one file. Small `private` helper types nested inside the type are the only exception. Every SwiftUI view ships with a `#Preview`. See [`ha-ios-ui`](.agents/skills/ha-ios-ui/SKILL.md) for the full UI rules.
 - **No navigation title under an Apple-like header**: a screen whose `List` starts with `AppleLikeListTopRowHeader` already shows its title in that header, so it must not also set `.navigationTitle`. Two titles stack as the user scrolls.
 - **SwiftUI confirmations stay on the trigger**: apply `.confirmationDialog` directly to the `Button` that opens it, not to a parent `List`, `Section`, or container view. This keeps confirmation ownership local and avoids dialogs firing from unrelated controls.
+- **TestFlight gating is `Current.isTestFlight`, and always paired with an ungating PR**: `Current.isTestFlight` is the only supported way to limit a feature to beta builds — never add a bespoke flag, build setting, or `#if` for it. Every change that puts a feature behind that gate must be accompanied by a parallel draft PR that removes the gate, so shipping the feature to everyone is a one-click merge. See [`ha-ios-workflow-ci`](.agents/skills/ha-ios-workflow-ci/SKILL.md) for the full procedure.
 
 ## Skills
 
@@ -31,7 +32,7 @@ These apply to every change, even if you don't load the matching skill:
 | [`ha-ios-push-live-activities`](.agents/skills/ha-ios-push-live-activities/SKILL.md) | Implementing or fixing push notifications or Live Activities across the local-push and remote-push flows |
 | [`ha-ios-ui`](.agents/skills/ha-ios-ui/SKILL.md) | Building UI, choosing SwiftUI vs UIKit, or following the one-struct-per-file, inline-body, and `#Preview` rules |
 | [`ha-ios-testing`](.agents/skills/ha-ios-testing/SKILL.md) | Writing unit or snapshot tests, or mocking dependencies by overriding `Current` |
-| [`ha-ios-workflow-ci`](.agents/skills/ha-ios-workflow-ci/SKILL.md) | Preparing a change for commit or understanding the CI gates that must pass before merge |
+| [`ha-ios-workflow-ci`](.agents/skills/ha-ios-workflow-ci/SKILL.md) | Preparing a change for commit, gating a feature behind TestFlight, or understanding the CI gates that must pass before merge |
 | [`ha-ios-skill-maintenance`](.agents/skills/ha-ios-skill-maintenance/SKILL.md) | Adding, editing, or reorganizing these skills, or updating this router |
 
 ## Additional Resources


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Documents two rules for beta-only features in the AI agent instructions: a feature is gated to TestFlight with `Current.isTestFlight` and nothing else, and every gate must be paired with a parallel draft PR that removes it, so releasing the feature to everyone is a single merge.

The full procedure lives in the `ha-ios-workflow-ci` skill, with a non-negotiable bullet in `AGENTS.md` and a cross-reference from the architecture skill. Docs only, no code changes.

## Screenshots

N/A, no user-facing change.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

None.
