### PR TITLE
Fix Focus name sensor reporting "Not focused" while a Focus is running

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
@@ -28,7 +28,7 @@ final class FocusNameSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
             self?.signal()
         }
         // …and the Focus status tells us when every Focus ended, which no filter reports.
-        focusStatusCancellable = Current.focusStatus.trigger.observe { [weak self] _ in
+        focusStatusCancellable = Current.focusStatus.receivedStatus.observe { [weak self] _ in
             self?.signal()
         }
         isObserving = true
@@ -51,16 +51,16 @@ final class FocusNameSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
 ///
 /// The user creates the names in the app's Focus settings and pairs each one with a Focus in
 /// Settings › Focus › Focus Filters; activating that Focus runs our filter, which stores the paired
-/// name for this sensor to send. `FocusStatusWrapper` clears that name again when the Focus status
-/// says every Focus ended, so a name only sticks around while some Focus is running.
+/// name for this sensor to send. `FocusReport` pairs that name with the Focus status iOS pushes us
+/// to work out whether it is still the Focus that is running.
 final class FocusNameSensor: SensorProvider {
     public enum FocusNameError: Error, Equatable {
         /// No Focus name has been created, so there is nothing this sensor could ever report.
         case unconfigured
     }
 
-    /// Reported while iOS says no Focus is running. The stored name is normally already cleared by
-    /// then; this also covers the window before that clear lands, and reads taken without one.
+    /// Reported once iOS has told us every Focus ended, and while nothing has ever told us one is
+    /// running.
     static let notFocusedState = "Not focused"
     /// Reported while a Focus is running that no Focus Filter has named — either the user hasn't
     /// paired that Focus yet, or the Focus status permission is missing so we can't tell.
@@ -72,19 +72,18 @@ final class FocusNameSensor: SensorProvider {
     }
 
     func sensors() -> Promise<[WebhookSensor]> {
-        let activeName = Current.focusFilter.activeFocusName()
+        let report = FocusReport.current()
 
-        guard activeName != nil || !FocusName.all().isEmpty else {
+        guard report.name != nil || !FocusName.all().isEmpty else {
             return .init(error: FocusNameError.unconfigured)
         }
 
-        let isFocused = currentIsFocused()
         let state: String
 
-        if isFocused == false {
+        if let name = report.name {
+            state = name
+        } else if report.isFocused == false {
             state = Self.notFocusedState
-        } else if let activeName, !activeName.isEmpty {
-            state = activeName
         } else {
             state = Self.unknownState
         }
@@ -95,7 +94,7 @@ final class FocusNameSensor: SensorProvider {
             icon: "mdi:moon-waning-crescent",
             state: state
         )) {
-            if let isFocused {
+            if let isFocused = report.isFocused {
                 $0.Attributes = ["Is focused": isFocused]
             }
         }
@@ -104,15 +103,5 @@ final class FocusNameSensor: SensorProvider {
         let _: FocusNameSensorUpdateSignaler = request.dependencies.updateSignaler(for: self)
 
         return .value([sensor])
-    }
-
-    /// Whether any Focus is running, when the user granted the Focus status permission. `nil` when
-    /// iOS won't tell us, in which case the last name the filter reported is the best we have.
-    private func currentIsFocused() -> Bool? {
-        guard Current.focusStatus.isAvailable(),
-              Current.focusStatus.authorizationStatus() == .authorized else {
-            return nil
-        }
-        return Current.focusStatus.status().isFocused
     }
 }

--- a/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusSensor.swift
@@ -20,7 +20,7 @@ final class FocusSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderU
     override func observe() {
         super.observe()
         guard !isObserving else { return }
-        cancellable = Current.focusStatus.trigger.observe { [weak self] _ in
+        cancellable = Current.focusStatus.receivedStatus.observe { [weak self] _ in
             #if os(watchOS)
             self?.signal()
             #else

--- a/Sources/Shared/Environment/FocusFilterWrapper.swift
+++ b/Sources/Shared/Environment/FocusFilterWrapper.swift
@@ -30,9 +30,15 @@ public class FocusFilterStateSync: UserDefaultsValueSync<FocusFilterState> {
 public class FocusFilterWrapper {
     private(set) lazy var state = FocusFilterStateSync()
 
+    /// The last Focus Filter run, with the moment it happened so it can be ordered against what
+    /// the Focus status pushed us.
+    public lazy var activeFocusState: () -> FocusFilterState? = { [weak self] in
+        self?.state.value
+    }
+
     /// The name reported by the last Focus Filter run, if any.
     public lazy var activeFocusName: () -> String? = { [weak self] in
-        self?.state.value?.name
+        self?.activeFocusState()?.name
     }
 
     /// Called by the Focus Filter's App Intent when a Focus activates.

--- a/Sources/Shared/Environment/FocusReport.swift
+++ b/Sources/Shared/Environment/FocusReport.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// What we currently know about Focus: which named Focus is running, and whether any is at all.
+///
+/// Two sources each know half of it and neither is complete on its own. The Focus Filter runs when
+/// a Focus *starts* and is the only thing that ever tells us its name. `INShareFocusStatusIntent`
+/// pushes whether any Focus is running, which is the only thing that tells us one ended — but
+/// asking iOS for that status back reports `false` for a Focus whose status the user doesn't
+/// share, and during a switch it still describes the Focus that just ended.
+///
+/// So neither source is allowed to overrule the other outright: they are ordered by when they
+/// happened, and a filter run that nothing newer has ended stands as proof that its Focus is on.
+public struct FocusReport: Equatable {
+    /// The name the Focus Filter reported for the running Focus. `nil` when no Focus is running, or
+    /// when the running one has no filter pairing it with a name.
+    public let name: String?
+    /// Whether any Focus is running, or `nil` when nothing we have access to can say.
+    public let isFocused: Bool?
+
+    public init(name: String?, isFocused: Bool?) {
+        self.name = name
+        self.isFocused = isFocused
+    }
+
+    /// iOS starts the new Focus — running its filter — before it reports the previous one ending,
+    /// so a status saying nothing is running this soon after a filter run is the tail end of a
+    /// switch rather than the Focus we were just told about ending.
+    static let switchGracePeriod: TimeInterval = 5
+
+    public static func current() -> FocusReport {
+        let filterState = Current.focusFilter.activeFocusState()
+        let receivedStatus = Current.focusStatus.lastReceived()
+
+        if let filterState, !hasEnded(filterState: filterState, receivedStatus: receivedStatus) {
+            let reportedName = filterState.name
+            return .init(
+                name: reportedName?.isEmpty == false ? reportedName : nil,
+                // A filter only runs when a Focus starts, and nothing has told us it ended since.
+                isFocused: true
+            )
+        }
+
+        return .init(name: nil, isFocused: receivedStatus?.isFocused ?? liveIsFocused())
+    }
+
+    /// Whether iOS said every Focus had ended after the filter ran, which is what makes the name it
+    /// reported stale. Checked against the last such moment rather than the current status, so a
+    /// Focus that started without a filter can't inherit the name of the one before it.
+    private static func hasEnded(filterState: FocusFilterState, receivedStatus: FocusStatusState?) -> Bool {
+        guard let lastEndedDate = receivedStatus?.lastEndedDate else { return false }
+        return lastEndedDate > filterState.date.addingTimeInterval(switchGracePeriod)
+    }
+
+    /// Asking iOS directly, which only the app can do, and which only answers for Focuses whose
+    /// status the user shares. The fallback for when no status was ever pushed to us.
+    private static func liveIsFocused() -> Bool? {
+        guard Current.focusStatus.isAvailable(),
+              Current.focusStatus.authorizationStatus() == .authorized else {
+            return nil
+        }
+        return Current.focusStatus.status().isFocused
+    }
+}

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -1,14 +1,34 @@
 import Intents
 import PromiseKit
 
-public class FocusStateTrigger: UserDefaultsValueSync<Date> {
+/// The Focus status iOS last pushed to us, kept in the app group with the moment it arrived so any
+/// process can order it against what the Focus Filter reported.
+public struct FocusStatusState: Codable, Equatable {
+    /// Whether any Focus was running, or `nil` when iOS sent a status without saying.
+    public var isFocused: Bool?
+    /// When this status arrived, so it can be told apart from an older or newer Focus Filter run.
+    public var date: Date
+    /// When iOS last said every Focus had ended, kept across later updates. A name the filter
+    /// reported before that moment belongs to a Focus that is over; one reported after it doesn't.
+    public var lastEndedDate: Date?
+
+    public init(isFocused: Bool?, date: Date, lastEndedDate: Date?) {
+        self.isFocused = isFocused
+        self.date = date
+        self.lastEndedDate = lastEndedDate
+    }
+}
+
+public class FocusStatusStateSync: UserDefaultsValueSync<FocusStatusState> {
     init() {
-        super.init(settingsKey: "FocusStateTriggerKey")
+        super.init(settingsKey: "FocusStatusStateKey")
     }
 }
 
 public class FocusStatusWrapper {
-    private(set) lazy var trigger = FocusStateTrigger()
+    /// Every Focus status iOS pushed us, in the app group. Observed to signal the Focus sensors,
+    /// and read back by `FocusReport` to decide whether a reported name is still current.
+    private(set) lazy var receivedStatus = FocusStatusStateSync()
 
     public enum AuthorizationStatus: Equatable {
         case notDetermined
@@ -78,14 +98,17 @@ public class FocusStatusWrapper {
         precondition(Current.isAppExtension)
         lastStatus = status.flatMap { Status(focusStatus: $0) }
 
-        // A Focus Filter only runs when a Focus starts, so nothing ever tells us the name it
-        // reported has gone stale. This is the moment we learn every Focus ended, so drop it here
-        // rather than leave the last name sitting in the app group.
-        if lastStatus?.isFocused == false {
-            Current.focusFilter.setActiveFocusName(nil)
-        }
+        let now = Current.date()
+        let isFocused = lastStatus?.isFocused
 
-        trigger.value = Current.date()
+        // Recorded rather than acted on: iOS runs the next Focus' filter before it tells us the
+        // previous one ended, so which of the two is current is decided when they are read back
+        // together, not by letting whichever arrives last overwrite the other.
+        receivedStatus.value = FocusStatusState(
+            isFocused: isFocused,
+            date: now,
+            lastEndedDate: isFocused == false ? now : receivedStatus.value?.lastEndedDate
+        )
     }
 
     public lazy var status: () -> Status = { [weak self] in
@@ -94,5 +117,10 @@ public class FocusStatusWrapper {
         } else {
             return .init(focusStatus: INFocusStatusCenter.default.focusStatus)
         }
+    }
+
+    /// The last status iOS pushed us, from whichever process received it.
+    public lazy var lastReceived: () -> FocusStatusState? = { [weak self] in
+        self?.receivedStatus.value
     }
 }

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -1,12 +1,13 @@
 import Intents
 import PromiseKit
 
-/// The Focus status iOS last pushed to us, kept in the app group with the moment it arrived so any
-/// process can order it against what the Focus Filter reported.
+/// The Focus status iOS last pushed to us, kept in the app group so every process reads the same
+/// thing instead of asking iOS itself, along with when a Focus last ended — which is what decides
+/// whether the name the Focus Filter reported is still the Focus that is running.
 public struct FocusStatusState: Codable, Equatable {
     /// Whether any Focus was running, or `nil` when iOS sent a status without saying.
     public var isFocused: Bool?
-    /// When this status arrived, so it can be told apart from an older or newer Focus Filter run.
+    /// When this status arrived, so pushing the same status twice still notifies observers.
     public var date: Date
     /// When iOS last said every Focus had ended, kept across later updates. A name the filter
     /// reported before that moment belongs to a Focus that is over; one reported after it doesn't.

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -12,18 +12,26 @@ class FocusNameSensorTests: XCTestCase {
         serverVersion: Version()
     )
 
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         try clearFocusNames()
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
+        Current.focusFilter.state.value = nil
+        Current.focusStatus.receivedStatus.value = nil
+        Current.date = { [now] in now }
     }
 
     override func tearDownWithError() throws {
         try clearFocusNames()
+        Current.focusFilter.state.value = nil
+        Current.focusStatus.receivedStatus.value = nil
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
         Current.isAppExtension = false
+        Current.date = Date.init
         try super.tearDownWithError()
     }
 
@@ -33,20 +41,42 @@ class FocusNameSensorTests: XCTestCase {
         }
     }
 
+    /// - Parameters:
+    ///   - filterRan: how long before now the Focus Filter reported `activeFocusName`, so a test
+    ///     can place it before or after what the Focus status pushed.
+    ///   - receivedStatus: what iOS last pushed us, which is what tells us a Focus ended.
     private func setUpDependencies(
         activeFocusName: String?,
-        isFocused: Bool?,
+        filterRan: TimeInterval = -60,
+        receivedStatus: FocusStatusState? = nil,
+        liveIsFocused: Bool? = nil,
         focusAuthorization: FocusStatusWrapper.AuthorizationStatus = .authorized,
         focusAvailable: Bool = true
     ) {
-        Current.focusFilter.activeFocusName = { activeFocusName }
+        Current.focusFilter.activeFocusState = { [now] in
+            activeFocusName.map { FocusFilterState(name: $0, date: now.addingTimeInterval(filterRan)) }
+        }
+        Current.focusStatus.lastReceived = { receivedStatus }
         Current.focusStatus.isAvailable = { focusAvailable }
         Current.focusStatus.authorizationStatus = { focusAuthorization }
-        Current.focusStatus.status = { .init(isFocused: isFocused) }
+        Current.focusStatus.status = { .init(isFocused: liveIsFocused) }
+    }
+
+    private func received(
+        isFocused: Bool?,
+        at offset: TimeInterval,
+        lastEnded: TimeInterval? = nil
+    ) -> FocusStatusState {
+        let date = now.addingTimeInterval(offset)
+        return FocusStatusState(
+            isFocused: isFocused,
+            date: date,
+            lastEndedDate: lastEnded.map { now.addingTimeInterval($0) } ?? (isFocused == false ? date : nil)
+        )
     }
 
     func testUnconfiguredWithoutNamesOrActiveName() throws {
-        setUpDependencies(activeFocusName: nil, isFocused: true)
+        setUpDependencies(activeFocusName: nil, liveIsFocused: true)
 
         let promise = FocusNameSensor(request: request).sensors()
         XCTAssertThrowsError(try hang(promise)) { error in
@@ -56,7 +86,7 @@ class FocusNameSensorTests: XCTestCase {
 
     func testReportsActiveNameWhileFocused() throws {
         FocusName(name: "Work").save()
-        setUpDependencies(activeFocusName: "Work", isFocused: true)
+        setUpDependencies(activeFocusName: "Work", receivedStatus: received(isFocused: true, at: -59))
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors.count, 1)
@@ -65,78 +95,125 @@ class FocusNameSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
     }
 
-    func testReportsNotFocusedEvenWithStaleName() throws {
+    /// The bug behind #5467: iOS runs the new Focus' filter before it reports the status of the
+    /// switch, and reading the status back at that moment still says nothing is running — which
+    /// used to throw away the name the filter had just reported.
+    func testReportsNameReportedRightBeforeAStatusSayingNothingIsRunning() throws {
+        FocusName(name: "Personal").save()
+        setUpDependencies(
+            activeFocusName: "Personal",
+            filterRan: -1,
+            receivedStatus: received(isFocused: false, at: 0),
+            liveIsFocused: false
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Personal")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
+    }
+
+    /// A Focus whose status the user doesn't share reads back as "not focused" for as long as it
+    /// runs, so the name has to stand on the filter's word alone.
+    func testReportsNameWhileTheLiveStatusKeepsSayingNotFocused() throws {
+        FocusName(name: "Personal").save()
+        setUpDependencies(activeFocusName: "Personal", liveIsFocused: false)
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Personal")
+    }
+
+    func testReportsNotFocusedOnceEveryFocusEnded() throws {
         FocusName(name: "Work").save()
-        setUpDependencies(activeFocusName: "Work", isFocused: false)
+        setUpDependencies(activeFocusName: "Work", receivedStatus: received(isFocused: false, at: -10))
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, FocusNameSensor.notFocusedState)
         XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, false)
     }
 
+    /// A Focus without a filter starting after every Focus ended must not inherit the name of the
+    /// Focus before it, even though the status now says one is running again.
+    func testReportsUnknownWhenAnUnpairedFocusStartsAfterTheNameWentStale() throws {
+        FocusName(name: "Work").save()
+        setUpDependencies(
+            activeFocusName: "Work",
+            receivedStatus: received(isFocused: true, at: -5, lastEnded: -10)
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, FocusNameSensor.unknownState)
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
+    }
+
     /// A configured name with nothing reported yet: the user created names but hasn't paired a
     /// Focus Filter with them, so we can't tell which Focus is running.
     func testReportsUnknownWhenNoFilterReported() throws {
         FocusName(name: "Work").save()
-        setUpDependencies(activeFocusName: nil, isFocused: true)
+        setUpDependencies(activeFocusName: nil, receivedStatus: received(isFocused: true, at: -5))
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, FocusNameSensor.unknownState)
     }
 
-    /// Without the Focus status permission the filter's name is all we have, and the "no Focus is
-    /// running" attribute has to be left off rather than guessed.
+    /// iOS sending a status without saying whether a Focus is running is not the same as saying
+    /// none is, so the reported name has to survive it.
+    func testKeepsTheNameWhenTheReceivedStatusIsUnknown() throws {
+        FocusName(name: "Work").save()
+        setUpDependencies(activeFocusName: "Work", receivedStatus: received(isFocused: nil, at: -5))
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Work")
+    }
+
+    /// Without the Focus status permission nothing can tell us a Focus ended, so the filter's own
+    /// report is all there is — and it only ever runs when a Focus starts.
     func testReportsNameWithoutFocusAuthorization() throws {
-        setUpDependencies(activeFocusName: "Sleep", isFocused: false, focusAuthorization: .denied)
+        setUpDependencies(activeFocusName: "Sleep", focusAuthorization: .denied)
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, "Sleep")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
+    }
+
+    func testReportsUnknownWithoutAuthorizationAndWithoutAnyReport() throws {
+        FocusName(name: "Sleep").save()
+        setUpDependencies(activeFocusName: nil, focusAuthorization: .denied)
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, FocusNameSensor.unknownState)
         XCTAssertNil(sensors[0].Attributes?["Is focused"])
     }
 
     func testReportsNameWhenFocusStatusUnavailable() throws {
-        setUpDependencies(activeFocusName: "Sleep", isFocused: false, focusAvailable: false)
+        setUpDependencies(activeFocusName: "Sleep", focusAvailable: false)
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, "Sleep")
-        XCTAssertNil(sensors[0].Attributes?["Is focused"])
     }
 
-    /// The Focus Filter only runs when a Focus starts, so a received status saying nothing is
-    /// running is the only signal that the reported name is stale.
-    func testReceivedStatusClearsTheNameWhenEveryFocusEnded() throws {
+    /// The received status is what every process reads back, so it has to survive the one that
+    /// received it going away — and it has to remember when a Focus last ended.
+    func testReceivedStatusIsStoredWithWhenEveryFocusLastEnded() throws {
         Current.isAppExtension = true
-        var storedName: String? = "Work"
-        Current.focusFilter.activeFocusName = { storedName }
-        Current.focusFilter.setActiveFocusName = { storedName = $0 }
+
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.isFocused, false)
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastEndedDate, now)
+
+        Current.date = { [now] in now.addingTimeInterval(60) }
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: true))
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.isFocused, true)
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastEndedDate, now)
+    }
+
+    /// A received status must not destroy the reported name: whether it is still current depends on
+    /// when the filter ran, which is only known when the two are read back together.
+    func testReceivedStatusKeepsTheReportedName() throws {
+        Current.isAppExtension = true
+        Current.focusFilter.setActiveFocusName("Work")
 
         Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
 
-        XCTAssertNil(storedName)
-    }
-
-    func testReceivedStatusKeepsTheNameWhileAFocusRuns() throws {
-        Current.isAppExtension = true
-        var storedName: String? = "Work"
-        Current.focusFilter.activeFocusName = { storedName }
-        Current.focusFilter.setActiveFocusName = { storedName = $0 }
-
-        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: true))
-
-        XCTAssertEqual(storedName, "Work")
-    }
-
-    /// iOS sends an unknown focus state when the permission is there but it won't say; that is not
-    /// the same as "no Focus is running", so the name has to survive it.
-    func testReceivedStatusKeepsTheNameWhenFocusStateIsUnknown() throws {
-        Current.isAppExtension = true
-        var storedName: String? = "Work"
-        Current.focusFilter.activeFocusName = { storedName }
-        Current.focusFilter.setActiveFocusName = { storedName = $0 }
-
-        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: nil))
-        Current.focusStatus.update(fromReceived: nil)
-
-        XCTAssertEqual(storedName, "Work")
+        XCTAssertEqual(Current.focusFilter.activeFocusName(), "Work")
     }
 }

