### PR TITLE
Remove Smart back gesture action

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewGestureHandler.swift
@@ -19,8 +19,6 @@ final class WebViewGestureHandler {
             webViewNavigateBack()
         case .nextPage:
             webViewNavigateForward()
-        case .smartBack:
-            smartBack()
         case .showServersList:
             showServersList()
         case .nextServer:
@@ -51,22 +49,14 @@ final class WebViewGestureHandler {
             .cauterize()
     }
 
-    @discardableResult
-    private func webViewNavigateBack() -> Bool {
-        guard webView?.canGoBack ?? false else { return false }
+    private func webViewNavigateBack() {
+        guard webView?.canGoBack ?? false else { return }
         webView?.goBack()
-        return true
     }
 
     private func webViewNavigateForward() {
         if webView?.canGoForward ?? false {
             webView?.goForward()
-        }
-    }
-
-    private func smartBack() {
-        if !webViewNavigateBack() {
-            showSidebar()
         }
     }
 

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -68,13 +68,11 @@ extension MacWebViewTitleBar {
             static let serverPickerHorizontalPadding: CGFloat = 8
         }
 
-        // Gestures excluding no-op, already existing toolbar actions and
-        // Smart back, which is not available as a toolbar action
+        // Gestures excluding no-op and already existing toolbar actions
         private static let gestureActions: [HAGestureAction] = HAGestureAction.allCases.filter { ![
             .none,
             .nextPage,
-            .backPage,
-            .smartBack
+            .backPage
         ].contains($0) }
 
         private weak var webViewController: WebViewController?
@@ -407,8 +405,6 @@ extension MacWebViewTitleBar {
                 .arrowUturnBackward
             case .nextPage:
                 .arrowUturnForward
-            case .smartBack:
-                .arrowUturnBackward
             case .showServersList:
                 .serverRack
             case .nextServer:

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -628,7 +628,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.value.option.more_info.search_commands" = "Search commands";
 "gestures.value.option.more_info.search_devices" = "Search devices";
 "gestures.value.option.more_info.search_entities" = "Search entities";
-"gestures.value.option.more_info.smart_back" = "Goes back to the previous page, or shows the sidebar when there is no page to go back to";
 "gestures.value.option.next_page" = "Go to next page";
 "gestures.value.option.next_server" = "Next server";
 "gestures.value.option.none" = "None";
@@ -641,7 +640,6 @@ This server requires a client certificate (mTLS) but the operation was cancelled
 "gestures.value.option.servers_list" = "Servers list";
 "gestures.value.option.show_settings" = "Open App settings";
 "gestures.value.option.show_sidebar" = "Show sidebar";
-"gestures.value.option.smart_back" = "Smart back";
 "grdb.config.migration_error.failed_access_grdb" = "Failed to access database (GRDB), error: %@";
 "grdb.config.migration_error.failed_to_save" = "Failed to save new config, error: %@";
 "ha_api.api_error.cant_build_url" = "Cant build API URL";

--- a/Sources/App/Settings/Gestures/GesturesSetupView.swift
+++ b/Sources/App/Settings/Gestures/GesturesSetupView.swift
@@ -95,8 +95,7 @@ struct GesturesSetupView: View {
                 ListPickerContent.Item(
                     id: action.rawValue,
                     title: action.localizedString,
-                    subtitle: action.moreInfo,
-                    showsLabsLabel: action.isLabsFeature
+                    subtitle: action.moreInfo
                 )
             }
             sections.append(.init(id: category.rawValue, title: category.localizedString, items: items))

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -35,7 +35,6 @@ public enum HAGestureAction: String, Codable, CaseIterable {
     // Page
     case backPage
     case nextPage
-    case smartBack
     // Servers
     case showServersList
     case nextServer
@@ -46,11 +45,18 @@ public enum HAGestureAction: String, Codable, CaseIterable {
     // Other
     case none
 
+    public init(from decoder: Decoder) throws {
+        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        // Actions removed in newer versions decode as no-op instead of throwing, otherwise a single
+        // stale entry would make the whole persisted gesture configuration fall back to defaults.
+        self = HAGestureAction(rawValue: rawValue) ?? .none
+    }
+
     public var category: HAGestureActionCategory {
         switch self {
         case .showSidebar, .quickSearch, .searchEntities, .searchDevices, .searchCommands, .assist:
             .homeAssistant
-        case .backPage, .nextPage, .smartBack:
+        case .backPage, .nextPage:
             .page
         case .showServersList, .nextServer, .previousServer:
             .servers
@@ -69,8 +75,6 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             L10n.Gestures.Value.Option.backPage
         case .nextPage:
             L10n.Gestures.Value.Option.nextPage
-        case .smartBack:
-            L10n.Gestures.Value.Option.smartBack
         case .quickSearch:
             L10n.Gestures.Value.Option.quickSearch
         case .searchEntities:
@@ -96,16 +100,6 @@ public enum HAGestureAction: String, Codable, CaseIterable {
         }
     }
 
-    /// Whether the action is experimental and should display a Labs label
-    public var isLabsFeature: Bool {
-        switch self {
-        case .smartBack:
-            true
-        default:
-            false
-        }
-    }
-
     public var moreInfo: String? {
         switch self {
         case .showSidebar:
@@ -114,8 +108,6 @@ public enum HAGestureAction: String, Codable, CaseIterable {
             nil
         case .nextPage:
             nil
-        case .smartBack:
-            L10n.Gestures.Value.Option.MoreInfo.smartBack
         case .quickSearch:
             L10n.Gestures.Value.Option.MoreInfo.quickSearch
         case .searchEntities:

--- a/Sources/Shared/AppGesture.swift
+++ b/Sources/Shared/AppGesture.swift
@@ -46,10 +46,15 @@ public enum HAGestureAction: String, Codable, CaseIterable {
     case none
 
     public init(from decoder: Decoder) throws {
-        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        let decodedRawValue = try decoder.singleValueContainer().decode(String.self)
         // Actions removed in newer versions decode as no-op instead of throwing, otherwise a single
         // stale entry would make the whole persisted gesture configuration fall back to defaults.
-        self = HAGestureAction(rawValue: rawValue) ?? .none
+        if let action = HAGestureAction(rawValue: decodedRawValue) {
+            self = action
+        } else {
+            Current.Log.info("Unknown gesture action '\(decodedRawValue)' decoded as none")
+            self = .none
+        }
     }
 
     public var category: HAGestureActionCategory {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2273,8 +2273,6 @@ public enum L10n {
         public static var showSettings: String { return L10n.tr("Localizable", "gestures.value.option.show_settings") }
         /// Show sidebar
         public static var showSidebar: String { return L10n.tr("Localizable", "gestures.value.option.show_sidebar") }
-        /// Smart back
-        public static var smartBack: String { return L10n.tr("Localizable", "gestures.value.option.smart_back") }
         public enum MoreInfo {
           /// Quick search
           public static var quickSearch: String { return L10n.tr("Localizable", "gestures.value.option.more_info.quick_search") }
@@ -2284,8 +2282,6 @@ public enum L10n {
           public static var searchDevices: String { return L10n.tr("Localizable", "gestures.value.option.more_info.search_devices") }
           /// Search entities
           public static var searchEntities: String { return L10n.tr("Localizable", "gestures.value.option.more_info.search_entities") }
-          /// Goes back to the previous page, or shows the sidebar when there is no page to go back to
-          public static var smartBack: String { return L10n.tr("Localizable", "gestures.value.option.more_info.smart_back") }
         }
       }
     }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Removes the experimental "Smart back" option from the gesture actions, along with its strings, Labs flag and Mac toolbar handling.

## Screenshots

n/a, the option is simply gone from the gesture action list.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Gesture settings are stored as a single encoded dictionary, so a saved "Smart back" binding would have made the whole dictionary fail to decode and reset every gesture to its default. Unknown actions now decode as "None", so only that one gesture is cleared.
