### PR TITLE
Hide watch home empty state when areas are visible

### DIFF
--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -326,9 +326,9 @@ struct WatchHomeView: View {
     private var listContent: some View {
         if viewModel.watchConfig.items.isEmpty {
             // The areas rows fill the screen on their own, so the "add items with +" hint only
-            // shows when there is genuinely nothing else — including while editing, where the
-            // areas are hidden.
-            if isEditing || !viewModel.showsAreasContent {
+            // shows when there is genuinely nothing else. It also stays out of edit mode, where the
+            // header swaps the + for Done and the hint would point at a button that isn't there.
+            if !isEditing, !viewModel.showsAreasContent {
                 Text(verbatim: L10n.Watch.Labels.noConfigAddPlus)
                     .font(.footnote)
                     .foregroundStyle(.secondary)

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -325,10 +325,15 @@ struct WatchHomeView: View {
     @ViewBuilder
     private var listContent: some View {
         if viewModel.watchConfig.items.isEmpty {
-            Text(verbatim: L10n.Watch.Labels.noConfigAddPlus)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .listRowBackground(Color.clear)
+            // The areas rows fill the screen on their own, so the "add items with +" hint only
+            // shows when there is genuinely nothing else — including while editing, where the
+            // areas are hidden.
+            if isEditing || !viewModel.showsAreasContent {
+                Text(verbatim: L10n.Watch.Labels.noConfigAddPlus)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .listRowBackground(Color.clear)
+            }
         } else if !isEditing, viewModel.watchConfig.resolvedLayout == .grid {
             gridContent
         } else {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -733,6 +733,20 @@ final class WatchHomeViewModel: ObservableObject {
         }
     }
 
+    /// Whether the home screen actually renders area content — the inline area rows or the grouped
+    /// "Areas" navigation row. The empty state text is suppressed when this is true: with no
+    /// configured items the screen still has the areas to browse, so it isn't empty.
+    var showsAreasContent: Bool {
+        switch areasMode {
+        case .hidden:
+            return false
+        case let .inline(areas):
+            return !areas.isEmpty
+        case .grouped:
+            return groupedAreasDestination() != nil
+        }
+    }
+
     /// Where the grouped "Areas" row goes: straight to the single server's areas, or through the
     /// server picker when several servers have them.
     func groupedAreasDestination() -> WatchHomeNavigation? {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The watch home screen shows the "no config, add items with +" text whenever there are no configured items, even though areas are now displayed by default. This hides that text when any area row or the grouped Areas navigation row is visible, so it only shows when the screen is really empty (including while editing, where areas are hidden).

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
