### PR TITLE
Show fewer items in commonly used entities widget

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -790,6 +790,7 @@
 				Widgets/Common/WidgetTileInteraction.swift,
 				Widgets/Common/WidgetTimelineProviderSupport.swift,
 				Widgets/Common/WidgetType.swift,
+				"Widgets/Common/WidgetsKind+TileCapacity.swift",
 				Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntities.swift,
 				Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift,
 				Widgets/Controls/Cover/CoverIntent.swift,

--- a/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetBasicContainerView.swift
@@ -108,13 +108,9 @@ struct WidgetBasicContainerView_Previews: PreviewProvider {
             #endif
         }
 
+    /// These previews are drawn as `.custom`, so they go all the way to the packed count.
     private static func maxTiles(for familySize: WidgetFamily) -> Int {
-        switch familySize {
-        case .systemSmall: 3
-        case .systemMedium: 6
-        case .systemLarge: 12
-        default: 12
-        }
+        WidgetFamilySizes.size(for: familySize, capacity: .packed)
     }
 
     private static func configurations(for familySize: WidgetFamily)
@@ -262,6 +258,7 @@ struct WidgetBasicContainerWrapperView: View {
             contents: contents,
             family: family,
             kind: type.tileKind,
+            capacity: widgetKind.tileCapacity,
             serverName: showServerName ? serverName : nil,
             emptyView: emptyViewGenerator,
             refreshControl: refreshControl,

--- a/Sources/Extensions/Widgets/Common/WidgetFamilySizes.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetFamilySizes.swift
@@ -9,8 +9,8 @@ import WidgetKit
 /// widgets agree on them. This is the widget extension's door onto that, plus the one piece that
 /// can't move: App Intents' compile-time collection size.
 enum WidgetFamilySizes {
-    static func size(for family: WidgetFamily) -> Int {
-        WidgetTileLayout.size(for: family)
+    static func size(for family: WidgetFamily, capacity: WidgetTileCapacity = .packed) -> Int {
+        WidgetTileLayout.size(for: family, capacity: capacity)
     }
 
     /// How many events the calendar widget lists.

--- a/Sources/Extensions/Widgets/Common/WidgetsKind+TileCapacity.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetsKind+TileCapacity.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Shared
+
+extension WidgetsKind {
+    /// How full the family gets packed with tiles.
+    ///
+    /// Widgets people fill themselves pack the family. The commonly-used widget is the exception:
+    /// it picks its own contents, so it stops at the count that still draws as entity tiles rather
+    /// than filling the family with a compressed grid nobody chose.
+    var tileCapacity: WidgetTileCapacity {
+        self == .commonlyUsedEntities ? .tile : .packed
+    }
+}

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesTimelineProvider.swift
@@ -109,7 +109,7 @@ struct WidgetCommonlyUsedEntitiesTimelineProvider: WidgetSingleEntryTimelineProv
             )
         }
 
-        return Array(magicItems.prefix(WidgetFamilySizes.size(for: context.family)))
+        return Array(magicItems.prefix(WidgetFamilySizes.size(for: context.family, capacity: .tile)))
     }
 
     private func entitiesState(

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCapacity.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCapacity.swift
@@ -1,0 +1,12 @@
+#if !os(watchOS)
+import Foundation
+
+/// How full a widget family is allowed to be packed with tiles.
+public enum WidgetTileCapacity: String, CaseIterable, Sendable {
+    /// Every tile the family physically fits, compressing the cards away once they stop fitting.
+    /// What a widget gets unless it asks otherwise.
+    case packed
+    /// The most tiles that still read as entity tiles: every one keeps its padding, border and card.
+    case tile
+}
+#endif

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileContainerView.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileContainerView.swift
@@ -11,6 +11,7 @@ public struct WidgetTileContainerView<Item: WidgetTileRepresentable>: View {
     private let contents: [Item]
     private let family: WidgetFamily
     private let kind: WidgetTileKind
+    private let capacity: WidgetTileCapacity
     private let serverName: String?
     private let emptyView: () -> AnyView
     /// The reload control, when the widget offers one. `nil` leaves the footer off entirely.
@@ -22,6 +23,7 @@ public struct WidgetTileContainerView<Item: WidgetTileRepresentable>: View {
         contents: [Item],
         family: WidgetFamily,
         kind: WidgetTileKind,
+        capacity: WidgetTileCapacity = .packed,
         serverName: String? = nil,
         emptyView: @escaping () -> AnyView = { AnyView(EmptyView()) },
         refreshControl: (() -> AnyView)? = nil,
@@ -31,6 +33,7 @@ public struct WidgetTileContainerView<Item: WidgetTileRepresentable>: View {
         self.contents = contents
         self.family = family
         self.kind = kind
+        self.capacity = capacity
         self.serverName = serverName
         self.emptyView = emptyView
         self.refreshControl = refreshControl
@@ -79,8 +82,8 @@ public struct WidgetTileContainerView<Item: WidgetTileRepresentable>: View {
     }
 
     private var grid: some View {
-        let visible = Array(contents.prefix(WidgetTileLayout.size(for: family)))
-        let rows = WidgetTileLayout.rows(for: family, models: visible)
+        let visible = Array(contents.prefix(WidgetTileLayout.size(for: family, capacity: capacity)))
+        let rows = WidgetTileLayout.rows(for: family, models: visible, capacity: capacity)
         return WidgetTileGridView(
             rows: rows,
             sizeStyle: WidgetTileLayout.sizeStyle(

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileLayout.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileLayout.swift
@@ -8,18 +8,36 @@ import WidgetKit
 /// where the layout it implies is decided, so every widget built out of tiles fills the same family
 /// the same way.
 public enum WidgetTileLayout {
-    // ATTENTION: Unfortunately these sizes below can't be set dynamically to widgets
-    // consider this as the source of truth
-    public static func size(for family: WidgetFamily) -> Int {
-        switch family {
-        case .systemSmall: return 3
-        case .systemMedium: return 6
-        case .systemLarge: return 12
-        case .systemExtraLarge, .systemExtraLargePortrait: return 20
-        case .accessoryRectangular, .accessoryCircular, .accessoryInline:
-            return 1
-        @unknown default:
-            return 1
+    /// ATTENTION: Unfortunately these sizes below can't be set dynamically to widgets,
+    /// consider this as the source of truth.
+    ///
+    /// The `.tile` counts stop where `compressedBreakpoint(for:)` does, so a widget filled to its
+    /// maximum still draws entity tiles rather than a compressed grid. Only the commonly-used
+    /// widget asks for that — it fills itself, so it is the one that has to stay legible unattended.
+    public static func size(for family: WidgetFamily, capacity: WidgetTileCapacity = .packed) -> Int {
+        switch capacity {
+        case .tile:
+            switch family {
+            case .systemSmall: return 2
+            case .systemMedium: return 4
+            case .systemLarge: return 10
+            case .systemExtraLarge, .systemExtraLargePortrait: return 20
+            case .accessoryRectangular, .accessoryCircular, .accessoryInline:
+                return 1
+            @unknown default:
+                return 1
+            }
+        case .packed:
+            switch family {
+            case .systemSmall: return 3
+            case .systemMedium: return 6
+            case .systemLarge: return 12
+            case .systemExtraLarge, .systemExtraLargePortrait: return 20
+            case .accessoryRectangular, .accessoryCircular, .accessoryInline:
+                return 1
+            @unknown default:
+                return 1
+            }
         }
     }
 
@@ -57,15 +75,7 @@ public enum WidgetTileLayout {
     // While previewing we want to display tile card style (with padding and border)
     // To do that we can't display the maximum amount of items otherwise we will show 'compressed' size style
     public static func sizeForPreview(for family: WidgetFamily) -> Int {
-        switch family {
-        case .systemSmall: return size(for: family) - 1
-        case .systemMedium, .systemLarge: return size(for: family) - 2
-        case .systemExtraLarge, .systemExtraLargePortrait: return 20
-        case .accessoryRectangular, .accessoryCircular, .accessoryInline:
-            return 1
-        @unknown default:
-            return 1
-        }
+        size(for: family, capacity: .tile)
     }
 
     /// More than this number: show compact (icon left, text right) version
@@ -159,8 +169,12 @@ public enum WidgetTileLayout {
     }
 
     /// The tiles a family can hold, arranged into the rows it draws them in.
-    public static func rows<Model>(for family: WidgetFamily, models: [Model]) -> [[Model]] {
-        let capped = Array(models.prefix(size(for: family)))
+    public static func rows<Model>(
+        for family: WidgetFamily,
+        models: [Model],
+        capacity: WidgetTileCapacity = .packed
+    ) -> [[Model]] {
+        let capped = Array(models.prefix(size(for: family, capacity: capacity)))
         return Array(rows(count: columns(family: family, modelCount: capped.count), models: capped))
     }
 }

--- a/Tests/Widgets/WidgetTileCapacity.test.swift
+++ b/Tests/Widgets/WidgetTileCapacity.test.swift
@@ -1,0 +1,40 @@
+@testable import HomeAssistant
+
+import HADesignSystem
+import Shared
+import Testing
+import WidgetKit
+
+/// Guards the requirement that the commonly-used widget is the only one that trades tiles for the
+/// entity-tile look; every other widget still packs the family full.
+struct WidgetTileCapacityTests {
+    @Test func commonlyUsedEntitiesKeepsTheEntityTileLook() {
+        #expect(WidgetsKind.commonlyUsedEntities.tileCapacity == .tile)
+        #expect(WidgetTileLayout.size(for: .systemSmall, capacity: .tile) == 2)
+        #expect(WidgetTileLayout.size(for: .systemMedium, capacity: .tile) == 4)
+        #expect(WidgetTileLayout.size(for: .systemLarge, capacity: .tile) == 10)
+    }
+
+    @Test func everyOtherWidgetKeepsTheOriginalSizes() {
+        for kind in WidgetsKind.allCases where kind != .commonlyUsedEntities {
+            #expect(kind.tileCapacity == .packed, "\(kind) must keep the original sizes")
+        }
+        #expect(WidgetTileLayout.size(for: .systemSmall) == 3)
+        #expect(WidgetTileLayout.size(for: .systemMedium) == 6)
+        #expect(WidgetTileLayout.size(for: .systemLarge) == 12)
+        #expect(WidgetTileLayout.size(for: .systemExtraLarge) == 20)
+    }
+
+    /// The point of the lower counts: filled to its maximum, a `.tile` widget must never cross the
+    /// breakpoint that strips the padding and border off every card.
+    @Test func tileCapacityNeverCompresses() {
+        for family in [WidgetFamily.systemSmall, .systemMedium, .systemLarge] {
+            let max = WidgetTileLayout.size(for: family, capacity: .tile)
+            let rows = WidgetTileLayout.rows(for: family, models: Array(0 ..< max), capacity: .tile)
+            #expect(
+                WidgetTileLayout.sizeStyle(family: family, modelsCount: max, rowsCount: rows.count) != .compressed,
+                "\(family) compresses at its maximum"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The commonly used entities widget now shows at most 2 items on small, 4 on medium and 10 on large, down from 3/6/12.

At the old counts the tiles crossed the breakpoint that removes their padding and border, so a full widget rendered as a flat compressed grid. The new counts stop right below that breakpoint, so every tile keeps the entity tile look.

This widget picks its own entities, so the user never chooses how many it shows — that is why it caps lower. Every other widget, including the custom widget, keeps its current sizes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The item count is now a `WidgetTileCapacity` on `WidgetsKind` rather than a single number shared by every widget. It could not be read off `WidgetType`, which calls both the custom and the commonly used widget `.custom` because they draw the same kind of tile.

`WidgetTileCapacityTests` iterates every `WidgetsKind` case and asserts the commonly used widget is the only one on the lower counts, and that a widget filled to its maximum never renders compressed.
