### PR TITLE
Append client events instead of rewriting the whole log

### DIFF
--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -132,17 +132,14 @@ final class ClientEventStore: ClientEventStoreProtocol {
         }
         defer { close(descriptor) }
 
-        line.withUnsafeBytes { buffer in
-            guard let baseAddress = buffer.baseAddress else { return }
-            var written = 0
-            while written < buffer.count {
-                let result = write(descriptor, baseAddress + written, buffer.count - written)
-                guard result > 0 else {
-                    Current.Log.error("Error appending client event, errno \(errno)")
-                    return
-                }
-                written += result
-            }
+        // One `write` call, never a loop: `O_APPEND` makes a single write atomic against the other
+        // processes in the app group, and resuming a partial one would let their bytes land in the
+        // middle of this event. A short write drops the event instead of corrupting its neighbours.
+        let written = line.withUnsafeBytes { buffer in
+            buffer.baseAddress.map { write(descriptor, $0, buffer.count) } ?? 0
+        }
+        if written != line.count {
+            Current.Log.error("Error appending client event, wrote \(written) of \(line.count), errno \(errno)")
         }
     }
 

--- a/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
+++ b/Sources/Shared/ClientEvents/Model/ClientEventStore.swift
@@ -10,27 +10,33 @@ public protocol ClientEventStoreProtocol {
 
 final class ClientEventStore: ClientEventStoreProtocol {
     static var jsonCacheName = "databases/clientEvents.json"
+
+    private static let eventsCacheLimit = 1000
+    private static let trimCheckInterval = 100
+
     /// Events are recorded from every queue in the app (main, the WatchConnectivity callbacks, the
-    /// expiring-activity queue, cooperative pool tasks). Appending is a read-modify-write of one shared
-    /// file, so without serialization concurrent writers lose each other's events — and a reader
-    /// landing mid-write decodes a truncated file, which throws away the whole history.
-    ///
-    /// A serial queue (instead of a lock held on the caller's thread) also keeps the cost off the
-    /// recording thread: every append decodes and atomically rewrites a file holding up to 1000
-    /// events, which is far too slow for the main thread — the very first event ("Application
-    /// Starting") is recorded during app launch.
+    /// expiring-activity queue, cooperative pool tasks). A serial queue keeps the file work off the
+    /// recording thread — the very first event ("Application Starting") is recorded during app launch.
     private static let ioQueue = DispatchQueue(label: "io.home-assistant.client-event-store", qos: .utility)
+
+    private static var appendsSinceTrim = 0
+    private static var didConvertLegacyFile = false
+
+    private static let encoder = JSONEncoder()
+    private static let decoder = JSONDecoder()
 
     public func addEvent(_ event: ClientEvent) {
         Current.Log.verbose("Adding event: \(event.text), \(event.jsonPayload)")
-        let eventsCacheLimit = 1000
         Self.ioQueue.async { [self] in
-            var events = readEvents()
-            events.append(event)
-            if events.count > eventsCacheLimit {
-                events = Array(events.suffix(eventsCacheLimit))
+            convertLegacyFileIfNeeded()
+            guard let line = encodedLine(for: event) else { return }
+            appendLine(line)
+
+            Self.appendsSinceTrim += 1
+            if Self.appendsSinceTrim >= Self.trimCheckInterval {
+                Self.appendsSinceTrim = 0
+                trimToCacheLimit()
             }
-            saveJSONData(events)
         }
     }
 
@@ -38,6 +44,14 @@ final class ClientEventStore: ClientEventStoreProtocol {
         // Sync on the serial queue so pending `addEvent` writes are visible to this read.
         Self.ioQueue.sync {
             readEvents()
+        }
+    }
+
+    public func clearAllEvents() {
+        Self.ioQueue.sync {
+            writeEvents([])
+            Self.appendsSinceTrim = 0
+            Self.didConvertLegacyFile = true
         }
     }
 
@@ -58,33 +72,101 @@ final class ClientEventStore: ClientEventStoreProtocol {
         }
 
         let data = FileManager.default.contents(atPath: fileURL.path) ?? Data()
+        guard !data.isEmpty else { return [] }
 
-        do {
-            let clientEvents = try JSONDecoder().decode([ClientEvent].self, from: data)
-            return clientEvents
-        } catch {
-            Current.Log.error("Failed to decode client events data from cache, error: \(error)")
-            return []
+        if Self.isLegacyArray(data) {
+            do {
+                return try Self.decoder.decode([ClientEvent].self, from: data)
+            } catch {
+                Current.Log.error("Failed to decode client events data from cache, error: \(error)")
+                return []
+            }
+        }
+
+        return data.split(separator: UInt8(ascii: "\n")).compactMap { line in
+            do {
+                return try Self.decoder.decode(ClientEvent.self, from: Data(line))
+            } catch {
+                Current.Log.error("Failed to decode client event line, error: \(error)")
+                return nil
+            }
         }
     }
 
-    public func clearAllEvents() {
-        Self.ioQueue.sync {
-            saveJSONData([])
+    /// A file written before events were stored one per line holds a single JSON array, and is
+    /// rewritten once so appends never mix the two formats.
+    private func convertLegacyFileIfNeeded() {
+        guard !Self.didConvertLegacyFile else { return }
+        Self.didConvertLegacyFile = true
+
+        let fileURL = AppConstants.clientEventsFile
+        guard let data = FileManager.default.contents(atPath: fileURL.path), Self.isLegacyArray(data) else {
+            return
+        }
+        writeEvents(readEvents())
+    }
+
+    private static func isLegacyArray(_ data: Data) -> Bool {
+        data.first == UInt8(ascii: "[")
+    }
+
+    private func encodedLine(for event: ClientEvent) -> Data? {
+        do {
+            var line = try Self.encoder.encode(event)
+            line.append(UInt8(ascii: "\n"))
+            return line
+        } catch {
+            Current.Log.error("Error encoding client event: \(error)")
+            return nil
+        }
+    }
+
+    /// Unsynchronized append; callers must be on `ioQueue`. `O_APPEND` keeps a write from another
+    /// process in the app group from overwriting ours.
+    private func appendLine(_ line: Data) {
+        let fileURL = AppConstants.clientEventsFile
+        let descriptor = open(fileURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        guard descriptor >= 0 else {
+            Current.Log.error("Error opening client events file for append, errno \(errno)")
+            return
+        }
+        defer { close(descriptor) }
+
+        line.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var written = 0
+            while written < buffer.count {
+                let result = write(descriptor, baseAddress + written, buffer.count - written)
+                guard result > 0 else {
+                    Current.Log.error("Error appending client event, errno \(errno)")
+                    return
+                }
+                written += result
+            }
         }
     }
 
     /// Unsynchronized write; callers must be on `ioQueue`.
-    private func saveJSONData(_ events: [ClientEvent]) {
-        do {
-            let fileURL = AppConstants.clientEventsFile
-            let jsonData = try JSONEncoder().encode(events)
-            // Atomic: the app group file is also read by the other processes sharing it (widgets, the
-            // watch app), which must never observe a half-written array.
-            try jsonData.write(to: fileURL, options: .atomic)
-            Current.Log.verbose("JSON saved successfully for client events, file URL: \(fileURL.absoluteString)")
-        } catch {
-            Current.Log.error("Error saving JSON for client events: \(error)")
+    private func writeEvents(_ events: [ClientEvent]) {
+        let fileURL = AppConstants.clientEventsFile
+        var data = Data()
+        for event in events {
+            guard let line = encodedLine(for: event) else { continue }
+            data.append(line)
         }
+        do {
+            // Atomic: the app group file is also read by the other processes sharing it (widgets, the
+            // watch app), which must never observe a half-written file.
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Current.Log.error("Error saving client events: \(error)")
+        }
+    }
+
+    /// Unsynchronized rewrite; callers must be on `ioQueue`.
+    private func trimToCacheLimit() {
+        let events = readEvents()
+        guard events.count > Self.eventsCacheLimit else { return }
+        writeEvents(Array(events.suffix(Self.eventsCacheLimit)))
     }
 }

--- a/Tests/Shared/ClientEventTests.swift
+++ b/Tests/Shared/ClientEventTests.swift
@@ -66,6 +66,22 @@ class ClientEventTests: XCTestCase {
         XCTAssertEqual(retrieved?.date.ISO8601Format(), date.ISO8601Format())
     }
 
+    func testReadsFileWrittenAsSingleJSONArray() throws {
+        let event = ClientEvent(text: "Legacy", type: .notification)
+        try JSONEncoder().encode([event]).write(to: AppConstants.clientEventsFile, options: .atomic)
+
+        let retrieved = store.getEvents()
+        XCTAssertEqual(1, retrieved.count)
+        XCTAssertEqual("Legacy", retrieved.first?.text)
+    }
+
+    func testKeepsEventsAcrossAppends() throws {
+        store.addEvent(ClientEvent(text: "First", type: .notification))
+        store.addEvent(ClientEvent(text: "Second", type: .notification))
+
+        XCTAssertEqual(["First", "Second"], store.getEvents().map(\.text))
+    }
+
     func testCanClearEvents() throws {
         let event = ClientEvent(text: "Yo", type: .notification)
         store.addEvent(event)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Recording one client event decoded the whole `clientEvents.json` array, appended to it, re-encoded all of it and atomically rewrote the file. With the cache holding up to 1000 events that is O(n) per event.

In a 21 s device trace that came to 2.2 of the app's 14.7 CPU-seconds — 15% of everything the app did — and made the file the most-looked-up app path in the trace.

Events are now stored one JSON object per line and appended with `O_APPEND`, so recording an event is O(1). The cache limit is enforced by rewriting the file once every 100 appends instead of on every one. A file still in the old array format is read as before and converted on the next append.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change — the events log view is unchanged. New tests cover reading an old-format file and reading back several appended events.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a performance fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The file is included as-is in the log/diagnostics export, which now contains one event per line.

One of several separate PRs from the same trace.
