### PR TITLE
Remove TestFlight gate from Focus name

### DIFF
--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -206,7 +206,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
         switch self {
         case .liveActivities:
             return Self.canShowLiveActivities
-        case .remindersSync, .focus:
+        case .remindersSync:
             // Labs feature, limited to TestFlight builds while it matures.
             return Current.isTestFlight
         case .macToolbar:

--- a/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/FocusNameSensor.swift
@@ -53,15 +53,10 @@ final class FocusNameSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProvi
 /// Settings › Focus › Focus Filters; activating that Focus runs our filter, which stores the paired
 /// name for this sensor to send. `FocusStatusWrapper` clears that name again when the Focus status
 /// says every Focus ended, so a name only sticks around while some Focus is running.
-///
-/// Labs feature, limited to TestFlight builds while it matures, matching the Focus settings screen
-/// where the names are created.
 final class FocusNameSensor: SensorProvider {
     public enum FocusNameError: Error, Equatable {
         /// No Focus name has been created, so there is nothing this sensor could ever report.
         case unconfigured
-        /// Labs feature, limited to TestFlight builds while it matures.
-        case unavailable
     }
 
     /// Reported while iOS says no Focus is running. The stored name is normally already cleared by
@@ -77,10 +72,6 @@ final class FocusNameSensor: SensorProvider {
     }
 
     func sensors() -> Promise<[WebhookSensor]> {
-        guard Current.isTestFlight else {
-            return .init(error: FocusNameError.unavailable)
-        }
-
         let activeName = Current.focusFilter.activeFocusName()
 
         guard activeName != nil || !FocusName.all().isEmpty else {

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -17,10 +17,6 @@ class FocusNameSensorTests: XCTestCase {
         try clearFocusNames()
         Current.focusFilter = FocusFilterWrapper()
         Current.focusStatus = FocusStatusWrapper()
-
-        let previousIsTestFlight = Current.isTestFlight
-        addTeardownBlock { Current.isTestFlight = previousIsTestFlight }
-        Current.isTestFlight = true
     }
 
     override func tearDownWithError() throws {
@@ -55,17 +51,6 @@ class FocusNameSensorTests: XCTestCase {
         let promise = FocusNameSensor(request: request).sensors()
         XCTAssertThrowsError(try hang(promise)) { error in
             XCTAssertEqual(error as? FocusNameSensor.FocusNameError, .unconfigured)
-        }
-    }
-
-    func testUnavailableOutsideTestFlight() throws {
-        Current.isTestFlight = false
-        FocusName(name: "Work").save()
-        setUpDependencies(activeFocusName: "Work", isFocused: true)
-
-        let promise = FocusNameSensor(request: request).sensors()
-        XCTAssertThrowsError(try hang(promise)) { error in
-            XCTAssertEqual(error as? FocusNameSensor.FocusNameError, .unavailable)
         }
     }
 


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Reverts #5469, so the Focus name sensor and the Focus entry point in Settings are available in every build again.

## Screenshots
No new UI, the existing Focus screen is only shown again in all builds.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Draft, meant to be merged once the feature is ready to ship.
