### PR TITLE
Fix Assist voice orb and on-device TTS volume with on-device STT

### DIFF
--- a/Sources/App/Assist/Audio/AudioPlayer.swift
+++ b/Sources/App/Assist/Audio/AudioPlayer.swift
@@ -34,7 +34,10 @@ final class AudioPlayer: NSObject, AudioPlayerProtocol {
             Current.Log.error("Failed to deactivate audio session before playback: \(error.localizedDescription)")
         }
         do {
-            try audioSession.setCategory(.playback)
+            // Naming the mode matters as much as the category here: it survives a category change on
+            // its own, so a preceding on-device transcription would otherwise leave `.measurement`
+            // in place and play the response back quietly.
+            try audioSession.setCategory(.playback, mode: .default)
         } catch {
             Current.Log.error("Failed to set playback category for audio player: \(error.localizedDescription)")
         }

--- a/Sources/App/Assist/Local/SpeechSynthesizer.swift
+++ b/Sources/App/Assist/Local/SpeechSynthesizer.swift
@@ -45,7 +45,13 @@ final class SpeechSynthesizer: NSObject, SpeechSynthesizerProtocol, AVSpeechSynt
         utterance.voice = voice
         if managesAudioSession {
             do {
-                try AVAudioSession.sharedInstance().setCategory(.playback)
+                // The mode has to be named explicitly: it is a session property of its own that
+                // `setCategory(.playback)` leaves alone, so without this the utterance inherits
+                // whatever the last recording left behind — `.measurement` after on-device STT,
+                // which the framework documents as lowering the output playback level.
+                let audioSession = AVAudioSession.sharedInstance()
+                try audioSession.setCategory(.playback, mode: .default)
+                try audioSession.setActive(true)
             } catch {
                 Current.Log.error("Failed to set audio session category for speech synthesis: \(error)")
             }

--- a/Sources/App/Assist/Local/SpeechTranscriber.swift
+++ b/Sources/App/Assist/Local/SpeechTranscriber.swift
@@ -54,7 +54,9 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
 
     private enum Constants {
         /// Window of microphone RMS power (dBFS) mapped onto the 0...1 voice level. Matches
-        /// `AudioRecorder`: narrow on purpose, so normal speech spans the whole range.
+        /// `AudioRecorder`: narrow on purpose, so normal speech spans the whole range. It assumes the
+        /// session's input dynamics processing is on, which is why `startListening` avoids
+        /// `.measurement` mode.
         static let powerFloor: Float = -45
         static let powerCeiling: Float = -15
         /// The tap runs on a real-time audio thread and fires far faster than a screen refresh, so
@@ -203,7 +205,14 @@ public final class SpeechTranscriber: ObservableObject, SpeechTranscriberProtoco
         // Configure audio session
         if managesAudioSession {
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+            // `.default` rather than `.measurement`, which the framework documents as disabling the
+            // dynamics processing on input *and* output. On input that is the gain the level window
+            // below is calibrated against, so the orb sits still; and because the mode is a separate
+            // session property that `setCategory(.playback)` does not reset, it stays on the session
+            // afterwards and is what makes on-device TTS play back quietly. Matching `AudioRecorder`'s
+            // category and mode keeps the orb behaving the same whichever transcription path is used.
+            // `.duckOthers` is only valid on the playback categories, so it is not passed here either.
+            try audioSession.setCategory(.record, mode: .default)
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
With on-device STT enabled, the voice orb did not react to the microphone and on-device TTS played back very quietly.

Both came from the audio session `.measurement` mode used while transcribing, which disables the system dynamics processing on input and output. On input it removed the gain the orb's level window is calibrated against; and since the mode is a session property that `setCategory(.playback)` does not reset, it stayed on the session afterwards and lowered the TTS playback level.

Recording now uses the `.default` mode, matching `AudioRecorder`, and both playback paths name the mode explicitly.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A, the orb and the voices are unchanged visually.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
`.duckOthers` was also dropped from the recording session: it is only valid on the ambient, play-and-record, playback and multi-route categories.
