### PR TITLE
Reorder complication content tokens by dragging

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2091,7 +2091,8 @@ Importing replaces every category listed on this screen, including app settings.
 "watch.complications.builder.preview" = "Preview";
 "watch.complications.builder.progress_bar_color" = "Progress bar color";
 "watch.complications.builder.remove_token" = "Remove %@";
-"watch.complications.builder.reorder_tokens_hint" = "Drag a token onto another one to reorder them.";
+"watch.complications.builder.reorder_token" = "Reorder %@";
+"watch.complications.builder.reorder_tokens_hint" = "Press and hold a token's handle to drag it into place.";
 "watch.complications.builder.show" = "Show";
 "watch.complications.builder.show_gauge" = "Show as gauge / ring";
 "watch.complications.builder.show_icon" = "Show icon";

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
@@ -1,8 +1,6 @@
-import CoreTransferable
 import Shared
 import SwiftUI
 import UIKit
-import UniformTypeIdentifiers
 
 /// The complication builder's configuration step: everything that shapes how the complication
 /// renders, once its source (entity or template) is picked. Presented as a medium/large sheet over
@@ -523,6 +521,22 @@ extension WatchComplicationConfigurationSheet {
         /// Attribute names offered by the Insert menu (entity kind; empty otherwise).
         let attributeKeys: [String]
 
+        /// Live reorder state: which pill the finger is carrying, how far it has travelled from the
+        /// slot it is laid out in, and the correction applied every time it trades places with a
+        /// neighbor so it keeps sitting under the finger.
+        @State private var draggingIndex: Int?
+        @State private var dragOffset: CGFloat = 0
+        @State private var dragCarry: CGFloat = 0
+        /// Measured pill widths by index: pills size to their content, so the distance to drag before
+        /// swapping is the neighbor's own width, not a fixed step.
+        @State private var pillWidths: [Int: CGFloat] = [:]
+        /// Mirrors the gesture's own lifetime: SwiftUI resets it when the drag is cancelled (and not
+        /// just when it ends), which is what releases a carried pill if the system interrupts the
+        /// gesture — otherwise the pill would stay offset and no further reorder could start.
+        @GestureState private var isCarryingPill = false
+
+        private static let pillSpacing = DesignSystem.Spaces.half
+
         private var family: WatchComplicationConfig.Family { config.widgetFamily }
 
         private var currentSlotConfig: ComplicationSlotConfig {
@@ -587,15 +601,18 @@ extension WatchComplicationConfigurationSheet {
                     // The formula is edited as pills, not raw token text: dynamic tokens are tinted
                     // capsules, hardcoded text is typed straight into neutral capsule fields, and each
                     // pill removes with its x. New pieces come from the + menu and land at the end,
-                    // from where a pill can be dragged onto another to reorder the formula.
+                    // from where a pill can be picked up by its grip and slid into place.
                     ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: DesignSystem.Spaces.half) {
+                        HStack(spacing: Self.pillSpacing) {
                             ForEach(Array(formula.parts.enumerated()), id: \.offset) { index, part in
                                 reorderablePartPill(at: index, part: part)
                             }
                             insertMenu
                         }
                         .padding(.vertical, DesignSystem.Spaces.half)
+                    }
+                    .onChange(of: isCarryingPill) { carrying in
+                        if !carrying { endDrag() }
                     }
                     // Only worth saying once there is something to reorder — a single pill has nowhere
                     // to go, and the hint would just be noise in every slot the user customizes.
@@ -616,35 +633,112 @@ extension WatchComplicationConfigurationSheet {
             }
         }
 
-        /// The drag payload for reordering: the dragged pill's position in the formula. A private
-        /// `Codable` type carried as JSON, so only a pill from this very list can be dropped onto
-        /// another one — text dragged in from elsewhere fails to decode and the drop is refused.
-        private struct DraggedFormulaPart: Codable, Transferable {
-            let index: Int
-
-            static var transferRepresentation: some TransferRepresentation {
-                CodableRepresentation(contentType: .json)
-            }
-        }
-
-        /// A pill the user can pick up and drop onto another one to reorder the formula. The drag
-        /// preview is the pill itself (minus its remove button, which has nothing to act on mid-drag),
-        /// and the same move is offered as VoiceOver actions, which cannot perform a drag.
+        /// A pill the user can pick up by its grip and slide along the row. The carried pill rides
+        /// above its neighbors and trades places with them as it passes them; the same move is offered
+        /// as VoiceOver actions, which cannot perform a drag.
+        ///
+        /// System drag and drop is deliberately not used here: a `.draggable` pill inside a form row
+        /// hands the drag to the row, so the whole row lifts instead of the pill.
         private func reorderablePartPill(at index: Int, part: ComplicationFormula.Part) -> some View {
-            partPill(at: index, part: part)
-                .draggable(DraggedFormulaPart(index: index)) {
-                    pillLabel(for: part)
+            let isDragging = draggingIndex == index
+            return partPill(at: index, part: part)
+                .background {
+                    // The swap thresholds need each pill's laid-out width; measured here rather than
+                    // guessed from the text, since pills hold text fields of arbitrary length.
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear { pillWidths[index] = proxy.size.width }
+                            .onChange(of: proxy.size.width) { width in pillWidths[index] = width }
+                    }
                 }
-                .dropDestination(for: DraggedFormulaPart.self) { items, _ in
-                    guard let source = items.first?.index else { return false }
-                    return movePart(from: source, to: index)
-                }
+                .offset(x: isDragging ? dragOffset : 0)
+                .scaleEffect(isDragging ? 1.05 : 1)
+                .shadow(color: .black.opacity(isDragging ? 0.25 : 0), radius: 6, y: 2)
+                // Keeps the carried pill above the ones it slides past.
+                .zIndex(isDragging ? 1 : 0)
                 .accessibilityAction(named: Text(L10n.Watch.Complications.Builder.moveTokenLeft)) {
                     _ = movePart(from: index, to: index - 1)
                 }
                 .accessibilityAction(named: Text(L10n.Watch.Complications.Builder.moveTokenRight)) {
                     _ = movePart(from: index, to: index + 1)
                 }
+        }
+
+        /// The reorder grip. The drag lives on this handle alone: a gesture spanning the whole capsule
+        /// would swallow the text field's taps and the remove button's.
+        private func dragHandle(at index: Int, part: ComplicationFormula.Part) -> some View {
+            Image(systemSymbol: .line3Horizontal)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(width: 22)
+                .contentShape(Rectangle())
+                .gesture(reorderGesture(at: index))
+                .accessibilityLabel(L10n.Watch.Complications.Builder.reorderToken(accessibilityTitle(for: part)))
+        }
+
+        /// Press-and-hold, then slide. A plain drag would compete with the pill row's horizontal
+        /// scrolling, the form's vertical scrolling and the sheet's detent drag — all of which begin
+        /// with the same touch — so the press is what claims the touch for reordering.
+        private func reorderGesture(at index: Int) -> some Gesture {
+            LongPressGesture(minimumDuration: 0.2)
+                .sequenced(before: DragGesture(minimumDistance: 0))
+                .updating($isCarryingPill) { _, carrying, _ in carrying = true }
+                .onChanged { value in
+                    switch value {
+                    case let .first(pressed):
+                        // The press reports in-progress touches too; only a completed one picks the
+                        // pill up, so a quick tap on the grip changes nothing.
+                        if pressed { beginDrag(at: index) }
+                    case let .second(pressed, drag):
+                        // The press can complete straight into the drag phase without a separate
+                        // .first update, so the pickup is (idempotently) confirmed here too.
+                        guard pressed else { return }
+                        beginDrag(at: index)
+                        if let drag {
+                            updateDrag(translation: drag.translation.width)
+                        }
+                    }
+                }
+                .onEnded { _ in endDrag() }
+        }
+
+        private func beginDrag(at index: Int) {
+            guard draggingIndex == nil else { return }
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+            dragOffset = 0
+            dragCarry = 0
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
+                draggingIndex = index
+            }
+        }
+
+        /// Follows the finger and, once the pill has covered half of the neighbor it is heading for,
+        /// trades slots with it. The carry cancels the layout jump that trade causes, so the pill stays
+        /// pinned under the finger instead of hopping a pill-width ahead.
+        private func updateDrag(translation: CGFloat) {
+            guard let dragging = draggingIndex else { return }
+            var offset = translation + dragCarry
+            if offset > 0, let width = pillWidths[dragging + 1], offset > (width + Self.pillSpacing) / 2,
+               movePart(from: dragging, to: dragging + 1) {
+                draggingIndex = dragging + 1
+                dragCarry -= width + Self.pillSpacing
+                offset = translation + dragCarry
+            } else if offset < 0, dragging > 0, let width = pillWidths[dragging - 1],
+                      offset < -(width + Self.pillSpacing) / 2, movePart(from: dragging, to: dragging - 1) {
+                draggingIndex = dragging - 1
+                dragCarry += width + Self.pillSpacing
+                offset = translation + dragCarry
+            }
+            dragOffset = offset
+        }
+
+        private func endDrag() {
+            guard draggingIndex != nil else { return }
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
+                draggingIndex = nil
+                dragOffset = 0
+                dragCarry = 0
+            }
         }
 
         /// Moves a pill to another position, keeping the rest of the formula in order. Returns whether
