### PR TITLE
Arm database suspension on background launches

### DIFF
--- a/Sources/App/LifecycleManager.swift
+++ b/Sources/App/LifecycleManager.swift
@@ -61,6 +61,14 @@ class LifecycleManager {
     }
 
     func didFinishLaunching() {
+        // A background launch (location event, WatchConnectivity wake, background URLSession, …)
+        // never passes through didEnterBackground, so suspension would stay unarmed and any
+        // database access could be caught holding the app-group SQLite file lock when the process
+        // freezes (0xdead10cc). Catalyst is excluded like the rest of its lifecycle handling: it can
+        // report .background at launch without a foreground transition ever following to resume.
+        if !Current.isCatalyst, UIApplication.shared.applicationState == .background {
+            AppDatabaseSuspension.suspend()
+        }
         Current.backgroundTask(withName: BackgroundTask.lifecycleManagerDidFinishLaunching.rawValue) { _ in
             when(fulfilled: Current.apis.map { api in
                 api.CreateEvent(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The top iOS crash right now is `0xdead10cc` (~1,400 devices in the last 14 days): the system kills the app for holding the app-group SQLite file lock while being suspended. The crash logs all share the same shape — the process was launched **in the background** (WatchConnectivity wake, background URLSession completion, location event) and a GRDB read was still in flight when the process froze.

Database suspension is only armed by `didEnterBackground`, which never fires on a background launch, so `resumeForAccess()` never protects those accesses with an expiring activity. This arms suspension at launch when the app starts in the background, so every database access in a background-launched process runs under the existing expiring-activity protection and GRDB is re-suspended before the process freezes. Catalyst is excluded, matching the rest of its lifecycle handling.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a crash fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same crash analysis.