### PR TITLE
Fix Settings navigation when opened from the frontend

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -2089,6 +2089,7 @@
 		42A7474C2E832FB8005E0332 /* fastlane */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = fastlane; sourceTree = "<group>"; };
 		42B980DA2DC2567F00BC5C08 /* Settings */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000001300510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Settings; sourceTree = "<group>"; };
 		42CA28AC2B101D320093B31A /* DesignSystem */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000000D00510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DesignSystem; sourceTree = "<group>"; };
+		42CE0001300000000051FC9B /* Container */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Container; sourceTree = "<group>"; };
 		42D14C6E301BB6330058088E /* WatchAppTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WatchAppTests; sourceTree = "<group>"; };
 		42D3E49F2C5BCCF600444BE6 /* Watch */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Watch; sourceTree = "<group>"; };
 		42DF4EE5302CACB600589E49 /* FlightGreetings */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = FlightGreetings; sourceTree = "<group>"; };
@@ -2611,6 +2612,7 @@
 				42EDBB893002FBBE0051FC9B /* Auth */,
 				42EDBB7B3002FBBE0051FC9B /* CarPlay */,
 				46F103242D7214F7002BC586 /* ClientEvents */,
+				42CE0001300000000051FC9B /* Container */,
 				42EDBB703002FBBE0051FC9B /* Extensions */,
 				119C786625CF845800D41734 /* LocalizedStrings.test.swift */,
 				42EDBB743002FBBE0051FC9B /* MagicItem */,
@@ -3152,6 +3154,7 @@
 				42EDBBEF3002FBC90051FC9B /* Notifications */,
 				42EDBBF33002FBC90051FC9B /* WhatsNew */,
 				46F103242D7214F7002BC586 /* ClientEvents */,
