### PR TITLE
Honour the server's UTC offset on todo due dates

### DIFF
--- a/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
+++ b/Sources/App/Utilities/RemindersSync/RemindersSyncItemSnapshot.swift
@@ -32,9 +32,8 @@ struct RemindersSyncItemSnapshot: Equatable {
         self.isCompleted = todoItem.status == "completed"
         self.notes = Self.normalizedNotes(todoItem.description)
         if let raw = todoItem.dueRaw {
-            // `TodoListItem` doesn't parse every server datetime format, so fall back to parsing
-            // the raw string ourselves. An uncanonicalized string would never compare equal to
-            // the reminder's canonical one and cause an update on every sync.
+            // An uncanonicalized string would never compare equal to the reminder's canonical
+            // one and cause an update on every sync.
             if raw.contains("T"), let date = todoItem.due ?? Self.parseDueDateTime(raw) {
                 self.due = Self.canonicalDueString(from: date)
             } else {
@@ -102,56 +101,10 @@ struct RemindersSyncItemSnapshot: Equatable {
     }
 
     static func canonicalDueString(from date: Date) -> String {
-        DueDateFormatters.current.internetDateTime.string(from: date)
+        TodoListItem.canonicalDueString(from: date)
     }
 
     static func parseDueDateTime(_ string: String) -> Date? {
-        let formatters = DueDateFormatters.current
-        if let date = formatters.internetDateTime.date(from: string) {
-            return date
-        }
-        if let date = formatters.fractionalInternetDateTime.date(from: string) {
-            return date
-        }
-        // Datetime without timezone offset, interpreted in the current timezone
-        return formatters.localDateTime.date(from: string)
-    }
-
-    private final class DueDateFormatters {
-        let timeZone: TimeZone
-        let internetDateTime: ISO8601DateFormatter
-        let fractionalInternetDateTime: ISO8601DateFormatter
-        let localDateTime: DateFormatter
-
-        private static let lock = NSLock()
-        private static var cached = DueDateFormatters(timeZone: .current)
-
-        static var current: DueDateFormatters {
-            let timeZone = TimeZone.current
-            lock.lock()
-            defer { lock.unlock() }
-            if cached.timeZone != timeZone {
-                cached = DueDateFormatters(timeZone: timeZone)
-            }
-            return cached
-        }
-
-        init(timeZone: TimeZone) {
-            self.timeZone = timeZone
-            self.internetDateTime = with(ISO8601DateFormatter()) {
-                $0.formatOptions = [.withInternetDateTime]
-                $0.timeZone = timeZone
-            }
-            self.fractionalInternetDateTime = with(ISO8601DateFormatter()) {
-                $0.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                $0.timeZone = timeZone
-            }
-            self.localDateTime = with(DateFormatter()) {
-                $0.calendar = Calendar(identifier: .gregorian)
-                $0.locale = Locale(identifier: "en_US_POSIX")
-                $0.timeZone = timeZone
-                $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-            }
-        }
+        TodoListItem.parseDueDateTime(string)
     }
 }

--- a/Sources/Shared/TodoListItem.swift
+++ b/Sources/Shared/TodoListItem.swift
@@ -22,32 +22,10 @@ public struct TodoListItem: HADataDecodable {
         self.description = try? data.decode("description") as String?
         self.dueRaw = try? data.decode("due") as String?
 
-        // Parse due date - can be date only (YYYY-MM-DD) or datetime (YYYY-MM-DDTHH:MM:SS+TZ)
         if let dueString = dueRaw {
-            if dueString.contains("T") {
-                // DateTime format - try ISO8601
-                let dateFormatter = ISO8601DateFormatter()
-                dateFormatter.formatOptions = [
-                    .withFullDate,
-                    .withTime,
-                    .withDashSeparatorInDate,
-                    .withColonSeparatorInTime,
-                ]
-                // Try with timezone first
-                if let date = dateFormatter.date(from: dueString) {
-                    self.due = date
-                } else {
-                    // Try with fractional seconds
-                    dateFormatter.formatOptions.insert(.withFractionalSeconds)
-                    self.due = dateFormatter.date(from: dueString)
-                }
-            } else {
-                // Date-only format (YYYY-MM-DD)
-                let dateOnlyFormatter = DateFormatter()
-                dateOnlyFormatter.dateFormat = "yyyy-MM-dd"
-                dateOnlyFormatter.timeZone = .current
-                self.due = dateOnlyFormatter.date(from: dueString)
-            }
+            self.due = dueString.contains("T")
+                ? Self.parseDueDateTime(dueString)
+                : Self.parseDueDate(dueString)
         } else {
             self.due = nil
         }
@@ -69,6 +47,30 @@ public struct TodoListItem: HADataDecodable {
         self.due = due
     }
 
+    /// Parses a `yyyy-MM-dd` due value into midnight in the current timezone.
+    public static func parseDueDate(_ string: String) -> Date? {
+        DueDateFormatters.current.localDate.date(from: string)
+    }
+
+    /// Parses a due datetime, honouring the UTC offset the server sends. A value without an
+    /// offset is a naive local wall clock time and is interpreted in the current timezone.
+    public static func parseDueDateTime(_ string: String) -> Date? {
+        let formatters = DueDateFormatters.current
+        if let date = formatters.internetDateTime.date(from: string) {
+            return date
+        }
+        if let date = formatters.fractionalInternetDateTime.date(from: string) {
+            return date
+        }
+        return formatters.localDateTime.date(from: string)
+    }
+
+    /// The canonical `due_datetime` representation: ISO8601 in the current timezone, offset
+    /// included, so the server can never mistake it for a naive local time.
+    public static func canonicalDueString(from date: Date) -> String {
+        DueDateFormatters.current.internetDateTime.string(from: date)
+    }
+
     /// Formatted due date string for display
     public var formattedDue: String? {
         guard let due else { return nil }
@@ -82,6 +84,52 @@ public struct TodoListItem: HADataDecodable {
             formatter.timeStyle = .none
         }
         return formatter.string(from: due)
+    }
+
+    private final class DueDateFormatters {
+        let timeZone: TimeZone
+        let internetDateTime: ISO8601DateFormatter
+        let fractionalInternetDateTime: ISO8601DateFormatter
+        let localDateTime: DateFormatter
+        let localDate: DateFormatter
+
+        private static let lock = NSLock()
+        private static var cached = DueDateFormatters(timeZone: .current)
+
+        static var current: DueDateFormatters {
+            let timeZone = TimeZone.current
+            lock.lock()
+            defer { lock.unlock() }
+            if cached.timeZone != timeZone {
+                cached = DueDateFormatters(timeZone: timeZone)
+            }
+            return cached
+        }
+
+        init(timeZone: TimeZone) {
+            self.timeZone = timeZone
+            let internetDateTime = ISO8601DateFormatter()
+            internetDateTime.formatOptions = [.withInternetDateTime]
+            internetDateTime.timeZone = timeZone
+            self.internetDateTime = internetDateTime
+
+            let fractionalInternetDateTime = ISO8601DateFormatter()
+            fractionalInternetDateTime.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            fractionalInternetDateTime.timeZone = timeZone
+            self.fractionalInternetDateTime = fractionalInternetDateTime
+
+            self.localDateTime = Self.fixedFormatter(format: "yyyy-MM-dd'T'HH:mm:ss", timeZone: timeZone)
+            self.localDate = Self.fixedFormatter(format: "yyyy-MM-dd", timeZone: timeZone)
+        }
+
+        private static func fixedFormatter(format: String, timeZone: TimeZone) -> DateFormatter {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .gregorian)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = timeZone
+            formatter.dateFormat = format
+            return formatter
+        }
     }
 }
 

--- a/Sources/Shared/TodoListItem.swift
+++ b/Sources/Shared/TodoListItem.swift
@@ -49,26 +49,23 @@ public struct TodoListItem: HADataDecodable {
 
     /// Parses a `yyyy-MM-dd` due value into midnight in the current timezone.
     public static func parseDueDate(_ string: String) -> Date? {
-        DueDateFormatters.current.localDate.date(from: string)
+        DueDateFormatters.withCurrent { $0.localDate.date(from: string) }
     }
 
     /// Parses a due datetime, honouring the UTC offset the server sends. A value without an
     /// offset is a naive local wall clock time and is interpreted in the current timezone.
     public static func parseDueDateTime(_ string: String) -> Date? {
-        let formatters = DueDateFormatters.current
-        if let date = formatters.internetDateTime.date(from: string) {
-            return date
+        DueDateFormatters.withCurrent { formatters in
+            formatters.internetDateTime.date(from: string)
+                ?? formatters.fractionalInternetDateTime.date(from: string)
+                ?? formatters.localDateTime.date(from: string)
         }
-        if let date = formatters.fractionalInternetDateTime.date(from: string) {
-            return date
-        }
-        return formatters.localDateTime.date(from: string)
     }
 
     /// The canonical `due_datetime` representation: ISO8601 in the current timezone, offset
     /// included, so the server can never mistake it for a naive local time.
     public static func canonicalDueString(from date: Date) -> String {
-        DueDateFormatters.current.internetDateTime.string(from: date)
+        DueDateFormatters.withCurrent { $0.internetDateTime.string(from: date) }
     }
 
     /// Formatted due date string for display
@@ -96,14 +93,16 @@ public struct TodoListItem: HADataDecodable {
         private static let lock = NSLock()
         private static var cached = DueDateFormatters(timeZone: .current)
 
-        static var current: DueDateFormatters {
+        /// The formatters are shared and `DateFormatter` must not be used from two threads at
+        /// once, so callers get them for the duration of the call rather than by reference.
+        static func withCurrent<T>(_ body: (DueDateFormatters) -> T) -> T {
             let timeZone = TimeZone.current
             lock.lock()
             defer { lock.unlock() }
             if cached.timeZone != timeZone {
                 cached = DueDateFormatters(timeZone: timeZone)
             }
-            return cached
+            return body(cached)
         }
 
         init(timeZone: TimeZone) {

--- a/Tests/Shared/Models/TodoListItem.test.swift
+++ b/Tests/Shared/Models/TodoListItem.test.swift
@@ -1,0 +1,103 @@
+import Foundation
+import HAKit
+@testable import Shared
+import Testing
+
+@Suite("TodoListItem due date parsing")
+struct TodoListItemTests {
+    /// 2026-08-27T00:30:00Z, i.e. 2026-08-26 19:30 in Central Daylight Time.
+    private let instant = Date(timeIntervalSince1970: 1_787_790_600)
+
+    private func decode(due: Any?) throws -> TodoListItem {
+        var value: [String: Any] = [
+            "summary": "Buy milk",
+            "uid": "todo-1",
+            "status": "needs_action",
+        ]
+        if let due {
+            value["due"] = due
+        }
+        return try TodoListItem(data: HAData(value: value))
+    }
+
+    @Test("Honours the UTC offset the server sends instead of reading the time as UTC")
+    func decodesOffsetDueDatetime() throws {
+        let item = try decode(due: "2026-08-26T19:30:00-05:00")
+
+        #expect(item.due == instant)
+        #expect(item.hasDueTime)
+    }
+
+    @Test("A Z-suffixed due datetime is the same instant as its offset form")
+    func decodesZuluDueDatetime() throws {
+        let item = try decode(due: "2026-08-27T00:30:00Z")
+
+        #expect(item.due == instant)
+    }
+
+    @Test("Fractional seconds do not defeat the offset-aware parse")
+    func decodesFractionalDueDatetime() throws {
+        let item = try decode(due: "2026-08-26T19:30:00.000-05:00")
+
+        #expect(item.due == instant)
+    }
+
+    @Test("A due datetime without an offset is a local wall clock time")
+    func decodesNaiveDueDatetimeInCurrentTimeZone() throws {
+        let item = try decode(due: "2026-08-26T19:30:00")
+        let due = try #require(item.due)
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: due)
+
+        #expect(components.year == 2026)
+        #expect(components.month == 8)
+        #expect(components.day == 26)
+        #expect(components.hour == 19)
+        #expect(components.minute == 30)
+    }
+
+    @Test("An all-day due date is midnight in the current timezone")
+    func decodesAllDayDueDate() throws {
+        let item = try decode(due: "2026-08-26")
+        let due = try #require(item.due)
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: due)
+
+        #expect(!item.hasDueTime)
+        #expect(components.year == 2026)
+        #expect(components.month == 8)
+        #expect(components.day == 26)
+        #expect(components.hour == 0)
+        #expect(components.minute == 0)
+    }
+
+    @Test("An item with no due date parses without one")
+    func decodesMissingDue() throws {
+        let item = try decode(due: nil)
+
+        #expect(item.dueRaw == nil)
+        #expect(item.due == nil)
+        #expect(!item.hasDueTime)
+    }
+
+    @Test("An unparseable due string yields no date but keeps the raw value")
+    func decodesMalformedDue() throws {
+        let item = try decode(due: "not a date")
+
+        #expect(item.dueRaw == "not a date")
+        #expect(item.due == nil)
+    }
+
+    @Test("The canonical due string round-trips back to the same instant")
+    func canonicalDueStringRoundTrips() {
+        let canonical = TodoListItem.canonicalDueString(from: instant)
+
+        #expect(TodoListItem.parseDueDateTime(canonical) == instant)
+    }
+
+    @Test("The canonical due string carries an offset so the server cannot read it as UTC")
+    func canonicalDueStringCarriesOffset() {
+        let canonical = TodoListItem.canonicalDueString(from: instant)
+        let offsetSuffix = canonical.dropFirst("2026-08-26T19:30:00".count)
+
+        #expect(offsetSuffix.hasPrefix("+") || offsetSuffix.hasPrefix("-") || offsetSuffix == "Z")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #5527, where a todo item due at 7:30 PM synced to Apple Reminders as 2:30 PM.

`TodoListItem` decoded the due datetime with an `ISO8601DateFormatter` whose `formatOptions` left out `.withTimeZone`. That formatter does not fail on a string carrying an offset, it silently ignores the offset and reads the wall clock as UTC, so `2026-08-26T19:30:00-05:00` came back as 14:30 local. Every consumer of the parsed date was off by the current UTC offset.

The decode path now uses an offset-aware formatter, falling back to a naive local parse for servers that send no offset. The Reminders sync snapshot already had a correct parser of its own, so both now share one implementation instead of two that can drift apart.

Also pins the date-only formatter to the Gregorian calendar and `en_US_POSIX`, since a bare `DateFormatter` read `2026-07-17` as Buddhist-era year 1483 under a `th_TH` locale.

Items already synced at the wrong time correct themselves on the next sync: the Home Assistant side now reads as changed while the reminder still matches the stored snapshot, so the planner updates the reminder.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
No functionality added, changed or removed, so no documentation change is needed.
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The todo list widget read the same parsed date, so its due countdown was off by the same amount and is fixed too.

Covered by new tests in `Tests/Shared/Models/TodoListItem.test.swift`, written to be timezone independent: the offset, `Z` and fractional-second forms must all decode to the same instant.