--- a/Tests/Shared/Sensors/FocusSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusSensor.test.swift
@@ -120,10 +120,14 @@ class FocusSensorTests: XCTestCase {
 
         let date = Date()
         Current.isForegroundApp = { false }
-        Current.focusStatus.trigger.value = date
+        Current.focusStatus.receivedStatus.value = .init(isFocused: true, date: date, lastEndedDate: nil)
 
         Current.isForegroundApp = { true }
-        Current.focusStatus.trigger.value = date.addingTimeInterval(1.0)
+        Current.focusStatus.receivedStatus.value = .init(
+            isFocused: true,
+            date: date.addingTimeInterval(1.0),
+            lastEndedDate: nil
+        )
 
         // so it sticks around, but we don't need to access it directly
         await fulfillment(of: [expectation2], timeout: 10)


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Switching between Focuses reported the new name and then immediately flipped to "Not focused".

The Focus Filter stores the name when a Focus starts, but reading the Focus status back at that moment still describes the switch that just ended, and it answers `false` for the whole run of a Focus whose status is not shared. That read was allowed to throw away the name the filter had just reported, so whichever sensor update landed last won.

The two sources are now ordered by when they happened instead. The received status is kept in the app group with its date and the moment a Focus last ended, so every process reads the same thing, and a filter run that nothing newer has ended stands on its own as proof that its Focus is on. Received statuses no longer clear the stored name, so a transient one can no longer strand the sensor on "Unknown" for the rest of a Focus that no filter runs for again.

Fixes #5467

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The `focus` binary sensor is unchanged: it still reports what iOS shares, so it can read `off` while `focus_name` reports the running Focus.
