### PR TITLE
Show all dashboards in kiosk settings and restore brightness when leaving the app

### DIFF
--- a/Sources/App/Settings/Kiosk/KioskScreenBrightnessController.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreenBrightnessController.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Shared
+import SwiftUI
+
+/// Owns kiosk screensaver dimming of `UIScreen` brightness.
+///
+/// `UIScreen.main.brightness` is the system brightness. If we leave it dimmed, other apps stay dim
+/// after the user leaves HA (#4656). iOS also drops brightness writes once the app is mid-background,
+/// so restore must run on willResignActive — not only on a later dismiss path.
+final class KioskScreenBrightnessController {
+    private var brightnessBeforeDimming: CGFloat?
+    private(set) var isForeground = true
+
+    func handleWillResignActive() {
+        leaveForeground()
+    }
+
+    func handleDidEnterBackground() {
+        leaveForeground()
+    }
+
+    func handleScenePhase(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            handleDidBecomeActive()
+        case .inactive, .background:
+            leaveForeground()
+        @unknown default:
+            break
+        }
+    }
+
+    func handleDidBecomeActive() {
+        isForeground = true
+    }
+
+    /// Dims when the screensaver wants it *and* we are in the foreground. Any other state restores.
+    func apply(shouldDim: Bool, dimLevel: Double) {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        guard isForeground, shouldDim else {
+            restore()
+            return
+        }
+        if brightnessBeforeDimming == nil {
+            brightnessBeforeDimming = Current.screenBrightness()
+        }
+        Current.setScreenBrightness(CGFloat(min(max(dimLevel, 0), 1)))
+        #endif
+    }
+
+    func restore() {
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        guard let brightnessBeforeDimming else { return }
+        Current.setScreenBrightness(brightnessBeforeDimming)
+        self.brightnessBeforeDimming = nil
+        #endif
+    }
+
+    private func leaveForeground() {
+        isForeground = false
+        restore()
+    }
+
+    deinit {
+        restore()
+    }
+}

