### PR TITLE
Set macOS window titles and stop hardcoding the launch-screen caption

### DIFF
--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -26,7 +26,9 @@ struct ContainerView: View {
                 RecoveredServerReauthView(server: server, state: state)
             }
         }
-        .navigationTitle(" ") // Remove default macOS title
+        // Real title for the macOS Window menu. The web-view toolbar hides title-bar visibility, so this
+        // text is not shown in the title bar.
+        .navigationTitle(Text(verbatim: macWindowTitle))
         .onAppear {
             coordinator.onOpenServer = { state.showWebView(for: $0) }
             coordinator.onSetup = { state.reevaluate() }
@@ -102,5 +104,16 @@ struct ContainerView: View {
     /// old `presentOverlayController`'s `onDisappear { refresh() }`.
     private func refreshWebView() {
         Current.sceneManager.webViewControllerPromise.done { $0.refresh() }
+    }
+
+    private var macWindowTitle: String {
+        switch state.screen {
+        case let .webView(server, _):
+            MacWebViewTitleBar.windowTitle(for: server)
+        case let .recoveredServerReauth(server):
+            MacWebViewTitleBar.windowTitle(for: server)
+        case .onboarding, .recoveredServerImport:
+            L10n.About.Logo.title
+        }
     }
 }

--- a/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
+++ b/Sources/App/Container/LaunchSplash/OHFBrandingFooter.swift
@@ -1,15 +1,14 @@
 import Shared
 import SwiftUI
 
-/// The "A PROJECT FROM THE" caption over the Open Home Foundation wordmark, as laid out at the bottom
-/// of `LaunchScreen.storyboard`. Shared by the launch splash overlay and the first stand-by screen of a
-/// cold launch so the branding stays put across the splash → stand-by hand-off.
+/// Caption over the Open Home Foundation wordmark. Shared by the launch splash overlay and the first
+/// stand-by of a cold launch so branding stays put across the hand-off. `LaunchScreen.storyboard` omits
+/// the caption — launch screens don't localize reliably — and this view supplies `L10n.OhfBranding.caption`.
 struct OHFBrandingFooter: View {
     /// Mirrors the OHF logo constraints in `LaunchScreen.storyboard`.
     static let logoSize = CGSize(width: 220, height: 25)
     /// Mirrors the storyboard's OHF-logo-bottom-to-safe-area constraint.
     static let bottomPadding: CGFloat = 32
-    /// Mirrors the "A PROJECT FROM THE" caption above the OHF logo in `LaunchScreen.storyboard`.
     private static let captionFontSize: CGFloat = 13
 
     var body: some View {

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -4,11 +4,19 @@ import SwiftUI
 import UIKit
 #if targetEnvironment(macCatalyst)
 import AppKit
+import HAKit
 #endif
 
 struct MacWebViewTitleBar: UIViewControllerRepresentable {
     let server: Server
     weak var webViewController: WebViewController?
+
+    /// Title for the macOS Window menu. The custom toolbar hides the title bar, but the window/scene
+    /// still needs a real title or the menu lists a blank entry.
+    static func windowTitle(for server: Server?) -> String {
+        let name = server?.info.name.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return name.isEmpty ? L10n.About.Logo.title : name
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -78,24 +86,32 @@ extension MacWebViewTitleBar {
 
         private weak var webViewController: WebViewController?
         private weak var titlebar: UITitlebar?
+        private weak var windowScene: UIWindowScene?
         private weak var serverPickerItem: NSMenuToolbarItem?
         private var toolbar: NSToolbar?
         private var server: Server?
+        private var serverObserver: HACancellable?
         private var macToolbarItems: [MagicItem] = []
         private var macToolbarConfigObserver: NSObjectProtocol?
 
         func update(server: Server, webViewController: WebViewController?) {
+            let serverChanged = self.server?.identifier != server.identifier
             self.server = server
             self.webViewController = webViewController
 
             loadMacToolbarItems()
             observeMacToolbarConfigChanges()
+            if serverChanged || serverObserver == nil {
+                observeServerName()
+            }
 
             refreshToolbarState()
+            updateWindowTitle()
         }
 
         func attach(to windowScene: UIWindowScene?) {
-            guard let titlebar = windowScene?.titlebar else { return }
+            guard let windowScene, let titlebar = windowScene.titlebar else { return }
+            self.windowScene = windowScene
             self.titlebar = titlebar
 
             if toolbar == nil || titlebar.toolbar !== toolbar {
@@ -105,6 +121,7 @@ extension MacWebViewTitleBar {
                 toolbar.allowsUserCustomization = true
                 toolbar.autosavesConfiguration = true
 
+                // Hidden in the title bar (unified toolbar); window/scene title still feeds the Window menu.
                 titlebar.titleVisibility = .hidden
                 if #available(macCatalyst 14.0, *) {
                     titlebar.toolbarStyle = .unifiedCompact
@@ -115,6 +132,7 @@ extension MacWebViewTitleBar {
             }
 
             refreshToolbarState()
+            updateWindowTitle()
         }
 
         private func refreshToolbarState() {
@@ -124,6 +142,8 @@ extension MacWebViewTitleBar {
         }
 
         func removeToolbar() {
+            serverObserver?.cancel()
+            serverObserver = nil
             if let macToolbarConfigObserver {
                 NotificationCenter.default.removeObserver(macToolbarConfigObserver)
                 self.macToolbarConfigObserver = nil
@@ -131,6 +151,20 @@ extension MacWebViewTitleBar {
             guard titlebar?.toolbar === toolbar else { return }
             titlebar?.toolbar = nil
             toolbar = nil
+        }
+
+        private func observeServerName() {
+            serverObserver?.cancel()
+            serverObserver = server?.observe { [weak self] _ in
+                self?.updateWindowTitle()
+                self?.updateServerPicker()
+            }
+        }
+
+        private func updateWindowTitle() {
+            let title = MacWebViewTitleBar.windowTitle(for: server)
+            windowScene?.title = title
+            windowScene?.windows.forEach { $0.title = title }
         }
 
         private func loadMacToolbarItems() {

--- a/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Sources/App/Resources/Base.lproj/LaunchScreen.storyboard
@@ -31,19 +31,11 @@
                                     <constraint firstAttribute="height" constant="25" id="vTX-2e-0yP"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A PROJECT FROM THE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Kv-2m-Wq7">
-                                <rect key="frame" x="135" y="755" width="144" height="16"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
-                                <color key="textColor" systemColor="secondaryLabelColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ESo-tq-1hR"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="9Kv-2m-Wq7" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="3Rp-8n-Lc4"/>
-                            <constraint firstItem="pDB-na-0R2" firstAttribute="top" secondItem="9Kv-2m-Wq7" secondAttribute="bottom" id="7Tj-5w-Xa2"/>
                             <constraint firstItem="pDB-na-0R2" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="BRP-Fw-g6e"/>
                             <constraint firstItem="mQh-tn-BC1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-50" id="gXx-Ta-dWp"/>
                             <constraint firstItem="mQh-tn-BC1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="hcu-i7-wKs"/>
@@ -59,9 +51,6 @@
     <resources>
         <image name="launchScreen-logo" width="180" height="180"/>
         <image name="ohf-inline" width="2960" height="291"/>
-        <systemColor name="secondaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Tests/App/WebView/MacWebViewTitleBarTests.swift
+++ b/Tests/App/WebView/MacWebViewTitleBarTests.swift
@@ -1,0 +1,40 @@
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+final class MacWebViewTitleBarTests: XCTestCase {
+    func testWindowTitleUsesServerName() {
+        let server = Server.fake { $0.remoteName = "Office" }
+
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: server), "Office")
+    }
+
+    func testWindowTitleFallsBackToAppNameWhenServerIsNil() {
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: nil), L10n.About.Logo.title)
+    }
+
+    func testWindowTitleFallsBackToAppNameWhenServerNameIsBlank() {
+        let server = Server.fake { $0.remoteName = "   " }
+
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: server), L10n.About.Logo.title)
+    }
+
+    func testWindowTitlePrefersLocalNameOverRemoteName() {
+        let server = Server.fake {
+            $0.remoteName = "Remote"
+            $0.setSetting(value: "Cottage", for: .localName)
+        }
+
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: server), "Cottage")
+    }
+
+    func testWindowTitleTracksServerRename() {
+        let server = Server.fake { $0.remoteName = "Office" }
+
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: server), "Office")
+
+        server.update { $0.remoteName = "Studio" }
+
+        XCTAssertEqual(MacWebViewTitleBar.windowTitle(for: server), "Studio")
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The custom toolbar hid title-bar visibility without setting \`window.title\`, so the Window menu listed blank entries. Scene/window title is now the server name. The English-only caption is removed from \`LaunchScreen.storyboard\`; the SwiftUI splash still shows \`L10n.OhfBranding.caption\`.

Fixes #5086 #5316

**Test plan (Mac):** Window menu shows the server name. Launch in a non-English locale: no English \"A PROJECT FROM THE\" flash before the localized splash.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.