### PR TITLE
Remove release notes from the macOS update alert

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -277,7 +277,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Current.updater.check(dueToUserInteraction: dueToUserInteraction).done { [sceneManager] update in
             let alert = UIAlertController(
                 title: L10n.Updater.UpdateAvailable.title,
-                message: update.body,
+                message: nil,
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(

--- a/Sources/Shared/Environment/Updater.swift
+++ b/Sources/Shared/Environment/Updater.swift
@@ -6,7 +6,6 @@ public struct AvailableUpdate: Codable, Comparable {
     public var htmlUrl: URL
     public var tagName: String
     public var name: String
-    public var body: String
     public var prerelease: Bool
 
     var version: Version {

--- a/Tests/Shared/Updater.test.swift
+++ b/Tests/Shared/Updater.test.swift
@@ -269,7 +269,6 @@ private extension AvailableUpdate {
             htmlUrl: URL(string: "https://example.com/htmlUrl")!,
             tagName: "release/\(version)/\(build)",
             name: "\(version) (\(build))",
-            body: "example body",
             prerelease: prerelease,
             assets: assets
         )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The macOS update alert no longer shows the GitHub release notes as its message. Release notes are now handled by the What's New screen, so the alert just says an update is available and links to the release. The `body` field is no longer decoded from the releases API.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The update check itself is unchanged: it still runs automatically on launch and from the "Check for Updates…" menu item.
