### PR TITLE
Cache Reminders sync date formatters

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
@@ -147,9 +147,10 @@ struct RemindersSyncItemSnapshot: Equatable {
                 $0.timeZone = timeZone
             }
             self.localDateTime = with(DateFormatter()) {
-                $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-                $0.timeZone = timeZone
+                $0.calendar = Calendar(identifier: .gregorian)
                 $0.locale = Locale(identifier: "en_US_POSIX")
+                $0.timeZone = timeZone
+                $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
             }
         }
     }

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
@@ -102,26 +102,55 @@ struct RemindersSyncItemSnapshot: Equatable {
     }
 
     static func canonicalDueString(from date: Date) -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        formatter.timeZone = .current
-        return formatter.string(from: date)
+        DueDateFormatters.current.internetDateTime.string(from: date)
     }
 
     static func parseDueDateTime(_ string: String) -> Date? {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        if let date = formatter.date(from: string) {
+        let formatters = DueDateFormatters.current
+        if let date = formatters.internetDateTime.date(from: string) {
             return date
         }
-        formatter.formatOptions.insert(.withFractionalSeconds)
-        if let date = formatter.date(from: string) {
+        if let date = formatters.fractionalInternetDateTime.date(from: string) {
             return date
         }
         // Datetime without timezone offset, interpreted in the current timezone
-        let localFormatter = DateFormatter()
-        localFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        localFormatter.timeZone = .current
-        return localFormatter.date(from: string)
+        return formatters.localDateTime.date(from: string)
+    }
+
+    private final class DueDateFormatters {
+        let timeZone: TimeZone
+        let internetDateTime: ISO8601DateFormatter
+        let fractionalInternetDateTime: ISO8601DateFormatter
+        let localDateTime: DateFormatter
+
+        private static let lock = NSLock()
+        private static var cached = DueDateFormatters(timeZone: .current)
+
+        static var current: DueDateFormatters {
+            let timeZone = TimeZone.current
+            lock.lock()
+            defer { lock.unlock() }
+            if cached.timeZone != timeZone {
+                cached = DueDateFormatters(timeZone: timeZone)
+            }
+            return cached
+        }
+
+        init(timeZone: TimeZone) {
+            self.timeZone = timeZone
+            self.internetDateTime = with(ISO8601DateFormatter()) {
+                $0.formatOptions = [.withInternetDateTime]
+                $0.timeZone = timeZone
+            }
+            self.fractionalInternetDateTime = with(ISO8601DateFormatter()) {
+                $0.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                $0.timeZone = timeZone
+            }
+            self.localDateTime = with(DateFormatter()) {
+                $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+                $0.timeZone = timeZone
+                $0.locale = Locale(identifier: "en_US_POSIX")
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Reminders sync built a new `ISO8601DateFormatter`/`DateFormatter` for every item it looked at — up to three per call in `parseDueDateTime`. Each one loads ICU locale data from scratch.

A device trace and a runloop tailspin both caught the same 1.17 s main-thread hang here, with 86% of the samples inside `__ResetUDateFormat`.

The formatters are now built once and rebuilt only when the system time zone changes, so the normalized due strings still follow the device's offset. The fixed-format parser also gets `en_US_POSIX`, so a non-Gregorian device calendar can no longer break it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change. Existing `RemindersSyncItemSnapshotTests` cover both formatting paths and the local-datetime fallback.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a performance fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same trace.
