### PR TITLE
Match frontend entity icon colors in widgets, CarPlay and Watch

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */; };
 		13E4D63B90C14B0DA25F2827 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = C8FA7E5B23954D258050DD72 /* SFSafeSymbols */; };
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
+		42AA0008300100010001AAA1 /* EntityIconColorProvider.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AA0007300100010001AAA1 /* EntityIconColorProvider.test.swift */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
 		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -116,6 +117,10 @@
 		427E92BE2D65E43A0001566B /* WidgetInteractionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427E92BB2D65E3FE0001566B /* WidgetInteractionType.swift */; };
 		427E92BF2D65E43A0001566B /* WidgetInteractionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427E92BB2D65E3FE0001566B /* WidgetInteractionType.swift */; };
 		4286A2EF2F2A0F9200003459 /* EntityIconColorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */; };
+		42AA0005300100010001AAA1 /* EntityStateColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AA0004300100010001AAA1 /* EntityStateColor.swift */; };
+		42AA0006300100010001AAA1 /* EntityStateColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AA0004300100010001AAA1 /* EntityStateColor.swift */; };
+		42AA0002300100010001AAA1 /* EntityStateActive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AA0001300100010001AAA1 /* EntityStateActive.swift */; };
+		42AA0003300100010001AAA1 /* EntityStateActive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AA0001300100010001AAA1 /* EntityStateActive.swift */; };
 		4286A2F02F2A0F9200003459 /* EntityIconColorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */; };
 		42886D162FFE5C12004EB33B /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = 42886D152FFE5C12004EB33B /* Sodium */; };
 		42886D182FFE5C19004EB33B /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = 42886D172FFE5C19004EB33B /* Sodium */; };
@@ -613,6 +618,8 @@
 		42145A652F7F4CC000891E04 /* EntityColorAttributesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityColorAttributesParser.swift; sourceTree = "<group>"; };
 		42164BB8301320720077A903 /* ComplicationFormula.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationFormula.test.swift; sourceTree = "<group>"; };
 		4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIconColorProvider.swift; sourceTree = "<group>"; };
+		42AA0004300100010001AAA1 /* EntityStateColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityStateColor.swift; sourceTree = "<group>"; };
+		42AA0001300100010001AAA1 /* EntityStateActive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityStateActive.swift; sourceTree = "<group>"; };
 		423FB76C2FFFDFDE000CB8FD /* Extensions-WatchWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Extensions-WatchWidgets.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		424169A2303486F500672F1D /* WriteBehindServerManagerKeychain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteBehindServerManagerKeychain.test.swift; sourceTree = "<group>"; };
 		4245DC022EBA42C3005E0E04 /* AreasService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreasService.swift; sourceTree = "<group>"; };
@@ -689,6 +696,7 @@
 		D0C8845F211ED11900CCB501 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		D0EEF300214D8EAB00D1D360 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		DA5459C05BEB77340680D8C6 /* Domain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.test.swift; sourceTree = "<group>"; };
+		42AA0007300100010001AAA1 /* EntityIconColorProvider.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIconColorProvider.test.swift; sourceTree = "<group>"; };
 		FA11C0DE0000000000000100 /* BackgroundRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshManager.swift; sourceTree = "<group>"; };
 		FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+CarPlay.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2852,6 +2860,8 @@
 				42EDBE083002FC020051FC9B /* LiveActivity */,
 				42BB4C362CD26490003E47FD /* HATypedRequest+App.swift */,
 				4236229F2F05587800391BD0 /* EntityIconColorProvider.swift */,
+				42AA0004300100010001AAA1 /* EntityStateColor.swift */,
+				42AA0001300100010001AAA1 /* EntityStateActive.swift */,
 				42EDBE4E3002FC020051FC9B /* Models */,
 				4245DC022EBA42C3005E0E04 /* AreasService.swift */,
 				42EDBE1F3002FC020051FC9B /* Database */,
@@ -2951,6 +2961,7 @@
 				42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */,
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
+				42AA0007300100010001AAA1 /* EntityIconColorProvider.test.swift */,
 				42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */,
 				42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */,
 				42C11A0631AC500011AABB06 /* VacuumAreaMapping.test.swift */,
@@ -4319,6 +4330,8 @@
 				4298587F2EB1025E00E33710 /* LocationManager.swift in Sources */,
 				426D9C752C9C60B000F278AF /* ControlEntityProvider.swift in Sources */,
 				4286A2F02F2A0F9200003459 /* EntityIconColorProvider.swift in Sources */,
+				42AA0005300100010001AAA1 /* EntityStateColor.swift in Sources */,
+				42AA0002300100010001AAA1 /* EntityStateActive.swift in Sources */,
 				42DFE8802EFB23240058DADB /* HAEntity+CarPlay.swift in Sources */,
 				42FF5E972E22E5C100BDF5EF /* TodoListItem.swift in Sources */,
 				4278C9BF2C89DD5D00A7B5F4 /* HAAppEntity.swift in Sources */,
@@ -4352,6 +4365,8 @@
 				42C60FA72F081DA90071A6F6 /* DeviceClassProvider.swift in Sources */,
 				428EDB692DAFD9B900A271A1 /* HAEntity+DeviceClass.swift in Sources */,
 				4286A2EF2F2A0F9200003459 /* EntityIconColorProvider.swift in Sources */,
+				42AA0006300100010001AAA1 /* EntityStateColor.swift in Sources */,
+				42AA0003300100010001AAA1 /* EntityStateActive.swift in Sources */,
 				42FF5E982E22E5C100BDF5EF /* TodoListItem.swift in Sources */,
 				42145A622DAFD49A00891E04 /* HAEntity+CarPlay.swift in Sources */,
 				4298587E2EB1025E00E33710 /* LocationManager.swift in Sources */,
@@ -4395,6 +4410,7 @@
 				1165707C2702BAF5003906A7 /* DiskCache.test.swift in Sources */,
 				42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */,
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
+				42AA0008300100010001AAA1 /* EntityIconColorProvider.test.swift in Sources */,
 				42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */,
 				42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */,
 				42C11A0731AC500011AABB07 /* VacuumAreaMapping.test.swift in Sources */,

