### PR TITLE
Fix pull-to-refresh gap, accidental reloads, and overscroll bounce

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshObserver.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantPullToRefreshObserver.swift
@@ -11,9 +11,14 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
         /// Scaling with the height keeps the required finger travel at a constant fraction of the screen.
         static let thresholdHeightFraction: CGFloat = 0.2
         static let minimumThreshold: CGFloat = 64
+        /// Horizontal travel that means this pan is a canvas/map drag, not a page-level pull.
+        static let substantialHorizontalDistance: CGFloat = 24
+        static let atTopTolerance: CGFloat = 1
+        static let scrollableContentTolerance: CGFloat = 1
     }
 
     private weak var scrollView: UIScrollView?
+    private weak var loadingWebView: WKWebView?
     private let maximumThreshold: CGFloat
     private let onStateChange: (CGFloat, Bool) -> Void
     private let onRefresh: () -> Void
@@ -21,18 +26,45 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
     private let progressFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     private let refreshFeedbackGenerator = UINotificationFeedbackGenerator()
     private var contentOffsetObservation: NSKeyValueObservation?
+    private var contentSizeObservation: NSKeyValueObservation?
     private var isLoadingObservation: NSKeyValueObservation?
     private var isRefreshing = false
     private var didCrossThreshold = false
     private var lastHapticProgressStep: Int?
+    /// Pan began with the web view already at rest at the top, and is a page-level pull rather than an
+    /// in-page canvas/map drag.
+    private var isTrackingEligiblePull = false
+    private var panBeganAtTop = false
+    /// Read from the scroll-view KVO callback, which is not isolated to the main actor.
+    private nonisolated(unsafe) var isResettingOffset = false
+    private var lastPublishedProgress: CGFloat = 0
+    private var lastPublishedIsRefreshing = false
 
