### PR TITLE
Reduce app disk writes

### DIFF
--- a/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
+++ b/Sources/App/Frontend/Extensions/WebViewScriptMessageHandler.swift
@@ -24,7 +24,8 @@ final class WebViewScriptMessageHandler: NSObject, WKScriptMessageHandler {
             return
         }
 
-        Current.Log.verbose("message \(message.body)".replacingOccurrences(of: "\n", with: " "))
+        let messageType = messageBody["type"] as? String ?? "unknown"
+        Current.Log.verbose("message \(message.name) type \(messageType) keys \(messageBody.count)")
 
         handle(messageName: message.name, messageBody: messageBody)
     }

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -237,6 +237,9 @@ public class HomeAssistantAPI {
         headers["User-Agent"] = Self.userAgent
         configuration.httpAdditionalHeaders = headers
 
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+
         return Alamofire.Session(
             configuration: configuration,
             delegate: delegate,

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -871,11 +871,15 @@ private struct ProfilingTimer {
     init(_ label: String) {
         self.label = label
         self.startTime = CFAbsoluteTimeGetCurrent()
+        #if DEBUG
         Current.Log.debug("🔍 [Profiling] \(label)")
+        #endif
     }
 
     func end() {
+        #if DEBUG
         let duration = CFAbsoluteTimeGetCurrent() - startTime
         Current.Log.debug("⏱️ [Profiling] \(label) completed in \(String(format: "%.3f", duration))s")
+        #endif
     }
 }

--- a/Sources/Shared/Environment/AppDatabaseUpdater.swift
+++ b/Sources/Shared/Environment/AppDatabaseUpdater.swift
@@ -871,11 +871,11 @@ private struct ProfilingTimer {
     init(_ label: String) {
         self.label = label
         self.startTime = CFAbsoluteTimeGetCurrent()
-        Current.Log.info("🔍 [Profiling] \(label)")
+        Current.Log.debug("🔍 [Profiling] \(label)")
     }
 
     func end() {
         let duration = CFAbsoluteTimeGetCurrent() - startTime
-        Current.Log.info("⏱️ [Profiling] \(label) completed in \(String(format: "%.3f", duration))s")
+        Current.Log.debug("⏱️ [Profiling] \(label) completed in \(String(format: "%.3f", duration))s")
     }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
A `diskwrites_resource` report from a TestFlight build showed the app dirtying 1073 MB over ~22 hours (13.70 KB/s against a 12.43 KB/s budget). The captured stack was CFNetwork writing into SQLite, which is the on-disk `URLCache`.

Three changes:

- `HomeAssistantAPI.configureSessionManager` built every Alamofire session on `URLSessionConfiguration.default`, so responses were stored in the shared on-disk URL cache. This covers the REST helpers, `VideoStreamer()` (MJPEG) and the HLS `streamRequest` in the notification content extension, meaning camera streams were being written to disk as they played. The cache is now disabled for these sessions. Nothing on this path benefits from it: REST responses are live state, `DownloadDataAt` uses `download()` which bypasses the cache, and the `entity_component` icon map is fetched over the WebSocket.
- `WebViewScriptMessageHandler` logged the full body of every message the frontend sends over the script bridge. It now logs the name, type and key count.
- `ProfilingTimer` in `AppDatabaseUpdater` logged at `.info`, so its per-step lines shipped in release builds. Now compiled out entirely with `#if DEBUG`. Lowering the level alone would not have helped: the file destination's `outputLevel` is `.verbose`, which accepts `.debug` too.

## Screenshots
N/A, no user-facing change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Attribution rests on a single microstackshot (`Steps: 1`, `Num samples: 1`), so these are reasoned from the code rather than measured. Worth confirming with a File Activity trace before and after.

Not included here: the file log destination is still `.verbose` in release and TestFlight builds. Lowering it would cut more, but it trades away diagnostics from beta users, so it seemed worth deciding separately.