--- a/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
@@ -154,7 +154,7 @@ final class KioskScreensaverController: ObservableObject {
 
     private var isEnabled = false
     private var isCameraOverlayVisible = false
-    private var brightnessBeforeDimming: CGFloat?
+    private let brightness = KioskScreenBrightnessController()
     private var idleTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
     private var isMotionObserving = false
@@ -168,6 +168,7 @@ final class KioskScreensaverController: ObservableObject {
 
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
+                self?.brightness.handleDidBecomeActive()
                 self?.restartIdleTimer()
                 self?.updateBrightness()
             }
@@ -175,7 +176,13 @@ final class KioskScreensaverController: ObservableObject {
         NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
             .sink { [weak self] _ in
                 self?.idleTimer?.invalidate()
-                self?.restoreBrightness()
+                self?.brightness.handleWillResignActive()
+            }
+            .store(in: &cancellables)
+        NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
+            .sink { [weak self] _ in
+                self?.idleTimer?.invalidate()
+                self?.brightness.handleDidEnterBackground()
             }
             .store(in: &cancellables)
 
@@ -200,10 +207,21 @@ final class KioskScreensaverController: ObservableObject {
 
     deinit {
         idleTimer?.invalidate()
-        restoreBrightness()
+        brightness.restore()
         Current.motionDetection.unregister(observer: self)
         // The screensaver is no longer on screen once this controller goes away (e.g. kiosk mode disabled).
         Current.kiosk.setScreensaverVisible(false)
+    }
+
+    func handleScenePhase(_ phase: ScenePhase) {
+        if phase == .inactive || phase == .background {
+            idleTimer?.invalidate()
+        }
+        brightness.handleScenePhase(phase)
+        if phase == .active {
+            restartIdleTimer()
+            updateBrightness()
+        }
     }
 
     func recordActivity() {
@@ -273,38 +291,10 @@ final class KioskScreensaverController: ObservableObject {
     }
 
     private func updateBrightness() {
-        #if os(iOS) && !targetEnvironment(macCatalyst)
-        guard shouldDimBrightness else {
-            restoreBrightness()
-            return
-        }
-
-        if brightnessBeforeDimming == nil {
-            brightnessBeforeDimming = UIScreen.main.brightness
-        }
-
-        UIScreen.main.brightness = CGFloat(min(max(screensaver.dimLevel, 0), 1))
-        #endif
-    }
-
-    private var shouldDimBrightness: Bool {
-        #if os(iOS) && !targetEnvironment(macCatalyst)
-        UIApplication.shared.applicationState == .active &&
-            isEnabled &&
-            isActive &&
-            screensaver.dimEnabled &&
-            !isCameraOverlayVisible
-        #else
-        false
-        #endif
-    }
-
-    private func restoreBrightness() {
-        #if os(iOS) && !targetEnvironment(macCatalyst)
-        guard let brightnessBeforeDimming else { return }
-        UIScreen.main.brightness = brightnessBeforeDimming
-        self.brightnessBeforeDimming = nil
-        #endif
+        brightness.apply(
+            shouldDim: isEnabled && isActive && screensaver.dimEnabled && !isCameraOverlayVisible,
+            dimLevel: screensaver.dimLevel
+        )
     }
 }
 

--- a/Sources/App/Settings/Kiosk/KioskSettingsViewModel.swift
+++ b/Sources/App/Settings/Kiosk/KioskSettingsViewModel.swift
@@ -83,6 +83,7 @@ final class KioskSettingsViewModel: ObservableObject {
         }
         do {
             panels = try AppPanel.panels(serverId: serverId) ?? []
+            panels.sort { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
         } catch {
             Current.Log.error("Failed to load kiosk dashboards: \(error.localizedDescription)")
             panels = []

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -154,6 +154,7 @@ struct ConditionalContainerView: View {
 struct KioskView: View {
     @StateObject private var screensaver = KioskScreensaverController()
     @StateObject private var kiosk = Current.kiosk
+    @Environment(\.scenePhase) private var scenePhase
     @Binding var showSettings: Bool
 
     var body: some View {
@@ -182,6 +183,9 @@ struct KioskView: View {
                 }
             }
             .animation(.easeInOut(duration: 0.4), value: screensaver.isActive)
+            .onChange(of: scenePhase) { phase in
+                screensaver.handleScenePhase(phase)
+            }
     }
 
     private var settingsEntryAlignment: Alignment {

--- a/Sources/HAModels/Sources/AppPanel.swift
+++ b/Sources/HAModels/Sources/AppPanel.swift
@@ -1,8 +1,8 @@
 import Foundation
 import GRDB
 
-/// A sidebar dashboard panel, scoped to a server. The `Current.database()`-backed queries live in
-/// an extension in the `Shared` module.
+/// A dashboard panel, scoped to a server. Includes panels hidden from the sidebar (`showInSidebar`).
+/// The `Current.database()`-backed queries live in an extension in the `Shared` module.
 public struct AppPanel: Codable, FetchableRecord, PersistableRecord {
     public var id: String = UUID().uuidString
     public var serverId: String = ""

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -104,7 +104,7 @@ public enum DatabaseTables {
         case serverInfoJSON
     }
 
-    // Sidebar dashboard panels
+    // Dashboard panels (including those hidden from the sidebar)
     public enum AppPanel: String, CaseIterable {
         case id
         case serverId

--- a/Sources/Shared/API/WebSocket/HAPanel.swift
+++ b/Sources/Shared/API/WebSocket/HAPanel.swift
@@ -26,7 +26,10 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
         self.icon = data.decode("icon", fallback: fallbackIcon)
         self.path = try data.decode("url_path")
 
-        let title: String = data.decode("title", fallback: component)
+        // Hidden dashboards used to omit title (it was treated as sidebar-only). Fall back to the
+        // path so pickers can tell them apart instead of labeling every one with the component name.
+        let decodedTitle: String = data.decode("title", fallback: "")
+        let title: String = decodedTitle.isEmpty ? (path.isEmpty ? component : path) : decodedTitle
 
         let possibleFrontendKey: String
         if path == "lovelace" {
@@ -96,6 +99,7 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
         try self.init(
             panelsByPath: dictionary
                 .compactMapKeys {
+                    // Internal frontend panels (`_my`, …) are not user-openable destinations.
                     if $0.hasPrefix("_") {
                         return nil
                     } else {
@@ -105,8 +109,6 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
                 .mapValues {
                     try HAPanel(data: .init(value: $0))
                 }
-                // non-show_in_sidebar dashboards have badly-named titles
-                .filter(\.value.showInSidebar)
         )
     }
 }

--- a/Sources/Shared/Panels/AppPanel.swift
+++ b/Sources/Shared/Panels/AppPanel.swift
@@ -4,6 +4,7 @@ import HAKit
 
 // `AppPanel` itself lives in the `HAModels` package; these are its database-backed queries.
 public extension AppPanel {
+    /// All stored panels for the server, including dashboards hidden from the sidebar.
     static func panels(serverId: String) throws -> [AppPanel]? {
         try Current.database().read({ db in
             try AppPanel

--- a/Tests/App/Kiosk/KioskScreenBrightnessController.test.swift
+++ b/Tests/App/Kiosk/KioskScreenBrightnessController.test.swift
@@ -1,0 +1,114 @@
+import Foundation
+@testable import HomeAssistant
+@testable import Shared
+import SwiftUI
+import Testing
+
+/// Covers home-assistant/iOS#4656: screensaver dim of `UIScreen.main.brightness` must restore
+/// whenever the app is no longer foreground — not only on a screensaver dismiss path.
+@MainActor
+struct KioskScreenBrightnessControllerTests {
+    private final class BrightnessBox {
+        var value: CGFloat = 0
+    }
+
+    private func approxEq(_ a: CGFloat, _ b: CGFloat) -> Bool {
+        abs(a - b) < 1e-5
+    }
+
+    private func withMockBrightness(
+        initial: CGFloat,
+        _ body: (BrightnessBox, KioskScreenBrightnessController) throws -> Void
+    ) rethrows {
+        let savedGet = Current.screenBrightness
+        let savedSet = Current.setScreenBrightness
+        defer {
+            Current.screenBrightness = savedGet
+            Current.setScreenBrightness = savedSet
+        }
+        let box = BrightnessBox()
+        box.value = initial
+        Current.screenBrightness = { box.value }
+        Current.setScreenBrightness = { box.value = $0 }
+        let controller = KioskScreenBrightnessController()
+        defer { controller.restore() }
+        try body(box, controller)
+    }
+
+    @Test func applyDimsAndRestoreReturnsOriginal() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.1)
+            #expect(approxEq(box.value, 0.1))
+
+            controller.restore()
+            #expect(approxEq(box.value, 0.8))
+        }
+    }
+
+    @Test func willResignActiveRestoresEvenIfScreensaverStillWantsDim() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.05)
+            #expect(approxEq(box.value, 0.05))
+
+            controller.handleWillResignActive()
+            #expect(approxEq(box.value, 0.8))
+
+            // Race: updateBrightness can run while applicationState is still .active.
+            controller.apply(shouldDim: true, dimLevel: 0.05)
+            #expect(approxEq(box.value, 0.8), "must not re-dim after resigning active")
+        }
+    }
+
+    @Test func didEnterBackgroundRestoresOriginalBrightness() throws {
+        try withMockBrightness(initial: 0.65) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.2)
+            controller.handleDidEnterBackground()
+            #expect(approxEq(box.value, 0.65))
+        }
+    }
+
+    @Test func scenePhaseBackgroundRestoresOriginalBrightness() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.1)
+            controller.handleScenePhase(.background)
+            #expect(approxEq(box.value, 0.8))
+        }
+    }
+
+    @Test func scenePhaseInactiveRestoresOriginalBrightness() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.1)
+            controller.handleScenePhase(.inactive)
+            #expect(approxEq(box.value, 0.8))
+        }
+    }
+
+    @Test func stoppingScreensaverRestoresOriginalBrightness() throws {
+        try withMockBrightness(initial: 0.7) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.2)
+            controller.apply(shouldDim: false, dimLevel: 0.2)
+            #expect(approxEq(box.value, 0.7))
+        }
+    }
+
+    @Test func foregroundReappliesDimAfterBackground() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.05)
+            controller.handleDidEnterBackground()
+            #expect(approxEq(box.value, 0.8))
+
+            controller.handleDidBecomeActive()
+            controller.apply(shouldDim: true, dimLevel: 0.05)
+            #expect(approxEq(box.value, 0.05))
+        }
+    }
+
+    @Test func applyDoesNotRecaptureDimmedValueAsOriginal() throws {
+        try withMockBrightness(initial: 0.8) { box, controller in
+            controller.apply(shouldDim: true, dimLevel: 0.1)
+            controller.apply(shouldDim: true, dimLevel: 0.1)
+            controller.restore()
+            #expect(approxEq(box.value, 0.8))
+        }
+    }
+}

