### PR TITLE
Run watch background task deadlines off the main queue

### DIFF
--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -161,13 +161,14 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                 // isn't enough — always complete at a hard deadline, even mid-work.
                 let completionLock = NSLock()
                 var didComplete = false
-                let completeTask = {
+                let completeTask = { () -> Bool in
                     completionLock.lock()
                     let alreadyCompleted = didComplete
                     didComplete = true
                     completionLock.unlock()
-                    guard !alreadyCompleted else { return }
+                    guard !alreadyCompleted else { return false }
                     backgroundTask.setTaskCompletedWithSnapshot(false)
+                    return true
                 }
 
                 // Schedule the next refresh up front so a deadline hit can't skip it.
@@ -176,8 +177,12 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                 let deadline = DispatchSource.makeTimerSource(queue: Self.watchdogQueue)
                 deadline.schedule(deadline: .now() + 10)
                 deadline.setEventHandler {
-                    Current.Log.info("completing background refresh task at deadline; work still running")
-                    completeTask()
+                    if completeTask() {
+                        Current.Log.info("completed background refresh task at deadline; work still running")
+                    }
+                    // Also releases the handler's reference back to the source, which is what keeps
+                    // the timer alive when the refresh work never finishes.
+                    deadline.cancel()
                 }
                 deadline.resume()
 
@@ -195,7 +200,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                     }
                 }.ensure {
                     deadline.cancel()
-                    completeTask()
+                    _ = completeTask()
                 }.cauterize()
             case let snapshotTask as WKSnapshotRefreshBackgroundTask:
                 // Snapshot tasks have a unique completion call, make sure to set your expiration date

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -12,7 +12,14 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
     fileprivate var watchConnectivityBackgroundPromise: Guarantee<Void>
     fileprivate var watchConnectivityBackgroundSeal: (()) -> Void
-    fileprivate var watchConnectivityWatchdogTimer: Timer?
+    fileprivate var watchConnectivityWatchdogTimer: DispatchSourceTimer?
+
+    /// The deadlines below have to be able to complete a task while the main thread is blocked, so
+    /// they run on their own queue rather than on the main run loop.
+    private static let watchdogQueue = DispatchQueue(label: "background-task-watchdog", qos: .utility)
+
+    private let pendingConnectivityTasksLock = NSLock()
+    private var pendingConnectivityTasks: [WKWatchConnectivityRefreshBackgroundTask] = []
 
     private var immediateCommunicatorService: ImmediateCommunicatorService?
     /// Held for the app's lifetime — see `observeLegacyComplicationRenders`.
@@ -151,24 +158,28 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                 // wall-clock budget: 15s when warm, 25s when cold-launched for the refresh
                 // (CSLHandleBackgroundRefreshAction transgression). The refresh work below talks
                 // to the network with timeouts larger than that budget, so completing "when done"
-                // isn't enough — always complete at a hard deadline, even mid-work. Both paths run
-                // on the main queue (PromiseKit's default), so the flag needs no synchronization.
+                // isn't enough — always complete at a hard deadline, even mid-work.
+                let completionLock = NSLock()
                 var didComplete = false
                 let completeTask = {
-                    guard !didComplete else { return }
+                    completionLock.lock()
+                    let alreadyCompleted = didComplete
                     didComplete = true
+                    completionLock.unlock()
+                    guard !alreadyCompleted else { return }
                     backgroundTask.setTaskCompletedWithSnapshot(false)
                 }
 
                 // Schedule the next refresh up front so a deadline hit can't skip it.
                 Current.backgroundRefreshScheduler.schedule().cauterize()
 
-                after(seconds: 10).done {
-                    if !didComplete {
-                        Current.Log.info("completing background refresh task at deadline; work still running")
-                    }
+                let deadline = DispatchSource.makeTimerSource(queue: Self.watchdogQueue)
+                deadline.schedule(deadline: .now() + 10)
+                deadline.setEventHandler {
+                    Current.Log.info("completing background refresh task at deadline; work still running")
                     completeTask()
                 }
+                deadline.resume()
 
                 firstly {
                     when(fulfilled: Current.apis.map { $0.updateComplications(passively: true) })
@@ -183,6 +194,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                         }
                     }
                 }.ensure {
+                    deadline.cancel()
                     completeTask()
                 }.cauterize()
             case let snapshotTask as WKSnapshotRefreshBackgroundTask:
