### PR TITLE
Count watch mirror rows in the apply transaction

### DIFF
--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -340,12 +340,27 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// `registryEntities` precision slice is upserted (not wiped) so a v1 payload doesn't disturb
     /// registry rows a v2 sync delivered; a carried full `registry` replaces the table outright.
     public func apply() throws {
-        try Current.database().write { db in
+        let counts = try Current.database().write { db -> [String: Int] in
             try applyReferenceTables(in: db)
             try applySettingsTables(in: db)
             try applyComplicationTables(in: db, includeRegistryRows: true)
+            return try Self.mirroredRowCounts(in: db)
         }
-        logApplyOutcome()
+        logApplyOutcome(counts: counts)
+    }
+
+    /// Counted inside the apply's own transaction: a second one costs the watch another database
+    /// access — through the suspension machinery — inside the same background budget the apply is
+    /// already spending.
+    private static func mirroredRowCounts(in db: Database) throws -> [String: Int] {
+        try [
+            "entities": HAAppEntity.fetchCount(db),
+            "areas": AppArea.fetchCount(db),
+            "registry": EntityRegistryListForDisplay.Entity.fetchCount(db),
+            "devices": AppDeviceRegistry.fetchCount(db),
+            "pipelines": AssistPipelines.fetchCount(db),
+            "notificationSnoozeActions": NotificationSnoozeAction.fetchCount(db),
+        ]
     }
 
     /// Record which tables a payload actually carried and what the database holds afterwards.
@@ -354,18 +369,8 @@ public struct WatchDatabaseMirror: WatchCodable {
     /// retained the rest", and an apply that logs success can still leave a table empty — which is
     /// exactly the shape of the sync problems seen on device. Logging both ends of the operation
     /// makes a watch log enough on its own to tell which side lost the data.
-    private func logApplyOutcome() {
+    private func logApplyOutcome(counts: [String: Int]) {
         let carried = carriedDigestKeys.sorted().joined(separator: "+")
-        let counts = (try? Current.database().read { db in
-            try [
-                "entities": HAAppEntity.fetchCount(db),
-                "areas": AppArea.fetchCount(db),
-                "registry": EntityRegistryListForDisplay.Entity.fetchCount(db),
-                "devices": AppDeviceRegistry.fetchCount(db),
-                "pipelines": AssistPipelines.fetchCount(db),
-                "notificationSnoozeActions": NotificationSnoozeAction.fetchCount(db),
-            ]
-        }) ?? [:]
         let rows = counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }.joined(separator: " ")
         Current.Log.info("Applied mirror carrying [\(carried.isEmpty ? "nothing" : carried)]; rows now \(rows)")
     }

--- a/Sources/Shared/Watch/WatchDatabaseMirror.swift
+++ b/Sources/Shared/Watch/WatchDatabaseMirror.swift
@@ -344,7 +344,9 @@ public struct WatchDatabaseMirror: WatchCodable {
             try applyReferenceTables(in: db)
             try applySettingsTables(in: db)
             try applyComplicationTables(in: db, includeRegistryRows: true)
-            return try Self.mirroredRowCounts(in: db)
+            // Counting is only for the log line below, so a failing count must never roll the
+            // applied rows back.
+            return (try? Self.mirroredRowCounts(in: db)) ?? [:]
         }
         logApplyOutcome(counts: counts)
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Applying a watch database mirror opened a second, read-only transaction straight after the write, purely to count rows for the log line. On the watch that apply already runs inside a background budget it has been overrunning, and every database access there goes through the suspension machinery.

The counts are now read at the end of the write transaction that just made them true, so the log line is unchanged and the extra access is gone.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a performance fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same trace. Small on its own — it's one of the constant-factor items on the watch apply path.
