### PR TITLE
Fix crash when opening settings from the frontend

### DIFF
--- a/Sources/App/Container/AppSettingsPushRoute.swift
+++ b/Sources/App/Container/AppSettingsPushRoute.swift
@@ -1,9 +1,13 @@
 import Foundation
 
-/// The only destination the container's own navigation stack pushes: app Settings, opened by the frontend
-/// external bus. Every screen below it is pushed by `SettingsView` as a `SettingsItem` onto the same path, so
-/// the whole stack is value-driven — a boolean `navigationDestination(isPresented:)` sharing a stack with
-/// value-based destinations makes SwiftUI resolve the wrong view for the pushes that follow it.
+/// Every destination the container's own navigation stack pushes: app Settings (opened by the frontend
+/// external bus) and the screens `SettingsView` pushes below it, wrapped in `item`. The whole stack is
+/// value-driven — a boolean `navigationDestination(isPresented:)` sharing a stack with value-based
+/// destinations makes SwiftUI resolve the wrong view for the pushes that follow it — and single-typed:
+/// SwiftUI's path diffing fatally errors (`AnyNavigationPath.Error.comparisonTypeMismatch`) if it ever
+/// compares path elements of different types at the same position, so `SettingsItem` is never appended
+/// to the path directly.
 enum AppSettingsPushRoute: Hashable {
     case settings
+    case item(SettingsItem)
 }