@@ -302,39 +314,58 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
     }
 
     private func enqueueForCompletion(_ task: WKWatchConnectivityRefreshBackgroundTask) {
+        pendingConnectivityTasksLock.lock()
+        pendingConnectivityTasks.append(task)
+        pendingConnectivityTasksLock.unlock()
+
         DispatchQueue.main.async { [self] in
             guard Communicator.shared.hasPendingDataToBeReceived else {
                 // nothing else to be received
-                task.setTaskCompletedWithSnapshot(false)
+                completePendingConnectivityTasks()
                 return
             }
 
             // wait for it to send the next set of data
-            watchConnectivityBackgroundPromise.done {
-                task.setTaskCompletedWithSnapshot(false)
+            watchConnectivityBackgroundPromise.done { [weak self] in
+                self?.completePendingConnectivityTasks()
             }
 
-            if watchConnectivityWatchdogTimer == nil || watchConnectivityWatchdogTimer?.isValid == false {
+            if watchConnectivityWatchdogTimer == nil {
                 // 10s should be more than enough time, and the system timer's at 15s (last tested watchOS 7)
-                let timer = Timer.scheduledTimer(
-                    withTimeInterval: 10.0,
-                    repeats: true
-                ) { [weak self] _ in
+                let timer = DispatchSource.makeTimerSource(queue: Self.watchdogQueue)
+                timer.schedule(deadline: .now() + 10, repeating: 10)
+                timer.setEventHandler { [weak self] in
                     // we endeavor to not need this timer, but apple's api is so difficult to micromanage
                     // that it's just safer to guess and check every few seconds
                     Current.Log.info("ending background task due to our own watchdog timer")
                     // Force: data can stay "pending" indefinitely (e.g. a wedged file transfer), and
                     // holding the task past ~15s gets the app killed (CSLHandleBackgroundWCSessionAction
                     // transgression). The system delivers a new task when the data actually arrives.
+                    self?.completePendingConnectivityTasks()
                     self?.endWatchConnectivityBackgroundTaskIfNecessary(force: true)
                 }
+                timer.resume()
 
-                watchConnectivityBackgroundPromise.done {
-                    timer.invalidate()
+                watchConnectivityBackgroundPromise.done { [weak self] in
+                    timer.cancel()
+                    self?.watchConnectivityWatchdogTimer = nil
                 }
 
                 watchConnectivityWatchdogTimer = timer
             }
+        }
+    }
+
+    /// Completes every WatchConnectivity task still open. Safe to call off the main queue, which is
+    /// what lets the watchdog end them while the main thread is blocked.
+    private func completePendingConnectivityTasks() {
+        pendingConnectivityTasksLock.lock()
+        let tasks = pendingConnectivityTasks
+        pendingConnectivityTasks.removeAll()
+        pendingConnectivityTasksLock.unlock()
+
+        for task in tasks {
+            task.setTaskCompletedWithSnapshot(false)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The watch app has two deadlines that exist to complete a background task before the system kills it, and both needed the main thread to be free: the refresh deadline ran its callback on the main queue, and the WatchConnectivity watchdog was a `Timer` on the main run loop. A blocked main thread is exactly the case they are there for, so neither could fire in it.

A crash report from a background refresh shows the app killed after 25 s with the main thread blocked in a synchronous XPC.

Both are now `DispatchSourceTimer`s on their own queue, and the tasks they complete are held in a lock-guarded list so they can be finished from that queue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a crash fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
To be precise about what this does and doesn't fix: in that particular crash the main thread was stuck *inside* `setTaskCompletedWithSnapshot`, so no deadline could have saved it. What changes here is that a main thread blocked on anything else — a database write, another synchronous XPC — no longer takes the deadlines down with it.

Worth exercising on a real watch: it now calls `setTaskCompletedWithSnapshot` off the main queue when a deadline fires.

One of several separate PRs from the same trace.
