### PR TITLE
Remember the Assist window size and position separately from the main window

### DIFF
--- a/Sources/App/Scenes/AssistWindowSceneDelegate.swift
+++ b/Sources/App/Scenes/AssistWindowSceneDelegate.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+/// Scene delegate for the Mac Assist window. Its only job is remembering the window's size and position
+/// across openings: the SwiftUI `WindowGroup` lifecycle does not restore window geometry on its own, so the
+/// scene lifecycle is forwarded to `WindowScenesManager` (which saves the latest frame and re-applies it),
+/// exactly as `QuickActionWindowSceneDelegate` does for the main window.
+///
+/// Because the delegate is attached to a single scene configuration (see `SceneActivity.configuration`), it
+/// is what identifies the window kind to `WindowScenesManager` — the Assist window therefore never shares a
+/// stored frame with the main window, whatever user activity the scene was connected with.
+///
+/// It never creates or owns a `UIWindow` — SwiftUI keeps hosting the scene's content.
+final class AssistWindowSceneDelegate: UIResponder, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        WindowScenesManager.shared.sceneWillConnect(windowScene, activity: .assist)
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        WindowScenesManager.shared.sceneDidBecomeActive(windowScene, activity: .assist)
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        WindowScenesManager.shared.sceneWillResignActive(scene)
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        WindowScenesManager.shared.didDiscardScene(scene)
+    }
+}

--- a/Sources/App/Scenes/QuickActionWindowSceneDelegate.swift
+++ b/Sources/App/Scenes/QuickActionWindowSceneDelegate.swift
@@ -72,7 +72,7 @@ final class QuickActionWindowSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         guard let windowScene = scene as? UIWindowScene else { return }
-        WindowScenesManager.shared.sceneDidBecomeActive(windowScene)
+        WindowScenesManager.shared.sceneDidBecomeActive(windowScene, activity: .webView)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/Sources/App/Scenes/SceneActivity.swift
+++ b/Sources/App/Scenes/SceneActivity.swift
@@ -55,11 +55,30 @@ enum SceneActivity: CaseIterable {
 
     var configuration: UISceneConfiguration {
         switch self {
-        case .webView, .settings, .about, .assist, .onboarding: return .init(
-                name: configurationName,
-                sessionRole: .windowApplication
-            )
+        case .webView, .settings, .about, .assist, .onboarding:
+            let configuration = UISceneConfiguration(name: configurationName, sessionRole: .windowApplication)
+            configuration.delegateClass = sceneDelegateClass
+            return configuration
         case .carPlay: return .init(name: configurationName, sessionRole: .carTemplateApplication)
+        }
+    }
+
+    /// The size a window of this kind opens at before the user has ever placed it. `nil` leaves the window to
+    /// macOS, which opens it at the frontmost window's frame.
+    var defaultMacWindowSize: CGSize? {
+        switch self {
+        case .assist: return .init(width: 400, height: 600)
+        case .webView, .settings, .about, .carPlay, .onboarding: return nil
+        }
+    }
+
+    /// Windows that remember their geometry need a scene delegate to receive the lifecycle callbacks
+    /// `WindowScenesManager` acts on. The main window's delegate is attached in `AppDelegate` instead, since it
+    /// also carries quick-action and browser-launch behaviour.
+    private var sceneDelegateClass: AnyClass? {
+        switch self {
+        case .assist: return AssistWindowSceneDelegate.self
+        case .webView, .settings, .about, .carPlay, .onboarding: return nil
         }
     }
 }

--- a/Sources/App/Scenes/ScenesWindowSizeConfig.swift
+++ b/Sources/App/Scenes/ScenesWindowSizeConfig.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Shared
+import UIKit
+
+/// Stores the last known Mac window frame per window kind, so each window reopens where the user left it.
+enum ScenesWindowSizeConfig {
+    private static let mainSceneKey = "default-scene-latest-system-frame-data"
+
+    static func latestSystemFrame(for activity: SceneActivity) -> CGRect? {
+        guard let savedData = prefs.data(forKey: key(for: activity)) else { return nil }
+        return try? JSONDecoder().decode(CGRect.self, from: savedData)
+    }
+
+    static func setLatestSystemFrame(_ systemFrame: CGRect?, for activity: SceneActivity) {
+        guard let systemFrame else {
+            prefs.removeObject(forKey: key(for: activity))
+            return
+        }
+        guard let newData = try? JSONEncoder().encode(systemFrame) else { return }
+        prefs.set(newData, forKey: key(for: activity))
+    }
+
+    /// The main window shipped before secondary windows had geometry memory, so it keeps the original,
+    /// unsuffixed key and users' saved frame survives the upgrade.
+    static func key(for activity: SceneActivity) -> String {
+        activity == .webView ? mainSceneKey : "\(mainSceneKey)-\(activity.activityIdentifier)"
+    }
+}

