### PR TITLE
Fix re-authentication when a saved refresh token is revoked

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+EmptyState.swift
@@ -26,6 +26,8 @@ extension WebViewController {
         withAnimation(DesignSystem.Animation.easeInOutFaster) {
             overlayState?.emptyState = makeEmptyStateContent()
         }
+        // `.authInvalid` is a dead end until the user re-authenticates; the reconnect manager's
+        // hard reset would rebuild the web view and drop that state back to Retry-only.
         if connectionState == .disconnected || connectionState == .unknown {
             reconnectManager?.start { [weak self] in
                 self?.recoverDisconnectedFrontend()
@@ -84,6 +86,16 @@ extension WebViewController {
         guard !connectionState.isReadyForDisplay else { return }
         latestLoadError = Self.presentableExternalAuthError(for: error)
 
+        if HomeAssistantAPI.isPermanentAuthenticationFailure(error) {
+            Current.Log.error("Frontend authentication failed permanently, showing re-auth: \(error)")
+            connectionState = .authInvalid
+            overlayState?.connectionState = .authInvalid
+            emptyStateTimer?.invalidate()
+            emptyStateTimer = nil
+            showEmptyState()
+            return
+        }
+
         // The frontend retries in a tight loop, so only the first failure arms the grace period; an
         // empty state that is already up must not be pushed back by the retries behind it.
         guard emptyStateTimer == nil, overlayState?.emptyState == nil else { return }
@@ -126,6 +138,11 @@ extension WebViewController {
     }
 
     func recoverDisconnectedFrontend() {
+        guard connectionState != .authInvalid else {
+            Current.Log.info("Skipping disconnected frontend recovery while re-authentication is required")
+            reconnectManager?.stop()
+            return
+        }
         if let resetFrontendAction {
             resetFrontendAction()
         } else {

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -23,6 +23,17 @@ public class HomeAssistantAPI {
     struct TokenFetchFailure: LocalizedError {
         let underlyingType: String
         let shouldDisconnectPermanently: Bool
+        let statusCode: Int?
+
+        init(
+            underlyingType: String,
+            shouldDisconnectPermanently: Bool,
+            statusCode: Int? = nil
+        ) {
+            self.underlyingType = underlyingType
+            self.shouldDisconnectPermanently = shouldDisconnectPermanently
+            self.statusCode = statusCode
+        }
 
         var errorDescription: String? {
             "Token fetch failed (\(underlyingType))"
@@ -33,11 +44,25 @@ public class HomeAssistantAPI {
         let errorType = String(reflecting: type(of: error))
         let errorDescription = String(describing: error)
         let underlyingInfo = "\(errorType): \(errorDescription)"
+        let authenticationError = error.authenticationAPIError
 
         return TokenFetchFailure(
             underlyingType: underlyingInfo,
-            shouldDisconnectPermanently: error.authenticationAPIError?.shouldRequireReauthentication == true
+            shouldDisconnectPermanently: authenticationError?.shouldRequireReauthentication == true,
+            statusCode: authenticationError?.statusCode
         )
+    }
+
+    /// True when the server rejected credentials (`invalid_grant` / HTTP 400-403) and retrying
+    /// the connection cannot recover — the user has to re-authenticate.
+    public static func isPermanentAuthenticationFailure(_ error: Error) -> Bool {
+        if error.authenticationAPIError?.shouldRequireReauthentication == true {
+            return true
+        }
+        if let failure = error as? TokenFetchFailure {
+            return failure.shouldDisconnectPermanently
+        }
+        return false
     }
 
     public static let didConnectNotification = Notification.Name(rawValue: "HomeAssistantAPIConnected")
@@ -1680,9 +1705,25 @@ extension HomeAssistantAPI: HAConnectionDelegate {
             }
             Current.Log.info("stopping websocket reconnects after fatal auth token fetch failure")
             connection.disconnect()
+            requireReauthentication(for: tokenFetchFailure)
         case .connecting, .authenticating, .disconnected(reason: .disconnected):
             break
         }
+    }
+
+    /// Surfaces the same re-authentication path `TokenManager` uses on a 400-403 refresh failure.
+    /// HAKit wraps that failure as `TokenFetchFailure`, so the UI must not depend on `TokenManager.tap`
+    /// unwrapping the original `AuthenticationError`.
+    private func requireReauthentication(for failure: TokenFetchFailure) {
+        let statusCode = failure.statusCode ?? 401
+        Current.Log.error(
+            "Refresh token rejected (\(failure.underlyingType)); requiring re-authentication"
+        )
+        HANetworkingEnvironment.current.handleReauthenticationRequired(
+            server,
+            statusCode,
+            failure.underlyingType
+        )
     }
 
     /// A rejected websocket means the server refused the access token we just authenticated with, even

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -158,7 +158,11 @@ public class AppEnvironment {
         HANetworkingEnvironment.current.bundleID = AppConstants.BundleID
         HANetworkingEnvironment.current.defaultServerName = ServerInfo.defaultName
         HANetworkingEnvironment.current.isDebug = Current.appConfiguration == .debug
+        // TokenManager and HAAPI can both report the same revoked-token failure. Collapse those
+        // into one client event / onboarding transition so re-auth UI is not presented twice.
+        let reauthDeduper = ReauthenticationRequiredDeduper(date: { Current.date() })
         HANetworkingEnvironment.current.handleReauthenticationRequired = { server, statusCode, errorDescription in
+            guard reauthDeduper.shouldNotify(serverId: server.identifier.rawValue) else { return }
             Current.clientEventStore.addEvent(ClientEvent(
                 text: "Refresh token is invalid, notifying user",
                 type: .networkRequest,

--- a/Sources/Shared/Environment/ReauthenticationRequiredDeduper.swift
+++ b/Sources/Shared/Environment/ReauthenticationRequiredDeduper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Collapses TokenManager + HAAPI reporting the same revoked refresh token into one notification.
+final class ReauthenticationRequiredDeduper {
+    private enum Constants {
+        static let window: TimeInterval = 2
+    }
+
+    private let date: () -> Date
+    private var last: (serverId: String, at: Date)?
+
+    init(date: @escaping () -> Date) {
+        self.date = date
+    }
+
+    func shouldNotify(serverId: String) -> Bool {
+        let now = date()
+        if let last, last.serverId == serverId, now.timeIntervalSince(last.at) < Constants.window {
+            return false
+        }
+        last = (serverId, now)
+        return true
+    }
+}

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -150,6 +150,33 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.connectionState, .authInvalid)
     }
 
+    func testExternalAuthFailureWithInvalidGrantSetsAuthInvalid() {
+        let sut = makeSUT()
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+
+        sut.handleExternalAuthFailure(error: Self.invalidGrantError())
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.emptyState?.style, .unauthenticated)
+        XCTAssertNil(sut.emptyStateTimer)
+    }
+
+    func testExternalAuthFailureWithInvalidGrantUpgradesDisconnectedEmptyState() {
+        let sut = makeSUT()
+        let overlayState = WebFrontendOverlayState()
+        sut.overlayState = overlayState
+        sut.connectionState = .disconnected
+        sut.showEmptyState()
+        XCTAssertEqual(overlayState.emptyState?.style, .disconnected)
+
+        sut.handleExternalAuthFailure(error: Self.invalidGrantError())
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(overlayState.emptyState?.style, .unauthenticated)
+    }
+
     func testRepeatedExternalAuthFailuresDoNotPushBackTheEmptyState() {
         let sut = makeSUT()
         let overlayState = WebFrontendOverlayState()
@@ -397,6 +424,106 @@ final class WebViewControllerTests: XCTestCase {
         XCTAssertEqual(overlayState.emptyState?.style, .unauthenticated)
     }
 
+    func testShowEmptyStateDoesNotStartReconnectManagerForAuthInvalid() {
+        var scheduleCount = 0
+        let manager = WebViewReconnectManager(
+            isAppActive: { true },
+            scheduleTimer: { _, _ in
+                scheduleCount += 1
+                return {}
+            }
+        )
+        let sut = makeSUT()
+        sut.reconnectManager = manager
+        sut.overlayState = WebFrontendOverlayState()
+        sut.connectionState = .authInvalid
+
+        sut.showEmptyState()
+
+        XCTAssertEqual(scheduleCount, 0)
+        XCTAssertEqual(sut.overlayState?.emptyState?.style, .unauthenticated)
+    }
+
+    func testShowEmptyStateStartsReconnectManagerForDisconnected() {
+        var scheduleCount = 0
+        let manager = WebViewReconnectManager(
+            isAppActive: { true },
+            scheduleTimer: { _, _ in
+                scheduleCount += 1
+                return {}
+            }
+        )
+        let sut = makeSUT()
+        sut.reconnectManager = manager
+        sut.overlayState = WebFrontendOverlayState()
+        sut.connectionState = .disconnected
+
+        sut.showEmptyState()
+
+        XCTAssertEqual(scheduleCount, 1)
+    }
+
+    func testShowReAuthPopupStopsReconnectManager() {
+        var scheduleCount = 0
+        let manager = WebViewReconnectManager(
+            isAppActive: { true },
+            scheduleTimer: { _, _ in
+                scheduleCount += 1
+                return {}
+            }
+        )
+        let server = Server.fake()
+        let sut = makeSUT(server: server)
+        sut.webView = WKWebView(frame: .zero)
+        sut.reconnectManager = manager
+        sut.overlayState = WebFrontendOverlayState()
+        sut.connectionState = .disconnected
+        sut.showEmptyState()
+        XCTAssertEqual(scheduleCount, 1)
+
+        sut.showReAuthPopup(serverId: server.identifier.rawValue, code: 401)
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(scheduleCount, 1)
+        XCTAssertEqual(sut.overlayState?.emptyState?.style, .unauthenticated)
+    }
+
+    func testRecoverDisconnectedFrontendDoesNotRunWhileAuthInvalid() {
+        var resetCalled = false
+        let sut = makeSUT()
+        sut.overlayState = WebFrontendOverlayState()
+        sut.resetFrontendAction = { resetCalled = true }
+        sut.connectionState = .authInvalid
+
+        sut.recoverDisconnectedFrontend()
+
+        XCTAssertFalse(resetCalled)
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+    }
+
+    func testExternalAuthFailureWithInvalidGrantStopsReconnectManager() {
+        var scheduleCount = 0
+        let manager = WebViewReconnectManager(
+            isAppActive: { true },
+            scheduleTimer: { _, _ in
+                scheduleCount += 1
+                return {}
+            }
+        )
+        let sut = makeSUT()
+        sut.reconnectManager = manager
+        sut.overlayState = WebFrontendOverlayState()
+        sut.connectionState = .disconnected
+        sut.showEmptyState()
+        XCTAssertEqual(scheduleCount, 1)
+
+        sut.handleExternalAuthFailure(error: Self.invalidGrantError())
+
+        XCTAssertEqual(sut.connectionState, .authInvalid)
+        XCTAssertEqual(scheduleCount, 1)
+        XCTAssertEqual(sut.overlayState?.emptyState?.style, .unauthenticated)
+    }
+
     func testShowReAuthPopupIgnoresEventsForOtherServers() {
         let sut = makeSUT(server: .fake())
         let overlayState = WebFrontendOverlayState()
@@ -494,6 +621,16 @@ final class WebViewControllerTests: XCTestCase {
         let containerView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
         sut.setValue(containerView, forKey: "view")
         return sut
+    }
+
+    private static func invalidGrantError() -> Error {
+        AFError.responseValidationFailed(reason: .customValidationFailed(
+            error: AuthenticationAPI.AuthenticationError.serverError(
+                statusCode: 400,
+                errorCode: "invalid_grant",
+                error: nil
+            )
+        ))
     }
 
     private func waitUntil(

--- a/Tests/Shared/HAAPITokenFetchFailure.test.swift
+++ b/Tests/Shared/HAAPITokenFetchFailure.test.swift
@@ -49,27 +49,32 @@ class HAAPITokenFetchFailureTests: XCTestCase {
     }
 
     func testTokenFetchFailureMarksRevokedCredentialsAsPermanent() {
-        let error = AFError.responseValidationFailed(reason: .customValidationFailed(
-            error: AuthenticationAPI.AuthenticationError.serverError(
-                statusCode: 400,
-                errorCode: "invalid_grant",
-                error: nil
-            )
-        ))
+        let error = Self.invalidGrantError()
 
         let failure = HomeAssistantAPI.tokenFetchFailure(from: error)
 
         XCTAssertTrue(failure.shouldDisconnectPermanently)
+        XCTAssertEqual(failure.statusCode, 400)
         XCTAssertTrue(failure.errorDescription?.contains("invalid_grant") == true)
+        XCTAssertTrue(HomeAssistantAPI.isPermanentAuthenticationFailure(error))
+        XCTAssertTrue(HomeAssistantAPI.isPermanentAuthenticationFailure(failure))
     }
 
     func testTokenFetchFailureLeavesTransientErrorsRetryable() {
-        let failure = HomeAssistantAPI.tokenFetchFailure(from: URLError(.notConnectedToInternet))
+        let error = URLError(.notConnectedToInternet)
+        let failure = HomeAssistantAPI.tokenFetchFailure(from: error)
 
         XCTAssertFalse(failure.shouldDisconnectPermanently)
+        XCTAssertNil(failure.statusCode)
+        XCTAssertFalse(HomeAssistantAPI.isPermanentAuthenticationFailure(error))
+        XCTAssertFalse(HomeAssistantAPI.isPermanentAuthenticationFailure(failure))
     }
 
     func testConnectionDelegateStopsReconnectLoopForPermanentTokenFetchFailure() {
+        let previousHandler = HANetworkingEnvironment.current.handleReauthenticationRequired
+        defer { HANetworkingEnvironment.current.handleReauthenticationRequired = previousHandler }
+        HANetworkingEnvironment.current.handleReauthenticationRequired = { _, _, _ in }
+
         let api = HomeAssistantAPI(server: .fake())
         let connection = HAMockConnection()
         connection.delegate = api
@@ -89,7 +94,80 @@ class HAAPITokenFetchFailureTests: XCTestCase {
         XCTAssertEqual(connection.state, .disconnected(reason: .disconnected))
     }
 
+    func testConnectionDelegateRequestsReauthenticationForPermanentTokenFetchFailure() {
+        let previousHandler = HANetworkingEnvironment.current.handleReauthenticationRequired
+        defer { HANetworkingEnvironment.current.handleReauthenticationRequired = previousHandler }
+
+        var capturedServer: Server?
+        var capturedStatusCode: Int?
+        var capturedDescription: String?
+        HANetworkingEnvironment.current.handleReauthenticationRequired = { server, statusCode, description in
+            capturedServer = server
+            capturedStatusCode = statusCode
+            capturedDescription = description
+        }
+
+        let server = Server.fake()
+        let api = HomeAssistantAPI(server: server)
+        let connection = HAMockConnection()
+        connection.delegate = api
+        api.connection = connection
+
+        connection.setState(.disconnected(reason: .waitingToReconnect(
+            lastError: HomeAssistantAPI.TokenFetchFailure(
+                underlyingType: "Alamofire.AFError: invalid_grant",
+                shouldDisconnectPermanently: true,
+                statusCode: 400
+            ),
+            atLatest: Date(),
+            retryCount: 1
+        )), waitForQueue: false)
+
+        drainMainQueue()
+
+        XCTAssertEqual(connection.state, .disconnected(reason: .disconnected))
+        XCTAssertEqual(capturedServer?.identifier, server.identifier)
+        XCTAssertEqual(capturedStatusCode, 400)
+        XCTAssertEqual(capturedDescription, "Alamofire.AFError: invalid_grant")
+    }
+
+    func testConnectionDelegateDefaultsMissingStatusCodeTo401WhenRequiringReauthentication() {
+        let previousHandler = HANetworkingEnvironment.current.handleReauthenticationRequired
+        defer { HANetworkingEnvironment.current.handleReauthenticationRequired = previousHandler }
+
+        var capturedStatusCode: Int?
+        HANetworkingEnvironment.current.handleReauthenticationRequired = { _, statusCode, _ in
+            capturedStatusCode = statusCode
+        }
+
+        let api = HomeAssistantAPI(server: .fake())
+        let connection = HAMockConnection()
+        connection.delegate = api
+        api.connection = connection
+
+        connection.setState(.disconnected(reason: .waitingToReconnect(
+            lastError: HomeAssistantAPI.TokenFetchFailure(
+                underlyingType: "fatal",
+                shouldDisconnectPermanently: true
+            ),
+            atLatest: Date(),
+            retryCount: 1
+        )), waitForQueue: false)
+
+        drainMainQueue()
+
+        XCTAssertEqual(capturedStatusCode, 401)
+    }
+
     func testConnectionDelegateKeepsRetryingForNonPermanentTokenFetchFailure() {
+        let previousHandler = HANetworkingEnvironment.current.handleReauthenticationRequired
+        defer { HANetworkingEnvironment.current.handleReauthenticationRequired = previousHandler }
+
+        var didRequestReauthentication = false
+        HANetworkingEnvironment.current.handleReauthenticationRequired = { _, _, _ in
+            didRequestReauthentication = true
+        }
+
         let api = HomeAssistantAPI(server: .fake())
         let connection = HAMockConnection()
         connection.delegate = api
@@ -109,6 +187,7 @@ class HAAPITokenFetchFailureTests: XCTestCase {
         drainMainQueue()
 
         XCTAssertEqual(connection.state, expectedState)
+        XCTAssertFalse(didRequestReauthentication)
     }
 
     func testConnectionDelegateRecoversFromRejectedStateWhenReconnectSucceeds() {
@@ -165,6 +244,16 @@ class HAAPITokenFetchFailureTests: XCTestCase {
         // (which would keep tripping HA's auth-ban endpoint).
         XCTAssertEqual(connection.connectCount, 3)
         XCTAssertEqual(connection.state, .disconnected(reason: .rejected))
+    }
+
+    private static func invalidGrantError() -> Error {
+        AFError.responseValidationFailed(reason: .customValidationFailed(
+            error: AuthenticationAPI.AuthenticationError.serverError(
+                statusCode: 400,
+                errorCode: "invalid_grant",
+                error: nil
+            )
+        ))
     }
 }
 

--- a/Tests/Shared/ReauthenticationRequiredDeduper.test.swift
+++ b/Tests/Shared/ReauthenticationRequiredDeduper.test.swift
@@ -1,0 +1,23 @@
+@testable import Shared
+import XCTest
+
+final class ReauthenticationRequiredDeduperTests: XCTestCase {
+    func testSecondCallForTheSameServerInsideTheWindowIsDropped() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let deduper = ReauthenticationRequiredDeduper(date: { now })
+
+        XCTAssertTrue(deduper.shouldNotify(serverId: "a"))
+        XCTAssertFalse(deduper.shouldNotify(serverId: "a"))
+
+        now.addTimeInterval(3)
+        XCTAssertTrue(deduper.shouldNotify(serverId: "a"))
+    }
+
+    func testDifferentServerIsNotDropped() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let deduper = ReauthenticationRequiredDeduper(date: { now })
+
+        XCTAssertTrue(deduper.shouldNotify(serverId: "a"))
+        XCTAssertTrue(deduper.shouldNotify(serverId: "b"))
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
When Home Assistant rejects a saved refresh token (`invalid_grant` / HTTP 400-403), the websocket path only disconnected and the empty state stayed on Retry. The app now treats that as `authInvalid`, surfaces Reauthenticate, and stops `WebViewReconnectManager` so it cannot rebuild the web view out of that state.

Fixes #5278 #5346 #3304 #3951

**Test plan:** revoke the companion session (or reinstall HA), open the app, confirm Reauthenticate (not Retry-only) and that logging in again restores the dashboard.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.