### PR TITLE
Build Reminders sync snapshots off the main actor

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -256,20 +256,24 @@ final class RemindersSyncManager: ObservableObject {
         storedLinks: [RemindersSyncItemLink],
         features: TodoListEntityFeature?
     ) async -> ([String: RemindersSyncItemSnapshot], [RemindersSyncPlanner.LinkState]) {
-        let todoSnapshots = Dictionary(
-            todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0).trimmed(to: features)) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        let links = storedLinks
-            .map(RemindersSyncPlanner.LinkState.init(link:))
-            .map { link in
-                RemindersSyncPlanner.LinkState(
-                    todoItemUid: link.todoItemUid,
-                    reminderId: link.reminderId,
-                    snapshot: link.snapshot.trimmed(to: features)
-                )
-            }
-        return (todoSnapshots, links)
+        // Detached rather than relying on `nonisolated async` hopping executors on its own, which is
+        // a rule that has changed between language modes. `databaseAccess` above does the same.
+        await Task.detached {
+            let todoSnapshots = Dictionary(
+                todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0).trimmed(to: features)) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            let links = storedLinks
+                .map(RemindersSyncPlanner.LinkState.init(link:))
+                .map { link in
+                    RemindersSyncPlanner.LinkState(
+                        todoItemUid: link.todoItemUid,
+                        reminderId: link.reminderId,
+                        snapshot: link.snapshot.trimmed(to: features)
+                    )
+                }
+            return (todoSnapshots, links)
+        }.value
     }
 
     /// Counterpart to `LifecycleManager`'s suspend-on-background: after the sync touches the

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -248,6 +248,30 @@ final class RemindersSyncManager: ObservableObject {
         await Task.detached { access() }.value
     }
 
+    /// Snapshotting every todo item and stored link is pure value work, and running it on the main
+    /// actor alongside the rest of the sync is what froze the UI on a large list. `EKReminder`
+    /// snapshots deliberately stay on the actor: EventKit objects aren't safe to read off-thread.
+    private nonisolated static func planInputs(
+        todoItems: [TodoListItem],
+        storedLinks: [RemindersSyncItemLink],
+        features: TodoListEntityFeature?
+    ) async -> ([String: RemindersSyncItemSnapshot], [RemindersSyncPlanner.LinkState]) {
+        let todoSnapshots = Dictionary(
+            todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0).trimmed(to: features)) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let links = storedLinks
+            .map(RemindersSyncPlanner.LinkState.init(link:))
+            .map { link in
+                RemindersSyncPlanner.LinkState(
+                    todoItemUid: link.todoItemUid,
+                    reminderId: link.reminderId,
+                    snapshot: link.snapshot.trimmed(to: features)
+                )
+            }
+        return (todoSnapshots, links)
+    }
+
     /// Counterpart to `LifecycleManager`'s suspend-on-background: after the sync touches the
     /// database while backgrounded, GRDB goes back to the suspended state so nothing can hold the
     /// app-group SQLite lock when the process is frozen.
@@ -273,25 +297,18 @@ final class RemindersSyncManager: ObservableObject {
             let features = await todoListFeatures(server: server, entityId: config.todoEntityId)
             let todoItems = try await fetchTodoItems(api: api, listId: config.todoEntityId)
             let reminders = await fetchReminders(in: calendar)
-            let todoSnapshots = Dictionary(
-                todoItems.map { ($0.uid, RemindersSyncItemSnapshot(todoItem: $0).trimmed(to: features)) },
-                uniquingKeysWith: { first, _ in first }
-            )
             let remindersById = Dictionary(
                 reminders.map { ($0.calendarItemIdentifier, $0) },
                 uniquingKeysWith: { first, _ in first }
             )
 
             let configId = config.id
-            let links = await Self.databaseAccess { RemindersSyncItemLink.links(configId: configId) }
-                .map(RemindersSyncPlanner.LinkState.init(link:))
-                .map { link in
-                    RemindersSyncPlanner.LinkState(
-                        todoItemUid: link.todoItemUid,
-                        reminderId: link.reminderId,
-                        snapshot: link.snapshot.trimmed(to: features)
-                    )
-                }
+            let storedLinks = await Self.databaseAccess { RemindersSyncItemLink.links(configId: configId) }
+            let (todoSnapshots, links) = await Self.planInputs(
+                todoItems: todoItems,
+                storedLinks: storedLinks,
+                features: features
+            )
             details = try await applyPlan(
                 config: config,
                 api: api,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
`RemindersSyncManager` is `@MainActor` for the whole class, so snapshotting every todo item and every stored link ran on the main thread. That is per-item work whose cost grows with the list, and a device trace caught it hanging the main thread for over a second.

Those two mappings are pure value work, so they move to a `nonisolated` helper and run off the actor. `EKReminder` snapshots stay where they are — EventKit objects aren't safe to read off-thread — as do the store access and the writes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change. Covered by the existing `RemindersSyncPlannerTests` and `RemindersSyncItemSnapshotTests`.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a performance fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same trace. It touches the same area as the date formatter caching PR but a different part of the file, so they can land in either order.
