### PR TITLE
Fix complication text color not being applied

### DIFF
--- a/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
+++ b/Sources/App/Settings/AppleWatch/Complications/WatchComplicationConfigurationSheet.swift
@@ -346,6 +346,11 @@ struct WatchComplicationConfigurationSheet: View {
 
     // MARK: - Bindings
 
+    /// What the text color pickers show for a complication that sets none: the white every render
+    /// surface falls back to on the black watch face (see `ComplicationRenderContext.textColor`), so
+    /// the picker and the face never disagree about the default.
+    private static let defaultTextColor: Color = .white
+
     private func updateOptions(_ mutate: (inout WatchComplicationConfig.FamilyOptions) -> Void) {
         var options = viewModel.config.options(for: currentFamily)
         mutate(&options)
@@ -401,13 +406,23 @@ struct WatchComplicationConfigurationSheet: View {
         )
     }
 
-    /// Text/value color; defaults to primary when unset.
+    /// Text/value color; an unset color shows as the white the complication actually draws on the
+    /// black watch face.
+    ///
+    /// Not `.primary`: it has no static `cgColor`, so the color well can't show it and falls back to
+    /// its own default swatch — which read as a color the complication would render (it never did),
+    /// while the face kept drawing white. `.primary` would be wrong here anyway: the picker sits in
+    /// the iPhone's light/dark UI, where it resolves to black, and the complication is drawn on the
+    /// watch's black face, where it resolves to white.
     private var textColorBinding: Binding<Color> {
         Binding(
             get: { viewModel.config.textColor(for: currentFamily)
-                .map { Color(uiColor: UIColor(hex: $0)) } ?? .primary
+                .map { Color(uiColor: UIColor(hex: $0)) } ?? Self.defaultTextColor
             },
-            set: { value in updateOptions { $0.textColor = UIColor(value).hexString(true) } }
+            // Config-wide, not per-size (like the icon color): writing only the selected size left
+            // every other size drawing the face default — the color picked on circular never reached
+            // the corner slot the complication was actually sitting in.
+            set: { value in viewModel.config.setTextColor(UIColor(value).hexString(true)) }
         )
     }
 
@@ -418,7 +433,7 @@ struct WatchComplicationConfigurationSheet: View {
             get: {
                 let hex = viewModel.config.slotColor(.bottomText, for: currentFamily)
                     ?? viewModel.config.textColor(for: currentFamily)
-                return hex.map { Color(uiColor: UIColor(hex: $0)) } ?? .primary
+                return hex.map { Color(uiColor: UIColor(hex: $0)) } ?? Self.defaultTextColor
             },
             set: { value in
                 var slot = viewModel.config.slotConfig(.bottomText, for: currentFamily) ?? ComplicationSlotConfig()

--- a/Sources/HAModels/Sources/DatabaseTables.swift
+++ b/Sources/HAModels/Sources/DatabaseTables.swift
@@ -234,6 +234,7 @@ public enum DatabaseTables {
         case entityDisplayName
         case iconName
         case iconColor
+        case textColor
         case gaugeAttribute
         case valueAttribute
         case valuePrecision

--- a/Sources/HAModels/Sources/WatchComplicationConfig.swift
+++ b/Sources/HAModels/Sources/WatchComplicationConfig.swift
@@ -46,6 +46,11 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
     public var entityDisplayName: String?
     public var iconName: String?
     public var iconColor: String?
+    /// Hex color for the complication's text. Global (not per-size), like `iconColor`: a color is a
+    /// property of the complication, not of one of its sizes. A `FamilyOptions.textColor` still
+    /// overrides it for its own size, so configs saved while the color was per-size only render
+    /// unchanged.
+    public var textColor: String?
     /// Attribute used for a gauge/ring value; `nil` uses the entity state. Only meaningful when numeric.
     public var gaugeAttribute: String?
     /// Attribute whose value is shown as the complication's text (and used as the gauge basis when no
@@ -110,7 +115,9 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         public var tint: String?
         /// Raw value of `GaugeStyle`; nil defaults to `.open`. Only meaningful for circular.
         public var gaugeStyle: String?
-        /// Hex color for the value/text; nil uses the default (primary) color.
+        /// Per-size override for the complication's text color; nil falls back to the config-wide
+        /// `textColor`. Only configs saved while the color was per-size only still carry one — the
+        /// editor writes the config-wide color now.
         public var textColor: String?
         /// Per-slot customization, keyed by `ComplicationSlot.rawValue`. A missing slot (or a nil
         /// field inside one) falls back to the legacy flags above and the slot defaults, so configs
@@ -150,7 +157,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
 
     public enum CodingKeys: String, CodingKey {
         case id, serverId, widgetFamily, kind, name
-        case entityId, entityDisplayName, iconName, iconColor
+        case entityId, entityDisplayName, iconName, iconColor, textColor
         case gaugeAttribute, valueAttribute, valuePrecision, unitOverride, gaugeMin, gaugeMax
         case showValue, showUnit, showWhenInactive, showMin, showMax
         case customTextTemplate, customGaugeTemplate, sortOrder, families, isCustomized
@@ -167,6 +174,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         entityDisplayName: String? = nil,
         iconName: String? = nil,
         iconColor: String? = nil,
+        textColor: String? = nil,
         gaugeAttribute: String? = nil,
         valueAttribute: String? = nil,
         valuePrecision: Int? = nil,
@@ -196,6 +204,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         self.entityDisplayName = entityDisplayName
         self.iconName = iconName
         self.iconColor = iconColor
+        self.textColor = textColor
         self.gaugeAttribute = gaugeAttribute
         self.valueAttribute = valueAttribute
         self.valuePrecision = valuePrecision
@@ -233,7 +242,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
     /// The templates count too: a template-only color setup used to read as "off", hiding the very
     /// template fields that were driving the complication's colors.
     public func usesCustomColors() -> Bool {
-        if iconColor != nil { return true }
+        if iconColor != nil || textColor != nil { return true }
         if families?.values.contains(where: { $0.tint != nil || $0.textColor != nil }) == true { return true }
         return [customGaugeColorTemplate, customIconColorTemplate, customTextColorTemplate]
             .contains { !($0 ?? "").isEmpty }
@@ -243,6 +252,7 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
     /// keep tinting the complication (and would read back as the toggle being on).
     public mutating func clearCustomColors() {
         iconColor = nil
+        textColor = nil
         customGaugeColorTemplate = nil
         customIconColorTemplate = nil
         customTextColorTemplate = nil
@@ -386,9 +396,25 @@ public struct WatchComplicationConfig: Codable, FetchableRecord, PersistableReco
         families?[family.rawValue]?.tint ?? iconColor
     }
 
-    /// The value/text color for a family, or nil to use the default (primary) color.
+    /// The value/text color for a family, or nil to use the default (primary) color: the per-size
+    /// override when a config still carries one, else the complication's own color.
+    ///
+    /// The fallback is the point. Without it a color picked while one size was selected left every
+    /// other size drawing the face default — set the color on circular, add the complication to a
+    /// corner slot, and it rendered white.
     public func textColor(for family: Family) -> String? {
-        families?[family.rawValue]?.textColor
+        families?[family.rawValue]?.textColor ?? textColor
+    }
+
+    /// Sets the complication's text color, dropping the per-size overrides an older config may
+    /// carry — one left behind would keep that size on its old color and make the picker a lie again.
+    public mutating func setTextColor(_ hex: String?) {
+        textColor = hex
+        families = families?.mapValues { options in
+            var options = options
+            options.textColor = nil
+            return options
+        }
     }
 
     /// A slot's per-slot text color override (hex), or nil to fall back to the family's text color.

--- a/Sources/HAWatchComplications/Sources/RectangularComplicationContentView.swift
+++ b/Sources/HAWatchComplications/Sources/RectangularComplicationContentView.swift
@@ -60,7 +60,11 @@ public struct RectangularComplicationContentView: View {
                         minLabel: model.minLabel,
                         maxLabel: model.maxLabel,
                         valueLabel: model.showsValue ? model.valueText : nil,
-                        tint: model.tint
+                        tint: model.tint,
+                        // The value moves into the bar's thumb here, so it has to carry the text color
+                        // with it — otherwise the one slot the user picks a color *for* is the only
+                        // one that ignores it.
+                        valueColor: model.textColor
                     )
                 } else if model.showsValue, !model.valueText.isEmpty {
                     Text(model.valueText)

--- a/Sources/HAWatchComplications/Sources/RectangularProgressView.swift
+++ b/Sources/HAWatchComplications/Sources/RectangularProgressView.swift
@@ -39,22 +39,42 @@ public struct RectangularProgressView: View {
     let maxLabel: String?
     let valueLabel: String?
     let tint: Color
+    /// The complication's configured text color, or nil to pick automatically for contrast against
+    /// the pill. The value rides the bar rather than sitting in the text stack, so it is the one text
+    /// slot that would otherwise ignore the color the user set for it.
+    let valueColor: Color?
 
-    public init(fraction: Double, minLabel: String?, maxLabel: String?, valueLabel: String?, tint: Color) {
+    public init(
+        fraction: Double,
+        minLabel: String?,
+        maxLabel: String?,
+        valueLabel: String?,
+        tint: Color,
+        valueColor: Color? = nil
+    ) {
         self.fraction = fraction
         self.minLabel = minLabel
         self.maxLabel = maxLabel
         self.valueLabel = valueLabel
         self.tint = tint
+        self.valueColor = valueColor
     }
 
     @Environment(\.widgetRenderingMode) private var renderingMode
 
-    /// Full color: black on light tints, white on dark ones. In accented (tinted) mode the pill fill
-    /// is placed in the accent group and the text is left in the default group, so the system renders
-    /// them in two distinct tint shades; the explicit color is ignored there.
+    /// Full color: the complication's own text color when it has one, else black on light tints and
+    /// white on dark ones. In accented (tinted) mode the pill fill is placed in the accent group and
+    /// the text is left in the default group, so the system renders them in two distinct tint shades;
+    /// the explicit color is ignored there.
     private var valueTextColor: Color {
         guard renderingMode == .fullColor else { return .white }
+        return Self.valueLabelColor(configured: valueColor, tint: tint)
+    }
+
+    /// The pill label's color in full color: the configured text color wins, otherwise the shade that
+    /// reads best on the tint. Pure and static so the choice is testable without rendering a face.
+    public static func valueLabelColor(configured: Color?, tint: Color) -> Color {
+        if let configured { return configured }
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         UIColor(tint).getRed(&r, green: &g, blue: &b, alpha: &a)
         return (Luminance.red * r + Luminance.green * g + Luminance.blue * b) > Luminance.lightThreshold
@@ -146,6 +166,21 @@ public struct RectangularProgressView: View {
     RectangularProgressView(fraction: 0.68, minLabel: "0", maxLabel: "100", valueLabel: "68", tint: .green)
         .frame(width: 180)
         .padding()
+}
+
+// The complication's own text color applies to the value riding the bar, not just the text stack.
+@available(iOS 16.0, watchOS 10.0, *)
+#Preview("Custom value color") {
+    RectangularProgressView(
+        fraction: 0.68,
+        minLabel: "0",
+        maxLabel: "100",
+        valueLabel: "68",
+        tint: .green,
+        valueColor: .yellow
+    )
+    .frame(width: 180)
+    .padding()
 }
 
 // Fraction edge cases: the thumb stays inside the bar at the extremes, and out-of-range values clamp.

--- a/Sources/Shared/Database/GRDB+Initialization.swift
+++ b/Sources/Shared/Database/GRDB+Initialization.swift
@@ -347,6 +347,7 @@ final class WatchComplicationConfigTable: DatabaseTableProtocol {
                     t.column(DatabaseTables.WatchComplicationConfig.entityDisplayName.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.iconName.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.iconColor.rawValue, .text)
+                    t.column(DatabaseTables.WatchComplicationConfig.textColor.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.gaugeAttribute.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.valueAttribute.rawValue, .text)
                     t.column(DatabaseTables.WatchComplicationConfig.valuePrecision.rawValue, .integer)

--- a/Sources/WatchWidgets/Complications/CornerComplicationView.swift
+++ b/Sources/WatchWidgets/Complications/CornerComplicationView.swift
@@ -89,14 +89,22 @@ struct CornerComplicationView: View {
     private func bezelLabel(_ complication: WatchWidgetComplicationSnapshot) -> some View {
         if let fraction = complication.fraction(for: family) {
             Gauge(value: fraction) {
-                Text(arcText(complication))
+                arcLabel(complication)
             }
             .tint(complication.tintColor(for: family))
         } else {
-            Text(arcText(complication))
-                .minimumScaleFactor(0.5)
-                .lineLimit(1)
+            arcLabel(complication)
         }
+    }
+
+    /// The arc's text, colored like the corner's own. Whichever half of the complication the corner
+    /// isn't already showing ends up here — for an icon-led corner that is the value itself — so
+    /// leaving it uncolored made the configured color apply or not depending on the layout.
+    private func arcLabel(_ complication: WatchWidgetComplicationSnapshot) -> some View {
+        Text(arcText(complication))
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+            .foregroundStyle(complication.textColor(for: family) ?? .primary)
     }
 
     /// What rides the arc: whatever the corner isn't already showing. When the icon takes the corner the

--- a/Tests/Shared/Watch/WatchComplicationConfigTextColor.test.swift
+++ b/Tests/Shared/Watch/WatchComplicationConfigTextColor.test.swift
@@ -1,0 +1,74 @@
+import Foundation
+@testable import Shared
+import Testing
+
+/// The text color is a property of the complication, not of the size that happened to be selected
+/// when it was picked: a color set in the editor has to reach whichever size the complication is
+/// actually placed in on the watch face.
+struct WatchComplicationConfigTextColorTests {
+    private func templateConfig() -> WatchComplicationConfig {
+        WatchComplicationConfig(
+            serverId: "server",
+            kind: .customTemplate,
+            name: "Solar",
+            customTextTemplate: "{{ tpl }}"
+        )
+    }
+
+    @Test("The config-wide color applies to every size")
+    func configWideColorAppliesEverywhere() {
+        var config = templateConfig()
+        config.setTextColor("#FF9500FF")
+        for family in WatchComplicationConfig.Family.allCases {
+            #expect(config.textColor(for: family) == "#FF9500FF")
+        }
+    }
+
+    @Test("No color anywhere resolves to nil, so rendering falls back to the face default")
+    func noColorResolvesToNil() {
+        let config = templateConfig()
+        #expect(WatchComplicationConfig.Family.allCases.allSatisfy { config.textColor(for: $0) == nil })
+    }
+
+    @Test("A per-size override from an older config still wins for its own size")
+    func perSizeOverrideWins() {
+        var config = templateConfig()
+        config.textColor = "#FF9500FF"
+        config.setOptions(.init(textColor: "#34C759FF"), for: .circular)
+        #expect(config.textColor(for: .circular) == "#34C759FF")
+        #expect(config.textColor(for: .corner) == "#FF9500FF")
+    }
+
+    @Test("Picking a color clears the per-size overrides that would shadow it")
+    func pickingAColorClearsOverrides() {
+        var config = templateConfig()
+        config.setOptions(.init(tint: "#000000FF", textColor: "#34C759FF"), for: .circular)
+        config.setTextColor("#FF9500FF")
+        #expect(config.textColor(for: .circular) == "#FF9500FF")
+        #expect(config.textColor(for: .corner) == "#FF9500FF")
+        // Only the text color is cleared — the size keeps the rest of its customization.
+        #expect(config.options(for: .circular).tint == "#000000FF")
+    }
+
+    @Test("Clearing the custom colors clears the config-wide text color too")
+    func clearCustomColorsClearsTextColor() {
+        var config = templateConfig()
+        config.setTextColor("#FF9500FF")
+        #expect(config.usesCustomColors())
+        config.clearCustomColors()
+        #expect(!config.usesCustomColors())
+        #expect(config.textColor(for: .corner) == nil)
+    }
+
+    @Test("The text color round-trips through Codable")
+    func codableRoundTrip() throws {
+        var config = templateConfig()
+        config.setTextColor("#FF9500FF")
+        let decoded = try JSONDecoder().decode(
+            WatchComplicationConfig.self,
+            from: JSONEncoder().encode(config)
+        )
+        #expect(decoded.textColor == "#FF9500FF")
+        #expect(decoded.textColor(for: .corner) == "#FF9500FF")
+    }
+}

--- a/Tests/WatchComplications/RectangularProgressValueColor.test.swift
+++ b/Tests/WatchComplications/RectangularProgressValueColor.test.swift
@@ -1,0 +1,24 @@
+import HAWatchComplications
+import SwiftUI
+import Testing
+
+/// The rectangular complication draws its value inside the progress bar's thumb, not in the text
+/// stack, so that one slot resolves its color separately — these pin that it still honors the color
+/// the user picked for the complication's text, and only falls back to the automatic contrast shade
+/// when there is none.
+struct RectangularProgressValueColorTests {
+    @Test("A configured text color wins over the automatic contrast shade")
+    func configuredColorWins() {
+        #expect(RectangularProgressView.valueLabelColor(configured: .yellow, tint: .green) == .yellow)
+        // Even when the automatic choice would have picked the same shade the user did.
+        #expect(RectangularProgressView.valueLabelColor(configured: .white, tint: .green) == .white)
+    }
+
+    @Test("Without a configured color, the value reads against the tint")
+    func automaticContrast() {
+        #expect(RectangularProgressView.valueLabelColor(configured: nil, tint: .black) == .white)
+        #expect(RectangularProgressView.valueLabelColor(configured: nil, tint: .white) == .black)
+        // The Home Assistant default tint is dark enough for white.
+        #expect(RectangularProgressView.valueLabelColor(configured: nil, tint: .complicationDefaultTint) == .white)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

A complication rendered its text in white however the text color was set.

The color was stored per size with no fallback. The editor writes it into the size the family switcher is on — circular for a new complication — so the color never reached the size the complication was actually placed in. It is now a config-wide property like the icon color, with the per-size value kept as an override so existing configs render unchanged.

Two slots ignored the color entirely: the corner's bezel arc, which carries the value when the corner leads with an icon, and the rectangular progress bar's value pill, which picked its color from the tint's luminance alone.

The editor's color pickers also showed `.primary` for an unset color. It has no static `cgColor`, so the color well fell back to its own swatch and read as a color the complication would render — they now show the white the face actually draws.

## Screenshots

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes

`rectangularComplicationVariants.custom-text-color` still holds its pre-change reference image (the pill label was white, it is now yellow) and needs re-recording.
