### PR TITLE
Add Labs label to focus name sensor row

### DIFF
--- a/Sources/App/Settings/Sensors/List/SensorRow.swift
+++ b/Sources/App/Settings/Sensors/List/SensorRow.swift
@@ -13,8 +13,14 @@ struct SensorRow: View {
                     .foregroundColor(isEnabled ? .accentColor : .secondary)
             }
             VStack(alignment: .leading) {
-                Text(sensor.Name ?? L10n.unknownLabel)
-                    .foregroundColor(isEnabled ? .primary : .secondary)
+                HStack(spacing: DesignSystem.Spaces.one) {
+                    Text(sensor.Name ?? L10n.unknownLabel)
+                        .foregroundColor(isEnabled ? .primary : .secondary)
+                    // The focus name sensor is a Labs feature, so the row says so next to its name.
+                    if sensor.UniqueID == WebhookSensorId.focusName.rawValue {
+                        LabsLabel()
+                    }
+                }
                 if isEnabled {
                     Text(sensor.StateDescription ?? L10n.unknownLabel)
                         .foregroundColor(.secondary)


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The focus name sensor is a Labs feature, so its row in the sensors list now shows the `LabsLabel` badge right next to the "Focus name" text.

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
