### PR TITLE
Stop sensor updates from hanging the main thread

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/AudioOutputSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/AudioOutputSensor.swift
@@ -6,6 +6,11 @@ import Intents
 import PromiseKit
 
 final class iOSAudioOutputSensorUpdateSignaler: BaseSensorUpdateSignaler, SensorProviderUpdateSignaler {
+    /// Activating or deactivating an audio session (Assist recording, TTS playback, a camera stream)
+    /// fires several route changes in a row, and each signal costs a full sensor update, so wait for
+    /// the route to settle and send one.
+    private static let routeChangeDebounce: DispatchQueue.SchedulerTimeType.Stride = .milliseconds(500)
+
     private var cancellables: Set<AnyCancellable> = []
     private let signal: () -> Void
 
@@ -20,6 +25,7 @@ final class iOSAudioOutputSensorUpdateSignaler: BaseSensorUpdateSignaler, Sensor
         super.observe()
         guard !isObserving else { return }
         NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)
+            .debounce(for: Self.routeChangeDebounce, scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.signal()
             }

--- a/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorContainer.swift
@@ -197,7 +197,7 @@ public class SensorContainer {
             return sensors
         }
 
-        setLastUpdate(.init(sensors: generatedSensors.map { [lastSentSensors] new in
+        setLastUpdate(.init(sensors: generatedSensors.map { [lastSentSensors, weak self] new in
             // doesn't store the sent values, that happens when the network request ends
             // this is just what's presented to the user, so we always have the latest version
             let ignoringExisting: Bool
@@ -210,12 +210,17 @@ public class SensorContainer {
                 ignoringExisting = false
             }
 
+            // Read once for the whole sort: asking the store per comparison turns one update into
+            // hundreds of app group defaults reads, which is enough to hang the main thread.
+            let enabledUniqueIDs = self?.enablement.enabledUniqueIDs() ?? []
+
             return lastSentSensors.mutate { lastSentSensors -> AnyCollection<WebhookSensor> in
                 lastSentSensors.combine(with: new, ignoringExisting: ignoringExisting)
                 return lastSentSensors.sensors
-            }.sorted(by: { [weak self] lhs, rhs in
-                guard let self else { return true }
-                switch (isEnabled(sensor: lhs), isEnabled(sensor: rhs)) {
+            }.sorted(by: { lhs, rhs in
+                let isLhsEnabled = lhs.UniqueID.map { enabledUniqueIDs.contains($0) } ?? false
+                let isRhsEnabled = rhs.UniqueID.map { enabledUniqueIDs.contains($0) } ?? false
+                switch (isLhsEnabled, isRhsEnabled) {
                 case (true, true): return lhs < rhs
                 case (false, false): return lhs < rhs
                 case (true, false): return true

--- a/Sources/Shared/API/Webhook/Sensors/SensorEnablementStore.swift
+++ b/Sources/Shared/API/Webhook/Sensors/SensorEnablementStore.swift
@@ -49,6 +49,13 @@ public final class SensorEnablementStore {
         return enabledSensorIDs.contains(uniqueID)
     }
 
+    /// The whole selection in a single read, for callers that would otherwise ask about many sensors
+    /// in a row: every `isEnabled(uniqueID:)` re-reads the allowlist out of the app group defaults.
+    public func enabledUniqueIDs() -> Set<String> {
+        prepareIfNeeded()
+        return enabledSensorIDs
+    }
+
     /// - Returns: whether the stored selection actually changed.
     @discardableResult
     public func setEnabled(_ value: Bool, forUniqueID uniqueID: String) -> Bool {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Starting or stopping an audio session caused several main thread hangs of 100ms or more, which drop frames in whatever is on screen. Two causes, fixed here:

- The sensor list sort asked the enablement store per comparison, and each call re-read the allowlist from the app group defaults. It is now read once per update.
- Every audio route change signaled a sensor update, and one session change fires several. The signal is now debounced, the same way the kiosk volume sensor does it.

Profiling the same interaction after these two changes, main thread time in the enablement store went from 618ms (all of it inside the record start and stop windows) to 50ms across a longer session, and the sweep no longer shows up in any hang.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not user facing.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Found while profiling the Assist recording screen, but the hangs affect any audio route change, such as TTS playback or opening a camera stream.
