### PR TITLE
Hold a background task assertion during watch mirror pushes

### DIFF
--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -360,6 +360,19 @@ public enum WatchMirrorPushCoordinator {
     }
 
     private static func push(reason: Reason) {
+        // The debounce commonly fires after its trigger's own lifetime has ended — e.g. a background
+        // URLSession or WatchConnectivity wake — so the snapshot read and transfer hand-off run under
+        // a background task assertion, keeping the process alive instead of letting it be frozen
+        // mid-read holding the app-group SQLite file lock (0xdead10cc).
+        Current.backgroundTask(withName: BackgroundTask.watchMirrorPush.rawValue) { _ in
+            Promise<Void> { seal in
+                performPush(reason: reason)
+                seal.fulfill(())
+            }
+        }.cauterize()
+    }
+
+    private static func performPush(reason: Reason) {
         // Consumed up front: whether the watch gets asked to re-render is decided per push, and a
         // failed one leaves the ask to the next push rather than firing against data that never landed.
         let refreshesComplications = pendingComplicationRefresh

--- a/Sources/Shared/API/WatchHelpers.swift
+++ b/Sources/Shared/API/WatchHelpers.swift
@@ -364,11 +364,9 @@ public enum WatchMirrorPushCoordinator {
         // URLSession or WatchConnectivity wake — so the snapshot read and transfer hand-off run under
         // a background task assertion, keeping the process alive instead of letting it be frozen
         // mid-read holding the app-group SQLite file lock (0xdead10cc).
-        Current.backgroundTask(withName: BackgroundTask.watchMirrorPush.rawValue) { _ in
-            Promise<Void> { seal in
-                performPush(reason: reason)
-                seal.fulfill(())
-            }
+        Current.backgroundTask(withName: BackgroundTask.watchMirrorPush.rawValue) { _ -> Promise<Void> in
+            performPush(reason: reason)
+            return .value(())
         }.cauterize()
     }
 

--- a/Sources/Shared/Common/BackgroundTask.swift
+++ b/Sources/Shared/Common/BackgroundTask.swift
@@ -25,6 +25,7 @@ public enum BackgroundTask: String {
     case remindersSync = "reminders-sync"
     case legacyModelCleanup = "legacy-model-cleanup"
     case focusFilterSensorUpdate = "focus-filter-sensor-update"
+    case watchMirrorPush = "watch-mirror-push"
 }
 
 public enum BackgroundTaskError: Error {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The largest iOS `0xdead10cc` crash cluster catches `WatchMirrorPushCoordinator`'s snapshot read on the app-group database at the moment the process is suspended. The push is debounced by 3 seconds, so it commonly fires after the lifetime of whatever woke the process — a background URLSession completion or a WatchConnectivity callback — leaving a multi-hundred-kilobyte database read running with nothing keeping the process alive.

The snapshot build and transfer hand-off now run under a background task assertion (`Current.backgroundTask`), so the system keeps the process alive until the read has finished and the file transfer has been handed to the WatchConnectivity daemon, instead of freezing it mid-read holding the SQLite file lock.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: not needed, this is a crash fix and adds, changes or removes no functionality.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The wrapper invokes its body synchronously, so the push still runs on the coordinator's serial queue and the de-dup state stays queue-confined. One of several separate PRs from the same crash analysis.