### PR TITLE
Allow FLAC in the Mac file picker, restore app-icon MDI icons, and open the App Store for updates

### DIFF
--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+OpenPanel.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+OpenPanel.swift
@@ -1,0 +1,35 @@
+#if targetEnvironment(macCatalyst)
+import UniformTypeIdentifiers
+import WebKit
+
+extension WebViewController {
+    /// Mac Catalyst does not present a file picker for `<input type="file">` unless this
+    /// `WKUIDelegate` method is implemented. Safari's `NSOpenPanel` allows FLAC; the default
+    /// Catalyst picker does not, so allowed types are widened when WebKit's list is empty or
+    /// an audio subset that omits FLAC.
+    @available(iOS 18.4, *)
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void
+    ) {
+        if presentedViewController != nil {
+            Current.Log.error("attempted to present an open panel when already presenting, bailing")
+            completionHandler(nil)
+            return
+        }
+
+        let requestedTypes = WebViewOpenPanelContentTypes.requestedTypes(from: parameters)
+        let presenter = WebViewOpenPanelPresenter()
+        presenter.present(
+            from: self,
+            sourceView: webView,
+            allowsMultipleSelection: parameters.allowsMultipleSelection,
+            allowsDirectories: parameters.allowsDirectories,
+            requestedTypes: requestedTypes,
+            completion: completionHandler
+        )
+    }
+}
+#endif

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewOpenPanelContentTypes.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewOpenPanelContentTypes.swift
@@ -1,0 +1,62 @@
+import UniformTypeIdentifiers
+
+/// Resolves the content types used by the Mac Catalyst file-open panel.
+///
+/// WebKit's `WKOpenPanelParameters.allowedContentTypes` is often empty or a tight audio subset
+/// that omits FLAC even when the frontend `accept` list (and Safari) would allow it. Empty and
+/// audio-related type lists are widened to `public.audio`, `public.item`, and `.flac`.
+enum WebViewOpenPanelContentTypes {
+    static let audioFallbackTypes: [UTType] = [.audio, .item, .flac]
+
+    static func contentTypes(requested: [UTType]) -> [UTType] {
+        if requested.isEmpty {
+            return audioFallbackTypes
+        }
+        if allowsSelectingFlac(requested) {
+            return requested
+        }
+        guard isAudioRelated(requested) else {
+            return requested
+        }
+        var types = requested
+        for extra in audioFallbackTypes where !types.contains(extra) {
+            types.append(extra)
+        }
+        return types
+    }
+
+    /// Types advertised by `WKOpenPanelParameters`, when the property exists.
+    static func requestedTypes(from parameters: AnyObject) -> [UTType] {
+        guard parameters.responds(to: Selector(("allowedContentTypes"))) else {
+            return []
+        }
+        guard let value = parameters.value(forKey: "allowedContentTypes") else {
+            return []
+        }
+        if let types = value as? [UTType] {
+            return types
+        }
+        guard let items = value as? [Any] else {
+            return []
+        }
+        return items.compactMap { item in
+            if let type = item as? UTType {
+                return type
+            }
+            if let identifier = item as? String {
+                return UTType(identifier)
+            }
+            return nil
+        }
+    }
+
+    static func allowsSelectingFlac(_ types: [UTType]) -> Bool {
+        types.contains { UTType.flac.conforms(to: $0) }
+    }
+
+    static func isAudioRelated(_ types: [UTType]) -> Bool {
+        types.contains { type in
+            type.conforms(to: .audio) || type.identifier.contains("audio")
+        }
+    }
+}

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewOpenPanelPresenter.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewOpenPanelPresenter.swift
@@ -1,0 +1,62 @@
+import UniformTypeIdentifiers
+import UIKit
+
+/// Presents the system file picker for `WKWebView` file inputs and reports the chosen URLs.
+///
+/// On Mac Catalyst this surfaces as `NSOpenPanel`. The presenter retains itself for the lifetime
+/// of the picker so the completion handler still runs if the web view is released.
+final class WebViewOpenPanelPresenter: NSObject, UIDocumentPickerDelegate {
+    private var completion: (([URL]?) -> Void)?
+    private var selfRetain: WebViewOpenPanelPresenter?
+
+    func present(
+        from viewController: UIViewController,
+        sourceView: UIView,
+        allowsMultipleSelection: Bool,
+        allowsDirectories: Bool,
+        requestedTypes: [UTType],
+        completion: @escaping ([URL]?) -> Void
+    ) {
+        finish(nil)
+
+        var types = WebViewOpenPanelContentTypes.contentTypes(requested: requestedTypes)
+        if allowsDirectories, !types.contains(.folder) {
+            types.append(.folder)
+        }
+
+        self.completion = completion
+        selfRetain = self
+
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: types, asCopy: true)
+        picker.delegate = self
+        picker.allowsMultipleSelection = allowsMultipleSelection
+        picker.popoverPresentationController?.sourceView = sourceView
+        picker.popoverPresentationController?.sourceRect = CGRect(
+            x: sourceView.bounds.midX,
+            y: sourceView.bounds.midY,
+            width: 0,
+            height: 0
+        )
+
+        viewController.present(picker, animated: true)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        finish(urls)
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        finish(nil)
+    }
+
+    deinit {
+        completion?(nil)
+    }
+
+    private func finish(_ urls: [URL]?) {
+        let completion = completion
+        self.completion = nil
+        selfRetain = nil
+        completion?(urls)
+    }
+}

