### PR TITLE
Increase corner radius of widget tiles at the widget's corners

### DIFF
--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCardStyleModifier.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCardStyleModifier.swift
@@ -11,6 +11,9 @@ public extension View {
 }
 
 public struct WidgetTileCardStyleModifier: ViewModifier {
+    /// Which corners this tile shares with the widget, set by ``WidgetTileGridView``.
+    @Environment(\.widgetTileCorners) private var widgetTileCorners
+
     public let sizeStyle: WidgetTileSizeStyle
     public let tinted: Bool
     public let model: WidgetTileModel
@@ -34,9 +37,9 @@ public struct WidgetTileCardStyleModifier: ViewModifier {
                     return .widgetTileBackground
                 }
             }())
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .clipShape(shape)
             .overlay {
-                RoundedRectangle(cornerRadius: cornerRadius)
+                shape
                     .stroke(Color.tileBorder, lineWidth: sizeStyle == .single ? 0 : 1)
                     .modify { view in
                         if #available(iOS 18, *) {
@@ -48,8 +51,35 @@ public struct WidgetTileCardStyleModifier: ViewModifier {
             }
     }
 
+    /// The radius a corner has when it sits inside the widget rather than in one of its corners.
     private var cornerRadius: CGFloat {
         sizeStyle == .compressed ? .zero : 14
+    }
+
+    /// The radius a corner has when it is the one sitting in a corner of the widget.
+    ///
+    /// A tile in the widget's corner reads as pinched when it rounds tighter than the widget does,
+    /// so it gets the widget's own radius less the padding holding it off the edge. That is a fixed
+    /// number rather than a measured one: the widget is never asked how round it is, and the answer
+    /// varies by platform anyway. This is the one value to tune if the two stop agreeing.
+    private static let edgeCornerRadius: CGFloat = 20
+
+    /// The card's outline: ``edgeCornerRadius`` on the corners the tile shares with the widget,
+    /// ``cornerRadius`` on the rest.
+    private var shape: AnyShape {
+        guard !widgetTileCorners.isEmpty else {
+            return AnyShape(RoundedRectangle(cornerRadius: cornerRadius))
+        }
+        return AnyShape(UnevenRoundedRectangle(
+            topLeadingRadius: radius(for: .topLeading),
+            bottomLeadingRadius: radius(for: .bottomLeading),
+            bottomTrailingRadius: radius(for: .bottomTrailing),
+            topTrailingRadius: radius(for: .topTrailing)
+        ))
+    }
+
+    private func radius(for corner: WidgetTileCorners) -> CGFloat {
+        widgetTileCorners.contains(corner) ? Self.edgeCornerRadius : cornerRadius
     }
 }
 #endif

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileContainerView.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileContainerView.swift
@@ -93,6 +93,8 @@ public struct WidgetTileContainerView<Item: WidgetTileRepresentable>: View {
             ),
             family: family,
             kind: kind,