--- a/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
+++ b/Sources/App/Settings/MagicItem/Edit/MagicItemCustomizationView.swift
@@ -128,16 +128,16 @@ struct MagicItemCustomizationView: View {
     @ViewBuilder
     private func customizationView(info: MagicItem.Info) -> some View {
         Section {
+            // Seeding the picker is a read, so it must not write the seed back: an entity only
+            // drops the color the frontend gives it once the user actually picks one here.
             ColorPicker(L10n.MagicItem.IconColor.title, selection: .init(get: {
-                var color = Color.haPrimary
                 if let configIconColor = viewModel.item.customization?.iconColor {
-                    color = Color(hex: configIconColor)
-                } else {
-                    viewModel.item.customization?.iconColor = color.hex()
+                    return Color(hex: configIconColor)
                 }
-                return color
+                return Color.haPrimary
             }, set: { newColor in
                 viewModel.item.customization?.iconColor = newColor.hex()
+                viewModel.item.customization?.iconColorIsCustomized = true
             }), supportsOpacity: false)
             if context != .carPlay {
                 Toggle(L10n.MagicItem.UseCustomColors.title, isOn: $useCustomColors)

--- a/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
+++ b/Sources/App/Settings/Widgets/Builder/WidgetCreationView.swift
@@ -207,7 +207,7 @@ struct WidgetCreationView: View {
         let models = viewModel.widget.items.map { magicItem in
             let info = viewModel.magicItemInfo(for: magicItem)
             let textColor = Color(hex: magicItem.customization?.textColor)
-            let iconColor = Color(hex: magicItem.customization?.iconColor)
+            let iconColor = Color(hex: magicItem.customization?.customIconColor)
             let backgroundColor = Color(hex: magicItem.customization?.backgroundColor)
             let icon: MaterialDesignIcons = {
                 if let info {

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -150,32 +150,24 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
     private func displayContent() -> DisplayContent {
         var displayText = entity.attributes.friendlyName ?? entity.entityId
         let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
-        var iconColor = entity.carPlayIconColor()
-        var image = entity.getMDI(componentIcons: componentIcons).carPlayIcon(color: iconColor)
 
+        // The color always comes from the entity's live state — the same palette the frontend, the
+        // widgets and the watch use. Only the *icon* is subject to the saved/customized choice: a
+        // user who picked a custom icon still wants to see whether the thing is on.
+        let customIconColor = (magicItem?.customization?.customIconColor).map { UIColor(hex: $0) }
+        let iconColor = entity.stateIconColor(customColor: customIconColor)
+
+        var icon = entity.getMDI(componentIcons: componentIcons)
         if let magicItem, let magicItemInfo {
             displayText = magicItem.name(info: magicItemInfo)
 
-            // Check if user has customized the icon color
-            let customIconColor: UIColor? = {
-                if let iconColorString = magicItem.customization?.iconColor {
-                    return UIColor(hex: iconColorString)
-                }
-                return nil
-            }()
-
             let userHasCustomizedIcon = magicItem.customization?.iconIsCustomized == true
             if !entityHasDynamicIcon || userHasCustomizedIcon {
-                // Use the configured icon, respecting any explicit user customization
-                iconColor = customIconColor ?? .haPrimary
-                image = magicItem.icon(info: magicItemInfo).carPlayIcon(color: iconColor)
-            } else {
-                // Dynamic entity icons should reflect the live server-provided color,
-                // matching the main entities/controls views instead of saved quick-access tint.
-                iconColor = entity.carPlayIconColor()
-                image = entity.getMDI(componentIcons: componentIcons).carPlayIcon(color: iconColor)
+                // Use the configured icon, respecting any explicit user customization.
+                icon = magicItem.icon(info: magicItemInfo)
             }
         }
+        let image = icon.carPlayIcon(color: iconColor)
 
         var detailText: String?
         if !entityHasIrrelevantState {

--- a/Sources/Extensions/Widgets/Common/WidgetPreviewSample.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetPreviewSample.swift
@@ -28,14 +28,21 @@ enum WidgetPreviewSample {
         entity(id: "fan.preview", name: CoreStrings.componentFanTitle, domain: .fan, state: .off),
         entity(id: "lock.preview", name: CoreStrings.componentLockTitle, domain: .lock, state: .locked),
         entity(id: "scene.preview", name: CoreStrings.componentSceneTitle, domain: .scene, state: nil),
-        entity(id: "script.preview", name: CoreStrings.componentScriptTitle, domain: .script, state: nil),
+        entity(
+            id: "script.preview",
+            name: CoreStrings.componentScriptTitle,
+            domain: .script,
+            state: nil,
+            rawState: Domain.State.off.rawValue
+        ),
         entity(
             id: "sensor.preview",
             name: L10n.Climate.Control.Temperature.title,
             domain: .sensor,
             state: nil,
             iconName: MaterialDesignIcons.thermometerIcon.name,
-            stateValue: temperatureValue
+            stateValue: temperatureValue,
+            rawState: "21.5"
         ),
     ]
 
@@ -78,13 +85,16 @@ enum WidgetPreviewSample {
         return states
     }
 
+    /// - Parameter rawState: the state the tile is colored from, for the samples whose displayed
+    ///   value isn't one of the `Domain.State` cases (a sensor reading, a script's last run).
     private static func entity(
         id: String,
         name: String,
         domain: Domain,
         state: Domain.State?,
         iconName: String? = nil,
-        stateValue: String? = nil
+        stateValue: String? = nil,
+        rawState: String? = nil
     ) -> WidgetPreviewSampleEntity {
         WidgetPreviewSampleEntity(
             magicItem: .init(id: id, serverId: serverId, type: .entity),
@@ -92,7 +102,10 @@ enum WidgetPreviewSample {
             state: .init(
                 value: stateValue ?? state.map(stateName(for:)) ?? "",
                 domainState: state,
-                hexColor: nil
+                rawState: rawState ?? state?.rawValue ?? EntityStateActive.unknown,
+                deviceClass: nil,
+                liveColorHex: nil,
+                groupMemberDomain: nil
             )
         )
     }

--- a/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
@@ -5,11 +5,27 @@ import WidgetKit
 struct WidgetEntityState: Codable {
     let value: String
     let domainState: Domain.State?
-    let hexColor: String?
+    /// The raw, lowercased entity state and its device class, kept so the icon color can be
+    /// resolved at render time — the frontend's palette keys off both, and resolving here would
+    /// freeze the color to whatever appearance the timeline provider happened to run under.
+    let rawState: String
+    let deviceClass: String?
+    /// Hex of the light's own color, when it reports one.
+    let liveColorHex: String?
+    /// For a `group`, the domain all of its members share.
+    let groupMemberDomain: String?
 
-    var color: Color? {
-        guard let hexColor else { return nil }
-        return Color(hex: hexColor)
+    /// The icon color home-assistant/frontend gives this entity, or `customColor` when the user
+    /// picked one — which, as in the tile card, only applies while the entity is active.
+    func iconColor(domain: Domain?, customColor: Color? = nil) -> Color {
+        EntityIconColorProvider.iconColor(
+            domain: domain?.rawValue ?? "",
+            deviceClass: deviceClass,
+            state: rawState,
+            liveColor: liveColorHex.map { Color(hex: $0) },
+            groupMemberDomain: groupMemberDomain,
+            customColor: customColor
+        )
     }
 }
 
@@ -123,7 +139,10 @@ struct WidgetEntityStateProvider {
                 states[item] = .init(
                     value: value,
                     domainState: state.domainState,
-                    hexColor: state.color?.hex()
+                    rawState: state.rawState,
+                    deviceClass: state.deviceClass,
+                    liveColorHex: state.liveColor?.hex(),
+                    groupMemberDomain: state.groupMemberDomain
                 )
             } else {
                 Current.Log.error(

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntities.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntities.swift
@@ -70,17 +70,12 @@ struct WidgetCommonlyUsedEntities: Widget {
                 }
             }()
 
+            // The icon takes the color home-assistant/frontend gives the entity — its domain's and
+            // device class's `--state-…` palette. Items the widget fetches no state for keep the
+            // app's tint.
             let iconColor: Color = {
-                let domainsWithActiveState: [Domain] = [.light, .switch, .inputBoolean, .cover, .fan, .climate]
-                if showStates, let domain = magicItem.domain, domainsWithActiveState.contains(domain) {
-                    if state?.domainState?.isActive ?? false {
-                        return state?.color ?? Color.haPrimary
-                    } else {
-                        return Color.gray
-                    }
-                } else {
-                    return Color.haPrimary
-                }
+                guard showStates, let state else { return Color.haPrimary }
+                return state.iconColor(domain: magicItem.domain)
             }()
 
             let title: String = {

--- a/Sources/Extensions/Widgets/Custom/WidgetCustom.swift
+++ b/Sources/Extensions/Widgets/Custom/WidgetCustom.swift
@@ -76,26 +76,22 @@ struct WidgetCustom: Widget {
                 }
             }()
 
+            // The icon takes the color home-assistant/frontend gives the entity — its domain's and
+            // device class's `--state-…` palette — unless the user picked one for this tile.
             let iconColor: Color = {
-                let magicItemIconColor = {
-                    if let iconColor = magicItem.customization?.iconColor {
-                        return Color(hex: iconColor)
-                    } else {
-                        return Color.haPrimary
-                    }
-                }()
-
                 if !widget.itemsStates.isEmpty {
                     return Color.gray
-                } else if showStates, [.light, .switch, .inputBoolean, .cover, .fan].contains(magicItem.domain) {
-                    if state?.domainState?.isActive ?? false {
-                        return state?.color ?? magicItemIconColor
-                    } else {
-                        return Color.gray
-                    }
-                } else {
-                    return magicItemIconColor
                 }
+
+                let customIconColor = magicItem.customization?.customIconColor.map { Color(hex: $0) }
+
+                // Items the widget never fetches a state for (scripts, scenes, buttons, Assist)
+                // have nothing to color from, and keep the app's tint.
+                guard showStates, let state else {
+                    return customIconColor ?? Color.haPrimary
+                }
+
+                return state.iconColor(domain: magicItem.domain, customColor: customIconColor)
             }()
 
             let title: String = {

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -17,13 +17,33 @@ public final class ControlEntityProvider {
         public let value: String
         public let unitOfMeasurement: String?
         public let domainState: Domain.State?
-        public let color: Color?
+        /// The raw, lowercased entity state. `value` is formatted for display (precision, unit,
+        /// device-class wording), so anything that keys off the state itself — the frontend's icon
+        /// color palette — needs the original.
+        public let rawState: String
+        /// The raw `device_class` attribute, which that palette also keys off.
+        public let deviceClass: String?
+        /// The light's own color, already contrast-adjusted, when it reports one.
+        public let liveColor: Color?
+        /// For a `group`, the domain all of its members share, whose palette the group borrows.
+        public let groupMemberDomain: String?
 
-        public init(value: String, unitOfMeasurement: String?, domainState: Domain.State?, color: Color? = nil) {
+        public init(
+            value: String,
+            unitOfMeasurement: String?,
+            domainState: Domain.State?,
+            rawState: String = "",
+            deviceClass: String? = nil,
+            liveColor: Color? = nil,
+            groupMemberDomain: String? = nil
+        ) {
             self.value = value
             self.unitOfMeasurement = unitOfMeasurement
             self.domainState = domainState
-            self.color = color
+            self.rawState = rawState
+            self.deviceClass = deviceClass
+            self.liveColor = liveColor
+            self.groupMemberDomain = groupMemberDomain
         }
     }
 
@@ -177,93 +197,69 @@ public final class ControlEntityProvider {
             return nil
         }
 
-        var stateValue = (state["state"] as? String) ?? "N/A"
-        stateValue = StatePrecision.adjustPrecision(
+        let rawStateValue = (state["state"] as? String) ?? "N/A"
+        var stateValue = StatePrecision.adjustPrecision(
             serverId: server.identifier.rawValue,
             entityId: entityId,
-            stateValue: stateValue
+            stateValue: rawStateValue
         )
         stateValue = stateValue.capitalizedFirst
 
         let attributes = state["attributes"] as? [String: Any]
-        let colorAttributes = parseColorAttributes(from: attributes)
         let unitOfMeasurement = attributes?["unit_of_measurement"] as? String
 
         return buildState(
             entityId: entityId,
+            rawStateValue: rawStateValue.lowercased(),
             stateValue: stateValue,
             attributes: attributes,
-            colorAttributes: colorAttributes,
             unitOfMeasurement: unitOfMeasurement
         )
     }
 
-    private func parseColorAttributes(from attributes: [String: Any]?) -> (
-        colorMode: String?,
-        rgbColor: [Int]?,
-        hsColor: [Double]?
-    ) {
-        EntityColorAttributesParser.parse(from: attributes)
-    }
-
     private func buildState(
         entityId: String,
+        rawStateValue: String,
         stateValue: String,
         attributes: [String: Any]?,
-        colorAttributes: (colorMode: String?, rgbColor: [Int]?, hsColor: [Double]?),
         unitOfMeasurement: String?
     ) -> State {
         let domain = Domain(entityId: entityId)
         let domainState = Domain.State(rawValue: stateValue.lowercased())
+        let rawDomain = entityId.components(separatedBy: ".").first ?? ""
+        let colorAttributes = EntityColorAttributesParser.parse(from: attributes)
 
-        if let deviceClass = extractDeviceClass(from: attributes),
+        // The color is left to the view layer to resolve from these ingredients rather than baked
+        // in here: the widgets cache this state, and a resolved color would be flattened to a
+        // single appearance instead of following the current color scheme.
+        let liveColor = EntityIconColorProvider.liveColor(
+            domain: rawDomain,
+            rgbColor: colorAttributes.rgbColor,
+            hsColor: colorAttributes.hsColor
+        )
+        let deviceClass = attributes?["device_class"] as? String
+        let groupMemberDomain = rawDomain == Domain.group.rawValue
+            ? EntityIconColorProvider.groupMemberDomain(attributes: attributes)
+            : nil
+
+        var value = stateValue
+        var unit = unitOfMeasurement
+        if let deviceClass = deviceClass.flatMap(DeviceClass.init(rawValue:)),
            let domainState,
            unitOfMeasurement == nil,
            let stateForDeviceClass = domain?.stateForDeviceClass(deviceClass, state: domainState) {
-            let computedColor = computeIconColor(
-                entityId: entityId,
-                stateValue: stateValue,
-                colorAttributes: colorAttributes
-            )
-            return .init(
-                value: stateForDeviceClass,
-                unitOfMeasurement: nil,
-                domainState: domainState,
-                color: computedColor
-            )
-        } else {
-            let computedColor = computeIconColor(
-                entityId: entityId,
-                stateValue: stateValue,
-                colorAttributes: colorAttributes
-            )
-            return .init(
-                value: stateValue,
-                unitOfMeasurement: unitOfMeasurement,
-                domainState: domainState,
-                color: computedColor
-            )
+            value = stateForDeviceClass
+            unit = nil
         }
-    }
 
-    private func extractDeviceClass(from attributes: [String: Any]?) -> DeviceClass? {
-        guard let rawDeviceClass = attributes?["device_class"] as? String else {
-            return nil
-        }
-        return DeviceClass(rawValue: rawDeviceClass)
-    }
-
-    private func computeIconColor(
-        entityId: String,
-        stateValue: String,
-        colorAttributes: (colorMode: String?, rgbColor: [Int]?, hsColor: [Double]?)
-    ) -> Color? {
-        EntityIconColorProvider.iconColor(
-            domain: Domain(entityId: entityId) ?? .switch,
-            state: stateValue.lowercased(),
-            colorMode: colorAttributes.colorMode,
-            rgbColor: colorAttributes.rgbColor,
-            hsColor: colorAttributes.hsColor
+        return .init(
+            value: value,
+            unitOfMeasurement: unit,
+            domainState: domainState,
+            rawState: rawStateValue,
+            deviceClass: deviceClass,
+            liveColor: liveColor,
+            groupMemberDomain: groupMemberDomain
         )
     }
 }

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -83,30 +83,7 @@ public enum Domain: String, CaseIterable {
 
         case unknown
         case unavailable
-
-        /// States that represent an "active" condition
-        public var isActive: Bool {
-            Domain.activeStates.contains(self)
-        }
     }
-
-    /// States that represent an "active" condition
-    /// such as for displaying accent color for entity tile icon
-    public static var activeStates: [State] = [
-        .on,
-        .open,
-        .unlocked,
-        .unlocking,
-        .locking,
-        .opening,
-        .closing,
-    ]
-
-    /// States that represent a "problem" condition
-    public static var problemStates: [State] = [
-        .jammed,
-        .unavailable,
-    ]
 
     public var states: [State] {
         var states: [State] = []

--- a/Sources/Shared/EntityIconColorProvider.swift
+++ b/Sources/Shared/EntityIconColorProvider.swift
@@ -2,110 +2,172 @@ import Foundation
 import HADesignSystem
 import SwiftUI
 
+/// The color an entity's icon is drawn with, following home-assistant/frontend's tile card
+/// (`hui-tile-card`'s `_computeStateColor` plus the neutral defaults its stylesheet sets):
+///
+/// 1. a light's own color, when it reports one;
+/// 2. the `--state-…` palette for the entity's domain, device class and state — see
+///    ``EntityStateColor``;
+/// 3. `--state-icon-color` when active and `--state-inactive-color` when not, for the domains that
+///    take no state color at all (sensors, numbers, scripts, …).
 public enum EntityIconColorProvider {
-    /// Frontend state palette (`color.globals.ts` in home-assistant/frontend), for states that
-    /// have no domain accent or live color of their own.
-    public static let activeColor = Color(hex: "#FFC107") // --state-active-color (amber)
-    public static let lockLockedColor = Color(hex: "#4CAF50") // --state-lock-locked-color (green)
-    public static let lockUnlockedColor = Color(hex: "#F44336") // --state-lock-unlocked/jammed-color (red)
-    public static let lockTransitionColor = Color(hex: "#FF9800") // --state-lock-locking/unlocking-color (orange)
-
+    /// The color for an entity whose live color (if any) has already been resolved.
+    ///
+    /// - Parameters:
+    ///   - domain: the entity's own domain, lowercased.
+    ///   - deviceClass: the raw `device_class` attribute, if any.
+    ///   - state: the raw entity state; case is normalized here.
+    ///   - liveColor: the light's own color, from ``liveColor(domain:rgbColor:hsColor:)``.
+    ///   - groupMemberDomain: for a `group`, the single domain all its members share.
+    ///   - customColor: a color the user picked for this entity on this surface, which takes
+    ///     precedence over everything below it.
     public static func iconColor(
-        domain: Domain,
+        domain: String,
+        deviceClass: String? = nil,
         state: String,
-        colorMode: String?,
+        liveColor: Color? = nil,
+        groupMemberDomain: String? = nil,
+        customColor: Color? = nil
+    ) -> Color {
+        let normalizedState = state.lowercased()
+        let active = EntityStateActive.isActive(domain: domain, state: normalizedState)
+
+        // The tile card's `color` option: a picked color only applies while the entity is active,
+        // so an off light still reads as off.
+        if let customColor {
+            return active ? customColor : neutralColor(active: false)
+        }
+
+        // A light that is on shows its own color rather than the domain accent.
+        if active, let liveColor {
+            return liveColor
+        }
+
+        if let stateColor = EntityStateColor.color(
+            domain: domain,
+            deviceClass: deviceClass,
+            state: normalizedState,
+            groupMemberDomain: groupMemberDomain
+        ) {
+            return stateColor
+        }
+
+        return neutralColor(active: active)
+    }
+
+    /// The same, reading the device class, the light's color and a group's shared domain straight
+    /// out of the entity's attributes.
+    public static func iconColor(
+        domain: String,
+        state: String,
+        attributes: [String: Any]?,
+        customColor: Color? = nil
+    ) -> Color {
+        let colorAttributes = EntityColorAttributesParser.parse(from: attributes)
+        return iconColor(
+            domain: domain,
+            deviceClass: attributes?["device_class"] as? String,
+            state: state,
+            liveColor: liveColor(
+                domain: domain,
+                rgbColor: colorAttributes.rgbColor,
+                hsColor: colorAttributes.hsColor
+            ),
+            groupMemberDomain: domain == Domain.group.rawValue ? groupMemberDomain(attributes: attributes) : nil,
+            customColor: customColor
+        )
+    }
+
+    /// `computeGroupDomain`: the domain every member of a group shares, when they all share one.
+    public static func groupMemberDomain(attributes: [String: Any]?) -> String? {
+        guard let entityIds = attributes?["entity_id"] as? [String] else { return nil }
+        let domains = Set(entityIds.compactMap { $0.split(separator: ".").first.map(String.init) })
+        return domains.count == 1 ? domains.first : nil
+    }
+
+    /// What the tile card falls back to when a domain has no state color of its own:
+    /// `--state-icon-color` while active, `--state-inactive-color` otherwise.
+    public static func neutralColor(active: Bool) -> Color {
+        active ? FrontendColors.stateIconColor.color : FrontendColors.stateInactiveColor.color
+    }
+
+    /// A light's own color, contrast-adjusted the way the tile card does before painting with it:
+    /// nearly unsaturated colors are pushed to 40% saturation, and a white light is dimmed instead,
+    /// so a "white" bulb doesn't render as an invisible icon.
+    ///
+    /// `nil` for every other domain, and for a light that reports no color at all.
+    public static func liveColor(
+        domain: String,
         rgbColor: [Int]?,
         hsColor: [Double]?
-    ) -> Color {
-        // Locks carry their own per-state palette in the frontend; match it before the generic
-        // active/inactive handling ("locked" isn't an active state and would come out gray).
-        if domain == .lock, let lockState = Domain.State(rawValue: state),
-           let lockColor = lockColor(for: lockState) {
-            return lockColor
-        }
-
-        guard Domain.activeStates.map(\.rawValue).contains(state) else {
-            if Domain.problemStates.map(\.rawValue).contains(state) {
-                return .red
-            } else {
-                return .gray
-            }
-        }
-
-        // Check color_mode first if available to prioritize the correct attribute
-        if let colorMode {
-            switch colorMode {
-            case "rgb", "rgbw", "rgbww":
-                if let rgb = rgbColor, rgb.count == 3 {
-                    return Color(
-                        red: Double(rgb[0]) / 255.0,
-                        green: Double(rgb[1]) / 255.0,
-                        blue: Double(rgb[2]) / 255.0
-                    )
-                }
-            case "hs":
-                if let hs = hsColor, hs.count == 2 {
-                    return Color(hue: hs[0] / 360.0, saturation: hs[1] / 100.0, brightness: 1.0)
-                }
-            case "xy", "color_temp":
-                // Home Assistant usually provides rgb_color approximation for xy and color_temp
-                if let rgb = rgbColor, rgb.count == 3 {
-                    return Color(
-                        red: Double(rgb[0]) / 255.0,
-                        green: Double(rgb[1]) / 255.0,
-                        blue: Double(rgb[2]) / 255.0
-                    )
-                }
-            default:
-                break
-            }
-        }
-
-        // Fallback or if color_mode is missing
-        if let rgb = rgbColor, rgb.count == 3 {
-            return Color(
-                red: Double(rgb[0]) / 255.0,
-                green: Double(rgb[1]) / 255.0,
-                blue: Double(rgb[2]) / 255.0
-            )
-        }
-
-        if let hs = hsColor, hs.count == 2 {
-            return Color(hue: hs[0] / 360.0, saturation: hs[1] / 100.0, brightness: 1.0)
-        }
-
-        return domain.accentColor
-    }
-
-    private static func lockColor(for state: Domain.State) -> Color? {
-        switch state {
-        case .locked:
-            return lockLockedColor
-        case .unlocked, .jammed, .open:
-            return lockUnlockedColor
-        case .locking, .unlocking, .opening:
-            return lockTransitionColor
-        default:
-            // Unknown/unavailable fall through to the generic handling.
+    ) -> Color? {
+        guard domain == Domain.light.rawValue else { return nil }
+        guard let rgb = rgbComponents(rgbColor: rgbColor, hsColor: hsColor) else {
             return nil
         }
-    }
-}
 
-public extension Domain {
-    var accentColor: Color {
-        switch self {
-        case .light:
-            Color.Domain.light
-        case .switch:
-            Color.Domain.switch
-        case .fan:
-            Color.Domain.fan
-        case .cover:
-            Color.Domain.cover
-        default:
-            // The frontend's generic active color (--state-active-color).
-            EntityIconColorProvider.activeColor
+        let adjusted = contrastAdjusted(rgb)
+        return Color(
+            .sRGB,
+            red: adjusted[0] / 255,
+            green: adjusted[1] / 255,
+            blue: adjusted[2] / 255
+        )
+    }
+
+    private static func rgbComponents(rgbColor: [Int]?, hsColor: [Double]?) -> [Double]? {
+        // `rgb_color` is the only attribute the frontend reads, and Home Assistant fills it in for
+        // every color mode. `hs_color` is a fallback for the rare light that reports hue and
+        // saturation without the RGB approximation.
+        if let rgbColor, rgbColor.count == 3 {
+            return rgbColor.map(Double.init)
         }
+        if let hsColor, hsColor.count == 2 {
+            return hsv2rgb([hsColor[0], hsColor[1] / 100, 255])
+        }
+        return nil
+    }
+
+    private static func contrastAdjusted(_ rgb: [Double]) -> [Double] {
+        var hsv = rgb2hsv(rgb)
+        if hsv[1] < 0.4 {
+            if hsv[1] < 0.1 {
+                // Special case for a very light color (e.g. white): darken it instead.
+                hsv[2] = 225
+            } else {
+                hsv[1] = 0.4
+            }
+        }
+        return hsv2rgb(hsv)
+    }
+
+    /// `rgb2hsv` from `common/color/convert-color.ts`: hue in degrees, saturation 0-1, value 0-255.
+    static func rgb2hsv(_ rgb: [Double]) -> [Double] {
+        let (red, green, blue) = (rgb[0], rgb[1], rgb[2])
+        let value = max(red, green, blue)
+        let chroma = value - min(red, green, blue)
+
+        var hue: Double = 0
+        if chroma != 0 {
+            if value == red {
+                hue = (green - blue) / chroma
+            } else if value == green {
+                hue = 2 + (blue - red) / chroma
+            } else {
+                hue = 4 + (red - green) / chroma
+            }
+        }
+
+        return [60 * (hue < 0 ? hue + 6 : hue), value == 0 ? 0 : chroma / value, value]
+    }
+
+    /// `hsv2rgb` from `common/color/convert-color.ts`.
+    static func hsv2rgb(_ hsv: [Double]) -> [Double] {
+        let (hue, saturation, value) = (hsv[0], hsv[1], hsv[2])
+        func component(_ n: Double) -> Double {
+            let k = (n + hue / 60).truncatingRemainder(dividingBy: 6)
+            return value - value * saturation * max(min(k, 4 - k, 1), 0)
+        }
+        return [component(5), component(3), component(1)]
     }
 }

--- a/Sources/Shared/EntityStateActive.swift
+++ b/Sources/Shared/EntityStateActive.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Port of `common/entity/state_active.ts` in home-assistant/frontend: whether an entity's state
+/// counts as "active", which is what decides between the accent and the muted icon color.
+///
+/// Kept string-based, like the frontend, so domains the app's ``Domain`` enum doesn't model (plant,
+/// tag, …) still resolve the way the frontend does.
+public enum EntityStateActive {
+    public static let unavailable = "unavailable"
+    public static let unknown = "unknown"
+
+    /// `TIMESTAMP_STATE_DOMAINS` in `common/const.ts` — domains whose state is a timestamp, so any
+    /// value other than `unavailable` means the entity is fine.
+    public static let timestampStateDomains: Set<String> = [
+        "ai_task",
+        "button",
+        "conversation",
+        "event",
+        "image",
+        "infrared",
+        "input_button",
+        "notify",
+        "radio_frequency",
+        "scene",
+        "stt",
+        "tag",
+        "tts",
+        "wake_word",
+        "datetime",
+    ]
+
+    /// - Parameters:
+    ///   - domain: the entity's own domain, lowercased (`light`, `binary_sensor`, …).
+    ///   - state: the raw entity state, lowercased.
+    public static func isActive(domain: String, state: String) -> Bool {
+        if timestampStateDomains.contains(domain) {
+            return state != unavailable
+        }
+
+        if state == unavailable || state == unknown {
+            return false
+        }
+
+        // "off" is inactive for most domains, but not for `alert`, where "off" only means the alert
+        // was acknowledged and "idle" is the state that means nothing is going on.
+        if state == "off", domain != "alert" {
+            return false
+        }
+
+        switch domain {
+        case "alarm_control_panel":
+            return state != "disarmed"
+        case "alert":
+            return state != "idle"
+        case "cover":
+            return state != "closed"
+        case "device_tracker", "person":
+            return state != "not_home"
+        case "lawn_mower":
+            return !["docked", "paused"].contains(state)
+        case "lock":
+            return state != "locked"
+        case "media_player":
+            return state != "standby"
+        case "vacuum":
+            return !["idle", "docked", "paused"].contains(state)
+        case "valve":
+            return state != "closed"
+        case "plant":
+            return state == "problem"
+        case "group":
+            return ["on", "home", "open", "locked", "problem"].contains(state)
+        case "timer":
+            return state == "active"
+        case "camera":
+            return ["streaming", "recording"].contains(state)
+        default:
+            return true
+        }
+    }
+
+    public static func isActive(domain: Domain?, state: String) -> Bool {
+        isActive(domain: domain?.rawValue ?? "", state: state.lowercased())
+    }
+}

--- a/Sources/Shared/EntityStateColor.swift
+++ b/Sources/Shared/EntityStateColor.swift
@@ -1,0 +1,155 @@
+import Foundation
+import HADesignSystem
+import SwiftUI
+
+/// Port of `common/entity/state_color.ts` (and `common/entity/color/battery_color.ts`) in
+/// home-assistant/frontend: the `--state-…` custom property an entity's icon is painted with.
+///
+/// The frontend builds a `var()` fallback chain from most to least specific and lets CSS pick the
+/// first property that is actually defined. ``FrontendColors`` is generated from the same
+/// `color.globals.ts`, so "is defined" here is simply "has a case", and the chain resolves the same
+/// way — including the device-class defaults (`--state-binary_sensor-gas-on-color`, …).
+public enum EntityStateColor {
+    /// `STATE_COLORED_DOMAIN`: the domains that take a state color at all. Anything else keeps the
+    /// neutral icon color.
+    public static let stateColoredDomains: Set<String> = [
+        "alarm_control_panel",
+        "alert",
+        "automation",
+        "binary_sensor",
+        "calendar",
+        "camera",
+        "climate",
+        "cover",
+        "device_tracker",
+        "fan",
+        "group",
+        "humidifier",
+        "input_boolean",
+        "lawn_mower",
+        "light",
+        "lock",
+        "media_player",
+        "person",
+        "plant",
+        "remote",
+        "schedule",
+        "script",
+        "siren",
+        "sun",
+        "switch",
+        "timer",
+        "update",
+        "vacuum",
+        "valve",
+        "water_heater",
+        "weather",
+    ]
+
+    /// The custom property names the frontend would try, most specific first.
+    public static func properties(
+        domain: String,
+        deviceClass: String?,
+        state: String,
+        active: Bool
+    ) -> [String] {
+        var properties: [String] = []
+        let stateKey = slugify(state)
+        let activeKey = active ? "active" : "inactive"
+
+        if let deviceClass, !deviceClass.isEmpty {
+            properties.append("--state-\(domain)-\(deviceClass)-\(stateKey)-color")
+        }
+
+        properties.append(contentsOf: [
+            "--state-\(domain)-\(stateKey)-color",
+            "--state-\(domain)-\(activeKey)-color",
+            "--state-\(activeKey)-color",
+        ])
+
+        return properties
+    }
+
+    /// The color the frontend gives this entity, or `nil` when its domain isn't state-colored — the
+    /// caller then falls back to the neutral defaults the tile card's CSS provides.
+    ///
+    /// - Parameters:
+    ///   - domain: the entity's own domain, lowercased.
+    ///   - deviceClass: the raw `device_class` attribute, if any.
+    ///   - state: the raw entity state, lowercased.
+    ///   - groupMemberDomain: for a `group`, the single domain all its members share, whose palette
+    ///     the group borrows.
+    public static func color(
+        domain: String,
+        deviceClass: String?,
+        state: String,
+        groupMemberDomain: String? = nil
+    ) -> Color? {
+        if state == EntityStateActive.unavailable {
+            return FrontendColors.stateUnavailableColor.color
+        }
+
+        let active = EntityStateActive.isActive(domain: domain, state: state)
+
+        // Battery sensors are colored by level rather than by state.
+        if domain == "sensor", deviceClass == "battery", let property = batteryColorProperty(for: state) {
+            return property.color
+        }
+
+        // A group whose members all share one domain borrows that domain's palette, while staying
+        // active/inactive by the group's own rules.
+        if domain == "group", let groupMemberDomain, stateColoredDomains.contains(groupMemberDomain) {
+            return resolve(propertyDomain: groupMemberDomain, deviceClass: deviceClass, state: state, active: active)
+        }
+
+        guard stateColoredDomains.contains(domain) else { return nil }
+        return resolve(propertyDomain: domain, deviceClass: deviceClass, state: state, active: active)
+    }
+
+    /// `batteryStateColorProperty`: a battery sensor is green/orange/red by percentage, and keeps
+    /// the ordinary state handling when its state isn't a number.
+    public static func batteryColorProperty(for state: String) -> FrontendColors? {
+        guard let value = Double(state) else { return nil }
+        if value >= 70 { return .stateSensorBatteryHighColor }
+        if value >= 30 { return .stateSensorBatteryMediumColor }
+        return .stateSensorBatteryLowColor
+    }
+
+    private static func resolve(
+        propertyDomain: String,
+        deviceClass: String?,
+        state: String,
+        active: Bool
+    ) -> Color? {
+        for name in properties(domain: propertyDomain, deviceClass: deviceClass, state: state, active: active) {
+            if let variable = FrontendColors(rawValue: name) {
+                return variable.color
+            }
+        }
+        return nil
+    }
+
+    /// The frontend slugifies the state before building the property name (`slugify(state, "_")`).
+    /// States come from the backend as ASCII slugs already, so the transliteration table `slugify`
+    /// carries for user-entered names has nothing to do here.
+    static func slugify(_ value: String) -> String {
+        var slug = ""
+        var lastWasDelimiter = false
+        for character in value.lowercased() {
+            if character.isASCII, character.isLetter || character.isNumber {
+                slug.append(character)
+                lastWasDelimiter = false
+            } else if !lastWasDelimiter {
+                slug.append("_")
+                lastWasDelimiter = true
+            }
+        }
+        while slug.hasPrefix("_") {
+            slug.removeFirst()
+        }
+        while slug.hasSuffix("_") {
+            slug.removeLast()
+        }
+        return slug.isEmpty ? "unknown" : slug
+    }
+}

--- a/Sources/Shared/HAEntity+CarPlay.swift
+++ b/Sources/Shared/HAEntity+CarPlay.swift
@@ -17,34 +17,25 @@ public extension HAEntity {
     func getIcon() -> UIImage? {
         let image = getMDI()
         #if os(iOS)
-        return image.carPlayIcon(color: carPlayIconColor())
+        return image.carPlayIcon(color: stateIconColor())
         #else
         return image.image(ofSize: .init(width: 50, height: 50), color: nil)
         #endif
     }
 
-    func carPlayIconColor(activeColorOverride: UIColor? = nil) -> UIColor? {
-        let normalizedState = state.lowercased()
-        if Domain.activeStates.map(\.rawValue).contains(normalizedState),
-           let activeColorOverride {
-            return activeColorOverride
-        }
-
-        let colorAttributes = EntityColorAttributesParser.parse(from: attributes.dictionary)
-        guard let domain = Domain(rawValue: domain) else {
-            return fallbackCarPlayIconColor(
-                for: normalizedState,
-                activeColorOverride: activeColorOverride
-            )
-        }
-
-        return UIColor(
+    /// The icon color home-assistant/frontend gives this entity — its domain's, device class's and
+    /// state's `--state-…` palette, or a light's own color. Shared by CarPlay and the watch so both
+    /// read the same as the widgets and the frontend itself.
+    ///
+    /// - Parameter customColor: a color the user picked for this entity on the calling surface. As
+    ///   in the frontend's tile card, it only applies while the entity is active.
+    func stateIconColor(customColor: UIColor? = nil) -> UIColor? {
+        UIColor(
             EntityIconColorProvider.iconColor(
                 domain: domain,
-                state: normalizedState,
-                colorMode: colorAttributes.colorMode,
-                rgbColor: colorAttributes.rgbColor,
-                hsColor: colorAttributes.hsColor
+                state: state.lowercased(),
+                attributes: attributes.dictionary,
+                customColor: customColor.map(Color.init)
             )
         )
     }
@@ -240,20 +231,5 @@ public extension HAEntity {
 
         return CoreStrings.getDomainStateLocalizedTitle(state: state) ?? FrontendStrings
             .getDefaultStateLocalizedTitle(state: state) ?? state
-    }
-
-    private func fallbackCarPlayIconColor(
-        for normalizedState: String,
-        activeColorOverride: UIColor?
-    ) -> UIColor {
-        if Domain.problemStates.map(\.rawValue).contains(normalizedState) {
-            return .red
-        }
-
-        if Domain.activeStates.map(\.rawValue).contains(normalizedState) {
-            return activeColorOverride ?? AppConstants.lighterTintColor
-        }
-
-        return .gray
     }
 }

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -158,9 +158,36 @@ public struct MagicItem: Codable, Equatable, Hashable {
         public var icon: String?
         /// True only when the user explicitly picked a custom icon via the icon picker
         public var iconIsCustomized: Bool?
+        /// True only when the user explicitly picked a custom icon color via the color picker
+        public var iconColorIsCustomized: Bool?
 
         public var useCustomColors: Bool {
             textColor != nil || backgroundColor != nil
+        }
+
+        /// The icon color the user deliberately chose, or `nil` to let the entity keep the color
+        /// home-assistant/frontend gives it.
+        ///
+        /// The customization screen seeds its color picker with the app's tint the first time it
+        /// opens, so a stored color on its own never meant the user picked one. Items saved before
+        /// ``iconColorIsCustomized`` existed are therefore only treated as customized when their
+        /// color differs from that seed.
+        public var customIconColor: String? {
+            guard let iconColor else { return nil }
+            if iconColorIsCustomized == true { return iconColor }
+            return normalizedHex(iconColor) == normalizedHex(MagicItem.defaultIconColorHex)
+                ? nil
+                : iconColor
+        }
+
+        /// Uppercased six-digit hex, so the seed comparison isn't thrown off by a `#` prefix or an
+        /// opaque alpha channel — the app writes the same color in both shapes.
+        private func normalizedHex(_ hex: String) -> String {
+            var normalized = hex.uppercased().replacingOccurrences(of: "#", with: "")
+            if normalized.count == 8, normalized.hasSuffix("FF") {
+                normalized = String(normalized.dropLast(2))
+            }
+            return normalized
         }
 
         public init(
@@ -169,7 +196,8 @@ public struct MagicItem: Codable, Equatable, Hashable {
             backgroundColor: String? = nil,
             requiresConfirmation: Bool = false,
             icon: String? = nil,
-            iconIsCustomized: Bool = false
+            iconIsCustomized: Bool = false,
+            iconColorIsCustomized: Bool = false
         ) {
             self.iconColor = iconColor
             self.textColor = textColor
@@ -177,6 +205,7 @@ public struct MagicItem: Codable, Equatable, Hashable {
             self.requiresConfirmation = requiresConfirmation
             self.icon = icon
             self.iconIsCustomized = iconIsCustomized
+            self.iconColorIsCustomized = iconColorIsCustomized
         }
     }
 
@@ -517,8 +546,13 @@ public enum ItemAction: Codable, CaseIterable, Equatable, Hashable {
 }
 
 public extension MagicItem {
-    static var defaultAssistIconColorHex: String {
+    /// The color the icon color picker seeds itself with when an item has none yet: the app's tint.
+    static var defaultIconColorHex: String {
         Color.haPrimary.hex() ?? Color.brand50.hex() ?? ""
+    }
+
+    static var defaultAssistIconColorHex: String {
+        defaultIconColorHex
     }
 
     /// Single entry point for executing a magic item.

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -64,7 +64,7 @@ final class WatchCoverControlsViewModel: ObservableObject {
 
     var iconColor: UIColor {
         if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.carPlayIconColor() ?? .white
+            return entity.stateIconColor() ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -62,9 +62,12 @@ final class WatchCoverControlsViewModel: ObservableObject {
         return item.icon(info: itemInfo)
     }
 
+    /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
+    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
     var iconColor: UIColor {
-        if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.stateIconColor() ?? .white
+        if let entity {
+            let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }
+            return entity.stateIconColor(customColor: customColor) ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -79,7 +79,7 @@ final class WatchLightControlsViewModel: ObservableObject {
 
     var iconColor: UIColor {
         if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.carPlayIconColor() ?? .white
+            return entity.stateIconColor() ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -77,9 +77,12 @@ final class WatchLightControlsViewModel: ObservableObject {
         return item.icon(info: itemInfo)
     }
 
+    /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
+    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
     var iconColor: UIColor {
-        if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.stateIconColor() ?? .white
+        if let entity {
+            let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }
+            return entity.stateIconColor(customColor: customColor) ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -52,8 +52,7 @@ final class WatchLockControlsViewModel: ObservableObject {
     }
 
     /// Same live-icon rule as the home row: locks have a state-dependent icon, so render from the
-    /// entity unless the user explicitly picked a custom icon. The color codes the state (locked
-    /// vs. unlocked vs. jammed) through the shared entity color provider.
+    /// entity unless the user explicitly picked a custom icon.
     var icon: MaterialDesignIcons {
         if let entity, itemInfo.customization?.iconIsCustomized != true {
             return entity.getMDI()
@@ -61,9 +60,12 @@ final class WatchLockControlsViewModel: ObservableObject {
         return item.icon(info: itemInfo)
     }
 
+    /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
+    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
     var iconColor: UIColor {
-        if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.stateIconColor() ?? .white
+        if let entity {
+            let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }
+            return entity.stateIconColor(customColor: customColor) ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -63,7 +63,7 @@ final class WatchLockControlsViewModel: ObservableObject {
 
     var iconColor: UIColor {
         if let entity, itemInfo.customization?.iconIsCustomized != true {
-            return entity.carPlayIconColor() ?? .white
+            return entity.stateIconColor() ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -130,8 +130,8 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         return domain.contextualStateDescription(for: liveEntity, serverId: item.serverId)
     }
 
-    /// Mirrors CarPlay: dynamic domains render the live state-driven icon and color unless the
-    /// user explicitly picked a custom icon; everything else uses the configured icon and color.
+    /// Mirrors CarPlay: only the domains whose icon changes with state render the live icon, and
+    /// only until the user explicitly picks one of their own.
     var icon: MaterialDesignIcons {
         if let liveEntity, usesLiveIcon {
             return liveEntity.getMDI()
@@ -139,9 +139,13 @@ final class WatchMagicViewRowViewModel: ObservableObject {
         return item.icon(info: itemInfo)
     }
 
+    /// The color home-assistant/frontend gives the entity, the same as the widgets and CarPlay —
+    /// independent of which icon is drawn, so a custom icon still shows whether the thing is on.
+    /// Items with no live entity behind them (scripts, scenes, Assist) keep their configured color.
     var iconColor: UIColor {
-        if let liveEntity, usesLiveIcon {
-            return liveEntity.carPlayIconColor() ?? .white
+        if let liveEntity, item.type == .entity {
+            let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }
+            return liveEntity.stateIconColor(customColor: customColor) ?? .white
         }
         if let hex = itemInfo.customization?.iconColor {
             return UIColor(hex: hex)

--- a/Tests/Shared/EntityIconColorProvider.test.swift
+++ b/Tests/Shared/EntityIconColorProvider.test.swift
@@ -1,3 +1,4 @@
+import HADesignSystem
 @testable import Shared
 import SwiftUI
 import Testing
@@ -5,62 +6,206 @@ import UIKit
 
 struct EntityIconColorProviderTests {
     private func color(
-        domain: Domain,
+        domain: String,
+        deviceClass: String? = nil,
         state: String,
-        colorMode: String? = nil,
         rgb: [Int]? = nil,
-        hs: [Double]? = nil
+        hs: [Double]? = nil,
+        groupMemberDomain: String? = nil
     ) -> Color {
         EntityIconColorProvider.iconColor(
             domain: domain,
+            deviceClass: deviceClass,
             state: state,
-            colorMode: colorMode,
-            rgbColor: rgb,
-            hsColor: hs
+            liveColor: EntityIconColorProvider.liveColor(
+                domain: domain,
+                rgbColor: rgb,
+                hsColor: hs
+            ),
+            groupMemberDomain: groupMemberDomain
         )
     }
 
-    @Test func lockStatesUseFrontendPalette() {
-        #expect(color(domain: .lock, state: "locked") == EntityIconColorProvider.lockLockedColor)
-        #expect(color(domain: .lock, state: "unlocked") == EntityIconColorProvider.lockUnlockedColor)
-        #expect(color(domain: .lock, state: "jammed") == EntityIconColorProvider.lockUnlockedColor)
-        #expect(color(domain: .lock, state: "locking") == EntityIconColorProvider.lockTransitionColor)
-        #expect(color(domain: .lock, state: "unlocking") == EntityIconColorProvider.lockTransitionColor)
+    // MARK: - Domain defaults
+
+    @Test func domainDefaultsMatchFrontendPalette() throws {
+        // Pinned to `color.globals.ts` in home-assistant/frontend — the source of truth.
+        try expectColor(color(domain: "light", state: "on"), isHex: "#FFC107") // --state-light-active-color
+        try expectColor(color(domain: "switch", state: "on"), isHex: "#FFC107") // --state-switch-active-color
+        try expectColor(color(domain: "fan", state: "on"), isHex: "#00BCD4") // --state-fan-active-color
+        try expectColor(color(domain: "cover", state: "open"), isHex: "#926BC7") // --state-cover-active-color
+        try expectColor(color(domain: "vacuum", state: "cleaning"), isHex: "#009688") // --state-vacuum-active-color
+        try expectColor(color(domain: "valve", state: "open"), isHex: "#2196F3") // --state-valve-active-color
+        try expectColor(color(domain: "siren", state: "on"), isHex: "#F44336") // --state-siren-active-color
+        try expectColor(color(domain: "media_player", state: "playing"), isHex: "#03A9F4")
+        // A domain with no accent of its own falls through to --state-active-color.
+        try expectColor(color(domain: "input_boolean", state: "on"), isHex: "#FFC107")
     }
 
-    @Test func inactiveStatesAreGray() {
-        #expect(color(domain: .light, state: "off") == .gray)
-        #expect(color(domain: .switch, state: "off") == .gray)
+    @Test func perStateColorsBeatTheDomainAccent() throws {
+        try expectColor(color(domain: "lock", state: "locked"), isHex: "#4CAF50")
+        try expectColor(color(domain: "lock", state: "unlocked"), isHex: "#F44336")
+        try expectColor(color(domain: "lock", state: "jammed"), isHex: "#F44336")
+        try expectColor(color(domain: "lock", state: "locking"), isHex: "#FF9800")
+        try expectColor(color(domain: "lock", state: "unlocking"), isHex: "#FF9800")
+        try expectColor(color(domain: "climate", state: "heat"), isHex: "#FF6F22")
+        try expectColor(color(domain: "climate", state: "cool"), isHex: "#2196F3")
+        try expectColor(color(domain: "sun", state: "below_horizon"), isHex: "#3F51B5")
+        try expectColor(color(domain: "weather", state: "sunny"), isHex: "#FFC107")
+        try expectColor(color(domain: "weather", state: "snowy"), isHex: "#C0E0FF")
+        try expectColor(color(domain: "person", state: "home"), isHex: "#4CAF50")
+        try expectColor(color(domain: "alarm_control_panel", state: "triggered"), isHex: "#F44336")
+        try expectColor(color(domain: "alarm_control_panel", state: "armed_away"), isHex: "#4CAF50")
     }
 
-    @Test func unavailableIsTreatedAsProblem() {
-        #expect(color(domain: .light, state: "unavailable") == .red)
-        #expect(color(domain: .lock, state: "unavailable") == .red)
+    // MARK: - Device class defaults
+
+    @Test func deviceClassBeatsTheDomainDefault() throws {
+        // --state-binary_sensor-gas-on-color, rather than --state-binary_sensor-active-color.
+        try expectColor(color(domain: "binary_sensor", deviceClass: "gas", state: "on"), isHex: "#F44336")
+        try expectColor(color(domain: "binary_sensor", deviceClass: "smoke", state: "on"), isHex: "#F44336")
+        try expectColor(color(domain: "binary_sensor", deviceClass: "moisture", state: "on"), isHex: "#F44336")
+        // A device class with no color of its own keeps the domain default.
+        try expectColor(color(domain: "binary_sensor", deviceClass: "motion", state: "on"), isHex: "#FFC107")
+        // …and an off binary sensor is inactive whatever its device class is.
+        try expectColor(color(domain: "binary_sensor", deviceClass: "gas", state: "off"), isHex: "#9E9E9E")
     }
 
-    @Test func liveColorWinsWhenActive() {
-        let live = color(domain: .light, state: "on", colorMode: "rgb", rgb: [255, 140, 0])
-        #expect(live == Color(red: 255.0 / 255.0, green: 140.0 / 255.0, blue: 0))
+    @Test func batterySensorsAreColoredByLevel() throws {
+        try expectColor(color(domain: "sensor", deviceClass: "battery", state: "95"), isHex: "#4CAF50")
+        try expectColor(color(domain: "sensor", deviceClass: "battery", state: "50"), isHex: "#FF9800")
+        try expectColor(color(domain: "sensor", deviceClass: "battery", state: "12"), isHex: "#F44336")
+        // A non-numeric battery state has no level to color from, and `sensor` takes no state color.
+        try expectColor(color(domain: "sensor", deviceClass: "battery", state: "charging"), isHex: "#44739E")
     }
 
-    @Test func activeWithoutDomainAccentFallsBackToFrontendActiveColor() {
-        #expect(color(domain: .inputBoolean, state: "on") == EntityIconColorProvider.activeColor)
-        #expect(Domain.humidifier.accentColor == EntityIconColorProvider.activeColor)
+    // MARK: - Neutral defaults
+
+    @Test func domainsWithoutStateColorsUseTheNeutralDefaults() throws {
+        // --state-icon-color while active, --state-inactive-color otherwise.
+        try expectColor(color(domain: "sensor", state: "21.5"), isHex: "#44739E")
+        try expectColor(color(domain: "number", state: "3"), isHex: "#44739E")
+        try expectColor(color(domain: "sensor", state: "unknown"), isHex: "#9E9E9E")
     }
 
-    @Test func frontendPaletteValues() throws {
-        // Pinned to color.globals.ts in home-assistant/frontend — the source of truth.
-        let expected: [(Color, String)] = [
-            (EntityIconColorProvider.activeColor, "#FFC107"),
-            (EntityIconColorProvider.lockLockedColor, "#4CAF50"),
-            (EntityIconColorProvider.lockUnlockedColor, "#F44336"),
-            (EntityIconColorProvider.lockTransitionColor, "#FF9800"),
-        ]
-        for (paletteColor, hex) in expected {
-            let reference = try #require(UIColor(rgbaString: hex))
-            for (actual, wanted) in zip(rgba(UIColor(paletteColor)), rgba(reference)) {
-                #expect(abs(actual - wanted) < 0.001, "Palette color should be \(hex)")
-            }
+    @Test func inactiveStatesUseTheInactiveColor() throws {
+        try expectColor(color(domain: "light", state: "off"), isHex: "#9E9E9E")
+        try expectColor(color(domain: "switch", state: "off"), isHex: "#9E9E9E")
+        try expectColor(color(domain: "cover", state: "closed"), isHex: "#9E9E9E")
+        try expectColor(color(domain: "person", state: "not_home"), isHex: "#9E9E9E")
+    }
+
+    @Test func unavailableUsesTheUnavailableColor() throws {
+        try expectColor(color(domain: "light", state: "unavailable"), isHex: "#BDBDBD")
+        try expectColor(color(domain: "lock", state: "unavailable"), isHex: "#BDBDBD")
+    }
+
+    // MARK: - Groups
+
+    @Test func groupsBorrowTheirMembersDomainPalette() throws {
+        try expectColor(color(domain: "group", state: "on", groupMemberDomain: "fan"), isHex: "#00BCD4")
+        // A mixed group has no single member domain, so it keeps the generic active color.
+        try expectColor(color(domain: "group", state: "on"), isHex: "#FFC107")
+        try expectColor(color(domain: "group", state: "off", groupMemberDomain: "fan"), isHex: "#9E9E9E")
+    }
+
+    @Test func groupMemberDomainIsTheOneEveryMemberShares() {
+        #expect(EntityIconColorProvider.groupMemberDomain(
+            attributes: ["entity_id": ["light.a", "light.b"]]
+        ) == "light")
+        #expect(EntityIconColorProvider.groupMemberDomain(
+            attributes: ["entity_id": ["light.a", "switch.b"]]
+        ) == nil)
+        #expect(EntityIconColorProvider.groupMemberDomain(attributes: [:]) == nil)
+    }
+
+    // MARK: - Live light color
+
+    @Test func liveColorWinsWhenTheLightIsOn() throws {
+        try expectColor(color(domain: "light", state: "on", rgb: [255, 140, 0]), isHex: "#FF8C00")
+    }
+
+    @Test func liveColorIsContrastAdjusted() throws {
+        // A white light would be invisible on the tile, so the frontend dims it to v = 225.
+        try expectColor(
+            color(domain: "light", state: "on", rgb: [255, 255, 255]),
+            isHex: "#E1E1E1"
+        )
+        // A barely saturated color is pushed to 40% saturation instead.
+        try expectColor(
+            color(domain: "light", state: "on", rgb: [255, 200, 200]),
+            isHex: "#FF9999"
+        )
+        // Under 10% saturation it is dimmed rather than saturated, like the white case.
+        try expectColor(
+            color(domain: "light", state: "on", rgb: [255, 235, 235]),
+            isHex: "#E1CFCF"
+        )
+    }
+
+    @Test func liveColorIsIgnoredOffAndOutsideLights() throws {
+        try expectColor(color(domain: "light", state: "off", rgb: [255, 140, 0]), isHex: "#9E9E9E")
+        #expect(EntityIconColorProvider.liveColor(domain: "switch", rgbColor: [255, 140, 0], hsColor: nil) == nil)
+        #expect(EntityIconColorProvider.liveColor(domain: "light", rgbColor: nil, hsColor: nil) == nil)
+    }
+
+    // MARK: - User override
+
+    @Test func aPickedColorOnlyAppliesWhileActive() throws {
+        let picked = Color(hex: "#FF00FF")
+        try expectColor(
+            EntityIconColorProvider.iconColor(domain: "light", state: "on", customColor: picked),
+            isHex: "#FF00FF"
+        )
+        // Off, the tile reads as off rather than as the picked color, as the tile card does.
+        try expectColor(
+            EntityIconColorProvider.iconColor(domain: "light", state: "off", customColor: picked),
+            isHex: "#9E9E9E"
+        )
+        // …and it beats a light's own color while on.
+        try expectColor(
+            EntityIconColorProvider.iconColor(
+                domain: "light",
+                state: "on",
+                liveColor: Color(hex: "#FF8C00"),
+                customColor: picked
+            ),
+            isHex: "#FF00FF"
+        )
+    }
+
+    // MARK: - Active state
+
+    @Test func activeStateFollowsTheFrontendRules() {
+        #expect(EntityStateActive.isActive(domain: "light", state: "on"))
+        #expect(!EntityStateActive.isActive(domain: "light", state: "off"))
+        #expect(!EntityStateActive.isActive(domain: "lock", state: "locked"))
+        #expect(EntityStateActive.isActive(domain: "lock", state: "unlocked"))
+        #expect(!EntityStateActive.isActive(domain: "cover", state: "closed"))
+        #expect(!EntityStateActive.isActive(domain: "alarm_control_panel", state: "disarmed"))
+        #expect(!EntityStateActive.isActive(domain: "vacuum", state: "docked"))
+        #expect(!EntityStateActive.isActive(domain: "person", state: "not_home"))
+        #expect(EntityStateActive.isActive(domain: "plant", state: "problem"))
+        #expect(!EntityStateActive.isActive(domain: "plant", state: "ok"))
+        // "off" is still an active alert; "idle" is the one that isn't.
+        #expect(EntityStateActive.isActive(domain: "alert", state: "off"))
+        #expect(!EntityStateActive.isActive(domain: "alert", state: "idle"))
+        // Timestamp-state domains are active as long as they're available.
+        #expect(EntityStateActive.isActive(domain: "scene", state: "2024-01-01T00:00:00+00:00"))
+        #expect(!EntityStateActive.isActive(domain: "scene", state: "unavailable"))
+    }
+
+    // MARK: - Helpers
+
+    private func expectColor(
+        _ color: Color,
+        isHex hex: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        let reference = try #require(UIColor(rgbaString: hex))
+        let resolved = UIColor(color).resolvedColor(with: .init(userInterfaceStyle: .light))
+        for (actual, wanted) in zip(rgba(resolved), rgba(reference)) {
+            #expect(abs(actual - wanted) < 0.004, "Expected \(hex), got \(resolved)", sourceLocation: sourceLocation)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Entity icons now use the same colors the frontend does, instead of a hardcoded accent for a handful of domains.

Ports `state_color.ts` and `state_active.ts` from the frontend, resolving the same `--state-…` property chain against the existing generated `FrontendColors`. That brings in the per-domain and per-device-class defaults (`--state-binary_sensor-gas-on-color`, `--state-climate-heat-color`, battery level colors, group colors, unavailable), which the app did not have before.

Applies to the custom and commonly used entities widgets, CarPlay and the Watch. On `WidgetCustom` the user's own icon color still wins, and — as in the frontend's tile card — only while the entity is active.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The color picker on the item customization screen used to write the app tint into `iconColor` on first render, so nearly every item looked customized and would never show a state color. It now only stores a color when one is actually picked, tracked by a new `iconColorIsCustomized` flag. Existing items keep their color when it differs from that seed.

CarPlay and the Watch previously decided whether to show a live color using `Domain.hasStateDependentIcon`, a list of the five domains whose *icon* changes with state. That list now governs only the icon; the color always follows the entity's state.
