### PR TITLE
Fix Focus name reporting when the app is not running

### DIFF
--- a/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
+++ b/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import Foundation
+import PromiseKit
 import Shared
 
 /// The Focus Filter the user adds to a Focus in Settings › Focus, picking one of the names they
@@ -15,6 +16,14 @@ struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent {
         "app_intents.focus_filter.description",
         defaultValue: "Reports the name you picked to Home Assistant while this Focus is on."
     ))
+
+    /// It is configured in Settings › Focus and only iOS ever runs it, so it has no place in the
+    /// Shortcuts editor or Spotlight.
+    static let isDiscoverable = false
+
+    /// How long to wait for the report to reach a server. iOS runs this in an app it may have just
+    /// launched in the background, where a first connection is slower than in a running app.
+    private static let reportTimeout: TimeInterval = 20
 
     @Parameter(title: .init("app_intents.focus_filter.focus_name.title", defaultValue: "Focus name"))
     var focusName: FocusNameAppEntity?
@@ -33,9 +42,24 @@ struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent {
         Current.focusFilter.setActiveFocusName(focusName?.name)
         Current.Log.info("focus filter set focus name to \(focusName?.name ?? "<none>")")
 
-        for api in Current.apis {
+        // `Current.apis` picks each server's URL from the cached network information, which a
+        // process iOS has just launched to run this doesn't have yet — leaving a server that is
+        // only reachable on the home network looking unusable, and the report going nowhere.
+        await Current.connectivity.refreshNetworkInformation()
+
+        let apis = Current.apis
+        guard !apis.isEmpty else {
+            Current.Log.error("focus filter has no server to report the focus name to")
+            return .result()
+        }
+
+        for api in apis {
             do {
-                try await api.UpdateSensors(trigger: .Signaled).async(timeout: 10)
+                // Held in a background task: the app is likely running only because iOS woke it
+                // for this, and gets suspended as soon as we return.
+                try await Current.backgroundTask(withName: BackgroundTask.focusFilterSensorUpdate.rawValue) { _ in
+                    api.updateFocusSensors()
+                }.async(timeout: Self.reportTimeout)
             } catch {
                 Current.Log.error("focus filter failed to update sensors on \(api.server.info.name): \(error)")
             }

--- a/Sources/App/Settings/Focus/FocusSettingsViewModel.swift
+++ b/Sources/App/Settings/Focus/FocusSettingsViewModel.swift
@@ -36,9 +36,7 @@ final class FocusSettingsViewModel: ObservableObject {
     func delete(_ focusName: FocusName) {
         focusName.delete()
         // A deleted name may still be selected in a Focus Filter, so stop reporting it right away.
-        if Current.focusFilter.activeFocusName() == focusName.name {
-            Current.focusFilter.setActiveFocusName(nil)
-        }
+        Current.focusFilter.forgetFocusName(focusName.name)
         load()
     }
 }

--- a/Sources/Shared/API/Webhook/Sensors/HomeAssistantAPI+FocusSensors.swift
+++ b/Sources/Shared/API/Webhook/Sensors/HomeAssistantAPI+FocusSensors.swift
@@ -1,0 +1,19 @@
+import Foundation
+import PromiseKit
+
+public extension HomeAssistantAPI {
+    /// Sends only the Focus sensors, for the callers that are reacting to a Focus change.
+    ///
+    /// A full update asks every provider — CoreMotion, HealthKit, the geocoder — and the Focus
+    /// Filter runs in an app iOS has just launched in the background, where all of that competes
+    /// with the launch itself and can outlast the little time the process gets. The two sensors
+    /// that changed are the only ones the caller is waiting on.
+    func updateFocusSensors(trigger: LocationUpdateTrigger = .Signaled) -> Promise<Void> {
+        var providers: [SensorProvider.Type] = [FocusSensor.self]
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        // Focus Filters, and so the name of the running Focus, are an iOS feature.
+        providers.append(FocusNameSensor.self)
+        #endif
+        return UpdateSensors(trigger: trigger, limitedTo: providers)
+    }
+}

--- a/Sources/Shared/Common/BackgroundTask.swift
+++ b/Sources/Shared/Common/BackgroundTask.swift
@@ -24,6 +24,7 @@ public enum BackgroundTask: String {
     case pushLocationRequest = "push-location-request"
     case remindersSync = "reminders-sync"
     case legacyModelCleanup = "legacy-model-cleanup"
+    case focusFilterSensorUpdate = "focus-filter-sensor-update"
 }
 
 public enum BackgroundTaskError: Error {

--- a/Sources/Shared/Environment/FocusFilterWrapper.swift
+++ b/Sources/Shared/Environment/FocusFilterWrapper.swift
@@ -33,6 +33,15 @@ public class FocusFilterStateSync: UserDefaultsValueSync<FocusFilterState> {
 /// sensor reads it back, and pairs it with `Current.focusStatus` to tell "no Focus is running" from
 /// "a Focus is running that we have no name for".
 public class FocusFilterWrapper {
+    /// How long a reported name is protected from the reset run that follows it.
+    ///
+    /// Switching Focus runs two filter passes — the starting Focus' with its name, the ending
+    /// Focus' with none — around the same moment and in no guaranteed order, and both are timed by
+    /// when the app got round to running them rather than by when iOS decided them. Without this,
+    /// a reset arriving second erases the name the switch just reported, and the sensor blanks
+    /// while a Focus is running.
+    static let resetGracePeriod: TimeInterval = 10
+
     private(set) lazy var state = FocusFilterStateSync()
 
     /// The last Focus Filter run, with the moment it happened so it can be ordered against what
@@ -52,12 +61,36 @@ public class FocusFilterWrapper {
     public lazy var setActiveFocusName: (String?) -> Void = { [weak self] name in
         guard let self else { return }
         let previous = state.value
+        let now = Current.date()
+        let isReset = name?.isEmpty != false
+
+        if isReset, let previous, let previousName = previous.name, !previousName.isEmpty,
+           now.timeIntervalSince(previous.date) < Self.resetGracePeriod {
+            // The Focus that just ended in a switch, reported after the one that started it.
+            Current.Log.info("focus filter ignoring reset run right after \(previousName) was reported")
+            return
+        }
+
         let lastKnownName: String?
         if let name, !name.isEmpty {
             lastKnownName = name
         } else {
             lastKnownName = previous?.lastKnownName ?? previous?.name
         }
-        state.value = FocusFilterState(name: name, date: Current.date(), lastKnownName: lastKnownName)
+        state.value = FocusFilterState(name: name, date: now, lastKnownName: lastKnownName)
+    }
+
+    /// Stops reporting a name the user deleted in settings, including the sticky `lastKnownName`
+    /// copy — otherwise a deleted name keeps being reported until another Focus runs. A filter
+    /// still paired with it reports it again the next time it runs, which is when the name exists
+    /// again as far as the app is concerned.
+    public lazy var forgetFocusName: (String) -> Void = { [weak self] name in
+        guard let self, let previous = state.value,
+              previous.name == name || previous.lastKnownName == name else { return }
+        state.value = FocusFilterState(
+            name: previous.name == name ? nil : previous.name,
+            date: Current.date(),
+            lastKnownName: previous.lastKnownName == name ? nil : previous.lastKnownName
+        )
     }
 }

--- a/Sources/Shared/Environment/FocusReport.swift
+++ b/Sources/Shared/Environment/FocusReport.swift
@@ -23,10 +23,16 @@ public struct FocusReport: Equatable {
         self.isFocused = isFocused
     }
 
+    /// How long after a filter run a status saying nothing is running is read as the tail end of a
+    /// switch rather than as that Focus ending.
+    ///
     /// iOS starts the new Focus — running its filter — before it reports the previous one ending,
-    /// so a status saying nothing is running this soon after a filter run is the tail end of a
-    /// switch rather than the Focus we were just told about ending.
-    static let switchGracePeriod: TimeInterval = 5
+    /// and the two land in different processes: the status in the Intents extension, the filter in
+    /// the app, which iOS often has to launch in the background first. The window has to cover
+    /// that launch, or a Focus started while the app isn't running blanks the sensor it just
+    /// reported to. Nothing hangs on the window being tight: the filter's own reset run is what
+    /// normally ends a Focus, and it clears the name whenever it lands.
+    static let switchGracePeriod: TimeInterval = 30
 
     public static func current() -> FocusReport {
         let filterState = Current.focusFilter.activeFocusState()
@@ -45,10 +51,26 @@ public struct FocusReport: Equatable {
             isFocused = receivedStatus?.isFocused ?? liveIsFocused()
         }
 
-        return .init(
+        let report = FocusReport(
             name: lastKnownName?.isEmpty == false ? lastKnownName : nil,
             isFocused: isFocused
         )
+
+        // Both Focus sensors stand on this, and every input comes from a different process at a
+        // different moment, so the inputs are logged alongside the answer to make a wrong report
+        // readable after the fact.
+        Current.Log.info {
+            let filter = filterState.map {
+                "name(\($0.name ?? "<none>")) lastKnown(\($0.lastKnownName ?? "<none>")) at(\($0.date))"
+            } ?? "<never ran>"
+            let status = receivedStatus.map {
+                "isFocused(\(String(describing: $0.isFocused))) at(\($0.date)) " +
+                    "lastEnded(\(String(describing: $0.lastEndedDate)))"
+            } ?? "<never received>"
+            return "focus report: \(report) from filter[\(filter)] status[\(status)]"
+        }
+
+        return report
     }
 
     /// Whether iOS said every Focus had ended after the filter ran, which is what makes the name it

--- a/Sources/Shared/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Shared/Intents/FocusStatusIntentHandler.swift
@@ -17,19 +17,14 @@ class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
         Current.focusStatus.update(fromReceived: currentState)
         Current.Log.info("starting, status from intent is \(String(describing: currentState)) from \(intent)")
 
-        let limitedTo: [SensorProvider.Type]?
-
-        if Current.isCatalyst {
-            limitedTo = [FocusSensor.self]
-        } else {
-            limitedTo = nil
-        }
-
         firstly {
             after(seconds: Self.settleDelay)
         }.then {
+            // Only the Focus sensors: an Intents extension gets little time to begin with, and the
+            // wait above spends some of it, so a full update risks being cut off before the state
+            // this handler exists to report goes out.
             when(fulfilled: Current.apis.map {
-                $0.UpdateSensors(trigger: .Siri, limitedTo: limitedTo)
+                $0.updateFocusSensors(trigger: .Siri)
             })
         }.done {
             Current.Log.info("finished successfully")

--- a/Sources/Shared/Intents/FocusStatusIntentHandler.swift
+++ b/Sources/Shared/Intents/FocusStatusIntentHandler.swift
@@ -3,6 +3,15 @@ import Intents
 import PromiseKit
 
 class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
+    /// How long to let a status change settle before reporting it.
+    ///
+    /// Switching Focus pushes "nothing is running" for the Focus that ended and runs the starting
+    /// Focus' filter separately — the filter in the app, which iOS may have to launch first.
+    /// Sending the moment the status arrives publishes that gap as a real state, so Home Assistant
+    /// sees the Focus sensors blank mid-switch and stays that way if the filter's own update never
+    /// lands. Waiting lets the filter run first, so one settled state goes out instead of two.
+    static var settleDelay: TimeInterval = 5
+
     func handle(intent: INShareFocusStatusIntent, completion: @escaping (INShareFocusStatusIntentResponse) -> Void) {
         let currentState = intent.focusStatus
         Current.focusStatus.update(fromReceived: currentState)
@@ -16,9 +25,13 @@ class FocusStatusIntentHandler: NSObject, INShareFocusStatusIntentHandling {
             limitedTo = nil
         }
 
-        when(fulfilled: Current.apis.map {
-            $0.UpdateSensors(trigger: .Siri, limitedTo: limitedTo)
-        }).done {
+        firstly {
+            after(seconds: Self.settleDelay)
+        }.then {
+            when(fulfilled: Current.apis.map {
+                $0.UpdateSensors(trigger: .Siri, limitedTo: limitedTo)
+            })
+        }.done {
             Current.Log.info("finished successfully")
             completion(.init(code: .success, userActivity: nil))
         }.catch { error in

--- a/Tests/App/Settings/FocusSettingsViewModel.test.swift
+++ b/Tests/App/Settings/FocusSettingsViewModel.test.swift
@@ -50,7 +50,9 @@ struct FocusSettingsViewModelTests {
         let viewModel = try makeViewModel()
         var reportedName: String? = "Work"
         Current.focusFilter.activeFocusName = { reportedName }
-        Current.focusFilter.setActiveFocusName = { reportedName = $0 }
+        Current.focusFilter.forgetFocusName = { name in
+            if reportedName == name { reportedName = nil }
+        }
 
         viewModel.add(name: "Work")
         viewModel.add(name: "Sleep")
@@ -66,7 +68,9 @@ struct FocusSettingsViewModelTests {
         let viewModel = try makeViewModel()
         var reportedName: String? = "Sleep"
         Current.focusFilter.activeFocusName = { reportedName }
-        Current.focusFilter.setActiveFocusName = { reportedName = $0 }
+        Current.focusFilter.forgetFocusName = { name in
+            if reportedName == name { reportedName = nil }
+        }
 
         viewModel.add(name: "Work")
         let work = try #require(viewModel.focusNames.first { $0.name == "Work" })

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -137,6 +137,23 @@ class FocusNameSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].State as? String, "Personal")
     }
 
+    /// The filter runs in an app iOS often has to launch in the background first, so the status of
+    /// the Focus that ended can be processed well after it: inside the switch window the name the
+    /// filter just reported still stands.
+    func testKeepsTheNameWhenTheEndedStatusIsProcessedLongAfterTheFilterRun() throws {
+        FocusName(name: "Sleep").save()
+        setUpDependencies(
+            activeFocusName: "Sleep",
+            filterRan: -20,
+            receivedStatus: received(isFocused: false, at: 0),
+            liveIsFocused: false
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Sleep")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
+    }
+
     /// Knowing every Focus ended blanks the name rather than reporting a made-up state.
     func testReportsEmptyOnceEveryFocusEnded() throws {
         FocusName(name: "Work").save()
@@ -269,6 +286,7 @@ class FocusNameSensorTests: XCTestCase {
     /// iOS won't re-run the filter when the same Focus quickly reactivates.
     func testFilterResetCarriesTheLastKnownNameForward() throws {
         Current.focusFilter.setActiveFocusName("Work")
+        Current.date = { [now] in now.addingTimeInterval(FocusFilterWrapper.resetGracePeriod + 1) }
         Current.focusFilter.setActiveFocusName(nil)
 
         XCTAssertNil(Current.focusFilter.state.value?.name)
@@ -276,5 +294,35 @@ class FocusNameSensorTests: XCTestCase {
 
         Current.focusFilter.setActiveFocusName("Sleep")
         XCTAssertEqual(Current.focusFilter.state.value?.lastKnownName, "Sleep")
+    }
+
+    /// Switching Focus runs the ending Focus' reset pass and the starting Focus' named pass around
+    /// the same moment and in no guaranteed order, so a reset landing second must not erase the
+    /// name the switch just reported.
+    func testFilterResetRightAfterANamedRunIsIgnored() throws {
+        Current.focusFilter.setActiveFocusName("Sleep")
+        Current.date = { [now] in now.addingTimeInterval(FocusFilterWrapper.resetGracePeriod - 1) }
+        Current.focusFilter.setActiveFocusName(nil)
+
+        XCTAssertEqual(Current.focusFilter.state.value?.name, "Sleep")
+        XCTAssertEqual(Current.focusFilter.state.value?.date, now)
+    }
+
+    /// A name the user deleted has to stop being reported, including through the sticky copy the
+    /// nil-name runs fall back to.
+    func testForgetFocusNameClearsTheNameAndTheLastKnownOne() throws {
+        Current.focusFilter.setActiveFocusName("Work")
+        Current.focusFilter.forgetFocusName("Work")
+
+        XCTAssertNil(Current.focusFilter.state.value?.name)
+        XCTAssertNil(Current.focusFilter.state.value?.lastKnownName)
+    }
+
+    func testForgetFocusNameKeepsAnUnrelatedName() throws {
+        Current.focusFilter.setActiveFocusName("Work")
+        Current.focusFilter.forgetFocusName("Sleep")
+
+        XCTAssertEqual(Current.focusFilter.state.value?.name, "Work")
+        XCTAssertEqual(Current.focusFilter.state.value?.lastKnownName, "Work")
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Makes the Focus name reach Home Assistant when a Focus changes while the app is not on screen (#5467).

- The Focus Filter refreshes network information before picking a server, sends only the Focus sensors, and holds a background task while it does. iOS runs it in an app it has just launched in the background, where a full sensor update did not finish before the process was suspended.
- A reset filter run landing right after a named one no longer erases the name. Switching Focus runs both, in no guaranteed order.
- A Focus status change waits a few seconds before reporting, so the filter run of the Focus that started is included instead of the gap mid-switch being published as a state.
- The window that decides whether a reported name is stale now covers a background launch.
- Deleting a name in settings also clears the sticky copy, so it stops being reported.
- Both Focus sensors log what they were built from, so a wrong report is readable in the logs.
- The filter is no longer discoverable in Shortcuts: it is configured in Settings › Focus.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Focus name is a TestFlight-only Labs feature, so this only affects beta builds.
