### PR TITLE
Fix UI lag on cold launch and when opening Settings

### DIFF
--- a/Sources/App/Settings/AppIconShortcuts/AppIconShortcutItemsUpdater.swift
+++ b/Sources/App/Settings/AppIconShortcuts/AppIconShortcutItemsUpdater.swift
@@ -19,22 +19,27 @@ enum AppIconShortcutItemsUpdater {
             publish(shortcutItems: forcedShortcutItems)
         }
 
-        let magicItemProvider = Current.magicItemProvider()
-        magicItemProvider.loadInformation { _ in
-            let config = (try? AppIconShortcutConfig.config()) ?? AppIconShortcutConfig()
-            let configuredShortcutItems = config.items
-                .filter { $0.type != .unsupported }
-                .prefix(maximumShortcutItems)
-                .map { item in
-                    UIApplicationShortcutItem(
-                        type: shortcutType(for: item),
-                        localizedTitle: title(for: item, provider: magicItemProvider),
-                        localizedSubtitle: subtitle(for: item, provider: magicItemProvider),
-                        icon: icon(for: item, provider: magicItemProvider)
-                    )
-                }
-            let shortcutItems = forcedShortcutItems + configuredShortcutItems
-            publish(shortcutItems: shortcutItems)
+        // `loadInformation` fetches every entity, area, and device row for every server
+        // synchronously on the calling thread, and `update()` runs at app launch — keep that work
+        // off the main thread. The resulting items are published back on main.
+        DispatchQueue.global(qos: .utility).async {
+            let magicItemProvider = Current.magicItemProvider()
+            magicItemProvider.loadInformation { _ in
+                let config = (try? AppIconShortcutConfig.config()) ?? AppIconShortcutConfig()
+                let configuredShortcutItems = config.items
+                    .filter { $0.type != .unsupported }
+                    .prefix(maximumShortcutItems)
+                    .map { item in
+                        UIApplicationShortcutItem(
+                            type: shortcutType(for: item),
+                            localizedTitle: title(for: item, provider: magicItemProvider),
+                            localizedSubtitle: subtitle(for: item, provider: magicItemProvider),
+                            icon: icon(for: item, provider: magicItemProvider)
+                        )
+                    }
+                let shortcutItems = forcedShortcutItems + configuredShortcutItems
+                publish(shortcutItems: shortcutItems)
+            }
         }
     }
 

--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -314,7 +314,10 @@ enum SettingsItem: String, Hashable, CaseIterable {
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         if Current.isDebug {
             return true
-        } else if case .paired = Communicator.shared.currentWatchState {
+        } else if case .paired = Communicator.shared.lastKnownWatchState {
+            // The cached state, not `currentWatchState`: `isVisible` runs on the main thread for
+            // every settings list evaluation, and the live getters synchronously wait on WCSession's
+            // internal operation queue, which can stall while the session is busy.
             return true
         }
         return false
@@ -339,9 +342,25 @@ struct MaterialDesignIconsImage: View {
     let icon: MaterialDesignIcons
     let size: CGFloat
 
+    /// Rendered glyph bitmaps keyed by icon and size. Rendering goes through CoreText into a bitmap
+    /// context, which is too slow to repeat for ~20 rows on every settings list body evaluation.
+    /// The image is displayed as a template (only its alpha channel matters), so the cache doesn't
+    /// need to vary by color or light/dark appearance.
+    private static let renderedImageCache = NSCache<NSString, UIImage>()
+
     var body: some View {
-        Image(uiImage: icon.image(ofSize: CGSize(width: size, height: size), color: .label))
+        Image(uiImage: Self.image(for: icon, size: size))
             .renderingMode(.template)
+    }
+
+    private static func image(for icon: MaterialDesignIcons, size: CGFloat) -> UIImage {
+        let cacheKey = "\(icon.unicode)-\(size)" as NSString
+        if let cached = renderedImageCache.object(forKey: cacheKey) {
+            return cached
+        }
+        let image = icon.image(ofSize: CGSize(width: size, height: size), color: .label)
+        renderedImageCache.setObject(image, forKey: cacheKey)
+        return image
     }
 }
 

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -335,8 +335,17 @@ struct SettingsView: View {
                     item.accessoryIcon
                 }
             }
