### PR TITLE
Fix custom widget state cache dropping tiles after the first 3

### DIFF
--- a/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
@@ -91,16 +91,21 @@ struct WidgetEntityStateProvider {
             return [:]
         }
 
-        if let cache = readCache(), cache.cacheCreatedDate.timeIntervalSinceNow > -cacheValiditySeconds {
+        let neededItems = items.filter(itemFilter)
+        if let cache = readCache(),
+           cache.cacheCreatedDate.timeIntervalSinceNow > -cacheValiditySeconds,
+           Set(neededItems).isSubset(of: Set(cache.states.keys)) {
             Current.Log.verbose("\(logPrefix) widget states cache is still valid, returning cached states")
             return cache.states
         }
 
         Current.Log.verbose("\(logPrefix) widget has no valid cache, fetching states")
 
-        var states: [MagicItem: WidgetEntityState] = [:]
+        // Merge so a small-family refresh (prefix of 3) cannot wipe states
+        // already fetched for medium/large. Fixes #3520.
+        var states = readCache()?.states ?? [:]
 
-        for item in items where itemFilter(item) {
+        for item in neededItems {
             let serverId = item.serverId
             let entityId = item.id
             guard let domain = item.domain,


### PR DESCRIPTION
## Summary
Custom widgets only showed HA state on the first 3 tiles after a save/reload because the small-family timeline (max 3 items) overwrote a shared widget-id cache that medium/large then reused.

## Changes
- Treat the states cache as valid only if it contains every requested item
- Merge newly fetched states into the existing cache instead of replacing it

Fixes #3520

## Test plan
- Custom widget, 4+ items, Show states ON, medium or large
- Edit the widget and save
- Confirm tiles 4+ still show state without waiting or adding a sensor widget