### PR TITLE
Replace widget last update text with reload button

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -795,6 +795,8 @@
 				Widgets/Common/WidgetPreviewMagicItemProvider.swift,
 				Widgets/Common/WidgetPreviewSample.swift,
 				Widgets/Common/WidgetPreviewSampleEntity.swift,
+				Widgets/Common/WidgetRefreshAppIntent.swift,
+				Widgets/Common/WidgetRefreshButton.swift,
 				Widgets/Common/WidgetTimelineProviderSupport.swift,
 				Widgets/Controls/Cover/CoverIntent.swift,
 				Widgets/Controls/Cover/IntentCoverEntity.swift,

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2761,6 +2761,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.preview.custom.description" = "Create your own widget inside the App and then display it here.";
 "widgets.preview.custom.title" = "Custom widget";
 "widgets.preview.empty.create.button" = "Create widget";
+"widgets.refresh_title" = "Refresh widget";
 "widgets.reload_widgets.app_intent.description" = "Reload all widgets timelines.";
 "widgets.reload_widgets.app_intent.title" = "Reload widgets";
 "widgets.scene.activate.title" = "Activate scene";

--- a/Sources/Extensions/Widgets/Assist/WidgetAssistView.swift
+++ b/Sources/Extensions/Widgets/Assist/WidgetAssistView.swift
@@ -65,7 +65,8 @@ struct WidgetAssistView: View {
                     )
                 }
             }(),
-            type: .button
+            type: .button,
+            widgetKind: .assist
         )
     }
 

--- a/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
@@ -12,6 +12,7 @@ struct WidgetBasicContainerView: View {
     let showLastUpdate: Bool
     let showServerName: Bool
     let serverName: String?
+    let widgetKind: WidgetsKind
 
     init(
         emptyViewGenerator: @escaping () -> AnyView,
@@ -19,7 +20,8 @@ struct WidgetBasicContainerView: View {
         type: WidgetType,
         showLastUpdate: Bool = false,
         showServerName: Bool = false,
-        serverName: String? = nil
+        serverName: String? = nil,
+        widgetKind: WidgetsKind
     ) {
         self.emptyViewGenerator = emptyViewGenerator
         self.contents = contents
@@ -27,6 +29,7 @@ struct WidgetBasicContainerView: View {
         self.showLastUpdate = showLastUpdate
         self.showServerName = showServerName
         self.serverName = serverName
+        self.widgetKind = widgetKind
     }
 
     var body: some View {
@@ -37,6 +40,7 @@ struct WidgetBasicContainerView: View {
             showLastUpdate: showLastUpdate,
             showServerName: showServerName,
             serverName: serverName,
+            widgetKind: widgetKind,
             family: family
         )
     }
@@ -197,6 +201,7 @@ struct WidgetBasicContainerView_Previews: PreviewProvider {
                 withIconBackgroundColor: withIconBackgroundColor
             ),
             type: .custom,
+            widgetKind: .custom,
             family: familySize
         )
     }
@@ -229,6 +234,7 @@ struct WidgetBasicContainerWrapperView: View {
     let family: WidgetFamily
     let showServerName: Bool
     let serverName: String?
+    let widgetKind: WidgetsKind
 
     init(
         emptyViewGenerator: @escaping () -> AnyView,
@@ -237,6 +243,7 @@ struct WidgetBasicContainerWrapperView: View {
         showLastUpdate: Bool = false,
         showServerName: Bool = false,
         serverName: String? = nil,
+        widgetKind: WidgetsKind,
         family: WidgetFamily
     ) {
         self.emptyViewGenerator = emptyViewGenerator
@@ -246,6 +253,7 @@ struct WidgetBasicContainerWrapperView: View {
         self.family = family
         self.showServerName = showServerName
         self.serverName = serverName
+        self.widgetKind = widgetKind
     }
 
     var body: some View {
@@ -256,24 +264,31 @@ struct WidgetBasicContainerWrapperView: View {
                 content(for: Array(contents.prefix(WidgetFamilySizes.size(for: family))))
             }
             if showLastUpdate, !contents.isEmpty {
-                let lastUpdatedTextView = Text("\(L10n.Widgets.Custom.ShowUpdateTime.title) ") +
-                    Text(Current.date(), style: .time)
-                Group {
-                    if showServerName, let serverName {
-                        Text(serverName) + Text(" · ") + lastUpdatedTextView
-                    } else {
-                        lastUpdatedTextView
-                    }
-                }
-                .font(.system(size: 10).bold())
-                .frame(maxWidth: .infinity, alignment: .center)
-                .multilineTextAlignment(.center)
-                .padding(.bottom, DesignSystem.Spaces.half)
-                .opacity(0.5)
+                lastUpdateFooter
             }
         }
         // Whenever Apple allow apps to use material backgrounds we should update this
         .widgetBackground(.primaryBackground)
+    }
+
+    /// The last refresh time doubles as the reload control, matching the energy widget: tapping the
+    /// glyph or the time reloads this widget's timeline.
+    @ViewBuilder
+    private var lastUpdateFooter: some View {
+        if #available(iOS 17, *) {
+            HStack(spacing: DesignSystem.Spaces.half) {
+                if showServerName, let serverName {
+                    Text(verbatim: "\(serverName) ·")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                WidgetRefreshButton(kind: widgetKind, date: Current.date())
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, DesignSystem.Spaces.half)
+            .padding(.bottom, DesignSystem.Spaces.half)
+        }
     }
 
     @ViewBuilder

--- a/Sources/Extensions/Widgets/Common/WidgetRefreshAppIntent.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetRefreshAppIntent.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import Foundation
+import Shared
+import WidgetKit
+
+@available(iOS 17.0, *)
+struct WidgetRefreshAppIntent: AppIntent {
+    static var title: LocalizedStringResource = .init(
+        "widgets.refresh_title",
+        defaultValue: "Refresh widget"
+    )
+    static var isDiscoverable: Bool = false
+
+    // No translation needed below, this is not a discoverable intent
+    @Parameter(title: "Widget kind")
+    var widgetKind: String?
+
+    func perform() async throws -> some IntentResult {
+        AppIntentHaptics.notify()
+        if let widgetKind {
+            WidgetCenter.shared.reloadTimelines(ofKind: widgetKind)
+        } else {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+        return .result()
+    }
+}

--- a/Sources/Extensions/Widgets/Common/WidgetRefreshAppIntent.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetRefreshAppIntent.swift
@@ -1,6 +1,5 @@
 import AppIntents
 import Foundation
-import Shared
 import WidgetKit
 
 @available(iOS 17.0, *)

--- a/Sources/Extensions/Widgets/Common/WidgetRefreshButton.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetRefreshButton.swift
@@ -1,0 +1,41 @@
+import SFSafeSymbols
+import Shared
+import SwiftUI
+
+/// The time the entry was last refreshed, preceded by a small reload glyph, mirroring the energy
+/// widget. The pair is one control: tapping either part reloads the widget's timeline.
+@available(iOS 17, *)
+struct WidgetRefreshButton: View {
+    let kind: WidgetsKind
+    let date: Date
+
+    private var refreshIntent: WidgetRefreshAppIntent {
+        let intent = WidgetRefreshAppIntent()
+        intent.widgetKind = kind.rawValue
+        return intent
+    }
+
+    var body: some View {
+        Button(intent: refreshIntent) {
+            HStack(spacing: DesignSystem.Spaces.micro) {
+                Image(systemSymbol: .arrowClockwise)
+                    .font(.system(size: 9, weight: .semibold))
+                Text(date, style: .time)
+                    .font(.system(size: 11))
+            }
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        // The visible text is a timestamp, so name the action explicitly and leave the time as the
+        // value — otherwise VoiceOver announces a bare time with no hint of what tapping does.
+        .accessibilityLabel(Text(L10n.Widgets.refreshTitle))
+        .accessibilityValue(Text(date, style: .time))
+    }
+}
+
+@available(iOS 17, *)
+#Preview {
+    WidgetRefreshButton(kind: .custom, date: Date())
+        .padding()
+}

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntities.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntities.swift
@@ -25,7 +25,8 @@ struct WidgetCommonlyUsedEntities: Widget {
                     type: .custom,
                     showLastUpdate: timelineEntry.showLastUpdateTime,
                     showServerName: timelineEntry.serverName != nil,
-                    serverName: timelineEntry.serverName
+                    serverName: timelineEntry.serverName,
+                    widgetKind: .commonlyUsedEntities
                 )
             } else {
                 emptyView

--- a/Sources/Extensions/Widgets/Custom/WidgetCustom.swift
+++ b/Sources/Extensions/Widgets/Custom/WidgetCustom.swift
@@ -20,7 +20,7 @@ struct WidgetCustom: Widget {
                     infoProvider: timelineEntry.magicItemInfoProvider,
                     states: timelineEntry.entitiesState,
                     showStates: timelineEntry.showStates
-                ), type: .custom, showLastUpdate: timelineEntry.showLastUpdateTime)
+                ), type: .custom, showLastUpdate: timelineEntry.showLastUpdateTime, widgetKind: .custom)
             } else {
                 emptyView
                     .widgetBackground(Color.clear)

--- a/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
+++ b/Sources/Extensions/Widgets/OpenPage/WidgetOpenPage.swift
@@ -32,7 +32,8 @@ struct WidgetOpenPage: Widget {
                             )
                         }
                     }(),