-        } else {
+        } else if Current.isCatalyst {
+            // The Catalyst sidebar lives in a `NavigationView`, which value-based links don't
+            // support, so it keeps the eager destination.
             NavigationLink(destination: item.destinationView) {
+                settingsItemLabel(item, subtitle: subtitle)
+            }
+        } else {
+            // Value-based, resolved by `navigationDestination(for:)` in `iOSNavigationContent`, so
+            // `item.destinationView` — and every destination's stored properties with it — is only
+            // constructed on navigation instead of for every row on every list evaluation.
+            NavigationLink(value: item) {
                 settingsItemLabel(item, subtitle: subtitle)
             }
         }

--- a/Sources/HADesignSystem/Sources/Components/LabsLabel.swift
+++ b/Sources/HADesignSystem/Sources/Components/LabsLabel.swift
@@ -7,17 +7,21 @@ public struct LabsLabel: View {
     @State private var showInfo = false
     private let info: String?
 
+    /// Rendered once and reused: the glyph is drawn through CoreText into a bitmap context, which is
+    /// too slow to repeat on every body evaluation of every row carrying the label.
+    private static let labsIcon = MaterialDesignIcons.testTubeIcon.image(
+        ofSize: .init(width: 15, height: 15),
+        color: .white
+    )
+
     public init(info: String? = nil) {
         self.info = info
     }
 
     public var body: some View {
         HStack(spacing: .zero) {
-            Image(uiImage: MaterialDesignIcons.testTubeIcon.image(
-                ofSize: .init(width: 15, height: 15),
-                color: .white
-            ))
-            .padding(.leading, DesignSystem.Spaces.one)
+            Image(uiImage: Self.labsIcon)
+                .padding(.leading, DesignSystem.Spaces.one)
             Text("Labs")
                 .font(.caption2.bold())
                 .padding(.leading, DesignSystem.Spaces.half)

--- a/Sources/HANetworking/Sources/ServerManager.swift
+++ b/Sources/HANetworking/Sources/ServerManager.swift
@@ -490,13 +490,23 @@ public final class ServerManagerImpl: ServerManager {
     }
 
     private func syncMirrorStoreFromKeychain() {
-        // The mirror is a best-effort startup snapshot, not a second source of truth.
-        // Rebuild it from the current Keychain contents whenever the app opens.
-        mirrorStore.removeAll()
-        for (key, value) in keychain.allServerInfo(decoder: decoder) {
-            mirrorStore.set(value, key: key)
+        // The mirror is a best-effort startup snapshot, not a second source of truth. Rebuild it
+        // from the current Keychain contents whenever the app opens — but only when the snapshot
+        // actually changed: this runs synchronously during launch, and the delete-all plus one
+        // insert per server otherwise costs several write transactions on the shared database
+        // queue every single launch.
+        let desired = keychain.allServerInfo(decoder: decoder)
+            .map { key, info in (key, info.mirroredForPersistence) }
+        let desiredByKey = Dictionary(desired, uniquingKeysWith: { first, _ in first })
+        let existingByKey = Dictionary(mirrorStore.allServerInfo(), uniquingKeysWith: { first, _ in first })
+
+        if desiredByKey != existingByKey {
+            mirrorStore.removeAll()
+            for (key, value) in desired {
+                mirrorStore.set(value, key: key)
+            }
         }
-        pruneRestoredMirroredServers(validKeys: Set(mirrorStore.allKeys()))
+        pruneRestoredMirroredServers(validKeys: Set(desiredByKey.keys))
     }
 
     private var restoredMirroredServers: Set<String> {

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -12,30 +12,36 @@ final class ClientEventStore: ClientEventStoreProtocol {
     static var jsonCacheName = "databases/clientEvents.json"
     /// Events are recorded from every queue in the app (main, the WatchConnectivity callbacks, the
     /// expiring-activity queue, cooperative pool tasks). Appending is a read-modify-write of one shared
-    /// file, so without this lock concurrent writers lose each other's events — and a reader landing
-    /// mid-write decodes a truncated file, which throws away the whole history.
-    private static let fileLock = NSLock()
+    /// file, so without serialization concurrent writers lose each other's events — and a reader
+    /// landing mid-write decodes a truncated file, which throws away the whole history.
+    ///
+    /// A serial queue (instead of a lock held on the caller's thread) also keeps the cost off the
+    /// recording thread: every append decodes and atomically rewrites a file holding up to 1000
+    /// events, which is far too slow for the main thread — the very first event ("Application
+    /// Starting") is recorded during app launch.
+    private static let ioQueue = DispatchQueue(label: "io.home-assistant.client-event-store", qos: .utility)
 
     public func addEvent(_ event: ClientEvent) {
         Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")
         let eventsCacheLimit = 1000
-        Self.fileLock.lock()
-        defer { Self.fileLock.unlock() }
-        var events = readEvents()
-        events.append(event)
-        if events.count > eventsCacheLimit {
-            events = events.suffix(eventsCacheLimit)
+        Self.ioQueue.async { [self] in
+            var events = readEvents()
+            events.append(event)
+            if events.count > eventsCacheLimit {
+                events = events.suffix(eventsCacheLimit)
+            }
+            saveJSONData(events)
         }
-        saveJSONData(events)
     }
 
     public func getEvents() -> [ClientEvent] {
-        Self.fileLock.lock()
-        defer { Self.fileLock.unlock() }
-        return readEvents()
+        // Sync on the serial queue so pending `addEvent` writes are visible to this read.
+        Self.ioQueue.sync {
+            readEvents()
+        }
     }
 
-    /// Unsynchronized read; callers must hold `fileLock`.
+    /// Unsynchronized read; callers must be on `ioQueue`.
     private func readEvents() -> [ClientEvent] {
         guard let containerURL = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: AppConstants.AppGroupID) else {
@@ -63,12 +69,12 @@ final class ClientEventStore: ClientEventStoreProtocol {
     }
 
     public func clearAllEvents() {
-        Self.fileLock.lock()
-        defer { Self.fileLock.unlock() }
-        saveJSONData([])
+        Self.ioQueue.sync {
+            saveJSONData([])
+        }
     }
 
-    /// Unsynchronized write; callers must hold `fileLock`.
+    /// Unsynchronized write; callers must be on `ioQueue`.
     private func saveJSONData(_ events: [ClientEvent]) {
         do {
             let fileURL = AppConstants.clientEventsFile

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -28,7 +28,7 @@ final class ClientEventStore: ClientEventStoreProtocol {
             var events = readEvents()
             events.append(event)
             if events.count > eventsCacheLimit {
-                events = events.suffix(eventsCacheLimit)
+                events = Array(events.suffix(eventsCacheLimit))
             }
             saveJSONData(events)
         }

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -107,14 +107,28 @@ public extension DatabaseQueue {
             GRDBDatabaseTable.appEntityRegistryListForDisplay.rawValue,
             "entityRegistry",
         ]
-        for tableName in obsoleteTables {
+        // Check existence in a single read first: on a steady-state launch none of these tables
+        // exist anymore, and this runs on the main thread as part of the first database access, so
+        // it must not open write transactions it doesn't need.
+        let existingObsoleteTables: [String]
+        do {
+            existingObsoleteTables = try database.read { db in
+                try obsoleteTables.filter { try db.tableExists($0) }
+            }
+        } catch {
+            Current.Log.verbose(
+                "Failed to check for obsolete GRDB tables, error: \(error.localizedDescription)"
+            )
+            return
+        }
+        for tableName in existingObsoleteTables {
             do {
                 try database.write { db in
                     try db.drop(table: tableName)
                 }
             } catch {
                 Current.Log.verbose(
-                    "Failed or not needed to drop obsolete GRDB table \(tableName), error: \(error.localizedDescription)"
+                    "Failed to drop obsolete GRDB table \(tableName), error: \(error.localizedDescription)"
                 )
             }
         }
@@ -377,24 +391,31 @@ protocol DatabaseTableProtocol {
 extension DatabaseTableProtocol {
     /// Migrates the table by adding new columns and removing obsolete columns
     func migrateColumns(database: DatabaseQueue) throws {
-        try database.write { db in
-            let existingColumns = try db.columns(in: tableName)
-            let definedColumnSet = Set(definedColumns)
+        // Inspect the schema in a read first and only open a write transaction when something
+        // actually changed: this runs for every table on the first database access of a launch
+        // (on the main thread), and on a steady-state launch nothing needs migrating.
+        let existingColumnNames = try database.read { db in
+            try db.columns(in: tableName).map(\.name)
+        }
+        let existingColumnSet = Set(existingColumnNames)
+        let definedColumnSet = Set(definedColumns)
 
+        let columnsToAdd = definedColumns.filter { !existingColumnSet.contains($0) }
+        let columnsToDrop = existingColumnNames.filter { !definedColumnSet.contains($0) }
+        guard !columnsToAdd.isEmpty || !columnsToDrop.isEmpty else { return }
+
+        try database.write { db in
             // Add new columns that don't exist yet
-            for columnName in definedColumns {
-                let shouldCreateColumn = !existingColumns.contains { $0.name == columnName }
-                if shouldCreateColumn {
-                    try db.alter(table: tableName) { tableAlteration in
-                        tableAlteration.add(column: columnName)
-                    }
+            for columnName in columnsToAdd {
+                try db.alter(table: tableName) { tableAlteration in
+                    tableAlteration.add(column: columnName)
                 }
             }
 
             // Remove columns that are no longer defined
-            for existingColumn in existingColumns where !definedColumnSet.contains(existingColumn.name) {
+            for columnName in columnsToDrop {
                 try db.alter(table: tableName) { tableAlteration in
-                    tableAlteration.drop(column: existingColumn.name)
+                    tableAlteration.drop(column: columnName)
                 }
             }
         }

--- a/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
+++ b/Sources/Shared/Watch/Connectivity/WatchConnectivityManager.swift
@@ -43,6 +43,10 @@ public final class WatchConnectivityManager: NSObject {
     private var cachedReceivedContext: [String: Any]?
     #if os(iOS)
     var complicationCompletions: [ObjectIdentifier: (Result<Int, Error>) -> Void] = [:]
+
+    /// In-memory copy of the most recently observed watch state; see `lastKnownWatchState`.
+    private let watchStateCacheLock = NSLock()
+    private var cachedWatchState: HAWatchConnectivity.WatchState?
     #endif
 
     public let state = HAWatchConnectivity.Observable<HAWatchConnectivity.SessionState>()
@@ -133,6 +137,20 @@ public final class WatchConnectivityManager: NSObject {
                 : .notEnabled
         return .paired(.installed(complicationState, session.watchDirectoryURLProxy))
     }
+
+    /// The watch state most recently broadcast by `notifyWatchState()` — i.e. read at activation and
+    /// on every `sessionWatchStateDidChange`, both away from the main thread.
+    ///
+    /// `currentWatchState` reads several `WCSession` properties that synchronously wait on the
+    /// session's internal operation queue (see `mostRecentlyReceivedContext` for the same problem),
+    /// so main-thread callers that only need the latest known state — e.g. deciding whether to show
+    /// watch-related UI — should read this instead of blocking on the live getters. `.notPaired`
+    /// until the session has activated.
+    public var lastKnownWatchState: HAWatchConnectivity.WatchState {
+        watchStateCacheLock.lock()
+        defer { watchStateCacheLock.unlock() }
+        return cachedWatchState ?? .notPaired
+    }
     #endif
 
     /// Claim `WCSession.default.delegate` and activate. Called once at startup by
@@ -165,7 +183,13 @@ public final class WatchConnectivityManager: NSObject {
     }
 
     #if os(iOS)
-    func notifyWatchState() { watchState.notify(currentWatchState) }
+    func notifyWatchState() {
+        let state = currentWatchState
+        watchStateCacheLock.lock()
+        cachedWatchState = state
+        watchStateCacheLock.unlock()
+        watchState.notify(state)
+    }
     #endif
 
     /// Resolve a file (blob) transfer completion by handle identity. Called by the delegate with the


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Cold launch stuttered the stand-by logo animation, and opening Settings janked the sheet presentation. Both were caused by synchronous work on the main thread:

- GRDB schema setup opened a write transaction per table on every launch even when nothing changed; the schema is now inspected in reads and only written when a migration is actually needed.
- The server-info mirror was rebuilt (delete-all + insert per server) on every launch; the rebuild is now skipped when the snapshot is unchanged.
- Client events rewrote a 1000-entry JSON file on the caller's thread (main at launch); the file I/O now runs on a serial background queue.
- App icon shortcuts loaded every entity/area/device row synchronously on the main thread at launch; the load now runs on a background queue.
- The Settings list re-rendered every Material Design icon through CoreText on each body evaluation; rendered images are now cached.
- Settings row visibility read blocking `WCSession` getters on the main thread; it now reads a cached watch state primed off-main.
- Settings rows eagerly built all destination views on every list evaluation; they now use value-based `NavigationLink`s (Catalyst keeps the eager form).

## Screenshots
Not applicable — performance-only change, no visual differences.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No functionality changes, so no documentation PR is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012RhmjAj9oUnhsTAX1sBVP2)_