--- a/Sources/App/Settings/AppIconShortcuts/AppIconShortcutItemsUpdater.swift
+++ b/Sources/App/Settings/AppIconShortcuts/AppIconShortcutItemsUpdater.swift
@@ -93,25 +93,35 @@ enum AppIconShortcutItemsUpdater {
         provider.getAreaName(for: item)
     }
 
-    private static func icon(for item: MagicItem, provider: MagicItemProviderProtocol) -> UIApplicationShortcutIcon? {
-        switch item.type {
-        case .script:
-            return .init(systemSymbol: .applescriptFill)
-        case .scene:
-            return .init(systemSymbol: .sparkles)
-        case .entity:
-            return .init(systemSymbol: .rectangleAndPaperclip)
-        case .folder:
-            return .init(systemSymbol: .folderFill)
-        case .area:
-            // Areas can only be added to the watch, so this is never reached in practice.
-            return .init(systemSymbol: .squareGrid2x2Fill)
-        case .assistPipeline, .assistPrompt:
-            return .init(systemSymbol: .micFill)
-        case .complication:
-            return .init(systemSymbol: .applewatch)
-        case .unsupported:
-            return nil
+    static func materialDesignIcon(
+        for item: MagicItem,
+        provider: MagicItemProviderProtocol
+    ) -> MaterialDesignIcons {
+        if let info = provider.getInfo(for: item) {
+            return item.icon(info: info)
         }
+        return fallbackIcon(for: item.type)
+    }
+
+    static func fallbackIcon(for type: MagicItem.ItemType) -> MaterialDesignIcons {
+        switch type {
+        case .script: return .scriptIcon
+        case .scene: return .paletteIcon
+        case .entity: return .dotsGridIcon
+        case .folder: return .folderIcon
+        case .area: return .textureBoxIcon
+        case .assistPipeline: return .microphoneIcon
+        case .assistPrompt: return .messageProcessingOutlineIcon
+        case .complication: return .watchIcon
+        case .unsupported: return .dotsGridIcon
+        }
+    }
+
+    private static func icon(for item: MagicItem, provider: MagicItemProviderProtocol) -> UIApplicationShortcutIcon? {
+        guard item.type != .unsupported else { return nil }
+        // Home-screen shortcut icons only accept SF Symbols / bundled templates. Map the item's
+        // MaterialDesignIcons glyph (enum names end with `Icon`) through `similarSFSymbol` rather
+        // than passing MDI names as string SF Symbols, which do not resolve and appear blank.
+        return .init(systemSymbol: materialDesignIcon(for: item, provider: provider).similarSFSymbol)
     }
 }

--- a/Sources/App/Utilities/MenuManager.swift
+++ b/Sources/App/Utilities/MenuManager.swift
@@ -124,6 +124,43 @@ enum StatusItemTitleRenderer {
 /// browser instead of spawning a web-view window. The preference is read live on every call because
 /// flipping it does not reconfigure the status item (it posts no `menuRelatedSettingDidChange`).
 enum StatusItemPrimaryAction {
+    struct CheckForUpdatesActions: Equatable {
+        /// Menu-bar-only (accessory) users must not be yanked into a web-view window.
+        var activatesWebView: Bool
+        var performsSparkleCheck: Bool
+        var opensAppStore: Bool
+    }
+
+    /// Direct-download Mac builds use Sparkle in-process. App Store builds have no Sparkle, so the
+    /// previous path activated the app and then no-op'd (`Updater.isSupported` is false).
+    static func checkForUpdatesActions(
+        isSupported: Bool = Current.updater.isSupported,
+        isCatalyst: Bool = Current.isCatalyst
+    ) -> CheckForUpdatesActions {
+        CheckForUpdatesActions(
+            activatesWebView: false,
+            performsSparkleCheck: isSupported,
+            opensAppStore: !isSupported && isCatalyst
+        )
+    }
+
+    static func checkForUpdates(from sender: AnyObject?) {
+        let actions = checkForUpdatesActions()
+        if actions.opensAppStore {
+            URLOpener.shared.open(AppConstants.WebURLs.macAppStore, options: [:], completionHandler: nil)
+            return
+        }
+        guard actions.performsSparkleCheck else { return }
+        // Under the SwiftUI `App` lifecycle `UIApplication.shared.delegate` is SwiftUI's internal
+        // delegate, which doesn't respond to `checkForUpdate(_:)`; target our recorded instance.
+        UIApplication.shared.sendAction(
+            #selector(AppDelegate.checkForUpdate(_:)),
+            to: AppDelegate.shared,
+            from: sender,
+            for: nil
+        )
+    }
+
     /// Opens Home Assistant in the default browser when the browser preference is on.
     /// - Returns: `true` if it handled the action (browser opened), `false` to fall through to the
     ///   normal toggle/activate behaviour.
@@ -229,17 +266,7 @@ class MenuManager {
                 callbackInfo.activate()
             },
             .init(name: L10n.Updater.CheckForUpdatesMenu.title) { callbackInfo in
-                Current.sceneManager.activateAnyScene(for: .webView)
-                callbackInfo.activate()
-
-                // Under the SwiftUI `App` lifecycle `UIApplication.shared.delegate` is SwiftUI's internal
-                // delegate, which doesn't respond to `checkForUpdate(_:)`; target our recorded instance.
-                UIApplication.shared.sendAction(
-                    #selector(AppDelegate.checkForUpdate(_:)),
-                    to: AppDelegate.shared,
-                    from: callbackInfo,
-                    for: nil
-                )
+                StatusItemPrimaryAction.checkForUpdates(from: callbackInfo as AnyObject)
             },
         ]
     }
@@ -457,15 +484,7 @@ final class StatusItemManager {
                 callbackInfo.activate()
             },
             .init(name: L10n.Updater.CheckForUpdatesMenu.title) { callbackInfo in
-                Current.sceneManager.activateAnyScene(for: .webView)
-                callbackInfo.activate()
-
-                UIApplication.shared.sendAction(
-                    #selector(AppDelegate.checkForUpdate(_:)),
-                    to: AppDelegate.shared,
-                    from: callbackInfo,
-                    for: nil
-                )
+                StatusItemPrimaryAction.checkForUpdates(from: callbackInfo as AnyObject)
             },
         ]
     }

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -16,6 +16,8 @@ public enum AppConstants {
         public static var betaMac = URL(string: "https://companion.home-assistant.io/app/ios/beta_mac")!
         public static var review = URL(string: "https://companion.home-assistant.io/app/ios/review")!
         public static var reviewMac = URL(string: "https://companion.home-assistant.io/app/ios/review_mac")!
+        /// Mac App Store listing for App Store builds (Check for Updates).
+        public static var macAppStore = URL(string: "macappstore://apps.apple.com/app/id1099568401")!
         public static var translate = URL(string: "https://companion.home-assistant.io/app/ios/translate")!
         public static var forums = URL(string: "https://community.home-assistant.io/")!
         public static var chat = URL(string: "https://companion.home-assistant.io/app/ios/chat")!

--- a/Tests/App/Settings/AppIconShortcutItemsUpdater.test.swift
+++ b/Tests/App/Settings/AppIconShortcutItemsUpdater.test.swift
@@ -1,0 +1,96 @@
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+final class AppIconShortcutItemsUpdaterTests: XCTestCase {
+    func testEntityUsesMaterialDesignIconFromInfo() {
+        let item = MagicItem(id: "light.kitchen", serverId: "1", type: .entity)
+        let provider = FakeMagicItemProvider(info: .init(
+            id: "1-light.kitchen",
+            name: "Kitchen",
+            iconName: "mdi:lightbulb"
+        ))
+
+        let icon = AppIconShortcutItemsUpdater.materialDesignIcon(for: item, provider: provider)
+
+        XCTAssertEqual(icon, MaterialDesignIcons.lightbulbIcon)
+        XCTAssertEqual(icon.similarSFSymbol, MaterialDesignIcons.lightbulbIcon.similarSFSymbol)
+        XCTAssertNotEqual(icon.similarSFSymbol.rawValue, "lightbulbIcon")
+    }
+
+    func testCustomizationIconWinsOverEntityIcon() {
+        let item = MagicItem(
+            id: "light.kitchen",
+            serverId: "1",
+            type: .entity,
+            customization: .init(icon: MaterialDesignIcons.lockIcon.name)
+        )
+        let provider = FakeMagicItemProvider(info: .init(
+            id: "1-light.kitchen",
+            name: "Kitchen",
+            iconName: "mdi:lightbulb"
+        ))
+
+        let icon = AppIconShortcutItemsUpdater.materialDesignIcon(for: item, provider: provider)
+
+        XCTAssertEqual(icon, MaterialDesignIcons.lockIcon)
+    }
+
+    func testMissingInfoFallsBackToTypeMaterialDesignIcon() {
+        let item = MagicItem(id: "script.open_gate", serverId: "1", type: .script)
+        let provider = FakeMagicItemProvider(info: nil)
+
+        let icon = AppIconShortcutItemsUpdater.materialDesignIcon(for: item, provider: provider)
+
+        XCTAssertEqual(icon, MaterialDesignIcons.scriptIcon)
+        XCTAssertEqual(icon, AppIconShortcutItemsUpdater.fallbackIcon(for: .script))
+    }
+
+    func testFallbackIconsAreMaterialDesignIconsNotStringSFSymbols() {
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .scene), .paletteIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .entity), .dotsGridIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .folder), .folderIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .area), .textureBoxIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .assistPipeline), .microphoneIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .assistPrompt), .messageProcessingOutlineIcon)
+        XCTAssertEqual(AppIconShortcutItemsUpdater.fallbackIcon(for: .complication), .watchIcon)
+    }
+
+    func testShortcutSymbolIsMappedFromMaterialDesignIcons() {
+        let item = MagicItem(id: "light.kitchen", serverId: "1", type: .entity)
+        let provider = FakeMagicItemProvider(info: .init(
+            id: "1-light.kitchen",
+            name: "Kitchen",
+            iconName: "mdi:home"
+        ))
+
+        let icon = AppIconShortcutItemsUpdater.materialDesignIcon(for: item, provider: provider)
+
+        XCTAssertEqual(icon, MaterialDesignIcons.homeIcon)
+        XCTAssertEqual(icon.similarSFSymbol.rawValue, "house")
+    }
+}
+
+private final class FakeMagicItemProvider: MagicItemProviderProtocol {
+    let info: MagicItem.Info?
+
+    init(info: MagicItem.Info?) {
+        self.info = info
+    }
+
+    func loadInformation(completion: @escaping ([String: [HAAppEntity]]) -> Void) {
+        completion([:])
+    }
+
+    func loadInformation() async -> [String: [HAAppEntity]] {
+        [:]
+    }
+
+    func getInfo(for item: MagicItem) -> MagicItem.Info? {
+        info
+    }
+
+    func getAreaName(for item: MagicItem) -> String? {
+        nil
+    }
+}

