### PR TITLE
Defer Spotlight reindexing to the foreground

### DIFF
--- a/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
+++ b/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
@@ -3,6 +3,7 @@ import CoreSpotlight
 import CryptoKit
 import Foundation
 import Shared
+import UIKit
 
 /// Publishes the entities and calendars cached in the local database to Spotlight, so searching the
 /// system for an entity's name (or its area, device or server) finds it and opens its more-info
@@ -46,7 +47,12 @@ final class SpotlightEntityIndexer: ServerObserver {
     private let index = CSSearchableIndex(name: Constants.indexName)
     private let defaults = UserDefaults(suiteName: AppConstants.AppGroupID)
     private var databaseObserver: NSObjectProtocol?
+    private var backgroundObserver: NSObjectProtocol?
+    private var foregroundObserver: NSObjectProtocol?
     private var reindexTask: Task<Void, Never>?
+    /// Set when a pass was cancelled or deferred because the app left the foreground, so the next
+    /// foreground redoes it instead of waiting for another database update.
+    private var needsReindexOnForeground = false
 
     private init() {}
 
@@ -62,8 +68,46 @@ final class SpotlightEntityIndexer: ServerObserver {
                 self?.scheduleReindex(reason: "database updated")
             }
         }
+        // Catalyst is excluded like the rest of its lifecycle handling: it can sit in .background
+        // without a foreground transition ever following, which would defer the reindex forever.
+        if !Current.isCatalyst {
+            backgroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.cancelPendingReindex()
+                }
+            }
+            foregroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.reindexAfterForegroundIfNeeded()
+                }
+            }
+        }
         Current.servers.add(observer: self)
         scheduleReindex(reason: "app launch")
+    }
+
+    /// A pass running while backgrounded reads the shared-container database with nothing keeping the
+    /// process alive, so a suspension mid-read is caught holding the SQLite file lock (0xdead10cc).
+    /// The index is only visible from Spotlight anyway, so the work can wait for the next foreground.
+    private func cancelPendingReindex() {
+        guard reindexTask != nil else { return }
+        reindexTask?.cancel()
+        reindexTask = nil
+        needsReindexOnForeground = true
+    }
+
+    private func reindexAfterForegroundIfNeeded() {
+        guard needsReindexOnForeground else { return }
+        needsReindexOnForeground = false
+        scheduleReindex(reason: "returned to foreground")
     }
 
     nonisolated func serversDidChange(_ serverManager: ServerManager) {
@@ -84,6 +128,13 @@ final class SpotlightEntityIndexer: ServerObserver {
     }
 
     private func reindex(reason: String) async {
+        // A trigger fired while backgrounded (background refresh, servers changing) lands here with
+        // the coalescing delay already spent; defer it to the foreground instead of reading the
+        // database from an unprotected background process.
+        if !Current.isCatalyst, UIApplication.shared.applicationState == .background {
+            needsReindexOnForeground = true
+            return
+        }
         let snapshot = await Task.detached(priority: .utility) { Self.makeSnapshot() }.value
         guard let snapshot else { return }
 

--- a/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
+++ b/Sources/App/Utilities/Spotlight/SpotlightEntityIndexer.swift
@@ -124,6 +124,12 @@ final class SpotlightEntityIndexer: ServerObserver {
             try? await Task.sleep(for: Constants.coalescingDelay)
             guard !Task.isCancelled else { return }
             await self?.reindex(reason: reason)
+            // Clear the finished pass so a background transition doesn't mistake it for pending
+            // work and re-arm a reindex. Cancellation is re-checked because a newer schedule may
+            // have replaced the stored task while this one was indexing; both run on the main
+            // actor, so the check and the clear can't interleave with a replacement.
+            guard !Task.isCancelled else { return }
+            self?.reindexTask = nil
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Several `0xdead10cc` crash clusters catch `SpotlightEntityIndexer.makeSnapshot()` mid-read on the app-group database when the process is suspended: the reindex is debounced by 2 seconds and runs in a detached utility-priority task, so backgrounding the app right after a database update leaves the read running with nothing keeping the process alive.

A pending or running pass is now cancelled when the app enters the background, and a pass whose trigger fired while backgrounded is deferred instead of reading the database. Either way the work is redone on the next foreground, which is also the only time a Spotlight index is useful. Catalyst keeps the old behavior, matching how the rest of the app treats its unreliable background lifecycle.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a crash fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
One of several separate PRs from the same crash analysis.