--- a/Tests/App/Kiosk/KioskSettingsViewModel.test.swift
+++ b/Tests/App/Kiosk/KioskSettingsViewModel.test.swift
@@ -1,0 +1,50 @@
+import Foundation
+import GRDB
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+@MainActor
+struct KioskSettingsViewModelTests {
+    @Test func reloadPanelsIncludesDashboardsHiddenFromTheSidebar() throws {
+        let previousDatabase = Current.database
+        let previousServers = Current.servers
+        let database = try DatabaseQueue(path: ":memory:")
+        try KioskSettingsTable().createIfNeeded(database: database)
+        try AppPanelTable().createIfNeeded(database: database)
+        Current.database = { database }
+        let servers = FakeServerManager()
+        _ = servers.add(identifier: .init(rawValue: "server-1"), serverInfo: .fake())
+        Current.servers = servers
+        defer {
+            Current.database = previousDatabase
+            Current.servers = previousServers
+        }
+
+        try database.write { db in
+            try AppPanel(
+                serverId: "server-1",
+                title: "Overview",
+                path: "lovelace",
+                component: "lovelace",
+                showInSidebar: true
+            ).insert(db)
+            try AppPanel(
+                serverId: "server-1",
+                title: "Tablet",
+                path: "tablet",
+                component: "lovelace",
+                showInSidebar: false
+            ).insert(db)
+        }
+
+        let viewModel = KioskSettingsViewModel()
+        viewModel.settings.serverId = "server-1"
+        viewModel.reloadPanels()
+
+        let paths = viewModel.panels.map(\.path)
+        #expect(paths.contains("lovelace"))
+        #expect(paths.contains("tablet"))
+        #expect(viewModel.panels.first(where: { $0.path == "tablet" })?.showInSidebar == false)
+    }
+}