@@ -662,11 +756,15 @@ extension WatchComplicationConfigurationSheet {
         }
 
         /// One formula piece as a pill: text parts are edited in place, dynamic tokens show their
-        /// friendly name; every pill carries its own remove button.
+        /// friendly name; every pill carries its own grip (once there is something to reorder) and
+        /// remove button.
         private func partPill(at index: Int, part: ComplicationFormula.Part) -> some View {
             let isText = isTextPart(part)
             return pillChrome(isText: isText) {
                 HStack(spacing: DesignSystem.Spaces.half) {
+                    if formula.parts.count > 1 {
+                        dragHandle(at: index, part: part)
+                    }
                     if isText {
                         TextField(L10n.Watch.Complications.Builder.tokenText, text: textBinding(at: index))
                             .autocorrectionDisabled()
@@ -688,16 +786,8 @@ extension WatchComplicationConfigurationSheet {
             }
         }
 
-        /// The pill under the finger while dragging: the same capsule with its title only — the text
-        /// field and the remove button have nothing to act on mid-drag.
-        private func pillLabel(for part: ComplicationFormula.Part) -> some View {
-            pillChrome(isText: isTextPart(part)) {
-                Text(verbatim: accessibilityTitle(for: part))
-            }
-        }
-
         /// The pill's chrome: the capsule fill and text color that tell a dynamic token apart from
-        /// hardcoded text. Shared by the editable pill and the drag preview so the two look alike.
+        /// hardcoded text.
         private func pillChrome(isText: Bool, @ViewBuilder content: () -> some View) -> some View {
             content()
                 .font(.callout)

--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
@@ -747,12 +747,27 @@ extension WatchComplicationConfigurationSheet {
         private func movePart(from source: Int, to destination: Int) -> Bool {
             guard source != destination, formula.parts.indices.contains(source),
                   formula.parts.indices.contains(destination) else { return false }
+            reindexPillWidths { widths in
+                widths.insert(widths.remove(at: source), at: destination)
+            }
             withAnimation {
                 updateParts { parts in
                     parts.insert(parts.remove(at: source), at: destination)
                 }
             }
             return true
+        }
+
+        /// Applies a pill's move (or removal) to the measured widths as well. They are keyed by index,
+        /// so leaving them alone would have every pill from that position on carrying its neighbor's
+        /// width until SwiftUI re-measures — long enough to mistime the next swap of a drag in flight.
+        private func reindexPillWidths(_ mutate: (inout [CGFloat?]) -> Void) {
+            let count = max(formula.parts.count, (pillWidths.keys.max() ?? -1) + 1)
+            var widths: [CGFloat?] = (0 ..< count).map { pillWidths[$0] }
+            mutate(&widths)
+            pillWidths = widths.enumerated().reduce(into: [:]) { result, element in
+                result[element.offset] = element.element
+            }
         }
 
         /// One formula piece as a pill: text parts are edited in place, dynamic tokens show their
@@ -831,8 +846,9 @@ extension WatchComplicationConfigurationSheet {
         }
 
         private func removePart(at index: Int) {
+            guard formula.parts.indices.contains(index) else { return }
+            reindexPillWidths { widths in widths.remove(at: index) }
             updateParts { parts in
-                guard parts.indices.contains(index) else { return }
                 parts.remove(at: index)
             }
         }

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6876,7 +6876,11 @@ public enum L10n {
         public static func removeToken(_ p1: Any) -> String {
           return L10n.tr("Localizable", "watch.complications.builder.remove_token", String(describing: p1))
         }
-        /// Drag a token onto another one to reorder them.
+        /// Reorder %@
+        public static func reorderToken(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "watch.complications.builder.reorder_token", String(describing: p1))
+        }
+        /// Press and hold a token's handle to drag it into place.
         public static var reorderTokensHint: String { return L10n.tr("Localizable", "watch.complications.builder.reorder_tokens_hint") }
         /// Show
         public static var show: String { return L10n.tr("Localizable", "watch.complications.builder.show") }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Reordering content tokens in the complication builder did not work: dragging a token dragged the whole form row instead of the token. The drag and drop is replaced by a grip on each token — press and hold it and slide the token into place. Move left / Move right remain available as accessibility actions.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
