### PR TITLE
Apply pushed watch database mirrors outside the WatchConnectivity task

### DIFF
--- a/Sources/Shared/Common/WatchBackgroundRefreshScheduler.swift
+++ b/Sources/Shared/Common/WatchBackgroundRefreshScheduler.swift
@@ -5,11 +5,11 @@ import WatchKit
 #endif
 
 public class WatchBackgroundRefreshScheduler {
-    public func schedule() -> Guarantee<Void> {
+    public func schedule(preferredDate: Date? = nil) -> Guarantee<Void> {
         #if os(watchOS)
         let (promise, seal) = Guarantee<Void>.pending()
 
-        let date = nextFireDate()
+        let date = preferredDate ?? nextFireDate()
 
         WKExtension.shared().scheduleBackgroundRefresh(
             withPreferredDate: date,

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -386,8 +386,11 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     private func applyStagedDatabaseMirrors() {
         guard PushedMirrorStagingStore.hasStagedMirrors else { return }
         Self.pushedMirrorQueue.async { [weak self] in
+            // Taking the entries removes them, so bail out before that when there is nothing left
+            // to apply them with — otherwise a staged mirror is dropped unread.
+            guard let self else { return }
             for entry in PushedMirrorStagingStore.takeAll() {
-                self?.decodeAndApplyPushedDatabaseMirror(entry.data, metadata: entry.metadata)
+                decodeAndApplyPushedDatabaseMirror(entry.data, metadata: entry.metadata)
             }
         }
     }

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -65,6 +65,10 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
         // schedule the next background refresh
         Current.backgroundRefreshScheduler.schedule().cauterize()
+
+        if WKApplication.shared().applicationState != .background {
+            applyStagedDatabaseMirrors()
+        }
     }
 
     func applicationDidBecomeActive() {
@@ -91,6 +95,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
     func applicationWillEnterForeground() {
         AppDatabaseSuspension.resume()
+        applyStagedDatabaseMirrors()
     }
 
     func applicationDidEnterBackground() {
@@ -162,6 +167,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
                 // Schedule the next refresh up front so a deadline hit can't skip it.
                 Current.backgroundRefreshScheduler.schedule().cauterize()
+
+                applyStagedDatabaseMirrors()
 
                 after(seconds: 10).done {
                     if !didComplete {
@@ -359,8 +366,29 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     /// when the watch app was suspended). Mirrors the watch-pull apply path so the watch's cached data
     /// (entities, areas, pipelines, complications) stays fresh without the user opening the app.
     private func applyPushedDatabaseMirror(_ data: Data, metadata: HAWatchConnectivity.Content?) {
+        // The decompress + decode + write costs more CPU than the WatchConnectivity background
+        // action's 2 second allowance, and that allowance covers the whole process — running it on
+        // another queue doesn't help. Backgrounded, the payload is staged and applied from a
+        // background refresh, whose budget is large enough for it.
+        guard WKApplication.shared().applicationState != .background else {
+            PushedMirrorStagingStore.store(data: data, metadata: metadata)
+            Current.backgroundRefreshScheduler
+                .schedule(preferredDate: Current.date().addingTimeInterval(1))
+                .cauterize()
+            return
+        }
+
         Self.pushedMirrorQueue.async { [weak self] in
             self?.decodeAndApplyPushedDatabaseMirror(data, metadata: metadata)
+        }
+    }
+
+    private func applyStagedDatabaseMirrors() {
+        guard PushedMirrorStagingStore.hasStagedMirrors else { return }
+        Self.pushedMirrorQueue.async { [weak self] in
+            for entry in PushedMirrorStagingStore.takeAll() {
+                self?.decodeAndApplyPushedDatabaseMirror(entry.data, metadata: entry.metadata)
+            }
         }
     }
 

--- a/Sources/WatchApp/PushedMirrorStagingStore.swift
+++ b/Sources/WatchApp/PushedMirrorStagingStore.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Shared
+
+/// Holds database mirrors the iPhone pushed while the watch app was backgrounded, until a task with
+/// a budget large enough to decode and apply them runs. Decoding one inside the WatchConnectivity
+/// delivery itself exhausts that action's 2 second CPU allowance and the app is killed.
+enum PushedMirrorStagingStore {
+    struct Entry {
+        let data: Data
+        let metadata: HAWatchConnectivity.Content?
+    }
+
+    private static let directoryName = "pushedMirrors"
+    private static let fileExtension = "plist"
+    private static let entryLimit = 10
+
+    private enum Key {
+        static let content = "content"
+        static let metadata = "metadata"
+    }
+
+    static func store(data: Data, metadata: HAWatchConnectivity.Content?) {
+        guard let directory = directoryURL() else { return }
+
+        var payload: [String: Any] = [Key.content: data]
+        if let metadata {
+            payload[Key.metadata] = metadata
+        }
+
+        let name = String(format: "%020.6f-%@", Current.date().timeIntervalSince1970, UUID().uuidString)
+        let fileURL = directory.appendingPathComponent(name).appendingPathExtension(fileExtension)
+        do {
+            let serialized = try PropertyListSerialization.data(fromPropertyList: payload, format: .binary, options: 0)
+            try serialized.write(to: fileURL, options: .atomic)
+            Current.Log.info("Staged pushed watch database mirror (\(data.count) bytes) for later apply")
+        } catch {
+            Current.Log.error("Failed to stage pushed watch database mirror: \(error)")
+            return
+        }
+
+        dropEntriesOverLimit()
+    }
+
+    /// Returns the staged mirrors in arrival order and removes them, so a failed apply doesn't
+    /// replay forever. The phone re-sends anything the watch is missing on its next sync request.
+    static func takeAll() -> [Entry] {
+        guard let directory = directoryURL() else { return [] }
+
+        return stagedFileURLs(in: directory).compactMap { fileURL in
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+            guard let serialized = try? Data(contentsOf: fileURL),
+                  let payload = try? PropertyListSerialization.propertyList(
+                      from: serialized,
+                      options: [],
+                      format: nil
+                  ) as? [String: Any],
+                  let data = payload[Key.content] as? Data else {
+                Current.Log.error("Discarding unreadable staged watch database mirror at \(fileURL.lastPathComponent)")
+                return nil
+            }
+            return Entry(data: data, metadata: payload[Key.metadata] as? HAWatchConnectivity.Content)
+        }
+    }
+
+    static var hasStagedMirrors: Bool {
+        guard let directory = directoryURL() else { return false }
+        return !stagedFileURLs(in: directory).isEmpty
+    }
+
+    private static func stagedFileURLs(in directory: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        return contents
+            .filter { $0.pathExtension == fileExtension }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private static func dropEntriesOverLimit() {
+        guard let directory = directoryURL() else { return }
+        let urls = stagedFileURLs(in: directory)
+        guard urls.count > entryLimit else { return }
+        for url in urls.prefix(urls.count - entryLimit) {
+            Current.Log.error("Dropping staged watch database mirror \(url.lastPathComponent), too many pending")
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private static func directoryURL() -> URL? {
+        let directory = AppConstants.AppGroupContainer.appendingPathComponent(directoryName, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            do {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            } catch {
+                Current.Log.error("Failed to create staged watch database mirror directory: \(error)")
+                return nil
+            }
+        }
+        return directory
+    }
+}

--- a/Sources/WatchApp/PushedMirrorStagingStore.swift
+++ b/Sources/WatchApp/PushedMirrorStagingStore.swift
@@ -14,12 +14,20 @@ enum PushedMirrorStagingStore {
     private static let fileExtension = "plist"
     private static let entryLimit = 10
 
+    /// Payloads are staged from the WatchConnectivity callback on the main queue and taken on the
+    /// decode queue, so the directory work is serialized rather than left to race.
+    private static let queue = DispatchQueue(label: "pushed-mirror-staging")
+
     private enum Key {
         static let content = "content"
         static let metadata = "metadata"
     }
 
     static func store(data: Data, metadata: HAWatchConnectivity.Content?) {
+        queue.async { storeUnsynchronized(data: data, metadata: metadata) }
+    }
+
+    private static func storeUnsynchronized(data: Data, metadata: HAWatchConnectivity.Content?) {
         guard let directory = directoryURL() else { return }
 
         var payload: [String: Any] = [Key.content: data]
@@ -44,6 +52,10 @@ enum PushedMirrorStagingStore {
     /// Returns the staged mirrors in arrival order and removes them, so a failed apply doesn't
     /// replay forever. The phone re-sends anything the watch is missing on its next sync request.
     static func takeAll() -> [Entry] {
+        queue.sync { takeAllUnsynchronized() }
+    }
+
+    private static func takeAllUnsynchronized() -> [Entry] {
         guard let directory = directoryURL() else { return [] }
 
         return stagedFileURLs(in: directory).compactMap { fileURL in
@@ -63,8 +75,10 @@ enum PushedMirrorStagingStore {
     }
 
     static var hasStagedMirrors: Bool {
-        guard let directory = directoryURL() else { return false }
-        return !stagedFileURLs(in: directory).isEmpty
+        queue.sync { () -> Bool in
+            guard let directory = directoryURL() else { return false }
+            return !stagedFileURLs(in: directory).isEmpty
+        }
     }
 
     private static func stagedFileURLs(in directory: URL) -> [URL] {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The watch app was killed twice in one day by `CSLHandleBackgroundWCSessionAction`, having used 2.22 s and 2.60 s of CPU against a 2.00 s allowance. Both crash reports catch it in the same place: the `pushed-mirror-decode` queue decoding the payload and `GRDB.DatabaseQueue` writing it.

That allowance is process-wide CPU, not main-thread time, so decoding on `pushedMirrorQueue` doesn't help — the work has to leave that background action.

When the payload arrives while the app is backgrounded it is now written to disk as-is and a background refresh is requested. The decode and apply happen from that refresh, which has a far larger budget. A payload arriving in the foreground is applied immediately, as before, and anything still staged is applied on the next launch or foreground.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a crash fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
A staged payload is dropped once read, so a failing apply can't replay forever — the phone re-sends whatever the watch is missing on its next sync request. The staging directory keeps at most 10 payloads.

This one is worth exercising on a real watch before merging: it changes when a pushed mirror lands, so the thing to check is that complications still follow phone-side changes without opening the app.

One of several separate PRs from the same trace.
