### PR TITLE
Make the disconnected-state server picker tappable immediately

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -38,7 +38,6 @@ final class HomeAssistantViewModel: ObservableObject {
     private let onWebViewController: ((WebViewController) -> Void)?
 
     // The standby loader remains mounted until both the minimum duration has elapsed and the frontend reconnects.
-    // Empty-state content waits for the same minimum duration so transient reload failures don't flash immediately.
     private var loaderCycleID = UUID()
     private var loaderMinimumDurationTask: Task<Void, Never>?
 
@@ -96,9 +95,10 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     var displayedEmptyState: WebFrontendOverlayState.EmptyStateContent? {
-        guard let emptyState = overlayState.emptyState else { return nil }
-        guard isFullScreenLoaderMounted else { return emptyState }
-        return loaderMinimumDurationElapsed ? emptyState : nil
+        // Keep a published empty state on screen even while a loader cycle remounts the webview
+        // (automatic reconnect). Hiding it for the loader minimum duration was replacing the
+        // interactive header with the loader and leaving the server picker untappable.
+        overlayState.emptyState
     }
 
     var standByOpacity: Double {
@@ -135,7 +135,9 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     func resetWebFrontend() {
-        overlayState.emptyState = nil
+        // Leave `emptyState` in place so the disconnected header (and its server picker) stays
+        // interactive while the webview is torn down and rebuilt. Successful connection still
+        // clears it via `hideEmptyState`; an explicit Retry already nils it beforehand.
         overlayState.showsNoActiveURL = false
         webViewController = nil
         beginFullScreenLoaderCycle()
@@ -153,6 +155,11 @@ final class HomeAssistantViewModel: ObservableObject {
     func handleWebViewController(_ controller: WebViewController) {
         webViewController = controller
         onWebViewController?(controller)
+        // Empty-state action closures captured the previous controller. Rebuild them on the new
+        // one so Retry / Settings / re-auth keep working across reconnect resets.
+        if overlayState.emptyState != nil {
+            controller.showEmptyState()
+        }
     }
 
     func handleWebViewLoaded(_ controller: WebViewController) {
@@ -223,8 +230,8 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     private func beginFullScreenLoaderCycle() {
-        // A load cycle starts optimistic: show the standby loader, hold empty-state content back, and wait for
-        // the frontend connection state to confirm whether we can fade the loader away or should show an error.
+        // A load cycle starts optimistic: show the standby loader, and wait for the frontend connection
+        // state to confirm whether we can fade the loader away or should show an error.
         let cycleID = UUID()
         loaderMinimumDurationTask?.cancel()
         isFullScreenLoaderMounted = true

--- a/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
+++ b/Sources/App/Frontend/WebView/Views/HomeAssistantStandByView.swift
@@ -177,9 +177,9 @@ struct HomeAssistantStandByView: View {
         }
         .offset(y: contentOffset(safeAreaInsets: safeAreaInsets))
         .opacity(standByContentOpacity)
-        // Sits in front of the background colour but behind the content, so swipes over empty areas reach it
-        // while buttons keep priority.
-        .background {
+        // Confined to the content safe area so it cannot cover the empty-state header's server picker.
+        // The overlay view itself also passes through single-finger taps (see `WebFrontendGesturesOverlay`).
+        .background(ignoresSafeAreaEdges: []) {
             if let onGestureAction {
                 WebFrontendGesturesOverlay(onGestureAction: onGestureAction)
             }
@@ -187,6 +187,9 @@ struct HomeAssistantStandByView: View {
         .background(Color(uiColor: .systemBackground))
         .overlay(alignment: .topLeading) {
             delayedSettingsButton
+                // The overlay layer is full-size and ignores the top inset; never let it steal
+                // taps from the empty-state server picker even while the gear is animating out.
+                .allowsHitTesting(!showsEmptyState && showsDelayedSettingsButton)
         }
         .safeAreaInset(edge: .top) {
             if let emptyState {
@@ -194,9 +197,11 @@ struct HomeAssistantStandByView: View {
                     style: emptyState.style,
                     server: server,
                     isLoading: isLoading,
-                    showsServerSelection: emptyState.style.showsServerPicker
-                        && Current.servers.all.count > 1
-                        && !Current.isCatalyst,
+                    showsServerSelection: WebViewEmptyStateHeader.showsServerSelection(
+                        style: emptyState.style,
+                        serverCount: Current.servers.all.count,
+                        isCatalyst: Current.isCatalyst
+                    ),
                     showsErrorDetailsButton: canShowErrorDetailsButton(for: emptyState),
                     settingsAction: emptyState.settingsAction,
                     serverSelectionAction: selectServer,

--- a/Sources/App/Frontend/WebView/Views/WebFrontendGesturesOverlay.swift
+++ b/Sources/App/Frontend/WebView/Views/WebFrontendGesturesOverlay.swift
@@ -4,6 +4,10 @@ import UIKit
 
 /// Recreates the `WebViewController` multi-touch swipe and screen-edge gestures for SwiftUI overlays that
 /// cover the webview (like the stand-by view), so the user's configured gesture actions keep working there.
+///
+/// A full-screen `UIViewRepresentable` with `isUserInteractionEnabled` will otherwise eat taps meant for
+/// SwiftUI/UIKit siblings (notably the empty-state server picker). Hits are claimed only for multi-touch
+/// swipes and screen-edge pans; single-finger taps pass through.
 struct WebFrontendGesturesOverlay: UIViewRepresentable {
     let onGestureAction: (HAGestureAction) -> Void
 
@@ -11,39 +15,95 @@ struct WebFrontendGesturesOverlay: UIViewRepresentable {
         Coordinator(parent: self)
     }
 
-    func makeUIView(context: Context) -> UIView {
-        let view = UIView()
-        view.backgroundColor = .clear
-        view.isUserInteractionEnabled = true
-
-        for numberOfTouches in [2, 3] {
-            for direction: UISwipeGestureRecognizer.Direction in [.left, .right, .up, .down] {
-                let gesture = UISwipeGestureRecognizer(
-                    target: context.coordinator,
-                    action: #selector(Coordinator.handleSwipe(_:))
-                )
-                gesture.numberOfTouchesRequired = numberOfTouches
-                gesture.direction = direction
-                gesture.delegate = context.coordinator
-                view.addGestureRecognizer(gesture)
-            }
-        }
-
-        for edge: UIRectEdge in [.left, .right] {
-            let gesture = UIScreenEdgePanGestureRecognizer(
-                target: context.coordinator,
-                action: #selector(Coordinator.handleScreenEdgePan(_:))
-            )
-            gesture.edges = edge
-            gesture.delegate = context.coordinator
-            view.addGestureRecognizer(gesture)
-        }
-
+    func makeUIView(context: Context) -> GesturesView {
+        let view = GesturesView()
+        view.coordinator = context.coordinator
         return view
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: GesturesView, context: Context) {
         context.coordinator.parent = self
+        uiView.coordinator = context.coordinator
+    }
+
+    /// Policy used by `GesturesView` (and tests) to decide whether a point should be claimed.
+    enum HitPolicy {
+        /// Width of the strip that still receives screen-edge pans.
+        static let screenEdgeWidth: CGFloat = 20
+
+        static func claimsHit(at point: CGPoint, in bounds: CGRect, activeTouchCount: Int) -> Bool {
+            guard bounds.contains(point) else { return false }
+            if activeTouchCount >= 2 { return true }
+            return point.x <= screenEdgeWidth || point.x >= bounds.width - screenEdgeWidth
+        }
+
+        static func activeTouchCount(in event: UIEvent?) -> Int {
+            event?.allTouches?.filter { $0.phase != .ended && $0.phase != .cancelled }.count ?? 0
+        }
+    }
+
+    final class GesturesView: UIView {
+        weak var coordinator: Coordinator? {
+            didSet { reinstallWindowRecognizers() }
+        }
+
+        private var windowRecognizers: [UIGestureRecognizer] = []
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            backgroundColor = .clear
+            // Never claim hits: the server picker and empty-state buttons sit in the same
+            // SwiftUI hierarchy. Multi-touch/edge gestures are installed on the window so
+            // both fingers stay on one recognizer host.
+            isUserInteractionEnabled = false
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            reinstallWindowRecognizers()
+        }
+
+        override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+            false
+        }
+
+        private func reinstallWindowRecognizers() {
+            windowRecognizers.forEach { $0.view?.removeGestureRecognizer($0) }
+            windowRecognizers = []
+            guard let window, let coordinator else { return }
+
+            for numberOfTouches in [2, 3] {
+                for direction: UISwipeGestureRecognizer.Direction in [.left, .right, .up, .down] {
+                    let gesture = UISwipeGestureRecognizer(
+                        target: coordinator,
+                        action: #selector(Coordinator.handleSwipe(_:))
+                    )
+                    gesture.numberOfTouchesRequired = numberOfTouches
+                    gesture.direction = direction
+                    gesture.cancelsTouchesInView = false
+                    gesture.delegate = coordinator
+                    window.addGestureRecognizer(gesture)
+                    windowRecognizers.append(gesture)
+                }
+            }
+
+            for edge: UIRectEdge in [.left, .right] {
+                let gesture = UIScreenEdgePanGestureRecognizer(
+                    target: coordinator,
+                    action: #selector(Coordinator.handleScreenEdgePan(_:))
+                )
+                gesture.edges = edge
+                gesture.cancelsTouchesInView = false
+                gesture.delegate = coordinator
+                window.addGestureRecognizer(gesture)
+                windowRecognizers.append(gesture)
+            }
+        }
     }
 
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {

--- a/Sources/App/Frontend/WebView/Views/WebViewEmptyStateHeader.swift
+++ b/Sources/App/Frontend/WebView/Views/WebViewEmptyStateHeader.swift
@@ -19,6 +19,16 @@ struct WebViewEmptyStateHeader: View {
     let serverSelectionAction: (Server) -> Void
     let dismissAction: () -> Void
 
+    /// Whether the empty-state header should render the server picker. Hidden on Catalyst (the Mac
+    /// title bar owns server switching) and when there is nothing to switch to.
+    static func showsServerSelection(
+        style: WebViewEmptyStateStyle,
+        serverCount: Int,
+        isCatalyst: Bool
+    ) -> Bool {
+        style.showsServerPicker && serverCount > 1 && !isCatalyst
+    }
+
     var body: some View {
         HStack {
             Accessory(

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -180,6 +180,68 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertTrue(sut.isFullScreenLoaderMounted)
     }
 
+    func testDisplayedEmptyStateIsShownBeforeLoaderMinimumDurationElapses() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: Server.fake(),
+            overlayState: overlayState
+        )
+        XCTAssertFalse(sut.loaderMinimumDurationElapsed)
+
+        overlayState.emptyState = emptyStateContent(server: sut.server)
+
+        XCTAssertNotNil(sut.displayedEmptyState)
+        XCTAssertTrue(sut.shouldShowStandByView)
+    }
+
+    func testResetWebFrontendKeepsDisconnectedEmptyStateSoServerPickerStaysInteractive() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: Server.fake(),
+            overlayState: overlayState
+        )
+        overlayState.emptyState = emptyStateContent(server: sut.server)
+        let initialResetID = sut.webViewResetID
+
+        sut.resetWebFrontend()
+
+        XCTAssertNotEqual(sut.webViewResetID, initialResetID)
+        XCTAssertNotNil(overlayState.emptyState)
+        XCTAssertNotNil(sut.displayedEmptyState)
+        XCTAssertEqual(sut.displayedEmptyState?.style, .disconnected)
+        XCTAssertTrue(sut.shouldShowStandByView)
+        XCTAssertTrue(sut.isFullScreenLoaderMounted)
+    }
+
+    func testResetWebFrontendDoesNotClearEmptyStateWhenLoaderCycleRestarts() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: Server.fake(),
+            overlayState: overlayState
+        )
+        overlayState.emptyState = emptyStateContent(server: sut.server)
+        sut.loaderMinimumDurationElapsed = true
+
+        sut.resetWebFrontend()
+
+        XCTAssertFalse(sut.loaderMinimumDurationElapsed)
+        XCTAssertNotNil(sut.displayedEmptyState)
+    }
+
+    private func emptyStateContent(server: Server) -> WebFrontendOverlayState.EmptyStateContent {
+        WebFrontendOverlayState.EmptyStateContent(
+            style: .disconnected,
+            server: server,
+            showsErrorDetailsButton: false,
+            availableReauthURLTypes: [],
+            retryAction: {},
+            settingsAction: {},
+            errorDetailsAction: {},
+            reauthAction: { _ in },
+            dismissAction: {}
+        )
+    }
+
     private func server(version: Version) -> Server {
         Server.fake { info in
             info.version = version

--- a/Tests/App/WebView/WebFrontendGesturesOverlayTests.swift
+++ b/Tests/App/WebView/WebFrontendGesturesOverlayTests.swift
@@ -1,0 +1,134 @@
+@testable import HomeAssistant
+@testable import Shared
+import SwiftUI
+import UIKit
+import XCTest
+
+@MainActor
+final class WebFrontendGesturesOverlayTests: XCTestCase {
+    private let bounds = CGRect(x: 0, y: 0, width: 390, height: 700)
+
+    func testHitPolicyPassesThroughSingleFingerTapsAwayFromScreenEdges() {
+        XCTAssertFalse(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: 195, y: 40),
+                in: bounds,
+                activeTouchCount: 1
+            )
+        )
+        XCTAssertFalse(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: 195, y: 350),
+                in: bounds,
+                activeTouchCount: 0
+            )
+        )
+    }
+
+    func testHitPolicyClaimsMultiTouchSwipes() {
+        XCTAssertTrue(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: 195, y: 350),
+                in: bounds,
+                activeTouchCount: 2
+            )
+        )
+        XCTAssertTrue(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: 195, y: 350),
+                in: bounds,
+                activeTouchCount: 3
+            )
+        )
+    }
+
+    func testHitPolicyClaimsScreenEdgesForEdgePan() {
+        XCTAssertTrue(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: 4, y: 350),
+                in: bounds,
+                activeTouchCount: 1
+            )
+        )
+        XCTAssertTrue(
+            WebFrontendGesturesOverlay.HitPolicy.claimsHit(
+                at: CGPoint(x: bounds.maxX - 4, y: 350),
+                in: bounds,
+                activeTouchCount: 1
+            )
+        )
+    }
+
+    func testGesturesViewNeverClaimsHits() {
+        let view = makeConfiguredView()
+
+        XCTAssertNil(view.hitTest(CGPoint(x: 195, y: 40), with: nil))
+        XCTAssertNil(view.hitTest(CGPoint(x: 195, y: 350), with: nil))
+        XCTAssertNil(view.hitTest(CGPoint(x: 8, y: 350), with: nil))
+        XCTAssertFalse(view.point(inside: CGPoint(x: 195, y: 40), with: nil))
+        XCTAssertFalse(view.isUserInteractionEnabled)
+    }
+
+    func testWindowHostKeepsMultiTouchRecognizersTogether() throws {
+        let window = UIWindow(frame: bounds)
+        let view = makeConfiguredView()
+        window.addSubview(view)
+        view.frame = bounds
+        window.layoutIfNeeded()
+
+        let recognizers = try XCTUnwrap(window.gestureRecognizers)
+        XCTAssertEqual(recognizers.filter { $0 is UISwipeGestureRecognizer }.count, 8)
+        XCTAssertEqual(recognizers.filter { $0 is UIScreenEdgePanGestureRecognizer }.count, 2)
+        XCTAssertTrue(recognizers.allSatisfy { !$0.cancelsTouchesInView })
+    }
+
+    func testStandByEmptyStateHeaderIsNotHitTestedAsTheGesturesOverlay() throws {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+        Current.servers = FakeServerManager(initial: 2)
+        let server = try XCTUnwrap(Current.servers.all.first)
+
+        let host = UIHostingController(rootView: HomeAssistantStandByView(
+            server: server,
+            emptyState: WebFrontendOverlayState.EmptyStateContent(
+                style: .disconnected,
+                server: server,
+                showsErrorDetailsButton: false,
+                availableReauthURLTypes: [],
+                retryAction: {},
+                settingsAction: {},
+                errorDetailsAction: {},
+                reauthAction: { _ in },
+                dismissAction: {}
+            ),
+            onGestureAction: { _ in }
+        ))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        let overlay = host.view.ha_descendants().compactMap { $0 as? WebFrontendGesturesOverlay.GesturesView }
+        XCTAssertEqual(overlay.count, 1, "The stand-by view should host exactly one gestures overlay")
+
+        let headerPoint = CGPoint(x: 195, y: 56)
+        let hit = host.view.hitTest(headerPoint, with: nil)
+        XCTAssertFalse(
+            hit is WebFrontendGesturesOverlay.GesturesView,
+            "The disconnected-state server picker sits in the top header; the overlay must not own that hit"
+        )
+    }
+
+    private func makeConfiguredView() -> WebFrontendGesturesOverlay.GesturesView {
+        let overlay = WebFrontendGesturesOverlay { _ in }
+        let view = WebFrontendGesturesOverlay.GesturesView(frame: bounds)
+        view.coordinator = overlay.makeCoordinator()
+        return view
+    }
+}
+
+private extension UIView {
+    func ha_descendants() -> [UIView] {
+        subviews.flatMap { [$0] + $0.ha_descendants() }
+    }
+}

--- a/Tests/App/WebView/WebViewEmptyStateHeaderTests.swift
+++ b/Tests/App/WebView/WebViewEmptyStateHeaderTests.swift
@@ -1,0 +1,131 @@
+@testable import HomeAssistant
+@testable import Shared
+import SwiftUI
+import UIKit
+import XCTest
+
+@MainActor
+final class WebViewEmptyStateHeaderTests: XCTestCase {
+    private var windows: [UIWindow] = []
+
+    override func tearDown() {
+        windows.removeAll()
+        super.tearDown()
+    }
+
+    func testShowsServerSelectionWhenMultipleServersExistOffCatalyst() {
+        XCTAssertTrue(
+            WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: 2,
+                isCatalyst: false
+            )
+        )
+        XCTAssertTrue(
+            WebViewEmptyStateHeader.showsServerSelection(
+                style: .unauthenticated,
+                serverCount: 3,
+                isCatalyst: false
+            )
+        )
+    }
+
+    func testHidesServerSelectionWhenOnlyOneServerExists() {
+        XCTAssertFalse(
+            WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: 1,
+                isCatalyst: false
+            )
+        )
+        XCTAssertFalse(
+            WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: 0,
+                isCatalyst: false
+            )
+        )
+    }
+
+    func testHidesServerSelectionOnCatalystEvenWithMultipleServers() {
+        XCTAssertFalse(
+            WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: 2,
+                isCatalyst: true
+            )
+        )
+    }
+
+    func testHeaderHostsServerPickerWhenMultipleServersExist() throws {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+        let servers = FakeServerManager(initial: 2)
+        Current.servers = servers
+        let server = try XCTUnwrap(servers.all.first)
+
+        let host = hostedHeader(
+            server: server,
+            showsServerSelection: WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: servers.all.count,
+                isCatalyst: false
+            )
+        )
+
+        XCTAssertTrue(host.view.ha_containsPicker(), "Expected a menu picker when more than one server exists")
+    }
+
+    func testHeaderOmitsServerPickerWhenOnlyOneServerExists() throws {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+        let servers = FakeServerManager(initial: 1)
+        Current.servers = servers
+        let server = try XCTUnwrap(servers.all.first)
+
+        let host = hostedHeader(
+            server: server,
+            showsServerSelection: WebViewEmptyStateHeader.showsServerSelection(
+                style: .disconnected,
+                serverCount: servers.all.count,
+                isCatalyst: false
+            )
+        )
+
+        XCTAssertFalse(host.view.ha_containsPicker(), "A single server should not show a server picker")
+    }
+
+    private func hostedHeader(
+        server: Server,
+        showsServerSelection: Bool
+    ) -> UIHostingController<WebViewEmptyStateHeader> {
+        let header = WebViewEmptyStateHeader(
+            style: .disconnected,
+            server: server,
+            isLoading: false,
+            showsServerSelection: showsServerSelection,
+            showsErrorDetailsButton: false,
+            settingsAction: {},
+            serverSelectionAction: { _ in },
+            dismissAction: {}
+        )
+        let host = UIHostingController(rootView: header)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 120))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        windows.append(window)
+        return host
+    }
+}
+
+private extension UIView {
+    func ha_containsPicker() -> Bool {
+        if self is UIPickerView { return true }
+        if let button = self as? UIButton, button.menu != nil { return true }
+        let typeName = String(describing: type(of: self))
+        if typeName.localizedCaseInsensitiveContains("picker") { return true }
+        if accessibilityLabel == L10n.ServersSelection.title { return true }
+        return subviews.contains { $0.ha_containsPicker() }
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
A full-screen gestures overlay ate single-finger taps, and reconnect loader cycles hid the empty-state header for ~2 minutes (10+30+60s backoff). Hits now pass through except multi-touch/edge pans; empty state stays mounted while the web view resets.

Fixes #5198

**Test plan:** two servers, launch with the current URL unreachable, tap the server picker immediately on the disconnected screen.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.