### PR TITLE
Add "Open page in browser" gesture action

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -19,6 +19,8 @@ final class WebViewGestureHandler {
             webViewNavigateBack()
         case .nextPage:
             webViewNavigateForward()
+        case .openInBrowser:
+            webView?.openInBrowser()
         case .showServersList:
             showServersList()
         case .nextServer:

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -72,7 +72,8 @@ extension MacWebViewTitleBar {
         private static let gestureActions: [HAGestureAction] = HAGestureAction.allCases.filter { ![
             .none,
             .nextPage,
-            .backPage
+            .backPage,
+            .openInBrowser
         ].contains($0) }
 
         private weak var webViewController: WebViewController?
@@ -405,6 +406,8 @@ extension MacWebViewTitleBar {
                 .arrowUturnBackward
             case .nextPage:
                 .arrowUturnForward
+            case .openInBrowser:
+                .safari
             case .showServersList:
                 .serverRack
             case .nextServer:

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+StatusBar.swift
@@ -42,17 +42,26 @@ extension WebViewController {
     }
 
     @objc func openServerInSafari() {
-        if let url = webView.url {
-            guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                return
-            }
-            // Remove external_auth=1 query item from URL
-            urlComponents.queryItems = urlComponents.queryItems?.filter { $0.name != "external_auth" }
+        guard let url = externalURLForCurrentPage() else { return }
+        URLOpener.shared.open(url, options: [:], completionHandler: nil)
+    }
 
-            if let url = urlComponents.url {
-                URLOpener.shared.open(url, options: [:], completionHandler: nil)
-            }
+    /// Gesture counterpart of the macOS toolbar's "Open in Safari" action. Unlike the toolbar item, it
+    /// honors the browser picked in General settings, which is only offered outside of macOS.
+    func openInBrowser() {
+        guard let url = externalURLForCurrentPage() else { return }
+        openURLInBrowser(url, self)
+    }
+
+    /// The URL currently displayed, without the `external_auth` query item that only makes sense to the
+    /// frontend running inside our webview.
+    private func externalURLForCurrentPage() -> URL? {
+        guard let url = webView.url,
+              var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
         }
+        urlComponents.queryItems = urlComponents.queryItems?.filter { $0.name != "external_auth" }
+        return urlComponents.url
     }
 
     @objc func copyCurrentSelectedContent() {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewControllerProtocol.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewControllerProtocol.swift
@@ -28,6 +28,7 @@ protocol WebViewControllerProtocol: AnyObject {
     func openDebug()
     func goBack()
     func goForward()
+    func openInBrowser()
     func styleUI()
     func styleUI(publishesThemedStatusBar: Bool)
 }

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -624,6 +624,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.swipe_right.title" = "Swipe Right";
 "gestures.value.option.assist" = "Open Assist";
 "gestures.value.option.back_page" = "Back to previous page";
+"gestures.value.option.more_info.open_in_browser" = "Opens the page currently shown in the app in your preferred browser";
 "gestures.value.option.more_info.quick_search" = "Quick search";
 "gestures.value.option.more_info.search_commands" = "Search commands";
 "gestures.value.option.more_info.search_devices" = "Search devices";
@@ -632,6 +633,7 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.value.option.next_server" = "Next server";
 "gestures.value.option.none" = "None";
 "gestures.value.option.open_debug" = "Open debug";
+"gestures.value.option.open_in_browser" = "Open page in browser";
 "gestures.value.option.previous_server" = "Previous server";
 "gestures.value.option.quick_search" = "Quick search";
 "gestures.value.option.search_commands" = "Search commands";

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -35,6 +35,7 @@ public enum HAGestureAction: String, Codable, CaseIterable {
     // Page
     case backPage
     case nextPage
+    case openInBrowser
     // Servers
     case showServersList
     case nextServer
@@ -61,7 +62,7 @@ public enum HAGestureAction: String, Codable, CaseIterable {
         switch self {
         case .showSidebar, .quickSearch, .searchEntities, .searchDevices, .searchCommands, .assist:
             .homeAssistant
-        case .backPage, .nextPage:
+        case .backPage, .nextPage, .openInBrowser:
             .page
         case .showServersList, .nextServer, .previousServer:
             .servers
@@ -80,6 +81,8 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             L10n.Gestures.Value.Option.backPage
         case .nextPage:
             L10n.Gestures.Value.Option.nextPage
+        case .openInBrowser:
+            L10n.Gestures.Value.Option.openInBrowser
         case .quickSearch:
             L10n.Gestures.Value.Option.quickSearch
         case .searchEntities:
@@ -113,6 +116,8 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             nil
         case .nextPage:
             nil
+        case .openInBrowser:
+            L10n.Gestures.Value.Option.MoreInfo.openInBrowser
         case .quickSearch:
             L10n.Gestures.Value.Option.MoreInfo.quickSearch
         case .searchEntities:

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2257,6 +2257,8 @@ public enum L10n {
         public static var `none`: String { return L10n.tr("Localizable", "gestures.value.option.none") }
         /// Open debug
         public static var openDebug: String { return L10n.tr("Localizable", "gestures.value.option.open_debug") }
+        /// Open page in browser
+        public static var openInBrowser: String { return L10n.tr("Localizable", "gestures.value.option.open_in_browser") }
         /// Previous server
         public static var previousServer: String { return L10n.tr("Localizable", "gestures.value.option.previous_server") }
         /// Quick search
@@ -2274,6 +2276,8 @@ public enum L10n {
         /// Show sidebar
         public static var showSidebar: String { return L10n.tr("Localizable", "gestures.value.option.show_sidebar") }
         public enum MoreInfo {
+          /// Opens the page currently shown in the app in your preferred browser
+          public static var openInBrowser: String { return L10n.tr("Localizable", "gestures.value.option.more_info.open_in_browser") }
           /// Quick search
           public static var quickSearch: String { return L10n.tr("Localizable", "gestures.value.option.more_info.quick_search") }
           /// Search commands

--- a/Tests/App/WebView/Mocks/MockWebViewController.swift
+++ b/Tests/App/WebView/Mocks/MockWebViewController.swift
@@ -39,6 +39,7 @@ final class MockWebViewController: WebViewControllerProtocol {
     var handleExternalAuthFailureExpectation: XCTestExpectation?
     var showLoggedOutStateCalled = false
     var showLoggedOutStateExpectation: XCTestExpectation?
+    var openInBrowserCalled = false
 
     init() {
         self.webViewExternalMessageHandler = MockWebViewExternalMessageHandler()
@@ -62,6 +63,10 @@ final class MockWebViewController: WebViewControllerProtocol {
 
     func goForward() {
         // Simulate going forward
+    }
+
+    func openInBrowser() {
+        openInBrowserCalled = true
     }
 
     func styleUI() {

--- a/Tests/App/WebView/WebViewGestureHandlerTests.swift
+++ b/Tests/App/WebView/WebViewGestureHandlerTests.swift
@@ -1,0 +1,30 @@
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+@MainActor
+final class WebViewGestureHandlerTests: XCTestCase {
+    func testOpenInBrowserActionAsksWebViewToOpenCurrentPageInBrowser() {
+        let webView = MockWebViewController()
+        let sut = makeSUT(webView: webView)
+
+        sut.handleGestureAction(.openInBrowser)
+
+        XCTAssertTrue(webView.openInBrowserCalled)
+    }
+
+    func testNoneActionDoesNotOpenBrowser() {
+        let webView = MockWebViewController()
+        let sut = makeSUT(webView: webView)
+
+        sut.handleGestureAction(.none)
+
+        XCTAssertFalse(webView.openInBrowserCalled)
+    }
+
+    private func makeSUT(webView: MockWebViewController) -> WebViewGestureHandler {
+        let sut = WebViewGestureHandler()
+        sut.webView = webView
+        return sut
+    }
+}


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

macOS has an "Open in Safari" toolbar button, but there was no equivalent on iPhone and iPad. This adds a new `openInBrowser` gesture action so the current page can be opened in the browser from any configurable gesture.

It opens the current webview URL (without the `external_auth` query item) using the browser selected in Settings → General → Links, which is a preference only offered outside of macOS.

The macOS toolbar builds its optional items from the gesture actions, so the new action is excluded there to avoid a second "Open in Safari" entry in the toolbar customization palette.

## Screenshots

<!-- Gesture picker only, no new screen. -->

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Added a small unit test covering the gesture routing.