+				42CE0001300000000051FC9B /* Container */,
 			);
 			name = "Tests-App";
 			packageProductDependencies = (

--- a/Sources/App/Container/AppSettingsPresenter.swift
+++ b/Sources/App/Container/AppSettingsPresenter.swift
@@ -31,7 +31,25 @@ final class AppSettingsPresenter: ObservableObject {
     static let shared = AppSettingsPresenter()
 
     @Published var isSheetPresented = false
-    @Published var isPushPresented = false
+    /// The container's navigation stack on iPhone: `AppSettingsPushRoute.settings` while Settings is pushed
+    /// over the frontend, followed by whatever `SettingsView` pushed on top of it. The path is the single
+    /// source of truth for that stack so its own push and Settings' pushes can't disagree on its depth.
+    @Published var pushPath = NavigationPath()
+
+    /// Whether Settings is pushed over the frontend, expressed through `pushPath`. Setting it to `false`
+    /// takes the screens Settings pushed with it, which is what every caller means by closing Settings.
+    var isPushPresented: Bool {
+        get { !pushPath.isEmpty }
+        set {
+            if newValue {
+                guard pushPath.isEmpty else { return }
+                pushPath.append(AppSettingsPushRoute.settings)
+            } else if !pushPath.isEmpty {
+                pushPath = NavigationPath()
+            }
+        }
+    }
+
     @Published private(set) var mode: Mode = .full
     /// Whether Settings is mounted behind the picker. It stays mounted once shown so that its navigation
     /// survives a collapse back to the picker; a sheet opened straight on the picker doesn't pay for it until

--- a/Sources/App/Container/AppSettingsPushRoute.swift
+++ b/Sources/App/Container/AppSettingsPushRoute.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// The only destination the container's own navigation stack pushes: app Settings, opened by the frontend
+/// external bus. Every screen below it is pushed by `SettingsView` as a `SettingsItem` onto the same path, so
+/// the whole stack is value-driven — a boolean `navigationDestination(isPresented:)` sharing a stack with
+/// value-based destinations makes SwiftUI resolve the wrong view for the pushes that follow it.
+enum AppSettingsPushRoute: Hashable {
+    case settings
+}

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -12,10 +12,13 @@ struct ConditionalContainerView: View {
 
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {
-            NavigationStack {
+            // Path-driven so Settings and the screens it pushes share one mechanism: a boolean
+            // `navigationDestination(isPresented:)` alongside Settings' value-based destinations made
+            // SwiftUI push Settings again in place of the screen that was tapped.
+            NavigationStack(path: $appSettings.pushPath) {
                 content
                     .toolbar(.hidden, for: .navigationBar)
-                    .navigationDestination(isPresented: $appSettings.isPushPresented) {
+                    .navigationDestination(for: AppSettingsPushRoute.self) { _ in
                         SettingsView(embedInOwnNavigation: false)
                             .injectingViewControllerProvider()
                     }

--- a/Tests/App/Container/AppSettingsPresenterTests.swift
+++ b/Tests/App/Container/AppSettingsPresenterTests.swift
@@ -1,0 +1,54 @@
+@testable import HomeAssistant
+import SwiftUI
+import XCTest
+
+@MainActor
+final class AppSettingsPresenterTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AppSettingsPresenter.shared.pushPath = NavigationPath()
+    }
+
+    override func tearDown() {
+        AppSettingsPresenter.shared.pushPath = NavigationPath()
+        super.tearDown()
+    }
+
+    func testPushingSettingsPutsItAtTheRootOfThePushPath() {
+        AppSettingsPresenter.shared.isPushPresented = true
+
+        XCTAssertEqual(AppSettingsPresenter.shared.pushPath.count, 1)
+        XCTAssertTrue(AppSettingsPresenter.shared.isPushPresented)
+    }
+
+    func testPushingSettingsAgainWhileItIsOpenDoesNotStackAnotherCopy() {
+        AppSettingsPresenter.shared.isPushPresented = true
+        AppSettingsPresenter.shared.pushPath.append(SettingsItem.liveActivities)
+
+        AppSettingsPresenter.shared.isPushPresented = true
+
+        // The screen Settings pushed stays put: re-asking for Settings can't push a second one over it.
+        XCTAssertEqual(AppSettingsPresenter.shared.pushPath.count, 2)
+    }
+
+    func testClosingSettingsAlsoPopsTheScreensItPushed() {
+        AppSettingsPresenter.shared.isPushPresented = true
+        AppSettingsPresenter.shared.pushPath.append(SettingsItem.liveActivities)
+
+        AppSettingsPresenter.shared.isPushPresented = false
+
+        XCTAssertTrue(AppSettingsPresenter.shared.pushPath.isEmpty)
+        XCTAssertFalse(AppSettingsPresenter.shared.isPushPresented)
+    }
+
+    func testPushPresentedFollowsThePathWhenTheUserNavigatesBack() {
+        AppSettingsPresenter.shared.isPushPresented = true
+        AppSettingsPresenter.shared.pushPath.append(SettingsItem.liveActivities)
+
+        // Two pops, as the navigation stack would report them for two taps on Back.
+        AppSettingsPresenter.shared.pushPath.removeLast()
+        XCTAssertTrue(AppSettingsPresenter.shared.isPushPresented)
+        AppSettingsPresenter.shared.pushPath.removeLast()
+        XCTAssertFalse(AppSettingsPresenter.shared.isPushPresented)
+    }
+}


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

When Settings is opened from the frontend it is pushed onto the container's navigation stack, which also hosts the value based destinations of the settings rows. Mixing that with a boolean `navigationDestination(isPresented:)` made SwiftUI push Settings again instead of the tapped screen, so tapping e.g. Live Activities showed Settings and going back showed Live Activities.

The stack is now driven by a `NavigationPath`, so Settings and the screens it pushes use the same mechanism. Opening Settings as a sheet was never affected.

Also registered `Tests/App/Container` in the project, it was not part of the test target so its tests never ran.

## Screenshots

Navigation only fix, no visual changes.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Reported via TestFlight feedback.