--- a/Tests/App/Utilities/StatusItemPrimaryAction.test.swift
+++ b/Tests/App/Utilities/StatusItemPrimaryAction.test.swift
@@ -1,0 +1,20 @@
+@testable import HomeAssistant
+import XCTest
+
+final class StatusItemPrimaryActionTests: XCTestCase {
+    func testCheckForUpdatesDoesNotActivateAWebViewWindow() {
+        let actions = StatusItemPrimaryAction.checkForUpdatesActions(isSupported: true, isCatalyst: true)
+
+        XCTAssertFalse(actions.activatesWebView)
+        XCTAssertTrue(actions.performsSparkleCheck)
+        XCTAssertFalse(actions.opensAppStore)
+    }
+
+    func testAppStoreMacBuildOpensTheAppStoreInsteadOfSparkle() {
+        let actions = StatusItemPrimaryAction.checkForUpdatesActions(isSupported: false, isCatalyst: true)
+
+        XCTAssertFalse(actions.activatesWebView)
+        XCTAssertFalse(actions.performsSparkleCheck)
+        XCTAssertTrue(actions.opensAppStore)
+    }
+}

--- a/Tests/App/WebView/WebViewOpenPanelTests.swift
+++ b/Tests/App/WebView/WebViewOpenPanelTests.swift
@@ -1,0 +1,66 @@
+@testable import HomeAssistant
+import UniformTypeIdentifiers
+import XCTest
+
+final class WebViewOpenPanelTests: XCTestCase {
+    func testEmptyRequestedTypesAllowAudioItemAndFlac() {
+        let types = WebViewOpenPanelContentTypes.contentTypes(requested: [])
+
+        XCTAssertEqual(types, WebViewOpenPanelContentTypes.audioFallbackTypes)
+        XCTAssertTrue(types.contains(.audio))
+        XCTAssertTrue(types.contains(.item))
+        XCTAssertTrue(types.contains(.flac))
+    }
+
+    func testAudioSupertypeIsLeftAloneBecauseFlacConformsToIt() {
+        let types = WebViewOpenPanelContentTypes.contentTypes(requested: [.audio])
+
+        XCTAssertEqual(types, [.audio])
+        XCTAssertTrue(WebViewOpenPanelContentTypes.allowsSelectingFlac(types))
+    }
+
+    func testNarrowAudioListIsWidenedToIncludeFlac() {
+        let types = WebViewOpenPanelContentTypes.contentTypes(requested: [.mp3])
+
+        XCTAssertTrue(types.contains(.mp3))
+        XCTAssertTrue(types.contains(.audio))
+        XCTAssertTrue(types.contains(.item))
+        XCTAssertTrue(types.contains(.flac))
+        XCTAssertTrue(WebViewOpenPanelContentTypes.allowsSelectingFlac(types))
+    }
+
+    func testImageOnlyListsAreNotWidened() {
+        let types = WebViewOpenPanelContentTypes.contentTypes(requested: [.jpeg, .png])
+
+        XCTAssertEqual(types, [.jpeg, .png])
+        XCTAssertFalse(types.contains(.flac))
+    }
+
+    func testRequestedTypesReadsAllowedContentTypesWhenPresent() {
+        let parameters = FakeOpenPanelParameters(allowedContentTypes: [.mp3, .wav])
+
+        let types = WebViewOpenPanelContentTypes.requestedTypes(from: parameters)
+
+        XCTAssertEqual(types, [.mp3, .wav])
+    }
+
+    func testRequestedTypesReturnsEmptyWhenPropertyIsMissing() {
+        let types = WebViewOpenPanelContentTypes.requestedTypes(from: NSObject())
+
+        XCTAssertEqual(types, [])
+    }
+
+    func testAudioRelatedDetection() {
+        XCTAssertTrue(WebViewOpenPanelContentTypes.isAudioRelated([.mp3]))
+        XCTAssertTrue(WebViewOpenPanelContentTypes.isAudioRelated([.audio]))
+        XCTAssertFalse(WebViewOpenPanelContentTypes.isAudioRelated([.jpeg]))
+    }
+}
+
+private final class FakeOpenPanelParameters: NSObject {
+    @objc let allowedContentTypes: [UTType]
+
+    init(allowedContentTypes: [UTType]) {
+        self.allowedContentTypes = allowedContentTypes
+    }
+}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Mac Catalyst had no \`runOpenPanel\` WKUIDelegate, so FLAC was not selectable. Home-screen shortcut icons used generic per-type SF Symbols instead of the item MDI mapped through \`similarSFSymbol\`. Check for Updates no longer activates a web-view window; App Store Mac builds open the store listing.

Fixes #4643 #4819 #5103

**Test plan:** Media → Add media, select a .flac file. Home Screen actions show icons. Mac App Store build: Check for Updates opens the store, not a blank app window.

## Screenshots
N/A — logic/behavior change; please verify on device as noted in the test plan.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes


Test plan is in the Summary. CLA is signed on this account.