### PR TITLE
Speed up watch mirror table digests

### DIFF
--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -448,11 +448,17 @@ public struct WatchDatabaseMirror: WatchCodable {
     // MARK: - Delta sync digests
 
     /// Opaque per-table digests of this snapshot, generated and compared ONLY on the phone
-    /// (property-list encoding isn't guaranteed byte-stable across devices, so the watch never
-    /// computes these — it stores the map verbatim and echoes it on the next sync request).
+    /// (the encoding isn't guaranteed byte-stable across devices, so the watch never computes
+    /// these — it stores the map verbatim and echoes it on the next sync request).
     /// A group that is `nil` produces no digest, can never "match", and is always carried.
+    ///
+    /// Because these bytes never leave the phone, the encoding is free to be the fast one rather
+    /// than the payload's property list: fingerprinting every table on each push cost about as
+    /// much CPU as building the payload itself.
     public func tableDigests() -> [String: String] {
-        let encoder = PropertyListEncoder()
+        let encoder = with(JSONEncoder()) {
+            $0.outputFormatting = [.sortedKeys]
+        }
         var digests: [String: String] = [:]
         if let entities, let data = try? encoder.encode(entities) {
             digests["entities"] = Self.digest(of: [data])

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -52,19 +52,24 @@ struct WatchDatabaseMirrorFullReferenceTests {
         #expect(carried.devices != nil)
     }
 
-    @Test("Every carried table publishes a digest")
-    func digestsCoverEveryCarriedTable() {
-        let mirror = WatchDatabaseMirror(
-            entities: [],
-            areas: [],
-            pipelines: [],
-            registry: [.init(serverId: "s1", entityId: "light.a", hidden: true)],
-            devices: [Self.device(deviceId: "d1")]
-        )
-        // A table whose encoding fails silently loses its digest, which can never match, so it is
-        // re-sent on every push instead of only when it changed.
-        let digestKeys = Set(mirror.tableDigests().keys)
-        #expect(mirror.carriedDigestKeys.subtracting(digestKeys).isEmpty)
+    @Test("Every table a snapshot carries publishes a digest")
+    func digestsCoverEveryCarriedTable() throws {
+        try withDatabase { database in
+            try database.write { db in
+                try Self.entity(entityId: "light.kitchen", domain: "light").insert(db)
+                try Self.area(areaId: "kitchen").insert(db)
+                try EntityRegistryListForDisplay.Entity(serverId: "1", entityId: "light.kitchen").insert(db)
+                try Self.device(deviceId: "d1").insert(db)
+                try AssistPipelines(serverId: "1", preferredPipeline: "p", pipelines: []).insert(db)
+            }
+
+            // A table whose encoding fails silently loses its digest, which can never match, so it
+            // would be re-sent on every push instead of only when it changed.
+            let snapshot = try WatchDatabaseMirror.snapshot(version: WatchDatabaseMirror.fullReferenceVersion)
+            let digestKeys = Set(snapshot.tableDigests().keys)
+            #expect(!snapshot.carriedDigestKeys.isEmpty)
+            #expect(snapshot.carriedDigestKeys.subtracting(digestKeys).isEmpty)
+        }
     }
 
     @Test("Compression round-trips and rejects garbage")

--- a/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
+++ b/Tests/Shared/Watch/WatchDatabaseMirrorFullReference.test.swift
@@ -52,6 +52,21 @@ struct WatchDatabaseMirrorFullReferenceTests {
         #expect(carried.devices != nil)
     }
 
+    @Test("Every carried table publishes a digest")
+    func digestsCoverEveryCarriedTable() {
+        let mirror = WatchDatabaseMirror(
+            entities: [],
+            areas: [],
+            pipelines: [],
+            registry: [.init(serverId: "s1", entityId: "light.a", hidden: true)],
+            devices: [Self.device(deviceId: "d1")]
+        )
+        // A table whose encoding fails silently loses its digest, which can never match, so it is
+        // re-sent on every push instead of only when it changed.
+        let digestKeys = Set(mirror.tableDigests().keys)
+        #expect(mirror.carriedDigestKeys.subtracting(digestKeys).isEmpty)
+    }
+
     @Test("Compression round-trips and rejects garbage")
     func compression() throws {
         // Round-trip correctness is the contract; no size assertion — the codec doesn't guarantee


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Every watch mirror push property-list-encodes each table once to fingerprint it, then encodes the payload again to send it. In a device trace that showed up as 1.0 CPU-second of `PropertyListEncoder`, in two spikes matching two pushes — and most of it is the fingerprinting pass, which runs over every table even when nothing changed and there is nothing to send.

Those digest bytes never leave the phone: the watch stores the map verbatim and echoes it back. So the encoding doesn't have to match the payload's, and the fingerprints now use `JSONEncoder`, which is materially faster for these arrays.

Digests change shape, so the first push after updating carries every table once and then settles back to deltas.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change. Adds a test that every carried table publishes a digest, since an encoding failure would silently degrade the delta sync into a full push each time.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a performance fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same trace.
