### PR TITLE
Fix main thread hang when opening Assist settings

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1178,6 +1178,8 @@
 				AssistViewModel.swift,
 				Audio/AudioRecorder.swift,
 				"Audio/CMSampleBuffer+AudioSamples.swift",
+				Local/OnDeviceVoice.swift,
+				Local/OnDeviceVoiceCatalog.swift,
 				Local/SpeechSynthesizer.swift,
 				Local/SpeechTranscriber.swift,
 				Local/TTSVoicePickerView.swift,

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1182,6 +1182,7 @@
 				Local/OnDeviceVoiceCatalog.swift,
 				Local/SpeechSynthesizer.swift,
 				Local/SpeechTranscriber.swift,
+				Local/SupportedSpeechLocales.swift,
 				Local/TTSVoicePickerView.swift,
 				MacWindow/AssistWindowView.swift,
 				Views/AssistVoiceOrbView.swift,

--- a/Sources/App/Assist/AssistSettingsView.swift
+++ b/Sources/App/Assist/AssistSettingsView.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import SFSafeSymbols
 import Shared
@@ -10,33 +9,17 @@ struct AssistSettingsView: View {
     @StateObject private var viewModel = AssistSettingsViewModel()
     @Environment(\.dismiss) private var dismiss
 
-    private var supportedSTTLocales: [Locale] {
-        if #available(iOS 17.0, *) {
-            return SpeechTranscriber.supportedLocales
-        } else {
-            return []
-        }
-    }
-
     private var onDeviceSTTLocaleBinding: Binding<String> {
         Binding(
             get: {
                 viewModel.configuration.onDeviceSTTLocaleIdentifier
-                    ?? supportedSTTLocales.first?.identifier
+                    ?? viewModel.supportedSTTLocales.first?.identifier
                     ?? Locale.current.identifier
             },
             set: { newValue in
                 viewModel.configuration.onDeviceSTTLocaleIdentifier = newValue
             }
         )
-    }
-
-    private var selectedVoiceDisplayName: String {
-        guard let id = viewModel.configuration.onDeviceTTSVoiceIdentifier,
-              let voice = AVSpeechSynthesisVoice(identifier: id) else {
-            return L10n.Assist.Settings.OnDeviceTts.defaultVoice
-        }
-        return voice.name
     }
 
     private func localeDisplayName(_ locale: Locale) -> String {
@@ -50,13 +33,14 @@ struct AssistSettingsView: View {
                 muteToggle
                 labs
             }
-            .onChange(of: viewModel.configuration.enableOnDeviceSTT) { isEnabled in
-                guard isEnabled, !supportedSTTLocales.isEmpty else { return }
-                let supportedIdentifiers = Set(supportedSTTLocales.map(\.identifier))
-                let currentIdentifier = viewModel.configuration.onDeviceSTTLocaleIdentifier
-                if currentIdentifier == nil || !supportedIdentifiers.contains(currentIdentifier ?? "") {
-                    viewModel.configuration.onDeviceSTTLocaleIdentifier = supportedSTTLocales.first?.identifier
-                }
+            .task {
+                await viewModel.loadSupportedSTTLocales()
+            }
+            .task(id: viewModel.configuration.onDeviceTTSVoiceIdentifier) {
+                await viewModel.loadSelectedVoiceDisplayName()
+            }
+            .onChange(of: viewModel.configuration.enableOnDeviceSTT) { _ in
+                viewModel.selectDefaultSTTLocaleIfNeeded()
             }
             .navigationTitle(L10n.Assist.Settings.title)
             .navigationBarTitleDisplayMode(.inline)
@@ -103,9 +87,9 @@ struct AssistSettingsView: View {
                     toggleLabel(symbol: .micFill, text: L10n.Assist.Settings.OnDeviceStt.title)
                 }
 
-                if viewModel.configuration.enableOnDeviceSTT, !supportedSTTLocales.isEmpty {
+                if viewModel.configuration.enableOnDeviceSTT, !viewModel.supportedSTTLocales.isEmpty {
                     Picker(L10n.Assist.Settings.OnDeviceStt.language, selection: onDeviceSTTLocaleBinding) {
-                        ForEach(supportedSTTLocales, id: \.identifier) { locale in
+                        ForEach(viewModel.supportedSTTLocales, id: \.identifier) { locale in
                             Text(localeDisplayName(locale).capitalizedFirst)
                                 .tag(locale.identifier)
                         }
@@ -123,7 +107,7 @@ struct AssistSettingsView: View {
                         HStack {
                             Text(L10n.Assist.Settings.OnDeviceTts.voice)
                             Spacer()
-                            Text(selectedVoiceDisplayName)
+                            Text(viewModel.selectedVoiceDisplayName)
                                 .foregroundStyle(.secondary)
                         }
                     }

--- a/Sources/App/Assist/AssistSettingsViewModel.swift
+++ b/Sources/App/Assist/AssistSettingsViewModel.swift
@@ -29,8 +29,9 @@ final class AssistSettingsViewModel: ObservableObject {
     /// Probing the on-device speech locales blocks its caller for close to a second, so the list is
     /// filled in asynchronously instead of being read while the settings view builds.
     func loadSupportedSTTLocales() async {
+        // On-device transcription is an iOS 17 feature, so older versions never show the list.
         guard #available(iOS 17.0, *) else { return }
-        supportedSTTLocales = await SpeechTranscriber.supportedLocales()
+        supportedSTTLocales = await SupportedSpeechLocales.shared.locales()
         selectDefaultSTTLocaleIfNeeded()
     }
 

--- a/Sources/App/Assist/AssistSettingsViewModel.swift
+++ b/Sources/App/Assist/AssistSettingsViewModel.swift
@@ -2,8 +2,16 @@ import Combine
 import Foundation
 import Shared
 
+@MainActor
 final class AssistSettingsViewModel: ObservableObject {
     @Published var configuration: AssistConfiguration
+
+    /// Locales that support on-device speech recognition. Empty until `loadSupportedSTTLocales()`
+    /// finishes, and on OS versions without on-device transcription.
+    @Published private(set) var supportedSTTLocales: [Locale] = []
+
+    /// Name of the selected text-to-speech voice, falling back to the default-voice label.
+    @Published private(set) var selectedVoiceDisplayName = L10n.Assist.Settings.OnDeviceTts.defaultVoice
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -16,5 +24,33 @@ final class AssistSettingsViewModel: ObservableObject {
                 config.save()
             }
             .store(in: &cancellables)
+    }
+
+    /// Probing the on-device speech locales blocks its caller for close to a second, so the list is
+    /// filled in asynchronously instead of being read while the settings view builds.
+    func loadSupportedSTTLocales() async {
+        guard #available(iOS 17.0, *) else { return }
+        supportedSTTLocales = await SpeechTranscriber.supportedLocales()
+        selectDefaultSTTLocaleIfNeeded()
+    }
+
+    /// Resolving a voice identifier goes through the TextToSpeech daemon, which is too slow for a
+    /// view body; the view awaits this whenever the selected identifier changes.
+    func loadSelectedVoiceDisplayName() async {
+        guard let identifier = configuration.onDeviceTTSVoiceIdentifier else {
+            selectedVoiceDisplayName = L10n.Assist.Settings.OnDeviceTts.defaultVoice
+            return
+        }
+        let voice = await OnDeviceVoiceCatalog.voice(withIdentifier: identifier)
+        selectedVoiceDisplayName = voice?.name ?? L10n.Assist.Settings.OnDeviceTts.defaultVoice
+    }
+
+    /// Falls back to a supported locale when on-device transcription is enabled but the stored
+    /// locale is unset or not supported. Does nothing until the supported locales are known.
+    func selectDefaultSTTLocaleIfNeeded() {
+        guard configuration.enableOnDeviceSTT, !supportedSTTLocales.isEmpty else { return }
+        let supportedIdentifiers = Set(supportedSTTLocales.map(\.identifier))
+        guard !supportedIdentifiers.contains(configuration.onDeviceSTTLocaleIdentifier ?? "") else { return }
+        configuration.onDeviceSTTLocaleIdentifier = supportedSTTLocales.first?.identifier
     }
 }

--- a/Sources/App/Assist/Local/OnDeviceVoice.swift
+++ b/Sources/App/Assist/Local/OnDeviceVoice.swift
@@ -1,0 +1,24 @@
+import AVFoundation
+import Foundation
+
+/// An installed text-to-speech voice, reduced to the values the UI needs.
+///
+/// `AVSpeechSynthesisVoice` is a reference type backed by the TextToSpeech daemon, so voice lists
+/// are converted into these values off the main thread by `OnDeviceVoiceCatalog` and the UI never
+/// touches the framework objects while it builds a view.
+struct OnDeviceVoice: Identifiable, Hashable, Sendable {
+    let identifier: String
+    let name: String
+    /// BCP 47 language tag of the voice, e.g. `en-US`.
+    let language: String
+    let quality: AVSpeechSynthesisVoiceQuality
+
+    var id: String { identifier }
+
+    init(_ voice: AVSpeechSynthesisVoice) {
+        self.identifier = voice.identifier
+        self.name = voice.name
+        self.language = voice.language
+        self.quality = voice.quality
+    }
+}

--- a/Sources/App/Assist/Local/OnDeviceVoiceCatalog.swift
+++ b/Sources/App/Assist/Local/OnDeviceVoiceCatalog.swift
@@ -1,0 +1,24 @@
+import AVFoundation
+import Foundation
+
+/// Reads the installed text-to-speech voices off the main thread.
+///
+/// `AVSpeechSynthesisVoice.speechVoices()` and `AVSpeechSynthesisVoice(identifier:)` wait on the
+/// TextToSpeech daemon and can block their caller for over a hundred milliseconds — enough to hang
+/// the run loop when a view body resolves the selected voice — so every lookup goes through here.
+enum OnDeviceVoiceCatalog {
+    /// Every installed voice, sorted by name.
+    static func voices() async -> [OnDeviceVoice] {
+        await Task.detached(priority: .userInitiated) {
+            AVSpeechSynthesisVoice.speechVoices()
+                .map(OnDeviceVoice.init)
+                .sorted { $0.name < $1.name }
+        }.value
+    }
+
+    /// The installed voice with the given identifier, or `nil` when it is no longer installed.
+    static func voice(withIdentifier identifier: String) async -> OnDeviceVoice? {
+        let allVoices = await voices()
+        return allVoices.first { $0.identifier == identifier }
+    }
+}

--- a/Sources/App/Assist/Local/OnDeviceVoiceCatalog.swift
+++ b/Sources/App/Assist/Local/OnDeviceVoiceCatalog.swift
@@ -18,7 +18,8 @@ enum OnDeviceVoiceCatalog {
 
     /// The installed voice with the given identifier, or `nil` when it is no longer installed.
     static func voice(withIdentifier identifier: String) async -> OnDeviceVoice? {
-        let allVoices = await voices()
-        return allVoices.first { $0.identifier == identifier }
+        await Task.detached(priority: .userInitiated) {
+            AVSpeechSynthesisVoice(identifier: identifier).map(OnDeviceVoice.init)
+        }.value
     }
 }

--- a/Sources/App/Assist/Local/SpeechTranscriber.swift
+++ b/Sources/App/Assist/Local/SpeechTranscriber.swift
@@ -105,12 +105,6 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
     private let finalGracePeriod: TimeInterval = 0.5
     private var didReportFinalTranscript = false
 
-    /// Result of the last `supportedLocales()` probe, kept for the lifetime of the process.
-    private static var cachedSupportedLocales: [Locale]?
-    /// The probe currently running, so concurrent callers share one pass instead of each
-    /// paying for their own.
-    private static var supportedLocalesProbe: Task<[Locale], Never>?
-
     // kAFAssistantErrorDomain error codes that indicate a normal session cancellation
     // (internal Apple speech service domain, not publicly declared in the SDK)
     private let kAFAssistantErrorDomain = "kAFAssistantErrorDomain"
@@ -303,36 +297,6 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
         if wasListening {
             onListeningStateChange?(false)
         }
-    }
-
-    /// The locales that support on-device speech recognition.
-    ///
-    /// Working this out instantiates one `SFSpeechRecognizer` per locale the system knows about,
-    /// and every `supportsOnDeviceRecognition` read is a synchronous XPC round trip to the speech
-    /// daemon — close to a second in total on a phone in Low Power Mode. The probe therefore runs
-    /// off the main thread and its result is cached for the lifetime of the process, so a
-    /// dictation language installed while the app runs only shows up after a relaunch. Never build
-    /// this list from a view body or any other main-thread path.
-    public static func supportedLocales() async -> [Locale] {
-        if let cached = cachedSupportedLocales {
-            return cached
-        }
-        if let runningProbe = supportedLocalesProbe {
-            return await runningProbe.value
-        }
-
-        let probe = Task.detached(priority: .userInitiated) { Self.probeSupportedLocales() }
-        supportedLocalesProbe = probe
-        let locales = await probe.value
-        cachedSupportedLocales = locales
-        supportedLocalesProbe = nil
-        return locales
-    }
-
-    private nonisolated static func probeSupportedLocales() -> [Locale] {
-        SFSpeechRecognizer.supportedLocales()
-            .filter { SFSpeechRecognizer(locale: $0)?.supportsOnDeviceRecognition == true }
-            .sorted { $0.identifier < $1.identifier }
     }
 
     // MARK: - Private Methods

--- a/Sources/App/Assist/Local/SpeechTranscriber.swift
+++ b/Sources/App/Assist/Local/SpeechTranscriber.swift
@@ -105,6 +105,12 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
     private let finalGracePeriod: TimeInterval = 0.5
     private var didReportFinalTranscript = false
 
+    /// Result of the last `supportedLocales()` probe, kept for the lifetime of the process.
+    private static var cachedSupportedLocales: [Locale]?
+    /// The probe currently running, so concurrent callers share one pass instead of each
+    /// paying for their own.
+    private static var supportedLocalesProbe: Task<[Locale], Never>?
+
     // kAFAssistantErrorDomain error codes that indicate a normal session cancellation
     // (internal Apple speech service domain, not publicly declared in the SDK)
     private let kAFAssistantErrorDomain = "kAFAssistantErrorDomain"
@@ -299,10 +305,31 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
         }
     }
 
-    /// Get list of locales that support on-device speech recognition.
-    /// Nonisolated so non-main-actor callers (e.g. CarPlay settings) can read it; the
-    /// underlying Speech framework APIs are not main-actor-bound.
-    public nonisolated static var supportedLocales: [Locale] {
+    /// The locales that support on-device speech recognition.
+    ///
+    /// Working this out instantiates one `SFSpeechRecognizer` per locale the system knows about,
+    /// and every `supportsOnDeviceRecognition` read is a synchronous XPC round trip to the speech
+    /// daemon — close to a second in total on a phone in Low Power Mode. The probe therefore runs
+    /// off the main thread and its result is cached for the lifetime of the process, so a
+    /// dictation language installed while the app runs only shows up after a relaunch. Never build
+    /// this list from a view body or any other main-thread path.
+    public static func supportedLocales() async -> [Locale] {
+        if let cached = cachedSupportedLocales {
+            return cached
+        }
+        if let runningProbe = supportedLocalesProbe {
+            return await runningProbe.value
+        }
+
+        let probe = Task.detached(priority: .userInitiated) { Self.probeSupportedLocales() }
+        supportedLocalesProbe = probe
+        let locales = await probe.value
+        cachedSupportedLocales = locales
+        supportedLocalesProbe = nil
+        return locales
+    }
+
+    private nonisolated static func probeSupportedLocales() -> [Locale] {
         SFSpeechRecognizer.supportedLocales()
             .filter { SFSpeechRecognizer(locale: $0)?.supportsOnDeviceRecognition == true }
             .sorted { $0.identifier < $1.identifier }

--- a/Sources/App/Assist/Local/SupportedSpeechLocales.swift
+++ b/Sources/App/Assist/Local/SupportedSpeechLocales.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Speech
+
+/// The locales that support on-device speech recognition.
+///
+/// Working them out instantiates one `SFSpeechRecognizer` per locale the system knows about, and
+/// every `supportsOnDeviceRecognition` read is a synchronous XPC round trip to the speech daemon —
+/// close to a second in total on a phone in Low Power Mode. The actor serializes callers so the
+/// probe runs at most once per process and always off the main thread, which means a dictation
+/// language installed while the app runs only shows up after a relaunch. Never build this list
+/// from a view body or any other main-thread path.
+actor SupportedSpeechLocales {
+    static let shared = SupportedSpeechLocales()
+
+    private var cachedLocales: [Locale]?
+    private var runningProbe: Task<[Locale], Never>?
+
+    func locales() async -> [Locale] {
+        if let cached = cachedLocales {
+            return cached
+        }
+        if let probe = runningProbe {
+            return await probe.value
+        }
+
+        let probe = Task.detached(priority: .userInitiated) { Self.probeSupportedLocales() }
+        runningProbe = probe
+        let locales = await probe.value
+        cachedLocales = locales
+        runningProbe = nil
+        return locales
+    }
+
+    private static func probeSupportedLocales() -> [Locale] {
+        SFSpeechRecognizer.supportedLocales()
+            .filter { SFSpeechRecognizer(locale: $0)?.supportsOnDeviceRecognition == true }
+            .sorted { $0.identifier < $1.identifier }
+    }
+}

--- a/Sources/App/Assist/Local/TTSVoicePickerView.swift
+++ b/Sources/App/Assist/Local/TTSVoicePickerView.swift
@@ -7,27 +7,28 @@ struct TTSVoicePickerView: View {
     @Binding var selectedVoiceIdentifier: String?
     @Environment(\.dismiss) private var dismiss
     @State private var searchTerm = ""
-    @State private var voiceGroups: [VoiceGroup]
+    /// `nil` while the voice catalog is still loading.
+    @State private var voiceGroups: [VoiceGroup]?
 
     private struct VoiceGroup: Identifiable {
         let language: String
         let displayName: String
-        let voices: [AVSpeechSynthesisVoice]
+        let voices: [OnDeviceVoice]
         var id: String { language }
     }
 
     init(selectedVoiceIdentifier: Binding<String?>) {
         self._selectedVoiceIdentifier = selectedVoiceIdentifier
-        self._voiceGroups = State(initialValue: Self.makeVoiceGroups())
     }
 
     private var filteredVoiceGroups: [VoiceGroup] {
+        let groups = voiceGroups ?? []
         let trimmedSearchTerm = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSearchTerm.isEmpty else {
-            return voiceGroups
+            return groups
         }
 
-        return voiceGroups.compactMap { group in
+        return groups.compactMap { group in
             if group.displayName.localizedCaseInsensitiveContains(trimmedSearchTerm) {
                 return group
             }
@@ -70,7 +71,7 @@ struct TTSVoicePickerView: View {
 
             ForEach(filteredVoiceGroups) { group in
                 Section(group.displayName.capitalizedFirst) {
-                    ForEach(group.voices, id: \.identifier) { voice in
+                    ForEach(group.voices) { voice in
                         Button {
                             selectedVoiceIdentifier = voice.identifier
                             dismiss()
@@ -96,12 +97,21 @@ struct TTSVoicePickerView: View {
                 }
             }
         }
+        .overlay {
+            if voiceGroups == nil {
+                ProgressView()
+            }
+        }
         .searchable(text: $searchTerm)
         .navigationTitle(L10n.Assist.Settings.OnDeviceTts.voice)
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            guard voiceGroups == nil else { return }
+            voiceGroups = await Self.makeVoiceGroups()
+        }
     }
 
-    private func qualityLabel(for voice: AVSpeechSynthesisVoice) -> String? {
+    private func qualityLabel(for voice: OnDeviceVoice) -> String? {
         switch voice.quality {
         case .enhanced: return L10n.Assist.Settings.OnDeviceTts.Quality.enhanced
         case .premium: return L10n.Assist.Settings.OnDeviceTts.Quality.premium
@@ -109,8 +119,11 @@ struct TTSVoicePickerView: View {
         }
     }
 
-    private static func makeVoiceGroups() -> [VoiceGroup] {
-        let grouped = Dictionary(grouping: AVSpeechSynthesisVoice.speechVoices()) { $0.language }
+    /// Reading the voice catalog blocks on the TextToSpeech daemon, so the groups are built
+    /// asynchronously rather than while the view is created.
+    private static func makeVoiceGroups() async -> [VoiceGroup] {
+        let voices = await OnDeviceVoiceCatalog.voices()
+        let grouped = Dictionary(grouping: voices) { $0.language }
         return grouped
             .map { language, voices in
                 VoiceGroup(
@@ -120,5 +133,11 @@ struct TTSVoicePickerView: View {
                 )
             }
             .sorted { $0.displayName < $1.displayName }
+    }
+}
+
+#Preview {
+    NavigationView {
+        TTSVoicePickerView(selectedVoiceIdentifier: .constant(nil))
     }
 }

--- a/Sources/CarPlay/Templates/Servers/CarPlayAssistSettingsTemplate.swift
+++ b/Sources/CarPlay/Templates/Servers/CarPlayAssistSettingsTemplate.swift
@@ -78,7 +78,7 @@ final class CarPlayAssistSettingsTemplate {
         guard configuration.enableOnDeviceSTT else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let supportedIdentifiers = await SpeechTranscriber.supportedLocales().map(\.identifier)
+            let supportedIdentifiers = await SupportedSpeechLocales.shared.locales().map(\.identifier)
             // Re-read the configuration: the toggle can flip again while the probe runs.
             guard configuration.enableOnDeviceSTT,
                   !supportedIdentifiers.contains(configuration.onDeviceSTTLocaleIdentifier ?? "") else { return }
@@ -110,7 +110,7 @@ final class CarPlayAssistSettingsTemplate {
         Task { @MainActor [weak self] in
             guard let self else { return }
             let selectedIdentifier = configuration.onDeviceSTTLocaleIdentifier
-            let locales = await SpeechTranscriber.supportedLocales()
+            let locales = await SupportedSpeechLocales.shared.locales()
             let items = locales.map { locale in
                 let item = CPListItem(
                     text: localeDisplayName(locale.identifier) ?? locale.identifier,

--- a/Sources/CarPlay/Templates/Servers/CarPlayAssistSettingsTemplate.swift
+++ b/Sources/CarPlay/Templates/Servers/CarPlayAssistSettingsTemplate.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import CarPlay
 import Foundation
 import Shared
@@ -10,6 +9,11 @@ final class CarPlayAssistSettingsTemplate {
     private weak var interfaceController: CPInterfaceController?
     private weak var template: CPListTemplate?
 
+    /// Name of the selected text-to-speech voice. Resolving an identifier waits on the
+    /// TextToSpeech daemon, which is far too slow to do while building the list, so the row shows
+    /// this cached value and `loadSelectedVoiceDisplayName()` refreshes it in the background.
+    private var selectedVoiceDisplayName = L10n.Assist.Settings.OnDeviceTts.defaultVoice
+
     private var configuration: AssistConfiguration {
         AssistConfiguration.config
     }
@@ -19,6 +23,7 @@ final class CarPlayAssistSettingsTemplate {
         let template = CPListTemplate(title: L10n.Assist.Settings.title, sections: [])
         self.template = template
         template.updateSections(makeSections())
+        loadSelectedVoiceDisplayName()
         interfaceController?.pushTemplate(template, animated: true, completion: nil)
     }
 
@@ -57,19 +62,28 @@ final class CarPlayAssistSettingsTemplate {
         )
         item.accessoryType = .none
         item.handler = { [weak self] _, completion in
-            self?.updateConfiguration { configuration in
-                configuration.enableOnDeviceSTT.toggle()
-                guard configuration.enableOnDeviceSTT else { return }
-                // Same behavior as the in-app settings: default to a supported locale when
-                // the current one is unset or not supported for on-device recognition.
-                let supportedIdentifiers = SpeechTranscriber.supportedLocales.map(\.identifier)
-                if !supportedIdentifiers.contains(configuration.onDeviceSTTLocaleIdentifier ?? "") {
-                    configuration.onDeviceSTTLocaleIdentifier = supportedIdentifiers.first
-                }
-            }
+            self?.updateConfiguration { $0.enableOnDeviceSTT.toggle() }
+            self?.selectDefaultSTTLocaleIfNeeded()
             completion()
         }
         return item
+    }
+
+    /// Same behavior as the in-app settings: default to a supported locale when the current one is
+    /// unset or not supported for on-device recognition. Determining the supported locales blocks
+    /// its caller for close to a second, so it happens off the main thread and the list refreshes
+    /// once the answer arrives.
+    @available(iOS 17.0, *)
+    private func selectDefaultSTTLocaleIfNeeded() {
+        guard configuration.enableOnDeviceSTT else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let supportedIdentifiers = await SpeechTranscriber.supportedLocales().map(\.identifier)
+            // Re-read the configuration: the toggle can flip again while the probe runs.
+            guard configuration.enableOnDeviceSTT,
+                  !supportedIdentifiers.contains(configuration.onDeviceSTTLocaleIdentifier ?? "") else { return }
+            updateConfiguration { $0.onDeviceSTTLocaleIdentifier = supportedIdentifiers.first }
+        }
     }
 
     @available(iOS 17.0, *)
@@ -89,23 +103,30 @@ final class CarPlayAssistSettingsTemplate {
     @available(iOS 17.0, *)
     private func presentSTTLanguageSelection() {
         let selectionTemplate = CPListTemplate(title: L10n.Assist.Settings.OnDeviceStt.language, sections: [])
-        let selectedIdentifier = configuration.onDeviceSTTLocaleIdentifier
-        let items = SpeechTranscriber.supportedLocales.map { locale in
-            let item = CPListItem(
-                text: localeDisplayName(locale.identifier) ?? locale.identifier,
-                detailText: nil,
-                image: locale.identifier == selectedIdentifier ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
-            )
-            item.accessoryType = .none
-            item.handler = { [weak self] _, completion in
-                self?.updateConfiguration { $0.onDeviceSTTLocaleIdentifier = locale.identifier }
-                self?.interfaceController?.popTemplate(animated: true, completion: nil)
-                completion()
-            }
-            return item
-        }
-        selectionTemplate.updateSections([CPListSection(items: items)])
         interfaceController?.pushTemplate(selectionTemplate, animated: true, completion: nil)
+
+        // Pushed empty on purpose: the supported locales come from a probe that would otherwise
+        // hang the main thread while the template is built.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let selectedIdentifier = configuration.onDeviceSTTLocaleIdentifier
+            let locales = await SpeechTranscriber.supportedLocales()
+            let items = locales.map { locale in
+                let item = CPListItem(
+                    text: localeDisplayName(locale.identifier) ?? locale.identifier,
+                    detailText: nil,
+                    image: locale.identifier == selectedIdentifier ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
+                )
+                item.accessoryType = .none
+                item.handler = { [weak self] _, completion in
+                    self?.updateConfiguration { $0.onDeviceSTTLocaleIdentifier = locale.identifier }
+                    self?.interfaceController?.popTemplate(animated: true, completion: nil)
+                    completion()
+                }
+                return item
+            }
+            selectionTemplate.updateSections([CPListSection(items: items)])
+        }
     }
 
     private var onDeviceTTSItem: CPListItem {
@@ -135,57 +156,75 @@ final class CarPlayAssistSettingsTemplate {
         return item
     }
 
-    private var selectedVoiceDisplayName: String {
-        guard let identifier = configuration.onDeviceTTSVoiceIdentifier,
-              let voice = AVSpeechSynthesisVoice(identifier: identifier) else {
-            return L10n.Assist.Settings.OnDeviceTts.defaultVoice
+    private func loadSelectedVoiceDisplayName() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let name: String
+            if let identifier = configuration.onDeviceTTSVoiceIdentifier {
+                let voice = await OnDeviceVoiceCatalog.voice(withIdentifier: identifier)
+                name = voice?.name ?? L10n.Assist.Settings.OnDeviceTts.defaultVoice
+            } else {
+                name = L10n.Assist.Settings.OnDeviceTts.defaultVoice
+            }
+            guard name != selectedVoiceDisplayName else { return }
+            selectedVoiceDisplayName = name
+            reload()
         }
-        return voice.name
     }
 
     private func presentTTSVoiceSelection() {
         let selectionTemplate = CPListTemplate(title: L10n.Assist.Settings.OnDeviceTts.voice, sections: [])
-        let selectedIdentifier = configuration.onDeviceTTSVoiceIdentifier
+        interfaceController?.pushTemplate(selectionTemplate, animated: true, completion: nil)
 
-        let defaultItem = CPListItem(
-            text: L10n.Assist.Settings.OnDeviceTts.defaultVoice,
-            detailText: nil,
-            image: selectedIdentifier == nil ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
-        )
-        defaultItem.accessoryType = .none
-        defaultItem.handler = { [weak self] _, completion in
-            self?.updateConfiguration { $0.onDeviceTTSVoiceIdentifier = nil }
-            self?.interfaceController?.popTemplate(animated: true, completion: nil)
-            completion()
-        }
+        // Pushed empty on purpose: reading the installed voices waits on the TextToSpeech daemon
+        // and would hang the main thread while the template is built.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let selectedIdentifier = configuration.onDeviceTTSVoiceIdentifier
 
-        let items = [defaultItem] + selectableVoices(selectedIdentifier: selectedIdentifier).map { voice in
-            let item = CPListItem(
-                text: voice.name,
-                detailText: localeDisplayName(voice.language),
-                image: voice.identifier == selectedIdentifier ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
+            let defaultItem = CPListItem(
+                text: L10n.Assist.Settings.OnDeviceTts.defaultVoice,
+                detailText: nil,
+                image: selectedIdentifier == nil ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
             )
-            item.accessoryType = .none
-            item.handler = { [weak self] _, completion in
-                self?.updateConfiguration { $0.onDeviceTTSVoiceIdentifier = voice.identifier }
+            defaultItem.accessoryType = .none
+            defaultItem.handler = { [weak self] _, completion in
+                self?.selectedVoiceDisplayName = L10n.Assist.Settings.OnDeviceTts.defaultVoice
+                self?.updateConfiguration { $0.onDeviceTTSVoiceIdentifier = nil }
                 self?.interfaceController?.popTemplate(animated: true, completion: nil)
                 completion()
             }
-            return item
+
+            let voices = await selectableVoices(selectedIdentifier: selectedIdentifier)
+            let items = [defaultItem] + voices.map { voice in
+                let item = CPListItem(
+                    text: voice.name,
+                    detailText: localeDisplayName(voice.language),
+                    image: voice.identifier == selectedIdentifier ? MaterialDesignIcons.checkIcon.carPlayIcon() : nil
+                )
+                item.accessoryType = .none
+                item.handler = { [weak self] _, completion in
+                    self?.selectedVoiceDisplayName = voice.name
+                    self?.updateConfiguration { $0.onDeviceTTSVoiceIdentifier = voice.identifier }
+                    self?.interfaceController?.popTemplate(animated: true, completion: nil)
+                    completion()
+                }
+                return item
+            }
+            selectionTemplate.updateSections([CPListSection(items: items)])
         }
-        selectionTemplate.updateSections([CPListSection(items: items)])
-        interfaceController?.pushTemplate(selectionTemplate, animated: true, completion: nil)
     }
 
     /// The full voice catalog is too long for a driver-facing list, so the car offers the
     /// voices matching the device language (plus the currently selected voice); the complete
     /// searchable catalog stays available in the in-app settings.
-    private func selectableVoices(selectedIdentifier: String?) -> [AVSpeechSynthesisVoice] {
+    private func selectableVoices(selectedIdentifier: String?) async -> [OnDeviceVoice] {
         let languageCode = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
-        var voices = AVSpeechSynthesisVoice.speechVoices().filter { $0.language.hasPrefix(languageCode) }
+        let allVoices = await OnDeviceVoiceCatalog.voices()
+        var voices = allVoices.filter { $0.language.hasPrefix(languageCode) }
         if let selectedIdentifier,
            !voices.contains(where: { $0.identifier == selectedIdentifier }),
-           let selectedVoice = AVSpeechSynthesisVoice(identifier: selectedIdentifier) {
+           let selectedVoice = allVoices.first(where: { $0.identifier == selectedIdentifier }) {
             voices.append(selectedVoice)
         }
         return voices.sorted { $0.name < $1.name }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Opening Assist settings hangs the main thread for about a second. The view body read the on-device speech recognition locales, which creates one `SFSpeechRecognizer` per system locale and makes a synchronous XPC call for each, and it also resolved the selected text-to-speech voice through the TextToSpeech daemon.

Both lookups now run off the main thread and are published by the view model. The voice picker loads its list on appear instead of in `init`, and the CarPlay Assist settings screen gets the same treatment.

## Screenshots

No visual changes.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes

None.