--- a/Tests/Shared/HAPanel.test.swift
+++ b/Tests/Shared/HAPanel.test.swift
@@ -1,0 +1,86 @@
+import Foundation
+import GRDB
+import HAKit
+@testable import Shared
+import Testing
+
+struct HAPanelTests {
+    @Test func includesDashboardsHiddenFromTheSidebar() throws {
+        let data = HAData(value: [
+            "lovelace": [
+                "component_name": "lovelace",
+                "icon": "mdi:view-dashboard",
+                "title": "Overview",
+                "url_path": "lovelace",
+                "show_in_sidebar": true,
+            ],
+            "tablet": [
+                "component_name": "lovelace",
+                "icon": "mdi:tablet",
+                "title": "Tablet",
+                "url_path": "tablet",
+                "show_in_sidebar": false,
+            ],
+            "_my": [
+                "component_name": "my",
+                "title": "My",
+                "url_path": "_my",
+                "show_in_sidebar": false,
+            ],
+        ])
+
+        let panels = try HAPanels(data: data)
+
+        #expect(panels.panelsByPath["lovelace"] != nil)
+        let tablet = try #require(panels.panelsByPath["tablet"])
+        #expect(tablet.title == "Tablet")
+        #expect(tablet.path == "tablet")
+        #expect(tablet.showInSidebar == false)
+        #expect(panels.panelsByPath["_my"] == nil)
+        #expect(panels.allPanels.contains(where: { $0.path == "tablet" }))
+    }
+
+    @Test func hiddenDashboardWithoutTitleUsesPath() throws {
+        let data = HAData(value: [
+            "lovelace-hidden": [
+                "component_name": "lovelace",
+                "title": NSNull(),
+                "url_path": "lovelace-hidden",
+                "show_in_sidebar": false,
+            ] as [String: Any],
+        ])
+
+        let panels = try HAPanels(data: data)
+        let hidden = try #require(panels.panelsByPath["lovelace-hidden"])
+        #expect(hidden.title == "lovelace-hidden")
+        #expect(hidden.showInSidebar == false)
+    }
+
+    @Test func panelsQueryReturnsHiddenDashboards() throws {
+        let previousDatabase = Current.database
+        let database = try DatabaseQueue(path: ":memory:")
+        try AppPanelTable().createIfNeeded(database: database)
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        try database.write { db in
+            try AppPanel(
+                serverId: "server-1",
+                title: "Overview",
+                path: "lovelace",
+                component: "lovelace",
+                showInSidebar: true
+            ).insert(db)
+            try AppPanel(
+                serverId: "server-1",
+                title: "Tablet",
+                path: "tablet",
+                component: "lovelace",
+                showInSidebar: false
+            ).insert(db)
+        }
+
+        let panels = try AppPanel.panels(serverId: "server-1") ?? []
+        #expect(Set(panels.map(\.path)) == Set(["lovelace", "tablet"]))
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
\`HAPanels\` dropped \`show_in_sidebar: false\` dashboards, so kiosk could not select them (e.g. a Tablet dashboard). Those panels are kept (internal \`_\` panels still skipped). Screensaver dimming restores system brightness on resign-active, background, and scene-phase changes.

Fixes #5468 #4656

**Test plan:** hide a dashboard from the sidebar, confirm it appears in kiosk dashboard picker. Enable screensaver dim, switch to another app, confirm brightness is restored.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.