-    init(
+    convenience init(
         webView: WKWebView,
         maximumThreshold: CGFloat,
         onStateChange: @escaping (CGFloat, Bool) -> Void,
         onRefresh: @escaping () -> Void
     ) {
-        self.scrollView = webView.scrollView
+        self.init(
+            scrollView: webView.scrollView,
+            loadingWebView: webView,
+            maximumThreshold: maximumThreshold,
+            onStateChange: onStateChange,
+            onRefresh: onRefresh
+        )
+    }
+
+    /// Testable entry point that can be driven with a fake `UIScrollView`.
+    init(
+        scrollView: UIScrollView,
+        loadingWebView: WKWebView? = nil,
+        maximumThreshold: CGFloat,
+        onStateChange: @escaping (CGFloat, Bool) -> Void,
+        onRefresh: @escaping () -> Void
+    ) {
+        self.scrollView = scrollView
+        self.loadingWebView = loadingWebView
         self.maximumThreshold = maximumThreshold
         self.onStateChange = onStateChange
         self.onRefresh = onRefresh
@@ -42,27 +74,41 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
         progressFeedbackGenerator.prepare()
         refreshFeedbackGenerator.prepare()
 
-        let scrollView = webView.scrollView
         scrollView.bounces = true
-        scrollView.alwaysBounceVertical = true
+        updateVerticalBounce()
         scrollView.panGestureRecognizer.addTarget(self, action: #selector(handlePanGesture(_:)))
         self.contentOffsetObservation = scrollView
             .observe(\.contentOffset, options: [.new]) { [weak self] scrollView, _ in
+                // Skip before the MainActor hop: `resetScrollPosition()` clears `isResettingOffset`
+                // immediately after `setContentOffset`, so a deferred Task would still see the
+                // synthetic offset and republish progress.
+                if self?.isResettingOffset == true { return }
+                let offset = scrollView.contentOffset
                 Task { @MainActor in
-                    self?.handleContentOffset(scrollView.contentOffset)
+                    guard let self, !self.isResettingOffset else { return }
+                    self.handleContentOffset(offset)
                 }
             }
-        self.isLoadingObservation = webView
-            .observe(\.isLoading, options: [.new]) { [weak self] webView, _ in
-                guard !webView.isLoading else { return }
+        self.contentSizeObservation = scrollView
+            .observe(\.contentSize, options: [.new]) { [weak self] _, _ in
                 Task { @MainActor in
-                    self?.finishRefreshing()
+                    self?.updateVerticalBounce()
                 }
             }
+        if let loadingWebView {
+            self.isLoadingObservation = loadingWebView
+                .observe(\.isLoading, options: [.new]) { [weak self] webView, _ in
+                    guard !webView.isLoading else { return }
+                    Task { @MainActor in
+                        self?.finishRefreshing()
+                    }
+                }
+        }
     }
 
     deinit {
         contentOffsetObservation?.invalidate()
+        contentSizeObservation?.invalidate()
         isLoadingObservation?.invalidate()
         MainActor.assumeIsolated {
             scrollView?.panGestureRecognizer.removeTarget(self, action: #selector(handlePanGesture(_:)))
@@ -70,13 +116,17 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
     }
 
     func finishRefreshing() {
-        guard isRefreshing else { return }
         isRefreshing = false
         didCrossThreshold = false
         lastHapticProgressStep = nil
+        isTrackingEligiblePull = false
+        panBeganAtTop = false
         progressFeedbackGenerator.prepare()
         refreshFeedbackGenerator.prepare()
-        onStateChange(0, false)
+        // A leftover negative offset after reload is the stuck gap that intercepts hits (#5432).
+        resetScrollPosition()
+        updateVerticalBounce()
+        publish(progress: 0, isRefreshing: false)
     }
 
     /// Recomputed on every read so rotating the device immediately adopts the new viewport's threshold.
@@ -86,23 +136,130 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
         return min(maximumThreshold, max(Constants.minimumThreshold, heightBased))
     }
 
-    private func handleContentOffset(_ contentOffset: CGPoint) {
-        guard let scrollView else { return }
+    func handleContentOffset(_ contentOffset: CGPoint) {
+        guard let scrollView, !isResettingOffset else { return }
+
+        updateVerticalBounce()
 
         let topInset = scrollView.adjustedContentInset.top
         let pullDistance = max(0, -(contentOffset.y + topInset))
         let progress = min(1, pullDistance / currentThreshold)
 
-        if !isRefreshing {
-            emitPullProgressHapticIfNeeded(progress: progress, pullDistance: pullDistance)
-            didCrossThreshold = didCrossThreshold || progress >= 1
-            onStateChange(progress, false)
+        if isRefreshing { return }
+
+        let isActivelyDragging = scrollView.isDragging || scrollView.isTracking
+        if !isActivelyDragging {
+            clearLeftoverProgressIfNeeded(pullDistance: pullDistance, isDecelerating: scrollView.isDecelerating)
+            return
         }
 
-        if pullDistance == 0, !isRefreshing {
+        guard isTrackingEligiblePull else {
+            publish(progress: 0, isRefreshing: false)
+            return
+        }
+
+        emitPullProgressHapticIfNeeded(progress: progress, pullDistance: pullDistance)
+        didCrossThreshold = didCrossThreshold || progress >= 1
+        publish(progress: progress, isRefreshing: false)
+
+        if pullDistance == 0 {
             didCrossThreshold = false
             lastHapticProgressStep = nil
             progressFeedbackGenerator.prepare()
+        }
+    }
+
+    func handlePan(state: UIGestureRecognizer.State, locationInView: CGPoint, translation: CGPoint) {
+        switch state {
+        case .began:
+            beginTracking(locationInView: locationInView)
+        case .changed:
+            updateTracking(translation: translation)
+        case .ended:
+            endTracking(translation: translation)
+        case .cancelled, .failed:
+            cancelTracking()
+        default:
+            break
+        }
+    }
+
+    private func beginTracking(locationInView: CGPoint) {
+        panBeganAtTop = isAtTop
+        let beganInTopSafeArea = isInTopSafeArea(locationInView)
+        // PTR is a page-level pull from rest at the top: either from the status-bar/safe-area region, or
+        // the scroll view rubber-banding because the document itself can scroll. Middle-of-screen drags
+        // on a non-scrolling canvas (Zigbee mesh, maps) must not qualify.
+        isTrackingEligiblePull = panBeganAtTop && (beganInTopSafeArea || canScrollVertically)
+        didCrossThreshold = false
+        lastHapticProgressStep = nil
+        if !isTrackingEligiblePull {
+            publish(progress: 0, isRefreshing: false)
+        }
+        updateVerticalBounce()
+    }
+
+    private func updateTracking(translation: CGPoint) {
+        guard isTrackingEligiblePull, !isRefreshing else { return }
+        guard hasSubstantialHorizontalMovement(translation) else { return }
+        isTrackingEligiblePull = false
+        didCrossThreshold = false
+        publish(progress: 0, isRefreshing: false)
+        updateVerticalBounce()
+    }
+
+    private func endTracking(translation: CGPoint) {
+        let shouldRefresh = shouldStartRefresh(translation: translation)
+        isTrackingEligiblePull = false
+        if shouldRefresh {
+            startRefresh()
+        } else {
+            didCrossThreshold = false
+        }
+        updateVerticalBounce()
+    }
+
+    private func cancelTracking() {
+        isTrackingEligiblePull = false
+        didCrossThreshold = false
+        lastHapticProgressStep = nil
+        panBeganAtTop = false
+        if !isRefreshing {
+            publish(progress: 0, isRefreshing: false)
+        }
+        updateVerticalBounce()
+    }
+
+    private func shouldStartRefresh(translation: CGPoint) -> Bool {
+        isTrackingEligiblePull
+            && panBeganAtTop
+            && didCrossThreshold
+            && currentPullDistance() >= currentThreshold
+            && !isRefreshing
+            && isPrimarilyVertical(translation)
+            && !hasSubstantialHorizontalMovement(translation)
+    }
+
+    private func startRefresh() {
+        isRefreshing = true
+        didCrossThreshold = false
+        lastHapticProgressStep = nil
+        refreshFeedbackGenerator.notificationOccurred(.success)
+        refreshFeedbackGenerator.prepare()
+        resetScrollPosition()
+        publish(progress: 1, isRefreshing: true)
+        onRefresh()
+    }
+
+    private func clearLeftoverProgressIfNeeded(pullDistance: CGFloat, isDecelerating: Bool) {
+        guard pullDistance > 0 || lastPublishedProgress > 0 || didCrossThreshold else { return }
+        publish(progress: 0, isRefreshing: false)
+        didCrossThreshold = false
+        lastHapticProgressStep = nil
+        progressFeedbackGenerator.prepare()
+        // A bounce-back animation is allowed to settle; a parked negative offset is the stuck gap.
+        if pullDistance > 0, !isDecelerating {
+            resetScrollPosition()
         }
     }
 
@@ -124,34 +281,82 @@ final class HomeAssistantPullToRefreshObserver: NSObject {
         return max(0, -(scrollView.contentOffset.y + scrollView.adjustedContentInset.top))
     }
 
+    private var isAtTop: Bool {
+        guard let scrollView else { return false }
+        return scrollView.contentOffset.y <= -scrollView.adjustedContentInset.top + Constants.atTopTolerance
+    }
+
+    private var canScrollVertically: Bool {
+        guard let scrollView, scrollView.bounds.height > 0 else { return false }
+        let visibleHeight = scrollView.bounds.height
+            - scrollView.adjustedContentInset.top
+            - scrollView.adjustedContentInset.bottom
+        return scrollView.contentSize.height > visibleHeight + Constants.scrollableContentTolerance
+    }
+
+    private func currentTopSafeAreaHeight() -> CGFloat {
+        if let loadingWebView, loadingWebView.safeAreaInsets.top > 0 {
+            return loadingWebView.safeAreaInsets.top
+        }
+        return scrollView?.safeAreaInsets.top ?? 0
+    }
+
+    private func isInTopSafeArea(_ locationInView: CGPoint) -> Bool {
+        locationInView.y <= currentTopSafeAreaHeight()
+    }
+
+    private func isPrimarilyVertical(_ translation: CGPoint) -> Bool {
+        abs(translation.y) > abs(translation.x)
+    }
+
+    private func hasSubstantialHorizontalMovement(_ translation: CGPoint) -> Bool {
+        abs(translation.x) >= Constants.substantialHorizontalDistance
+            && abs(translation.x) >= abs(translation.y) * 0.5
+    }
+
+    private func visibleLocation(from recognizer: UIPanGestureRecognizer) -> CGPoint {
+        guard let scrollView else { return recognizer.location(in: nil) }
+        let location = recognizer.location(in: scrollView)
+        return CGPoint(
+            x: location.x - scrollView.bounds.origin.x,
+            y: location.y - scrollView.bounds.origin.y
+        )
+    }
+
+    private func updateVerticalBounce() {
+        guard let scrollView else { return }
+        scrollView.bounces = true
+        // Do not force bounce on short / inner-scrolling frontend pages; that makes canvas drags
+        // rubber-band the whole web view and is the aggressive overscroll in #5385 / #5320.
+        scrollView.alwaysBounceVertical = canScrollVertically || isTrackingEligiblePull || isRefreshing
+    }
+
     private func resetScrollPosition() {
         guard let scrollView else { return }
-        let restingOffset = CGPoint(x: scrollView.contentOffset.x, y: -scrollView.adjustedContentInset.top)
+        let restingY = -scrollView.adjustedContentInset.top
+        // Only snap out of an overscrolled-at-top offset. Never yank a user who has scrolled into
+        // the document, even if `finishRefreshing` runs after an unrelated load.
+        guard scrollView.contentOffset.y < restingY - 0.5 else { return }
+        isResettingOffset = true
         UIView.performWithoutAnimation {
-            scrollView.setContentOffset(restingOffset, animated: false)
+            scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: restingY), animated: false)
             scrollView.layoutIfNeeded()
         }
+        isResettingOffset = false
+    }
+
+    private func publish(progress: CGFloat, isRefreshing: Bool) {
+        guard progress != lastPublishedProgress || isRefreshing != lastPublishedIsRefreshing else { return }
+        lastPublishedProgress = progress
+        lastPublishedIsRefreshing = isRefreshing
+        onStateChange(progress, isRefreshing)
     }
 
     @objc private func handlePanGesture(_ recognizer: UIPanGestureRecognizer) {
-        switch recognizer.state {
-        case .ended:
-            guard didCrossThreshold, currentPullDistance() >= currentThreshold, !isRefreshing else {
-                didCrossThreshold = false
-                return
-            }
-            isRefreshing = true
-            didCrossThreshold = false
-            lastHapticProgressStep = nil
-            refreshFeedbackGenerator.notificationOccurred(.success)
-            refreshFeedbackGenerator.prepare()
-            resetScrollPosition()
-            onStateChange(1, true)
-            onRefresh()
-        case .cancelled, .failed:
-            didCrossThreshold = false
-        default:
-            break
-        }
+        handlePan(
+            state: recognizer.state,
+            locationInView: visibleLocation(from: recognizer),
+            translation: recognizer.translation(in: scrollView)
+        )
     }
 }

--- a/Tests/App/WebView/HomeAssistantPullToRefreshObserverTests.swift
+++ b/Tests/App/WebView/HomeAssistantPullToRefreshObserverTests.swift
@@ -1,0 +1,185 @@
+@testable import HomeAssistant
+import UIKit
+import XCTest
+
+@MainActor
+final class HomeAssistantPullToRefreshObserverTests: XCTestCase {
+    func testShortDocumentDoesNotForceVerticalBounce() {
+        let (scrollView, _, _) = makeSUT(contentHeight: 400)
+
+        XCTAssertTrue(scrollView.bounces)
+        XCTAssertFalse(scrollView.alwaysBounceVertical)
+    }
+
+    func testScrollableDocumentEnablesVerticalBounce() {
+        let (scrollView, _, _) = makeSUT(contentHeight: 1200)
+
+        XCTAssertTrue(scrollView.alwaysBounceVertical)
+    }
+
+    func testPullFromTopSafeAreaOnShortDashboardTriggersRefresh() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 400)
+
+        performEligiblePull(on: sut, scrollView: scrollView, location: CGPoint(x: 195, y: 20))
+
+        XCTAssertTrue(scrollView.alwaysBounceVertical)
+        XCTAssertEqual(state.progress, 1, accuracy: 0.001)
+        XCTAssertFalse(state.isRefreshing)
+
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 195, y: 20), translation: CGPoint(x: 0, y: 90))
+
+        XCTAssertEqual(state.refreshCount, 1)
+        XCTAssertTrue(state.isRefreshing)
+        XCTAssertEqual(state.progress, 1, accuracy: 0.001)
+        XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.5)
+    }
+
+    func testMiddleOfScreenDragOnShortDocumentDoesNotTriggerRefresh() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 400)
+
+        sut.handlePan(state: .began, locationInView: CGPoint(x: 195, y: 220), translation: .zero)
+        XCTAssertFalse(scrollView.alwaysBounceVertical)
+
+        pull(scrollView, to: -80, dragging: true)
+        sut.handleContentOffset(scrollView.contentOffset)
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 195, y: 220), translation: CGPoint(x: 0, y: 90))
+
+        XCTAssertEqual(state.refreshCount, 0)
+        XCTAssertEqual(state.progress, 0)
+        XCTAssertFalse(state.isRefreshing)
+    }
+
+    func testVerticalRubberBandFromTopOfScrollableDashboardTriggersRefresh() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 1200)
+
+        performEligiblePull(on: sut, scrollView: scrollView, location: CGPoint(x: 195, y: 220))
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 195, y: 220), translation: CGPoint(x: 0, y: 90))
+
+        XCTAssertEqual(state.refreshCount, 1)
+        XCTAssertTrue(state.isRefreshing)
+    }
+
+    func testHorizontalCanvasDragDoesNotTriggerRefresh() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 1200)
+
+        performEligiblePull(on: sut, scrollView: scrollView, location: CGPoint(x: 195, y: 220))
+        sut.handlePan(state: .changed, locationInView: CGPoint(x: 260, y: 220), translation: CGPoint(x: 40, y: 50))
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 260, y: 280), translation: CGPoint(x: 40, y: 90))
+
+        XCTAssertEqual(state.refreshCount, 0)
+        XCTAssertEqual(state.progress, 0)
+        XCTAssertFalse(state.isRefreshing)
+    }
+
+    func testPanThatDoesNotBeginAtTopDoesNotTriggerRefresh() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 1200)
+        scrollView.contentOffset = CGPoint(x: 0, y: 180)
+
+        sut.handlePan(state: .began, locationInView: CGPoint(x: 195, y: 20), translation: .zero)
+        pull(scrollView, to: -80, dragging: true)
+        sut.handleContentOffset(scrollView.contentOffset)
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 195, y: 20), translation: CGPoint(x: 0, y: 90))
+
+        XCTAssertEqual(state.refreshCount, 0)
+        XCTAssertFalse(state.isRefreshing)
+    }
+
+    func testFinishRefreshingResetsLeftoverOffsetAndProgress() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 400)
+
+        performEligiblePull(on: sut, scrollView: scrollView, location: CGPoint(x: 195, y: 20))
+        sut.handlePan(state: .ended, locationInView: CGPoint(x: 195, y: 20), translation: CGPoint(x: 0, y: 90))
+        XCTAssertEqual(state.refreshCount, 1)
+
+        pull(scrollView, to: -36, dragging: false)
+        sut.finishRefreshing()
+
+        XCTAssertEqual(state.progress, 0)
+        XCTAssertFalse(state.isRefreshing)
+        XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.5)
+        XCTAssertFalse(scrollView.alwaysBounceVertical)
+    }
+
+    func testLeftoverOffsetWhileNotDraggingDoesNotKeepProgress() {
+        let (scrollView, sut, state) = makeSUT(contentHeight: 400)
+
+        performEligiblePull(on: sut, scrollView: scrollView, location: CGPoint(x: 195, y: 20))
+        XCTAssertEqual(state.progress, 1, accuracy: 0.001)
+
+        pull(scrollView, to: -40, dragging: false)
+        sut.handleContentOffset(scrollView.contentOffset)
+
+        XCTAssertEqual(state.progress, 0)
+        XCTAssertFalse(state.isRefreshing)
+        XCTAssertEqual(scrollView.contentOffset.y, 0, accuracy: 0.5)
+    }
+
+    func testFinishRefreshingDoesNotYankScrolledContent() {
+        let (scrollView, sut, _) = makeSUT(contentHeight: 1200)
+        scrollView.contentOffset = CGPoint(x: 0, y: 240)
+
+        sut.finishRefreshing()
+
+        XCTAssertEqual(scrollView.contentOffset.y, 240, accuracy: 0.5)
+    }
+
+    private func performEligiblePull(
+        on sut: HomeAssistantPullToRefreshObserver,
+        scrollView: FakePullToRefreshScrollView,
+        location: CGPoint
+    ) {
+        sut.handlePan(state: .began, locationInView: location, translation: .zero)
+        pull(scrollView, to: -80, dragging: true)
+        sut.handleContentOffset(scrollView.contentOffset)
+    }
+
+    private func pull(_ scrollView: FakePullToRefreshScrollView, to offsetY: CGFloat, dragging: Bool) {
+        scrollView.stubIsDragging = dragging
+        scrollView.stubIsTracking = dragging
+        scrollView.stubIsDecelerating = false
+        scrollView.contentOffset = CGPoint(x: 0, y: offsetY)
+    }
+
+    private func makeSUT(
+        contentHeight: CGFloat,
+        boundsHeight: CGFloat = 400
+    ) -> (FakePullToRefreshScrollView, HomeAssistantPullToRefreshObserver, PullState) {
+        let scrollView = FakePullToRefreshScrollView(frame: CGRect(x: 0, y: 0, width: 390, height: boundsHeight))
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.contentSize = CGSize(width: 390, height: contentHeight)
+        scrollView.stubSafeAreaInsets = UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+
+        let state = PullState()
+        let sut = HomeAssistantPullToRefreshObserver(
+            scrollView: scrollView,
+            maximumThreshold: 148,
+            onStateChange: { progress, isRefreshing in
+                state.progress = progress
+                state.isRefreshing = isRefreshing
+            },
+            onRefresh: {
+                state.refreshCount += 1
+            }
+        )
+        return (scrollView, sut, state)
+    }
+}
+
+private final class PullState {
+    var progress: CGFloat = 0
+    var isRefreshing = false
+    var refreshCount = 0
+}
+
+private final class FakePullToRefreshScrollView: UIScrollView {
+    var stubSafeAreaInsets: UIEdgeInsets = .zero
+    var stubIsDragging = false
+    var stubIsTracking = false
+    var stubIsDecelerating = false
+
+    override var safeAreaInsets: UIEdgeInsets { stubSafeAreaInsets }
+    override var adjustedContentInset: UIEdgeInsets { contentInset }
+    override var isDragging: Bool { stubIsDragging }
+    override var isTracking: Bool { stubIsTracking }
+    override var isDecelerating: Bool { stubIsDecelerating }
+}

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -154,6 +154,33 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertFalse(sut.shouldShowStandByView)
     }
 
