### PR TITLE
Add Labs label to Apple Health sensors row

### DIFF
--- a/Sources/App/Settings/Sensors/List/SensorListView.swift
+++ b/Sources/App/Settings/Sensors/List/SensorListView.swift
@@ -132,6 +132,7 @@ struct SensorListView: View {
                 } label: {
                     HStack {
                         Text(L10n.SettingsSensors.Health.Sensors.title)
+                        LabsLabel()
                         Spacer()
                         // Inside the label rather than `.badge`, so the count sits between the
                         // title and the disclosure chevron instead of after it.


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The Apple Health sensors row in the sensors list now shows the `LabsLabel` badge right next to its title.

## Screenshots

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes
