### PR TITLE
Refresh network information when moving between Wi-Fi networks

### DIFF
--- a/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
+++ b/Sources/Shared/Common/Extensions/Reachability+NetworkType.swift
@@ -97,9 +97,15 @@ public enum NetworkType: Int, CaseIterable {
 
 #if os(iOS)
 public final class NetworkReachability {
+    /// Posted when connectivity actually changed, which `ConnectivityWrapper` decides after refreshing
+    /// network information: the network type changed, or the device moved to a different Wi-Fi network.
     public static let didChangeNotification = Notification.Name("NetworkReachabilityChanged")
 
-    private enum Connection: Equatable {
+    /// Posted for every path update, including the Wi-Fi to Wi-Fi transitions that leave the network
+    /// type unchanged but make the cached SSID stale.
+    public static let pathDidUpdateNotification = Notification.Name("NetworkReachabilityPathDidUpdate")
+
+    private enum Connection {
         case unavailable
         case wifi
         case cellular
@@ -107,16 +113,11 @@ public final class NetworkReachability {
 
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "io.home-assistant.reachability")
-    private var lastConnection: Connection?
 
     public init() {
-        monitor.pathUpdateHandler = { [weak self] path in
-            guard let self else { return }
-            let connection = Self.connection(for: path)
-            guard connection != lastConnection else { return }
-            self.lastConnection = connection
+        monitor.pathUpdateHandler = { _ in
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: NetworkReachability.didChangeNotification, object: nil)
+                NotificationCenter.default.post(name: NetworkReachability.pathDidUpdateNotification, object: nil)
             }
         }
         monitor.start(queue: queue)

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -64,6 +64,9 @@ public class ConnectivityWrapper {
     private let stateLock = NSLock()
     private var cachedNetworkState = NetworkState()
 
+    private let notificationLock = NSLock()
+    private var lastNotifiedNetworkType: NetworkType?
+
     public func updateLastKnownNetworkState(_ state: NetworkState) {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -245,16 +248,38 @@ public class ConnectivityWrapper {
         #if os(iOS) && !targetEnvironment(macCatalyst)
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(connectivityDidChange(_:)),
-            name: NetworkReachability.didChangeNotification,
+            selector: #selector(networkPathDidUpdate(_:)),
+            name: NetworkReachability.pathDidUpdateNotification,
             object: nil
         )
         #endif
     }
 
-    @objc private func connectivityDidChange(_ note: Notification) {
+    @objc private func networkPathDidUpdate(_ note: Notification) {
         Task { [weak self] in
-            await self?.refreshNetworkInformation()
+            await self?.handleNetworkPathUpdate()
         }
+    }
+
+    /// Refreshes network information for a path update and posts the connectivity-changed notification
+    /// when the network type or the Wi-Fi network the device is on actually changed.
+    ///
+    /// Moving straight from one Wi-Fi network to another keeps the network type at `.wifi`, so the path
+    /// update is the only signal that the cached SSID (and with it the internal/external URL decision)
+    /// no longer describes the network the device is on.
+    func handleNetworkPathUpdate() async {
+        let previousState = lastKnownNetworkState()
+        await refreshNetworkInformation()
+        let currentState = lastKnownNetworkState()
+        let networkType = simpleNetworkType()
+
+        notificationLock.lock()
+        let didChange = currentState != previousState || networkType != lastNotifiedNetworkType
+        lastNotifiedNetworkType = networkType
+        notificationLock.unlock()
+
+        guard didChange else { return }
+
+        NotificationCenter.default.post(name: connectivityDidChangeNotification(), object: nil)
     }
 }

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -66,6 +66,9 @@ public class ConnectivityWrapper {
 
     private let notificationLock = NSLock()
     private var lastNotifiedNetworkType: NetworkType?
+    private var lastNotifiedNetworkState: NetworkState?
+
+    private var pathUpdateTask: Task<Void, Never>?
 
     public func updateLastKnownNetworkState(_ state: NetworkState) {
         stateLock.lock()
@@ -256,7 +259,13 @@ public class ConnectivityWrapper {
     }
 
     @objc private func networkPathDidUpdate(_ note: Notification) {
-        Task { [weak self] in
+        // Path updates are posted on the main thread, so chaining onto the previous one here needs no
+        // further synchronization. Chaining keeps a burst of updates during a transition in order: a
+        // fetch can stay suspended for the length of the fetch timeout, and a newer one finishing first
+        // would otherwise be overwritten by an older, staler result.
+        let previousTask = pathUpdateTask
+        pathUpdateTask = Task { [weak self] in
+            await previousTask?.value
             await self?.handleNetworkPathUpdate()
         }
     }
@@ -268,13 +277,16 @@ public class ConnectivityWrapper {
     /// update is the only signal that the cached SSID (and with it the internal/external URL decision)
     /// no longer describes the network the device is on.
     func handleNetworkPathUpdate() async {
-        let previousState = lastKnownNetworkState()
         await refreshNetworkInformation()
-        let currentState = lastKnownNetworkState()
+        let networkState = lastKnownNetworkState()
         let networkType = simpleNetworkType()
 
+        // Compared against what was last notified rather than against the cache as it was before the
+        // refresh: any other caller refreshing in the meantime would otherwise make the two equal and
+        // swallow the notification for a network that did change.
         notificationLock.lock()
-        let didChange = currentState != previousState || networkType != lastNotifiedNetworkType
+        let didChange = networkState != lastNotifiedNetworkState || networkType != lastNotifiedNetworkType
+        lastNotifiedNetworkState = networkState
         lastNotifiedNetworkType = networkType
         notificationLock.unlock()
 

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -280,6 +280,11 @@ public class ConnectivityWrapper {
 
         guard didChange else { return }
 
-        NotificationCenter.default.post(name: connectivityDidChangeNotification(), object: nil)
+        // Observers update SwiftUI state directly in `onReceive`, so the notification has to arrive on
+        // the main thread rather than on whichever thread the refresh finished on.
+        let notificationName = connectivityDidChangeNotification()
+        await MainActor.run {
+            NotificationCenter.default.post(name: notificationName, object: nil)
+        }
     }
 }

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -7,6 +7,7 @@ class ConnectivityWrapperTests: XCTestCase {
     private var previousRefreshNetworkInformation: (() async -> Void)!
     private var previousPerformNetworkStateFetch: (() async -> NetworkState)!
     private var previousNetworkFetchTimeout: TimeInterval!
+    private var previousSimpleNetworkType: (() -> NetworkType)!
 
     override func setUp() {
         super.setUp()
@@ -15,6 +16,7 @@ class ConnectivityWrapperTests: XCTestCase {
         previousRefreshNetworkInformation = Current.connectivity.refreshNetworkInformation
         previousPerformNetworkStateFetch = Current.connectivity.performNetworkStateFetch
         previousNetworkFetchTimeout = Current.connectivity.networkFetchTimeout
+        previousSimpleNetworkType = Current.connectivity.simpleNetworkType
     }
 
     override func tearDown() {
@@ -23,6 +25,7 @@ class ConnectivityWrapperTests: XCTestCase {
         Current.connectivity.refreshNetworkInformation = previousRefreshNetworkInformation
         Current.connectivity.performNetworkStateFetch = previousPerformNetworkStateFetch
         Current.connectivity.networkFetchTimeout = previousNetworkFetchTimeout
+        Current.connectivity.simpleNetworkType = previousSimpleNetworkType
         super.tearDown()
     }
 
@@ -120,6 +123,57 @@ class ConnectivityWrapperTests: XCTestCase {
         // The fetch that lost the race must be dropped entirely, not applied after the fact.
         try await Task.sleep(nanoseconds: 1_000_000_000)
         XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "cached-ssid")
+    }
+
+    func testPathUpdateMovingToAnotherWiFiNetworkPostsConnectivityChange() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "home", bssid: "home-bssid") }
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "hotspot", bssid: "hotspot-bssid") }
+        let expectation = expectation(
+            forNotification: Current.connectivity.connectivityDidChangeNotification(),
+            object: nil
+        )
+
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "hotspot")
+    }
+
+    func testPathUpdateOnTheSameNetworkDoesNotPostConnectivityChange() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "home", bssid: "home-bssid") }
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        let expectation = expectation(
+            forNotification: Current.connectivity.connectivityDidChangeNotification(),
+            object: nil
+        )
+        expectation.isInverted = true
+
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        await fulfillment(of: [expectation], timeout: 0.5)
+    }
+
+    func testPathUpdateChangingNetworkTypePostsConnectivityChange() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "home") }
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        Current.connectivity.simpleNetworkType = { .cellular }
+        Current.connectivity.currentNetworkState = { NetworkState() }
+        let expectation = expectation(
+            forNotification: Current.connectivity.connectivityDidChangeNotification(),
+            object: nil
+        )
+
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNil(Current.connectivity.lastKnownNetworkState().ssid)
     }
 
     func testFetchThatCompletesUpdatesLastKnownState() async {

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -158,6 +158,25 @@ class ConnectivityWrapperTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 0.5)
     }
 