--- a/Sources/App/Scenes/WindowScenesManager.swift
+++ b/Sources/App/Scenes/WindowScenesManager.swift
@@ -5,11 +5,27 @@ import UIKit
 final class WindowScenesManager {
     static let shared = WindowScenesManager()
     private(set) var windowSizeObservers: [WindowSizeObserver] = []
+    /// macOS re-activates a window many times during its life. Re-applying the stored frame on every
+    /// activation would fight the user (and drift the window by the cascade inset), so each scene session
+    /// is restored only the first time it becomes active.
+    private var sessionsWithRestoredGeometry: Set<String> = []
 
-    func sceneDidBecomeActive(_ scene: UIWindowScene) {
-        guard scene.userActivity == nil else { return }
-        configureSceneSize(scene)
-        startObservingScene(scene)
+    /// Sizing a window while it is connecting, before it is on screen, avoids the visible jump of resizing one
+    /// the user can already see. The main window is sized on activation instead, since its own delegate may
+    /// still destroy the window while connecting ("Open Home Assistant UI in browser").
+    func sceneWillConnect(_ scene: UIWindowScene, activity: SceneActivity) {
+        guard sessionsWithRestoredGeometry.insert(scene.session.persistentIdentifier).inserted else { return }
+        configureSceneSize(scene, for: activity)
+    }
+
+    /// `activity` comes from the scene delegate that reported the activation, not from the scene itself: each
+    /// window kind has its own delegate, so the window a frame belongs to is never guessed from the user
+    /// activity or configuration name the scene happened to connect with.
+    func sceneDidBecomeActive(_ scene: UIWindowScene, activity: SceneActivity) {
+        if sessionsWithRestoredGeometry.insert(scene.session.persistentIdentifier).inserted {
+            configureSceneSize(scene, for: activity)
+        }
+        startObservingScene(scene, activity: activity)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -17,11 +33,13 @@ final class WindowScenesManager {
     }
 
     func didDiscardScene(_ scene: UIScene) {
+        sessionsWithRestoredGeometry.remove(scene.session.persistentIdentifier)
         stopObservingScene(scene)
     }
 
-    private func startObservingScene(_ scene: UIWindowScene) {
-        let observer = WindowSizeObserver(windowScene: scene)
+    private func startObservingScene(_ scene: UIWindowScene, activity: SceneActivity) {
+        guard !windowSizeObservers.contains(where: { $0.observedScene == scene }) else { return }
+        let observer = WindowSizeObserver(windowScene: scene, activity: activity)
         windowSizeObservers.append(observer)
     }
 
@@ -62,26 +80,54 @@ final class WindowScenesManager {
         return adjustedFrame
     }
 
-    private func configureSceneSize(_ scene: UIWindowScene) {
-        // Check is scene has a restoring state before proceeding
-        guard #available(macCatalyst 16.0, *),
-              let preferredSystemFrame = ScenesWindowSizeConfig.defaultSceneLatestSystemFrame,
-              preferredSystemFrame != .zero else { return }
+    private func configureSceneSize(_ scene: UIWindowScene, for activity: SceneActivity) {
+        guard #available(macCatalyst 16.0, *) else { return }
 
         let screenSize = scene.screen.bounds.size
-        guard sceneFrameIsValid(preferredSystemFrame, screenSize: screenSize) else { return }
-
-        let numberOfConnectedScenes = UIApplication.shared.connectedScenes.count
-        let adjustedSystemFrame = adjustedSystemFrame(
-            preferredSystemFrame,
-            for: screenSize,
-            numberOfConnectedScenes: numberOfConnectedScenes
-        )
+        guard let systemFrame = systemFrame(for: activity, screenSize: screenSize) else { return }
 
         #if targetEnvironment(macCatalyst)
-        scene.requestGeometryUpdate(.Mac(systemFrame: adjustedSystemFrame)) { error in
+        Current.Log.info("Sizing \(activity.configurationName) window to \(systemFrame)")
+        scene.requestGeometryUpdate(.Mac(systemFrame: systemFrame)) { error in
             Current.Log.info(userInfo: ["Failed to request mac geometry": error.localizedDescription])
         }
         #endif
+    }
+
+    /// The frame a window should open at: the one the user last left it at, or the window kind's own default
+    /// when it has never been placed. Without a default, macOS opens a new window at the frame of the window
+    /// that was already frontmost, which is why the Assist window used to inherit the main window's geometry.
+    func systemFrame(for activity: SceneActivity, screenSize: CGSize) -> CGRect? {
+        if let savedSystemFrame = ScenesWindowSizeConfig.latestSystemFrame(for: activity),
+           savedSystemFrame != .zero,
+           sceneFrameIsValid(savedSystemFrame, screenSize: screenSize) {
+            return restoredSystemFrame(savedSystemFrame, for: activity, screenSize: screenSize)
+        }
+        guard let defaultSize = activity.defaultMacWindowSize else { return nil }
+        return centeredFrame(for: defaultSize, screenSize: screenSize)
+    }
+
+    /// Only the main window can have several instances open at once, so it is the only one that cascades.
+    /// A single-instance window (Assist) reopens exactly where the user left it.
+    private func restoredSystemFrame(
+        _ preferredSystemFrame: CGRect,
+        for activity: SceneActivity,
+        screenSize: CGSize
+    ) -> CGRect {
+        guard activity == .webView else { return preferredSystemFrame }
+        return adjustedSystemFrame(
+            preferredSystemFrame,
+            for: screenSize,
+            numberOfConnectedScenes: UIApplication.shared.connectedScenes.count
+        )
+    }
+
+    private func centeredFrame(for size: CGSize, screenSize: CGSize) -> CGRect {
+        .init(
+            x: (screenSize.width - size.width) / 2,
+            y: (screenSize.height - size.height) / 2,
+            width: size.width,
+            height: size.height
+        )
     }
 }

--- a/Sources/App/Scenes/WindowScenesManager.swift
+++ b/Sources/App/Scenes/WindowScenesManager.swift
@@ -107,7 +107,8 @@ final class WindowScenesManager {
         return centeredFrame(for: defaultSize, screenSize: screenSize)
     }
 
-    /// Only the main window can have several instances open at once, so it is the only one that cascades.
+    /// Only the main window can have several instances open at once, so it is the only one that cascades, and
+    /// only its own windows count towards the inset: an open Assist window must not push the main window.
     /// A single-instance window (Assist) reopens exactly where the user left it.
     private func restoredSystemFrame(
         _ preferredSystemFrame: CGRect,
@@ -118,8 +119,14 @@ final class WindowScenesManager {
         return adjustedSystemFrame(
             preferredSystemFrame,
             for: screenSize,
-            numberOfConnectedScenes: UIApplication.shared.connectedScenes.count
+            numberOfConnectedScenes: numberOfConnectedScenes(for: activity)
         )
+    }
+
+    private func numberOfConnectedScenes(for activity: SceneActivity) -> Int {
+        UIApplication.shared.connectedScenes.filter { scene in
+            scene.session.configuration.name.flatMap(SceneActivity.init(configurationName:)) == activity
+        }.count
     }
 
     private func centeredFrame(for size: CGSize, screenSize: CGSize) -> CGRect {

--- a/Sources/App/Scenes/WindowSizeObserver.swift
+++ b/Sources/App/Scenes/WindowSizeObserver.swift
@@ -4,10 +4,12 @@ import UIKit
 
 final class WindowSizeObserver: NSObject {
     @objc private(set) var observedScene: UIWindowScene?
+    let activity: SceneActivity
     private var observation: NSKeyValueObservation?
 
-    init(windowScene: UIWindowScene) {
+    init(windowScene: UIWindowScene, activity: SceneActivity) {
         self.observedScene = windowScene
+        self.activity = activity
         super.init()
 
         guard Current.isCatalyst else { return }
@@ -17,10 +19,10 @@ final class WindowSizeObserver: NSObject {
     private func startObserving() {
         #if targetEnvironment(macCatalyst)
         guard #available(macCatalyst 16.0, *) else { return }
-        observation = observe(\.observedScene?.effectiveGeometry, options: [.new]) { _, change in
+        observation = observe(\.observedScene?.effectiveGeometry, options: [.new]) { [activity] _, change in
             guard let newSystemFrame = change.newValue??.systemFrame,
                   newSystemFrame.size != .zero, newSystemFrame.origin != .zero else { return }
-            ScenesWindowSizeConfig.defaultSceneLatestSystemFrame = newSystemFrame
+            ScenesWindowSizeConfig.setLatestSystemFrame(newSystemFrame, for: activity)
         }
         #endif
     }
@@ -28,33 +30,5 @@ final class WindowSizeObserver: NSObject {
     public func stopObserving() {
         observation?.invalidate()
         observation = nil
-    }
-}
-
-enum ScenesWindowSizeConfig {
-    private static let defaultSceneLatestSystemFrameDataKey = "default-scene-latest-system-frame-data"
-    private static var defaultSceneLatestSystemFrameData: Data? {
-        get {
-            prefs.data(forKey: ScenesWindowSizeConfig.defaultSceneLatestSystemFrameDataKey)
-        }
-        set {
-            prefs.set(newValue, forKey: ScenesWindowSizeConfig.defaultSceneLatestSystemFrameDataKey)
-        }
-    }
-
-    static var defaultSceneLatestSystemFrame: CGRect? {
-        get {
-            guard let savedData = defaultSceneLatestSystemFrameData else { return nil }
-            return try? JSONDecoder().decode(CGRect.self, from: savedData)
-        }
-        set {
-            if let newValue {
-                if let newData = try? JSONEncoder().encode(newValue) {
-                    defaultSceneLatestSystemFrameData = newData
-                }
-            } else {
-                defaultSceneLatestSystemFrameData = nil
-            }
-        }
     }
 }

--- a/Tests/App/Scenes/ScenesWindowSizeConfig.test.swift
+++ b/Tests/App/Scenes/ScenesWindowSizeConfig.test.swift
@@ -1,0 +1,61 @@
+@testable import HomeAssistant
+import XCTest
+
+final class ScenesWindowSizeConfigTests: XCTestCase {
+    private var savedFrames: [SceneActivity: Data?] = [:]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        for activity in SceneActivity.allCases {
+            savedFrames[activity] = prefs.data(forKey: ScenesWindowSizeConfig.key(for: activity))
+            prefs.removeObject(forKey: ScenesWindowSizeConfig.key(for: activity))
+        }
+    }
+
+    override func tearDownWithError() throws {
+        for (activity, data) in savedFrames {
+            if let data {
+                prefs.set(data, forKey: ScenesWindowSizeConfig.key(for: activity))
+            } else {
+                prefs.removeObject(forKey: ScenesWindowSizeConfig.key(for: activity))
+            }
+        }
+        savedFrames = [:]
+        try super.tearDownWithError()
+    }
+
+    func testMainWindowKeepsLegacyKeyForBackwardCompatibility() {
+        XCTAssertEqual(ScenesWindowSizeConfig.key(for: .webView), "default-scene-latest-system-frame-data")
+    }
+
+    func testSecondaryWindowsUseDistinctKeys() {
+        XCTAssertNotEqual(
+            ScenesWindowSizeConfig.key(for: .assist),
+            ScenesWindowSizeConfig.key(for: .webView)
+        )
+    }
+
+    func testFrameRoundTripsPerActivity() {
+        let mainFrame = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let assistFrame = CGRect(x: 300, y: 400, width: 420, height: 500)
+
+        ScenesWindowSizeConfig.setLatestSystemFrame(mainFrame, for: .webView)
+        ScenesWindowSizeConfig.setLatestSystemFrame(assistFrame, for: .assist)
+
+        XCTAssertEqual(ScenesWindowSizeConfig.latestSystemFrame(for: .webView), mainFrame)
+        XCTAssertEqual(ScenesWindowSizeConfig.latestSystemFrame(for: .assist), assistFrame)
+    }
+
+    func testSettingFrameForOneActivityDoesNotAffectAnother() {
+        ScenesWindowSizeConfig.setLatestSystemFrame(.init(x: 1, y: 2, width: 3, height: 4), for: .assist)
+
+        XCTAssertNil(ScenesWindowSizeConfig.latestSystemFrame(for: .webView))
+    }
+
+    func testNilFrameRemovesStoredValue() {
+        ScenesWindowSizeConfig.setLatestSystemFrame(.init(x: 1, y: 2, width: 3, height: 4), for: .assist)
+        ScenesWindowSizeConfig.setLatestSystemFrame(nil, for: .assist)
+
+        XCTAssertNil(ScenesWindowSizeConfig.latestSystemFrame(for: .assist))
+    }
+}

--- a/Tests/App/Scenes/WindowScenesManager.test.swift
+++ b/Tests/App/Scenes/WindowScenesManager.test.swift
@@ -3,23 +3,58 @@ import XCTest
 
 final class WindowScenesManagerTests: XCTestCase {
     private var sut: WindowScenesManager!
+    private var savedFrames: [SceneActivity: Data?] = [:]
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         sut = WindowScenesManager()
+        for activity in SceneActivity.allCases {
+            savedFrames[activity] = prefs.data(forKey: ScenesWindowSizeConfig.key(for: activity))
+            prefs.removeObject(forKey: ScenesWindowSizeConfig.key(for: activity))
+        }
     }
 
     override func tearDownWithError() throws {
+        for (activity, data) in savedFrames {
+            if let data {
+                prefs.set(data, forKey: ScenesWindowSizeConfig.key(for: activity))
+            } else {
+                prefs.removeObject(forKey: ScenesWindowSizeConfig.key(for: activity))
+            }
+        }
+        savedFrames = [:]
         try super.tearDownWithError()
         sut = nil
     }
 
     func testSceneDidBecomeActiveStartObservingScene() {
         guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        firstScene.userActivity = nil
-        sut.sceneDidBecomeActive(firstScene)
+        sut.sceneDidBecomeActive(firstScene, activity: .webView)
 
         XCTAssertEqual(sut.windowSizeObservers.count, 1)
+    }
+
+    func testSceneDidBecomeActiveObservesSceneActivatedByUserActivity() {
+        guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        firstScene.userActivity = NSUserActivity(activityType: "test")
+        sut.sceneDidBecomeActive(firstScene, activity: .webView)
+
+        XCTAssertEqual(sut.windowSizeObservers.count, 1)
+    }
+
+    func testSceneDidBecomeActiveTwiceDoesNotDuplicateObserver() {
+        guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        sut.sceneDidBecomeActive(firstScene, activity: .webView)
+        sut.sceneDidBecomeActive(firstScene, activity: .webView)
+
+        XCTAssertEqual(sut.windowSizeObservers.count, 1)
+    }
+
+    func testSceneDidBecomeActiveObserverKeepsActivityOfItsWindow() {
+        guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        sut.sceneDidBecomeActive(firstScene, activity: .assist)
+
+        XCTAssertEqual(sut.windowSizeObservers.first?.activity, .assist)
     }
 
     func testDidDiscardSceneRemoveObserver() {
@@ -41,11 +76,31 @@ final class WindowScenesManagerTests: XCTestCase {
         XCTAssertEqual(result, .init(x: 20, y: 80, width: 0, height: 0))
     }
 
-    func testSceneDidBecomeActiveNotConfigureScenesRestored() {
-        guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-        firstScene.userActivity = NSUserActivity(activityType: "test")
-        sut.sceneDidBecomeActive(firstScene)
+    func testSystemFrameCentersDefaultSizeWhenAssistWindowWasNeverPlaced() {
+        let result = sut.systemFrame(for: .assist, screenSize: .init(width: 1000, height: 1000))
 
-        XCTAssertEqual(sut.windowSizeObservers.count, 0)
+        XCTAssertEqual(result, .init(x: 300, y: 200, width: 400, height: 600))
+    }
+
+    func testSystemFrameIsNilWhenMainWindowWasNeverPlaced() {
+        let result = sut.systemFrame(for: .webView, screenSize: .init(width: 1000, height: 1000))
+
+        XCTAssertNil(result)
+    }
+
+    func testSystemFrameUsesSavedFramePerActivity() {
+        let assistFrame = CGRect(x: 12, y: 34, width: 300, height: 400)
+        ScenesWindowSizeConfig.setLatestSystemFrame(assistFrame, for: .assist)
+
+        XCTAssertEqual(sut.systemFrame(for: .assist, screenSize: .init(width: 1000, height: 1000)), assistFrame)
+        XCTAssertNil(sut.systemFrame(for: .webView, screenSize: .init(width: 1000, height: 1000)))
+    }
+
+    func testSystemFrameFallsBackToDefaultWhenSavedFrameIsBiggerThanScreen() {
+        ScenesWindowSizeConfig.setLatestSystemFrame(.init(x: 0, y: 0, width: 5000, height: 5000), for: .assist)
+
+        let result = sut.systemFrame(for: .assist, screenSize: .init(width: 1000, height: 1000))
+
+        XCTAssertEqual(result, .init(x: 300, y: 200, width: 400, height: 600))
     }
 }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
On Mac, the Assist window shared its remembered size and position with the main window, so both windows kept opening at each other's frame.

Window frames are now stored per window, and the Assist window opens centered at 400x600 the first time, as it did before the SwiftUI migration.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