+            // The footer, when there is one, is what sits against the widget's bottom edge.
+            reachesBottomEdge: refreshControl == nil,
             tileContent: tileContent,
             tileRegions: tileRegions
         )

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCorners.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCorners.swift
@@ -1,0 +1,22 @@
+#if !os(watchOS)
+import Foundation
+
+/// The corners of a tile that sit in one of the widget's own corners.
+///
+/// Only those corners round wider, to keep from reading as pinched inside the widget's own. A corner
+/// merely lying along one of the widget's edges is not one of them: widening those would round the
+/// seam where two rows meet. ``WidgetTileGridView`` is the only thing that knows which tile is
+/// where, so it is what sets this — see ``EnvironmentValues/widgetTileCorners``.
+public struct WidgetTileCorners: OptionSet, Hashable, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let topLeading = WidgetTileCorners(rawValue: 1 << 0)
+    public static let topTrailing = WidgetTileCorners(rawValue: 1 << 1)
+    public static let bottomLeading = WidgetTileCorners(rawValue: 1 << 2)
+    public static let bottomTrailing = WidgetTileCorners(rawValue: 1 << 3)
+}
+#endif

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCornersEnvironmentKey.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileCornersEnvironmentKey.swift
@@ -1,0 +1,19 @@
+#if !os(watchOS)
+import SwiftUI
+
+private struct WidgetTileCornersEnvironmentKey: EnvironmentKey {
+    static let defaultValue: WidgetTileCorners = []
+}
+
+public extension EnvironmentValues {
+    /// Which of a tile's corners sit in the widget's own corners.
+    ///
+    /// Carried in the environment rather than passed down, because the view that has to read it is
+    /// not always the tile: a widget swaps a tile waiting on a confirmation for a
+    /// ``WidgetTileConfirmationView``, and that stands in for the tile's card too.
+    var widgetTileCorners: WidgetTileCorners {
+        get { self[WidgetTileCornersEnvironmentKey.self] }
+        set { self[WidgetTileCornersEnvironmentKey.self] = newValue }
+    }
+}
+#endif

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileGridView.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileGridView.swift
@@ -55,9 +55,9 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
     public var body: some View {
         let spacing = sizeStyle == .compressed ? .zero : DesignSystem.Spaces.one
         VStack(alignment: .leading, spacing: spacing) {
-            ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, column in
+            ForEach(Array(rows.enumerated()), id: \.element) { rowIndex, column in
                 HStack(spacing: spacing) {
-                    ForEach(Array(column.enumerated()), id: \.element) { itemIndex, item in
+                    ForEach(Array(column.enumerated()), id: \.element.id) { itemIndex, item in
                         tileContent(item, sizeStyle, AnyView(tile(for: item)))
                             .environment(\.widgetTileCorners, corners(row: rowIndex, item: itemIndex, in: column))
                             .frame(maxHeight: maxTileHeight)

--- a/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileGridView.swift
+++ b/Sources/HADesignSystem/Sources/Widgets/Common/WidgetTileGridView.swift
@@ -28,6 +28,9 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
     private let sizeStyle: WidgetTileSizeStyle
     private let family: WidgetFamily
     private let kind: WidgetTileKind
+    /// Whether the grid is what sits against the widget's bottom edge. `false` when something else
+    /// is below it — the reload footer — which is what pushes the last row off that edge.
+    private let reachesBottomEdge: Bool
     private let tileContent: TileContent
     private let tileRegions: TileRegions
 
@@ -36,6 +39,7 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
         sizeStyle: WidgetTileSizeStyle,
         family: WidgetFamily,
         kind: WidgetTileKind,
+        reachesBottomEdge: Bool = true,
         tileContent: @escaping TileContent = { _, _, tile in tile },
         tileRegions: @escaping TileRegions = { _ in nil }
     ) {
@@ -43,6 +47,7 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
         self.sizeStyle = sizeStyle
         self.family = family
         self.kind = kind
+        self.reachesBottomEdge = reachesBottomEdge
         self.tileContent = tileContent
         self.tileRegions = tileRegions
     }
@@ -50,15 +55,16 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
     public var body: some View {
         let spacing = sizeStyle == .compressed ? .zero : DesignSystem.Spaces.one
         VStack(alignment: .leading, spacing: spacing) {
-            ForEach(rows, id: \.self) { column in
+            ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, column in
                 HStack(spacing: spacing) {
-                    ForEach(column) { item in
+                    ForEach(Array(column.enumerated()), id: \.element) { itemIndex, item in
                         tileContent(item, sizeStyle, AnyView(tile(for: item)))
+                            .environment(\.widgetTileCorners, corners(row: rowIndex, item: itemIndex, in: column))
                             .frame(maxHeight: maxTileHeight)
                             .frame(maxWidth: .infinity)
                     }
                     // Constraint item to single column
-                    if column.count == 1, family != .systemSmall, sizeStyle == .compact {
+                    if hasTrailingSpacer(column) {
                         Spacer()
                             .frame(maxWidth: .infinity)
                     }
@@ -71,6 +77,33 @@ public struct WidgetTileGridView<Item: WidgetTileRepresentable>: View {
 
     private var maxTileHeight: CGFloat? {
         (sizeStyle == .compact && family != .systemSmall) ? Self.maxTileHeightWhenCompact : nil
+    }
+
+    /// Which of the widget's corners this tile is the one sitting in, if any: the ends of the first
+    /// row take the top two, the ends of the last row take the bottom two — but only when the grid
+    /// is what reaches the widget's bottom edge rather than a footer below it.
+    ///
+    /// None of them when the grid is compressed: with no padding to hold a tile off the edge, the
+    /// widget's own clip already rounds the corners it reaches, so there is nothing left to widen.
+    private func corners(row: Int, item: Int, in tiles: [Item]) -> WidgetTileCorners {
+        guard sizeStyle != .compressed else { return [] }
+        // A row padded out with a spacer stops short of the widget's trailing edge.
+        let isLeading = item == .zero
+        let isTrailing = item == tiles.count - 1 && !hasTrailingSpacer(tiles)
+        var corners: WidgetTileCorners = []
+        if row == .zero {
+            if isLeading { corners.insert(.topLeading) }
+            if isTrailing { corners.insert(.topTrailing) }
+        }
+        if row == rows.count - 1, reachesBottomEdge {
+            if isLeading { corners.insert(.bottomLeading) }
+            if isTrailing { corners.insert(.bottomTrailing) }
+        }
+        return corners
+    }
+
+    private func hasTrailingSpacer(_ tiles: [Item]) -> Bool {
+        tiles.count == 1 && family != .systemSmall && sizeStyle == .compact
     }
 
     private func tile(for item: Item) -> some View {


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Every widget tile used the same 14pt corner radius, so a tile sitting in one of the widget's own corners rounded tighter than the widget did and read as pinched against it.

Those corners now use 20pt. The first row takes the widget's top corners, the last row takes the bottom ones — but only when the reload footer is not sitting below it. Every other corner keeps 14pt, so the seams between rows and columns are unchanged.

## Screenshots

Corner radius only, and identical in light and dark.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Compressed grids are left alone: with no padding to hold a tile off the edge, the widget's own clip already rounds the corners it reaches.
