### PR TITLE
Fix blank screen when creating a custom widget

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -134,7 +134,7 @@ final class EntityAddToHandler {
             serverId: webViewController.server.identifier.rawValue,
             type: .entity
         ))
-        let carPlaySettingsView = CarPlayConfigurationView(viewModel: viewModel)
+        let carPlaySettingsView = CarPlayConfigurationView(needsNavigationController: true, viewModel: viewModel)
         webViewController.presentOverlayController(
             controller: carPlaySettingsView.embeddedInHostingController(),
             animated: true
@@ -329,7 +329,7 @@ final class EntityAddToHandler {
             }
 
             // Open the widget creation view to let user see and further customize
-            let widgetCreationView = WidgetCreationView(widget: updatedWidget) {
+            let widgetCreationView = WidgetCreationView(needsNavigationController: true, widget: updatedWidget) {
                 // Reload widgets after changes
             }
             let hostingController = widgetCreationView
@@ -361,7 +361,7 @@ final class EntityAddToHandler {
             items: [newItem]
         )
 
-        let widgetCreationView = WidgetCreationView(widget: newWidget) {
+        let widgetCreationView = WidgetCreationView(needsNavigationController: true, widget: newWidget) {
             // Reload widgets after changes
         }
 

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -134,7 +134,7 @@ final class EntityAddToHandler {
             serverId: webViewController.server.identifier.rawValue,
             type: .entity
         ))
-        let carPlaySettingsView = CarPlayConfigurationView(needsNavigationController: true, viewModel: viewModel)
+        let carPlaySettingsView = CarPlayConfigurationView(needsNavigationStack: true, viewModel: viewModel)
         webViewController.presentOverlayController(
             controller: carPlaySettingsView.embeddedInHostingController(),
             animated: true
@@ -149,7 +149,7 @@ final class EntityAddToHandler {
             serverId: webViewController.server.identifier.rawValue,
             type: .entity
         ))
-        let watchSettingsView = WatchConfigurationView(needsNavigationController: true, viewModel: viewModel)
+        let watchSettingsView = WatchConfigurationView(needsNavigationStack: true, viewModel: viewModel)
             .preferredColorScheme(.dark)
         let viewController = watchSettingsView.embeddedInHostingController()
         viewController.overrideUserInterfaceStyle = .dark
@@ -329,7 +329,7 @@ final class EntityAddToHandler {
             }
 
             // Open the widget creation view to let user see and further customize
-            let widgetCreationView = WidgetCreationView(needsNavigationController: true, widget: updatedWidget) {
+            let widgetCreationView = WidgetCreationView(needsNavigationStack: true, widget: updatedWidget) {
                 // Reload widgets after changes
             }
             let hostingController = widgetCreationView
@@ -361,7 +361,7 @@ final class EntityAddToHandler {
             items: [newItem]
         )
 
-        let widgetCreationView = WidgetCreationView(needsNavigationController: true, widget: newWidget) {
+        let widgetCreationView = WidgetCreationView(needsNavigationStack: true, widget: newWidget) {
             // Reload widgets after changes
         }
 

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -14,6 +14,9 @@ struct WatchConfigurationView: View {
     @State private var showAddFolderSheet = false
     @State private var newFolderName: String = L10n.Watch.Configuration.Folder.defaultName
 
+    /// Whether the screen brings its own `NavigationStack`. Off by default because the screen is
+    /// normally pushed (from Settings), and nesting a navigation container inside a pushed destination
+    /// leaves it blank and pops it straight back out. Only a modal presentation opts in.
     private let needsNavigationController: Bool
 
     init(needsNavigationController: Bool = false, viewModel: WatchConfigurationViewModel? = nil) {

--- a/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
+++ b/Sources/App/Settings/AppleWatch/HomeCustomization/WatchConfigurationView.swift
@@ -17,15 +17,15 @@ struct WatchConfigurationView: View {
     /// Whether the screen brings its own `NavigationStack`. Off by default because the screen is
     /// normally pushed (from Settings), and nesting a navigation container inside a pushed destination
     /// leaves it blank and pops it straight back out. Only a modal presentation opts in.
-    private let needsNavigationController: Bool
+    private let needsNavigationStack: Bool
 
-    init(needsNavigationController: Bool = false, viewModel: WatchConfigurationViewModel? = nil) {
-        self.needsNavigationController = needsNavigationController
+    init(needsNavigationStack: Bool = false, viewModel: WatchConfigurationViewModel? = nil) {
+        self.needsNavigationStack = needsNavigationStack
         self._viewModel = .init(wrappedValue: viewModel ?? WatchConfigurationViewModel())
     }
 
     var body: some View {
-        if needsNavigationController {
+        if needsNavigationStack {
             NavigationStack {
                 content
             }

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -16,9 +16,13 @@ struct CarPlayConfigurationView: View {
     @State private var showAddFolderSheet = false
     @State private var newFolderName: String = L10n.Watch.Configuration.Folder.defaultName
 
+    /// Whether the screen brings its own `NavigationStack`. It defaults to off because the screen is
+    /// normally pushed (from Settings), and nesting a navigation container inside a pushed destination
+    /// leaves it blank and pops it straight back out. Only a modal presentation, which has no
+    /// surrounding stack to inherit, opts in.
     private let needsNavigationController: Bool
 
-    init(needsNavigationController: Bool = true, viewModel: CarPlayConfigurationViewModel? = nil) {
+    init(needsNavigationController: Bool = false, viewModel: CarPlayConfigurationViewModel? = nil) {
         self.needsNavigationController = needsNavigationController
         self._viewModel = .init(wrappedValue: viewModel ?? CarPlayConfigurationViewModel())
     }
@@ -373,7 +377,9 @@ struct CarPlayConfigurationView: View {
 }
 
 #Preview {
-    CarPlayConfigurationView()
+    NavigationStack {
+        CarPlayConfigurationView()
+    }
 }
 
 extension CarPlayConfigurationView: SettingsScreenSearchable {

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -20,15 +20,15 @@ struct CarPlayConfigurationView: View {
     /// normally pushed (from Settings), and nesting a navigation container inside a pushed destination
     /// leaves it blank and pops it straight back out. Only a modal presentation, which has no
     /// surrounding stack to inherit, opts in.
-    private let needsNavigationController: Bool
+    private let needsNavigationStack: Bool
 
-    init(needsNavigationController: Bool = false, viewModel: CarPlayConfigurationViewModel? = nil) {
-        self.needsNavigationController = needsNavigationController
+    init(needsNavigationStack: Bool = false, viewModel: CarPlayConfigurationViewModel? = nil) {
+        self.needsNavigationStack = needsNavigationStack
         self._viewModel = .init(wrappedValue: viewModel ?? CarPlayConfigurationViewModel())
     }
 
     var body: some View {
-        if needsNavigationController {
+        if needsNavigationStack {
             NavigationStack {
                 content
             }

--- a/Sources/App/Settings/Settings/SettingsItem.swift
+++ b/Sources/App/Settings/Settings/SettingsItem.swift
@@ -155,7 +155,7 @@ enum SettingsItem: String, Hashable, CaseIterable {
             WatchConfigurationView()
                 .environment(\.colorScheme, .dark)
         case .carPlay:
-            CarPlayConfigurationView(needsNavigationController: false)
+            CarPlayConfigurationView()
         case .complications:
             SettingsComplicationsView()
         case .help:

--- a/Sources/App/Settings/Widgets/Builder/CustomWidgetsListView.swift
+++ b/Sources/App/Settings/Widgets/Builder/CustomWidgetsListView.swift
@@ -94,7 +94,7 @@ struct CustomWidgetsListView: View {
         ForEach(viewModel.widgets, id: \.id) { widget in
             HStack {
                 NavigationLink {
-                    WidgetCreationView(needsNavigationController: false, widget: widget) {
+                    WidgetCreationView(widget: widget) {
                         viewModel.loadWidgets()
                     }
                 } label: {

--- a/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
@@ -9,10 +9,14 @@ struct WidgetCreationView: View {
     @StateObject private var viewModel: WidgetCreationViewModel
     private let dismissAction: () -> Void
 
+    /// Whether the screen brings its own `NavigationStack`. Off by default because the screen is
+    /// normally pushed (from the custom widgets list), and nesting a navigation container inside a
+    /// pushed destination leaves it blank and pops it straight back out. Only a modal presentation,
+    /// which has no surrounding stack to inherit, opts in.
     private let needsNavigationController: Bool
 
     init(
-        needsNavigationController: Bool = true,
+        needsNavigationController: Bool = false,
         widget: CustomWidget = CustomWidget(id: UUID().uuidString, name: "", items: []),
         dismissAction: @escaping () -> Void
     ) {
@@ -26,7 +30,6 @@ struct WidgetCreationView: View {
             NavigationStack {
                 content
             }
-            .navigationViewStyle(.stack)
         } else {
             content
         }
@@ -271,10 +274,7 @@ struct WidgetCreationView: View {
 }
 
 #Preview {
-    NavigationView {
-        VStack {}
-            .sheet(isPresented: .constant(true)) {
-                WidgetCreationView {}
-            }
+    NavigationStack {
+        WidgetCreationView {}
     }
 }

--- a/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
@@ -13,20 +13,20 @@ struct WidgetCreationView: View {
     /// normally pushed (from the custom widgets list), and nesting a navigation container inside a
     /// pushed destination leaves it blank and pops it straight back out. Only a modal presentation,
     /// which has no surrounding stack to inherit, opts in.
-    private let needsNavigationController: Bool
+    private let needsNavigationStack: Bool
 
     init(
-        needsNavigationController: Bool = false,
+        needsNavigationStack: Bool = false,
         widget: CustomWidget = CustomWidget(id: UUID().uuidString, name: "", items: []),
         dismissAction: @escaping () -> Void
     ) {
-        self.needsNavigationController = needsNavigationController
+        self.needsNavigationStack = needsNavigationStack
         self._viewModel = .init(wrappedValue: .init(widget: widget))
         self.dismissAction = dismissAction
     }
 
     var body: some View {
-        if needsNavigationController {
+        if needsNavigationStack {
             NavigationStack {
                 content
             }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Settings > Widgets > Create widget opened a blank screen that immediately dismissed itself, popping the widgets list along with it.

The row pushed `WidgetCreationView` with its default `needsNavigationStack: true`, so the pushed screen wrapped itself in a `NavigationStack` inside a stack it was already on. Editing an existing widget worked because that row passed `false`.

The flag stays (the frontend external bus presents the same screen modally, where it does need its own container), but the default flips to `false` so pushing is the safe default and only modal presentations opt in. `CarPlayConfigurationView` had the same unsafe default and is used the same two ways, so it flips too, matching `WatchConfigurationView`.

The flag is also renamed from `needsNavigationController` to `needsNavigationStack`, since it controls a SwiftUI `NavigationStack` rather than a UIKit navigation controller.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No other screen in Settings is affected: every other `NavigationView`/`NavigationStack` under `Sources/App/Settings` is sheet content, a preview, or the root of a stack rather than something pushed onto one.