+    func testWebViewContentOpacityFadesWithPullToRefreshProgress() {
+        let sut = HomeAssistantViewModel(server: Server.fake(), overlayState: WebFrontendOverlayState())
+        sut.forceDismissStandByView()
+        sut.fade(to: 1, reduceMotion: true)
+
+        sut.pullToRefreshProgress = 0.5
+
+        XCTAssertEqual(sut.webViewContentOpacity, 0.5, accuracy: 0.001)
+        XCTAssertTrue(sut.showsPullToRefresh)
+
+        sut.pullToRefreshProgress = 0
+
+        XCTAssertEqual(sut.webViewContentOpacity, 1, accuracy: 0.001)
+        XCTAssertFalse(sut.showsPullToRefresh)
+    }
+
+    func testWebViewContentOpacityIsZeroWhilePullToRefreshIsActive() {
+        let sut = HomeAssistantViewModel(server: Server.fake(), overlayState: WebFrontendOverlayState())
+        sut.forceDismissStandByView()
+        sut.fade(to: 1, reduceMotion: true)
+        sut.pullToRefreshProgress = 1
+        sut.isPullToRefreshActive = true
+
+        XCTAssertEqual(sut.webViewContentOpacity, 0)
+        XCTAssertTrue(sut.showsPullToRefresh)
+    }
+
     func testCleanCacheAndReloadClearsFrontendAssetCacheThenResetsFrontend() {
         let previousHandler = Current.websiteDataStoreHandler
         defer { Current.websiteDataStoreHandler = previousHandler }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Finish-refresh left a negative WKWebView content offset (dead hit-testing gap). In-page canvas drags (Zigbee map) triggered PTR because \`alwaysBounceVertical\` was forced. Bounce is now only enabled for scrollable documents or an eligible top-of-page pull; leftover offset is reset when refresh ends.

Fixes #5432 #5320 #5385

**Test plan:** pull-to-refresh a dashboard (no leftover gap; tiles tappable). Drag a Zigbee mesh node without reloading. Short dashboards should not rubber-band aggressively.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.