### PR TITLE
Show all domains in the Common Controls widget

### DIFF
--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
@@ -112,7 +112,7 @@ struct WidgetCommonlyUsedEntitiesTimelineProvider: WidgetSingleEntryTimelineProv
         // Every domain the prediction returns is rendered. Domains the widget can act on in place
         // (a toggle, a press, a scene) keep their in-widget action; everything else falls back to
         // `MagicItem.widgetInteractionType`'s more-info deeplink, which opens the entity in the app's
-        // web view — the same behaviour the custom widget already has for those domains.
+        // web view — the same behavior the custom widget already has for those domains.
         let magicItems = entities.map { entityId in
             MagicItem(
                 id: entityId,

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
@@ -109,12 +109,11 @@ struct WidgetCommonlyUsedEntitiesTimelineProvider: WidgetSingleEntryTimelineProv
             }
         }
 
-        let filteredEntities = entities.filter { entityId in
-            guard let domain = Domain(entityId: entityId) else { return false }
-            return Domain.commonlyUsedWidgetSupported.contains(domain)
-        }
-
-        let magicItems = filteredEntities.map { entityId in
+        // Every domain the prediction returns is rendered. Domains the widget can act on in place
+        // (a toggle, a press, a scene) keep their in-widget action; everything else falls back to
+        // `MagicItem.widgetInteractionType`'s more-info deeplink, which opens the entity in the app's
+        // web view — the same behaviour the custom widget already has for those domains.
+        let magicItems = entities.map { entityId in
             MagicItem(
                 id: entityId,
                 serverId: server.identifier.rawValue,

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -677,8 +677,7 @@ public extension Domain {
     static let watchAddable: [Domain] = watchSupported + watchDisplayOnly + controlScreenDomains
 
     /// Display order of the watch area screens' controllable entities, most commonly used domains
-    /// first (same spirit as `commonlyUsedWidgetSupported`, extended to every watch-runnable
-    /// domain). Domains not listed sort last.
+    /// first, covering every watch-runnable domain. Domains not listed sort last.
     static let watchAreaControlsOrder: [Domain] = [
         .light,
         .switch,
@@ -704,16 +703,6 @@ public extension Domain {
         }
         return index
     }
-
-    static let commonlyUsedWidgetSupported: [Domain] = [
-        .light,
-        .switch,
-        .cover,
-        .fan,
-        .inputBoolean,
-        .humidifier,
-        .valve,
-    ]
 
     static let sensorWidgetSupported: [Domain] = [
         .sensor,

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -249,72 +249,78 @@ public struct MagicItem: Codable, Equatable, Hashable {
             )
         }
 
-        guard let domain = magicItem.domain else { return .appIntent(.refresh) }
-
-        var interactionType: WidgetInteractionType = .appIntent(.refresh)
-
+        // An explicit action override wins over whatever the item's domain would do by default.
+        // None of these branches need the domain, so they're resolved before it.
         if let magicItemAction = magicItem.action, magicItemAction != .default {
             switch magicItemAction {
             case .default:
                 // This block of code should not be reached, default should not be handled here
                 // Returning something to avoid compiler error
-                interactionType = .appIntent(.refresh)
+                return .appIntent(.refresh)
             case .moreInfoDialog:
-                interactionType = navigateIntent(url: AppConstants.openEntityDeeplinkURL(
-                    entityId: magicItem.id,
-                    serverId: magicItem.serverId
-                ))
+                return moreInfoIntent()
             case .nothing:
-                interactionType = .appIntent(.refresh)
+                return .appIntent(.refresh)
             case let .navigate(path):
-                interactionType = navigateIntent(path: path)
+                return navigateIntent(path: path)
             case let .runScript(serverId, scriptId):
-                interactionType = .appIntent(.activate(
+                return .appIntent(.activate(
                     entityId: scriptId,
                     domain: Domain.script.rawValue,
                     serverId: serverId
                 ))
             case let .assist(serverId, pipelineId, startListening):
-                interactionType = assistIntent(
+                return assistIntent(
                     serverId: serverId,
                     pipelineId: pipelineId,
                     startListening: startListening
                 )
             }
-        } else if let mainAction = domain.mainAction {
-            switch mainAction {
-            case .press:
-                interactionType = .appIntent(.press(
-                    entityId: magicItem.id,
-                    domain: domain.rawValue,
-                    serverId: magicItem.serverId
-                ))
-            case .toggle, .trigger:
-                interactionType = .appIntent(.toggle(
-                    entityId: magicItem.id,
-                    domain: domain.rawValue,
-                    serverId: magicItem.serverId
-                ))
-            case .turnOn where domain == .scene || domain == .script:
-                interactionType = .appIntent(.activate(
-                    entityId: magicItem.id,
-                    domain: domain.rawValue,
-                    serverId: magicItem.serverId
-                ))
-            default:
-                interactionType = navigateIntent(url: AppConstants.openEntityDeeplinkURL(
-                    entityId: magicItem.id,
-                    serverId: magicItem.serverId
-                ))
-            }
-        } else {
-            interactionType = navigateIntent(url: AppConstants.openEntityDeeplinkURL(
-                entityId: magicItem.id,
-                serverId: magicItem.serverId
-            ))
         }
 
-        return interactionType
+        guard let domain = magicItem.domain else {
+            // An entity whose domain isn't modelled here (one from a custom integration, say) still
+            // has a more-info dialog, so open that instead of leaving the tile inert. Non-entity
+            // items have no entity id to open.
+            return magicItem.type == .entity ? moreInfoIntent() : .appIntent(.refresh)
+        }
+
+        // Domains without a single main action — sensors, media players, locks, anything read-only
+        // or too complex for one tap — open their more-info dialog in the web view instead.
+        guard let mainAction = domain.mainAction else {
+            return moreInfoIntent()
+        }
+
+        switch mainAction {
+        case .press:
+            return .appIntent(.press(
+                entityId: magicItem.id,
+                domain: domain.rawValue,
+                serverId: magicItem.serverId
+            ))
+        case .toggle, .trigger:
+            return .appIntent(.toggle(
+                entityId: magicItem.id,
+                domain: domain.rawValue,
+                serverId: magicItem.serverId
+            ))
+        case .turnOn where domain == .scene || domain == .script:
+            return .appIntent(.activate(
+                entityId: magicItem.id,
+                domain: domain.rawValue,
+                serverId: magicItem.serverId
+            ))
+        default:
+            return moreInfoIntent()
+        }
+    }
+
+    /// Opens this item's entity more-info dialog in the app's web view.
+    private func moreInfoIntent() -> WidgetInteractionType {
+        navigateIntent(url: AppConstants.openEntityDeeplinkURL(
+            entityId: id,
+            serverId: serverId
+        ))
     }
 
     private func navigateIntent(path: String) -> WidgetInteractionType {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -279,7 +279,7 @@ public struct MagicItem: Codable, Equatable, Hashable {
         }
 
         guard let domain = magicItem.domain else {
-            // An entity whose domain isn't modelled here (one from a custom integration, say) still
+            // An entity whose domain isn't modeled here (one from a custom integration, say) still
             // has a more-info dialog, so open that instead of leaving the tile inert. Non-entity
             // items have no entity id to open.
             return magicItem.type == .entity ? moreInfoIntent() : .appIntent(.refresh)

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -309,8 +309,7 @@ struct DomainMappingTests {
 }
 
 struct MagicItemWidgetInteractionTests {
-    private func interactionKind(forEntityId id: String) -> String {
-        let item = MagicItem(id: id, serverId: "server-1", type: .entity)
+    private func interactionKind(for item: MagicItem) -> String {
         guard case let .appIntent(intent) = item.widgetInteractionType else {
             return "widgetURL"
         }
@@ -323,6 +322,16 @@ struct MagicItemWidgetInteractionTests {
         }
     }
 
+    private func interactionKind(forEntityId id: String) -> String {
+        interactionKind(for: MagicItem(id: id, serverId: "server-1", type: .entity))
+    }
+
+    /// `openEntityDeeplinkURL` needs widget authenticity, which isn't available in every test
+    /// environment, so a more-info route is either the deeplink or the `refresh` no-op fallback.
+    private func isMoreInfoRoute(_ kind: String) -> Bool {
+        kind == "widgetURL" || kind == "refresh"
+    }
+
     @Test func widgetInteractionRoutesByMainAction() {
         #expect(interactionKind(forEntityId: "light.kitchen") == "toggle")
         #expect(interactionKind(forEntityId: "switch.porch") == "toggle")
@@ -330,8 +339,48 @@ struct MagicItemWidgetInteractionTests {
         #expect(interactionKind(forEntityId: "scene.movie") == "activate")
         #expect(interactionKind(forEntityId: "script.open_gate") == "activate")
         #expect(interactionKind(forEntityId: "automation.wakeup") == "toggle")
-        let readOnly = interactionKind(forEntityId: "sensor.temperature")
-        #expect(readOnly == "widgetURL" || readOnly == "refresh")
+        #expect(isMoreInfoRoute(interactionKind(forEntityId: "sensor.temperature")))
+    }
+
+    /// Widgets render entities of every domain, so a domain without a single main action must still
+    /// route somewhere — its more-info dialog in the web view — rather than producing an inert tile.
+    @Test func domainsWithoutMainActionOpenMoreInfo() {
+        for domain in Domain.allCases where domain.mainAction == nil {
+            let kind = interactionKind(forEntityId: "\(domain.rawValue).test")
+            #expect(isMoreInfoRoute(kind), "Domain.\(domain) should open more-info, got \(kind)")
+        }
+    }
+
+    /// Entities from custom integrations have domains this enum doesn't model; they still have a
+    /// more-info dialog, so they get the same route as any other non-actionable entity.
+    @Test func unmodelledDomainEntityOpensMoreInfo() {
+        #expect(isMoreInfoRoute(interactionKind(forEntityId: "some_custom_integration.thing")))
+    }
+
+    /// Non-entity items keyed by a UUID have no entity id to open, so they stay a no-op.
+    @Test func nonEntityItemWithoutDomainDoesNothing() {
+        let folder = MagicItem(id: "9C4E0A2E-0000-0000-0000-000000000000", serverId: "server-1", type: .folder)
+        #expect(interactionKind(for: folder) == "refresh")
+    }
+
+    /// An explicit action override is resolved before the domain, so it applies to entities whose
+    /// domain isn't modelled here too.
+    @Test func actionOverrideWinsOverUnmodelledDomain() {
+        let doNothing = MagicItem(
+            id: "some_custom_integration.thing",
+            serverId: "server-1",
+            type: .entity,
+            action: .nothing
+        )
+        #expect(interactionKind(for: doNothing) == "refresh")
+
+        let runScript = MagicItem(
+            id: "some_custom_integration.thing",
+            serverId: "server-1",
+            type: .entity,
+            action: .runScript("server-1", "script.open_gate")
+        )
+        #expect(interactionKind(for: runScript) == "activate")
     }
 }
 
@@ -447,11 +496,6 @@ struct DomainFeatureSupportTests {
         }
     }
 
-    @Test func commonlyUsedWidgetSupportedMembership() {
-        let expected: Set<Domain> = [.light, .switch, .cover, .fan, .inputBoolean, .humidifier, .valve]
-        #expect(Set(Domain.commonlyUsedWidgetSupported) == expected, "Domain.commonlyUsedWidgetSupported changed")
-    }
-
     @Test func sensorWidgetSupportedMembership() {
         let expected: Set<Domain> = [
             .sensor, .binarySensor, .inputBoolean, .person, .lock, .number, .inputNumber,
@@ -474,7 +518,6 @@ struct DomainFeatureSupportTests {
             ("watchDisplayOnly", Domain.watchDisplayOnly),
             ("watchAddable", Domain.watchAddable),
             ("controlScreenDomains", Domain.controlScreenDomains),
-            ("commonlyUsedWidgetSupported", Domain.commonlyUsedWidgetSupported),
             ("sensorWidgetSupported", Domain.sensorWidgetSupported),
             ("appDatabaseExcluded", Domain.appDatabaseExcluded),
         ]
@@ -490,7 +533,6 @@ struct DomainFeatureSupportTests {
             ("watchSupported", Domain.watchSupported),
             ("watchAddable", Domain.watchAddable),
             ("controlScreenDomains", Domain.controlScreenDomains),
-            ("commonlyUsedWidgetSupported", Domain.commonlyUsedWidgetSupported),
             ("sensorWidgetSupported", Domain.sensorWidgetSupported),
         ]
         for (name, list) in featureLists {

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -353,7 +353,7 @@ struct MagicItemWidgetInteractionTests {
 
     /// Entities from custom integrations have domains this enum doesn't model; they still have a
     /// more-info dialog, so they get the same route as any other non-actionable entity.
-    @Test func unmodelledDomainEntityOpensMoreInfo() {
+    @Test func unmodeledDomainEntityOpensMoreInfo() {
         #expect(isMoreInfoRoute(interactionKind(forEntityId: "some_custom_integration.thing")))
     }
 
@@ -364,8 +364,8 @@ struct MagicItemWidgetInteractionTests {
     }
 
     /// An explicit action override is resolved before the domain, so it applies to entities whose
-    /// domain isn't modelled here too.
-    @Test func actionOverrideWinsOverUnmodelledDomain() {
+    /// domain isn't modeled here too.
+    @Test func actionOverrideWinsOverUnmodeledDomain() {
         let doNothing = MagicItem(
             id: "some_custom_integration.thing",
             serverId: "server-1",


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

The Common Controls widget filtered the usage prediction response down to seven toggleable domains, so a frequently used lock, media player or climate entity was dropped from the widget.

Every entity the prediction returns is now rendered. Domains with a single main action keep their in-widget action; everything else opens the entity's more info dialog in the web view, which is what the custom widget already does.

Entities from custom integrations, whose domain the `Domain` enum doesn't model, used to produce an inert tile. They now open more info as well. Resolving an explicit `ItemAction` override moved ahead of the domain lookup so overrides still win for those items.

`Domain.commonlyUsedWidgetSupported` had no other callers and is removed.

## Screenshots

No layout change, only which entities the widget can show.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

None.
