### PR TITLE
Restore last-used server on launch instead of the first configured server

### DIFF
--- a/Sources/App/Container/AppContainerCoordinator.swift
+++ b/Sources/App/Container/AppContainerCoordinator.swift
@@ -90,6 +90,8 @@ final class AppContainerCoordinator: AppCoordinator {
 
     @discardableResult
     func open(server: Server) -> Guarantee<any WebFrontend> {
+        // Record before the web view loads so a kill during connection still restores this server.
+        Current.settingsStore.rememberLastActiveServer(identifier: server.identifier.rawValue)
         if let current = frontend, current.server.identifier == server.identifier {
             return .value(current)
         }

--- a/Sources/App/Container/OnboardingStateObservable.swift
+++ b/Sources/App/Container/OnboardingStateObservable.swift
@@ -39,6 +39,7 @@ final class OnboardingStateObservable: ObservableObject {
 
     /// Switches the displayed screen to `server`'s web view. Called by the app coordinator's `open(server:)`.
     func showWebView(for server: Server) {
+        persistLastActiveServer(server)
         screen = .webView(server, initialPath: nil)
     }
 
@@ -180,6 +181,12 @@ final class OnboardingStateObservable: ObservableObject {
         return .onboarding(.initial)
     }
 
+    /// Persist immediately on a server switch so a kill before the web view's first http(s) navigation
+    /// still restores this server on the next launch (#5064).
+    private func persistLastActiveServer(_ server: Server) {
+        Current.settingsStore.rememberLastActiveServer(identifier: server.identifier.rawValue)
+    }
+
     /// The server to show at launch: the kiosk-configured server when kiosk mode is enabled, otherwise the
     /// last server the user was viewing, falling back to the first registered server. Non-private for tests.
     static func preferredInitialServer() -> Server? {
@@ -221,9 +228,9 @@ final class OnboardingStateObservable: ObservableObject {
         case let .needed(type):
             switch type {
             case .error, .logout:
-                // A server was removed / logged out. Fall back to another server if one remains,
-                // otherwise restart onboarding. Mirrors `WebViewWindowController.onboardingStateDidChange`.
-                if let server = Current.servers.all.first {
+                // A server was removed / logged out. Fall back to the last-used remaining server
+                // (not `all.first`, which is Settings order and caused #5064 / #5234).
+                if let server = Self.preferredInitialServer() {
                     screen = .webView(server, initialPath: nil)
                 } else {
                     screen = .onboarding(.initial)
@@ -234,8 +241,8 @@ final class OnboardingStateObservable: ObservableObject {
                 break
             }
         case .complete:
-            if let server = Current.servers.all.first {
-                screen = .webView(server, initialPath: nil)
+            if let server = Self.preferredInitialServer() {
+                screen = .webView(server, initialPath: Self.restoredInitialPath(for: server))
             }
         case .didConnect:
             // Connection established mid-onboarding; the `.complete` transition drives the screen swap.

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebViewSetup.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebViewSetup.swift
@@ -58,7 +58,7 @@ extension WebViewController {
 
             // Persist the server and a host-agnostic path so cold launch reopens here; the base URL is
             // re-resolved from current connectivity at load time (see `resolvedLoadURL`).
-            Current.settingsStore.lastActiveServerIdentifier = server.identifier.rawValue
+            Current.settingsStore.rememberLastActiveServer(identifier: server.identifier.rawValue)
             if let components = URLComponents(url: cleanURL, resolvingAgainstBaseURL: false) {
                 var relative = components.path.isEmpty ? "/" : components.path
                 if let query = components.query {

--- a/Sources/Shared/Settings/SettingsStore.swift
+++ b/Sources/Shared/Settings/SettingsStore.swift
@@ -268,6 +268,15 @@ public class SettingsStore {
         }
     }
 
+    /// Records the server currently being viewed. When the identifier changes, the last-viewed path is
+    /// cleared so a path from another server is never restored onto this one.
+    public func rememberLastActiveServer(identifier: String) {
+        if lastActiveServerIdentifier != identifier {
+            lastActiveURLPath = nil
+        }
+        lastActiveServerIdentifier = identifier
+    }
+
     public var lastActiveURLPath: String? {
         get {
             prefs.string(forKey: "lastActiveURLPath")

--- a/Tests/App/Container/AppContainerCoordinatorTests.swift
+++ b/Tests/App/Container/AppContainerCoordinatorTests.swift
@@ -24,6 +24,8 @@ final class AppContainerCoordinatorTests: XCTestCase {
         AppSettingsPresenter.shared.isSheetPresented = false
         AppSettingsPresenter.shared.isPushPresented = false
         AppSettingsPresenter.shared.sheetDismissed()
+        Current.settingsStore.lastActiveServerIdentifier = nil
+        Current.settingsStore.lastActiveURLPath = nil
         super.tearDown()
     }
 
@@ -100,6 +102,35 @@ final class AppContainerCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(openedServer?.identifier, otherServer.identifier)
         XCTAssertEqual(frontend.navigateToRootCallCount, 0)
+    }
+
+    func testOpenPersistsLastActiveServerIdentifierImmediately() {
+        Current.settingsStore.lastActiveServerIdentifier = server.identifier.rawValue
+        Current.settingsStore.lastActiveURLPath = "/lovelace/kitchen"
+        let otherServer = Server.fake()
+        coordinator.onOpenServer = { _ in }
+
+        coordinator.open(server: otherServer)
+
+        XCTAssertEqual(Current.settingsStore.lastActiveServerIdentifier, otherServer.identifier.rawValue)
+        XCTAssertNil(Current.settingsStore.lastActiveURLPath)
+    }
+
+    func testOpenPersistsLastActiveServerIdentifierWhenAlreadyShowingThatServer() {
+        Current.settingsStore.lastActiveServerIdentifier = nil
+        coordinator.open(server: server)
+
+        XCTAssertEqual(Current.settingsStore.lastActiveServerIdentifier, server.identifier.rawValue)
+    }
+
+    func testOpenKeepsLastPathWhenReopeningTheSameServer() {
+        Current.settingsStore.lastActiveServerIdentifier = server.identifier.rawValue
+        Current.settingsStore.lastActiveURLPath = "/lovelace/kitchen"
+
+        coordinator.open(server: server)
+
+        XCTAssertEqual(Current.settingsStore.lastActiveServerIdentifier, server.identifier.rawValue)
+        XCTAssertEqual(Current.settingsStore.lastActiveURLPath, "/lovelace/kitchen")
     }
 
     func testSelectingAServerClearsWhatIsAlreadyPresentedFirst() {

--- a/Tests/App/Container/OnboardingStateObservableTests.swift
+++ b/Tests/App/Container/OnboardingStateObservableTests.swift
@@ -1,3 +1,4 @@
+import GRDB
 @testable import HomeAssistant
 @testable import Shared
 import XCTest
@@ -5,13 +6,14 @@ import XCTest
 @MainActor
 final class OnboardingStateObservableTests: XCTestCase {
     private var previousServers: ServerManager!
+    private var servers: FakeServerManager!
     private var firstServer: Server!
     private var secondServer: Server!
 
     override func setUp() {
         super.setUp()
         previousServers = Current.servers
-        let servers = FakeServerManager(initial: 0)
+        servers = FakeServerManager(initial: 0)
         firstServer = servers.add(identifier: .init(rawValue: "server-1"), serverInfo: .fake())
         secondServer = servers.add(identifier: .init(rawValue: "server-2"), serverInfo: .fake())
         Current.servers = servers
@@ -73,5 +75,112 @@ final class OnboardingStateObservableTests: XCTestCase {
         Current.settingsStore.lastActiveURLPath = "/lovelace/kitchen"
 
         XCTAssertNil(OnboardingStateObservable.restoredInitialPath(for: firstServer))
+    }
+
+    func testShowWebViewPersistsLastActiveServerIdentifier() {
+        Current.settingsStore.lastActiveServerIdentifier = "server-1"
+        Current.settingsStore.lastActiveURLPath = "/lovelace/kitchen"
+        let sut = OnboardingStateObservable()
+
+        sut.showWebView(for: secondServer)
+
+        XCTAssertEqual(Current.settingsStore.lastActiveServerIdentifier, "server-2")
+        XCTAssertNil(Current.settingsStore.lastActiveURLPath)
+        XCTAssertEqual(sut.screen, .webView(secondServer, initialPath: nil))
+    }
+
+    func testOnboardingCompleteRestoresLastUsedServerNotFirstInList() {
+        Current.settingsStore.lastActiveServerIdentifier = "server-2"
+        Current.settingsStore.lastActiveURLPath = "/lovelace/office"
+        let sut = OnboardingStateObservable()
+
+        sut.onboardingStateDidChange(to: .complete)
+
+        waitUntil { sut.screen == .webView(secondServer, initialPath: "/lovelace/office") }
+        XCTAssertEqual(sut.screen, .webView(secondServer, initialPath: "/lovelace/office"))
+    }
+
+    func testLogoutFallsBackToLastUsedRemainingServer() {
+        Current.settingsStore.lastActiveServerIdentifier = "server-2"
+        let sut = OnboardingStateObservable()
+
+        sut.onboardingStateDidChange(to: .needed(.logout))
+
+        waitUntil { sut.screen == .webView(secondServer, initialPath: nil) }
+        XCTAssertEqual(sut.screen, .webView(secondServer, initialPath: nil))
+    }
+
+    func testOnboardingCompleteFallsBackWhenLastUsedServerWasRemoved() {
+        Current.settingsStore.lastActiveServerIdentifier = "server-2"
+        let sut = OnboardingStateObservable()
+        servers.remove(identifier: secondServer.identifier)
+
+        sut.onboardingStateDidChange(to: .complete)
+
+        waitUntil { sut.screen == .webView(firstServer, initialPath: nil) }
+        XCTAssertEqual(sut.screen, .webView(firstServer, initialPath: nil))
+    }
+
+    func testPreferredInitialServerPrefersKioskServerWhenEnabled() throws {
+        try withKiosk(enabled: true, serverId: "server-2") {
+            Current.settingsStore.lastActiveServerIdentifier = "server-1"
+
+            XCTAssertEqual(OnboardingStateObservable.preferredInitialServer()?.identifier, secondServer.identifier)
+        }
+    }
+
+    func testOnboardingCompletePrefersKioskServerOverLastUsed() throws {
+        try withKiosk(enabled: true, serverId: "server-2") {
+            Current.settingsStore.lastActiveServerIdentifier = "server-1"
+            let sut = OnboardingStateObservable()
+
+            sut.onboardingStateDidChange(to: .complete)
+
+            waitUntil { sut.screen == .webView(secondServer, initialPath: nil) }
+            XCTAssertEqual(sut.screen, .webView(secondServer, initialPath: nil))
+        }
+    }
+
+    private func withKiosk(enabled: Bool, serverId: String, _ body: () throws -> Void) throws {
+        let previousDatabase = Current.database
+        let previousKiosk = Current.kiosk
+        defer {
+            Current.database = previousDatabase
+            Current.kiosk = previousKiosk
+        }
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try KioskSettingsTable().createIfNeeded(database: database)
+        Current.database = { database }
+        try database.write { db in
+            try KioskSettings(enabled: enabled, serverId: serverId).insert(db, onConflict: .replace)
+        }
+        Current.kiosk = KioskModeManager()
+
+        try body()
+    }
+
+    private func waitUntil(
+        _ condition: @escaping () -> Bool,
+        timeout: TimeInterval = 2,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = expectation(description: "condition")
+        let deadline = Date().addingTimeInterval(timeout)
+
+        func poll() {
+            if condition() {
+                expectation.fulfill()
+            } else if Date() > deadline {
+                XCTFail("Timed out waiting for condition", file: file, line: line)
+                expectation.fulfill()
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { poll() }
+            }
+        }
+
+        poll()
+        wait(for: [expectation], timeout: timeout + 1)
     }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Onboarding `.complete` / logout used `Current.servers.all.first` (Settings order), overwriting the last-used server after the SwiftUI lifecycle migration. Persist `lastActiveServerIdentifier` as soon as a server is opened.

Fixes #5064 #5234

**Test plan:** two servers, use the second, force-quit, relaunch — second server should open. Kiosk mode should still win when enabled.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.