--- a/Sources/App/Container/AppSettingsPushRoute.swift
+++ b/Sources/App/Container/AppSettingsPushRoute.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Every destination the container's own navigation stack pushes: app Settings (opened by the frontend
-/// external bus) and the screens `SettingsView` pushes below it, wrapped in `item`. The whole stack is
-/// value-driven — a boolean `navigationDestination(isPresented:)` sharing a stack with value-based
-/// destinations makes SwiftUI resolve the wrong view for the pushes that follow it — and single-typed:
-/// SwiftUI's path diffing fatally errors (`AnyNavigationPath.Error.comparisonTypeMismatch`) if it ever
-/// compares path elements of different types at the same position, so `SettingsItem` is never appended
-/// to the path directly.
+/// Every destination the container's navigation stack (driven by `AppSettingsPresenter.pushPath`)
+/// pushes: app Settings (opened by the frontend external bus) and the screens `SettingsView` pushes
+/// below it, wrapped in `item`. The stack is deliberately value-driven — presenting Settings through a
+/// boolean `navigationDestination(isPresented:)` previously made SwiftUI resolve the wrong view for the
+/// value-based pushes that followed it — and single-typed: SwiftUI's path diffing fatally errors
+/// (`AnyNavigationPath.Error.comparisonTypeMismatch`) if it ever compares path elements of different
+/// types at the same position, so `SettingsItem` is never appended to the path directly.
 enum AppSettingsPushRoute: Hashable {
     case settings
     case item(SettingsItem)

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -13,11 +13,12 @@ struct ConditionalContainerView: View {
 
     var body: some View {
         if horizontalSizeClass == .compact {
-            // Path-driven so Settings and the screens it pushes share one mechanism: a boolean
-            // `navigationDestination(isPresented:)` alongside Settings' value-based destinations made
-            // SwiftUI push Settings again in place of the screen that was tapped. Single-typed because
-            // SwiftUI's path diffing fatally errors comparing elements of different types at the same
-            // position, so Settings' own pushes arrive wrapped as `AppSettingsPushRoute.item`.
+            // Driven entirely by `appSettings.pushPath` so Settings and the screens it pushes share one
+            // value-based mechanism: the boolean `navigationDestination(isPresented:)` used here before
+            // made SwiftUI push Settings again in place of the screen that was tapped. The path is also
+            // single-typed, because SwiftUI's path diffing fatally errors comparing elements of
+            // different types at the same position: Settings' own pushes arrive wrapped as
+            // `AppSettingsPushRoute.item` instead of raw `SettingsItem` values.
             NavigationStack(path: $appSettings.pushPath) {
                 content
                     .toolbar(.hidden, for: .navigationBar)

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -15,13 +15,21 @@ struct ConditionalContainerView: View {
         if horizontalSizeClass == .compact {
             // Path-driven so Settings and the screens it pushes share one mechanism: a boolean
             // `navigationDestination(isPresented:)` alongside Settings' value-based destinations made
-            // SwiftUI push Settings again in place of the screen that was tapped.
+            // SwiftUI push Settings again in place of the screen that was tapped. Single-typed because
+            // SwiftUI's path diffing fatally errors comparing elements of different types at the same
+            // position, so Settings' own pushes arrive wrapped as `AppSettingsPushRoute.item`.
             NavigationStack(path: $appSettings.pushPath) {
                 content
                     .toolbar(.hidden, for: .navigationBar)
-                    .navigationDestination(for: AppSettingsPushRoute.self) { _ in
-                        SettingsView(embedInOwnNavigation: false)
-                            .injectingViewControllerProvider()
+                    .navigationDestination(for: AppSettingsPushRoute.self) { route in
+                        switch route {
+                        case .settings:
+                            SettingsView(embedInOwnNavigation: false)
+                                .injectingViewControllerProvider()
+                        case let .item(item):
+                            item.destinationView
+                                .injectingViewControllerProvider()
+                        }
                     }
             }
             .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -82,22 +82,21 @@ struct SettingsView: View {
 
     // MARK: - iOS List View
 
+    // When pushed onto the container's stack (`embedInOwnNavigation == false`) items are pushed as
+    // `AppSettingsPushRoute.item` instead, resolved by `ConditionalContainerView`: that path must stay
+    // single-typed or SwiftUI's path diffing can fatally error comparing elements of different types.
     @ViewBuilder
     private var iOSView: some View {
         if embedInOwnNavigation {
             NavigationStack {
-                iOSNavigationContent
+                iOSListContent
+                    .navigationDestination(for: SettingsItem.self) { item in
+                        item.destinationView
+                    }
             }
         } else {
-            iOSNavigationContent
+            iOSListContent
         }
-    }
-
-    private var iOSNavigationContent: some View {
-        iOSListContent
-            .navigationDestination(for: SettingsItem.self) { item in
-                item.destinationView
-            }
     }
 
     private var iOSListContent: some View {
@@ -341,11 +340,16 @@ struct SettingsView: View {
             NavigationLink(destination: item.destinationView) {
                 settingsItemLabel(item, subtitle: subtitle)
             }
-        } else {
-            // Value-based, resolved by `navigationDestination(for:)` in `iOSNavigationContent`, so
+        } else if embedInOwnNavigation {
+            // Value-based, resolved by `navigationDestination(for:)` in `iOSView`, so
             // `item.destinationView` — and every destination's stored properties with it — is only
             // constructed on navigation instead of for every row on every list evaluation.
             NavigationLink(value: item) {
+                settingsItemLabel(item, subtitle: subtitle)
+            }
+        } else {
+            // Pushed onto the container's stack, whose path must stay `AppSettingsPushRoute`-typed.
+            NavigationLink(value: AppSettingsPushRoute.item(item)) {
                 settingsItemLabel(item, subtitle: subtitle)
             }
         }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Opening settings from the frontend (`config_screen/show`) could crash with SwiftUI's `AnyNavigationPath.Error.comparisonTypeMismatch` fatal error: the container's navigation path mixed two element types (`AppSettingsPushRoute` for the settings root, `SettingsItem` for the screens below it), and SwiftUI's path diffing fatally errors when it compares elements of different types at the same position.

The path is now single-typed: `AppSettingsPushRoute` gained an `item(SettingsItem)` case, settings rows push that wrapper when settings is on the container's stack, and the container's `navigationDestination` resolves both cases. The settings sheet and Catalyst keep pushing `SettingsItem` on their own stacks, unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes