### PR TITLE
Fix cold launch hang in Reminders sync

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncAddViewModel.swift
@@ -53,7 +53,7 @@ final class RemindersSyncAddViewModel: ObservableObject {
         if RemindersSyncManager.shared.authorizationState == .notDetermined {
             _ = await RemindersSyncManager.shared.requestAccess()
         }
-        reminderLists = RemindersSyncManager.shared.reminderLists()
+        reminderLists = await RemindersSyncManager.shared.reminderLists()
 
         // A reload can invalidate earlier selections (e.g. the selected server's last todo list
         // was deleted): clear anything that no longer exists before filling in defaults.

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -150,9 +150,12 @@ final class RemindersSyncManager: ObservableObject {
     }
 
     /// The user's Reminders lists, for the configuration picker.
-    func reminderLists() -> [EKCalendar] {
-        eventStore.calendars(for: .reminder)
-            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    func reminderLists() async -> [EKCalendar] {
+        let store = eventStore
+        return await Self.eventStoreAccess {
+            store.calendars(for: .reminder)
+                .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        }
     }
 
     func syncNow() {
@@ -232,6 +235,24 @@ final class RemindersSyncManager: ObservableObject {
         }
     }
 
+    /// Runs a synchronous `EKEventStore` operation on a background thread instead of the main
+    /// actor. Store-level calls like `calendar(withIdentifier:)`, `calendars(for:)` and
+    /// `commit()` are synchronous XPC round-trips to the Reminders daemon; on a cold launch the
+    /// first of them additionally waits for the daemon connection to come up, which blocked the
+    /// main thread for over a second (UIKit-runloop hang reports with the whole hang inside
+    /// `-[EKEventStore calendarWithIdentifier:]`).
+    ///
+    /// `EKEventStore` itself is thread-safe, and the `EKCalendar`/`EKReminder` objects involved
+    /// are never used from two threads at once: the caller awaits the detached task, then uses
+    /// the result back on the main actor — the same serialized handoff that
+    /// `fetchReminders(matching:)` already performs with its internally-fetched reminders. No
+    /// `Sendable` constraints because EventKit types don't declare it.
+    private nonisolated static func eventStoreAccess<T>(
+        _ access: @escaping () -> T
+    ) async -> T {
+        await Task.detached { access() }.value
+    }
+
     /// Runs synchronous GRDB access on a background thread instead of the main actor. The
     /// 0xdead10cc termination this sync used to hit showed the main thread blocked in a commit's
     /// `fsync`: it couldn't service the `didEnterBackground` notification that suspends GRDB and
@@ -291,7 +312,11 @@ final class RemindersSyncManager: ObservableObject {
             Current.Log.error("Reminders sync skipped, no server/API for \(config.serverId)")
             return
         }
-        guard let calendar = eventStore.calendar(withIdentifier: config.reminderListId) else {
+        // Resolved off the main thread: this is the sync's first EventKit call, and cold-launch
+        // daemon startup made it hang the main thread (see `eventStoreAccess`).
+        let store = eventStore
+        let listId = config.reminderListId
+        guard let calendar = await Self.eventStoreAccess({ store.calendar(withIdentifier: listId) }) else {
             Current.Log.error("Reminders sync skipped, list \(config.reminderListName) no longer exists")
             return
         }
@@ -399,7 +424,10 @@ final class RemindersSyncManager: ObservableObject {
         }
 
         if needsCommit {
-            try eventStore.commit()
+            // Saves and removals above only stage changes (`commit: false`); this is the XPC
+            // round-trip that writes them, so it stays off the main thread too.
+            let store = eventStore
+            try await Self.eventStoreAccess { Result { try store.commit() } }.get()
         }
 
         if !createdTodoItemReminderIds.isEmpty {

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -245,12 +245,22 @@ final class RemindersSyncManager: ObservableObject {
     /// `EKEventStore` itself is thread-safe, and the `EKCalendar`/`EKReminder` objects involved
     /// are never used from two threads at once: the caller awaits the detached task, then uses
     /// the result back on the main actor — the same serialized handoff that
-    /// `fetchReminders(matching:)` already performs with its internally-fetched reminders. No
-    /// `Sendable` constraints because EventKit types don't declare it.
+    /// `fetchReminders(matching:)` already performs with its internally-fetched reminders.
+    /// EventKit types aren't `Sendable`, so the closure and result cross the task boundary in an
+    /// `@unchecked Sendable` box; the strictly serialized handoff is what makes that safe.
     private nonisolated static func eventStoreAccess<T>(
         _ access: @escaping () -> T
     ) async -> T {
-        await Task.detached { access() }.value
+        let boxedAccess = UncheckedSendableBox(value: access)
+        return await Task.detached {
+            UncheckedSendableBox(value: boxedAccess.value())
+        }.value.value
+    }
+
+    /// See `eventStoreAccess`: transfers one non-`Sendable` value across a task boundary where
+    /// access is strictly serialized by the surrounding `await`.
+    private struct UncheckedSendableBox<Value>: @unchecked Sendable {
+        let value: Value
     }
 
     /// Runs synchronous GRDB access on a background thread instead of the main actor. The

--- a/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncManager.swift
@@ -435,9 +435,10 @@ final class RemindersSyncManager: ObservableObject {
 
         if needsCommit {
             // Saves and removals above only stage changes (`commit: false`); this is the XPC
-            // round-trip that writes them, so it stays off the main thread too.
+            // round-trip that writes them, so it stays off the main thread too. `Swift.Result`
+            // spelled out because PromiseKit's `Result<T>` shadows it in this file.
             let store = eventStore
-            try await Self.eventStoreAccess { Result { try store.commit() } }.get()
+            try await Self.eventStoreAccess { Swift.Result(catching: { try store.commit() }) }.get()
         }
 
         if !createdTodoItemReminderIds.isEmpty {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Fixes a main-thread hang on cold launch. A hang report showed the main thread blocked for over a second in `EKEventStore.calendar(withIdentifier:)`, a synchronous XPC call to the Reminders daemon made by the first Reminders sync after launch. This moves the blocking EventKit store calls (calendar resolution, list fetch for the picker, commit) onto a background thread, following the same pattern the file already uses for database access.

## Screenshots
Not a user-facing change (no UI changes).

## Link to pull request in Documentation repository
No functionality added, changed or removed, so no documentation change is needed.
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`EKEventStore` is thread-safe; the returned EventKit objects are only used after hopping back to the main actor, matching the serialized handoff `fetchReminders(matching:)` already performs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7Q4iWE1ArhncHjYbaoCz8)_