-                    type: .button
+                    type: .button,
+                    widgetKind: .openPage
                 )
             }
         )

--- a/Sources/Extensions/Widgets/Script/WidgetScripts.swift
+++ b/Sources/Extensions/Widgets/Script/WidgetScripts.swift
@@ -34,7 +34,8 @@ struct WidgetScripts: Widget {
                         useCustomColors: false
                     )
                 },
-                type: .button
+                type: .button,
+                widgetKind: .scripts
             )
         }
         .contentMarginsDisabledIfAvailable()

--- a/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
+++ b/Sources/Extensions/Widgets/Sensor/WidgetSensors.swift
@@ -29,7 +29,8 @@ struct WidgetSensors: Widget {
                         useCustomColors: false
                     )
                 },
-                type: .sensor
+                type: .sensor,
+                widgetKind: .sensors
             )
         }
         .contentMarginsDisabledIfAvailable()

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -8380,6 +8380,8 @@ public enum L10n {
   }
 
   public enum Widgets {
+    /// Refresh widget
+    public static var refreshTitle: String { return L10n.tr("Localizable", "widgets.refresh_title") }
     public enum Action {
       public enum Name {
         /// Assist


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The "Last update: HH:MM" footer in the custom and commonly used entities widgets is now the same reload button the energy widget has: a small reload glyph next to the time, where tapping either part reloads that widget's timeline.

The button and its intent live in `Widgets/Common`, and the intent reloads only the kind it is given, so every widget using the shared container passes its own kind.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The "Show last update time" setting still controls whether the footer appears.