+    func testPathUpdateNotifiesEvenWhenAnotherRefreshCachedTheNewNetworkFirst() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "home") }
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        // Another caller, e.g. a webhook send, refreshed the cache to the new network first.
+        Current.connectivity.currentNetworkState = { NetworkState(ssid: "hotspot") }
+        Current.connectivity.updateLastKnownNetworkState(NetworkState(ssid: "hotspot"))
+
+        let expectation = expectation(
+            forNotification: Current.connectivity.connectivityDidChangeNotification(),
+            object: nil
+        )
+
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
     func testPathUpdateChangingNetworkTypePostsConnectivityChange() async {
         Current.connectivity.simpleNetworkType = { .wifi }
         Current.connectivity.currentNetworkState = { NetworkState(ssid: "home") }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
`NetworkReachability` only notified when the network type changed (unavailable/Wi-Fi/cellular), so moving straight from one Wi-Fi network to another was dropped: the type stayed `.wifi`. Network information was never refreshed, and the cached SSID kept naming the previous network.

That cached SSID decides `isOnInternalNetwork`, so after a Wi-Fi to Wi-Fi transition the app kept using the internal URL on a network where the instance is only reachable externally, and the SSID/BSSID sensors kept reporting the old network.

`NetworkReachability` now posts every path update, and `ConnectivityWrapper` refreshes network information on each one and posts the connectivity-changed notification when the network type or the Wi-Fi network actually changed.

Fixes #4851

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
