### PR TITLE
Fix widget entity states missing on some tiles

### DIFF
--- a/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
@@ -95,6 +95,12 @@ enum WidgetMagicItemInfoProvider {
 
 @available(iOS 17, *)
 struct WidgetEntityStateProvider {
+    /// How long the whole batch of state fetches gets before the entry is built from whatever
+    /// arrived. WidgetKit budgets timeline generation, so a request that stalls — a server that
+    /// stopped answering, an active URL that is no longer reachable — has to cost the widget one
+    /// stale tile rather than the entire refresh.
+    private static let fetchDeadline: TimeInterval = 8
+
     let logPrefix: String
     let cacheValiditySeconds: TimeInterval
     let cacheURL: () -> URL
@@ -116,47 +122,129 @@ struct WidgetEntityStateProvider {
             return [:]
         }
 
-        if let cache = readCache(), cache.cacheCreatedDate.timeIntervalSinceNow > -cacheValiditySeconds {
+        let cache = readCache()
+
+        if let cache, cache.cacheCreatedDate.timeIntervalSinceNow > -cacheValiditySeconds {
             Current.Log.verbose("\(logPrefix) widget states cache is still valid, returning cached states")
             return cache.states
         }
 
         Current.Log.verbose("\(logPrefix) widget has no valid cache, fetching states")
 
+        let itemsNeedingState = items.filter(itemFilter)
+        let fetched = await fetchStates(for: itemsNeedingState)
+
+        // A tile whose fetch failed keeps its last known state instead of going blank. Rendering
+        // only what this round managed to get made one bad batch drop the rest of the widget's
+        // values, and nothing brought them back until the next refresh 15 minutes later — which is
+        // why reloading the widget by hand appeared to be the fix.
         var states: [MagicItem: WidgetEntityState] = [:]
-
-        for item in items where itemFilter(item) {
-            let serverId = item.serverId
-            let entityId = item.id
-            guard let domain = item.domain,
-                  let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else { continue }
-
-            if let state: ControlEntityProvider.State = await ControlEntityProvider(domains: [domain]).state(
-                server: server,
-                entityId: entityId
-            ) {
-                let value = stateValueFormatter(state, serverId, entityId)
-                states[item] = .init(
-                    value: value,
-                    domainState: state.domainState,
-                    rawState: state.rawState,
-                    deviceClass: state.deviceClass,
-                    liveColorHex: state.liveColor?.hex(),
-                    groupMemberDomain: state.groupMemberDomain
-                )
-            } else {
-                Current.Log.error(
-                    "Failed to get state for entity in \(logPrefix) widget, entityId: \(entityId), serverId: \(serverId)"
-                )
+        var reusedCount = 0
+        for item in itemsNeedingState {
+            if let state = fetched[item] {
+                states[item] = state
+            } else if let cachedState = cache?.states[item] {
+                states[item] = cachedState
+                reusedCount += 1
             }
+        }
+
+        if reusedCount > 0 {
+            Current.Log.error(
+                "\(logPrefix) widget reused \(reusedCount) of \(itemsNeedingState.count) states from cache"
+            )
         }
 
         writeCache(states)
         return states
     }
 
+    /// Fetches every item's state at once, giving up on whatever has not arrived by the deadline.
+    ///
+    /// The REST API only offers one request per entity, but running them one after another made a
+    /// refresh cost the *sum* of its round trips, so the tiles at the end of a large widget's list
+    /// ran out of budget and rendered without a state. Concurrently the batch costs the slowest
+    /// single request instead.
+    private func fetchStates(for items: [MagicItem]) async -> [MagicItem: WidgetEntityState] {
+        guard !items.isEmpty else { return [:] }
+
+        return await withTaskGroup(of: (MagicItem, WidgetEntityState?)?.self) { group in
+            for item in items {
+                group.addTask { await fetchState(for: item) }
+            }
+
+            // The deadline is a task of its own rather than a wrapper around each request, so that
+            // it bounds the batch as a whole. `nil` is how it identifies itself; a fetch that failed
+            // still reports which item it was for.
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(Self.fetchDeadline * 1_000_000_000))
+                return nil
+            }
+
+            var states: [MagicItem: WidgetEntityState] = [:]
+            var outstanding = items.count
+
+            for await result in group {
+                guard let (item, state) = result else {
+                    Current.Log.error(
+                        "\(logPrefix) widget state fetch hit its deadline with \(outstanding) request(s) outstanding"
+                    )
+                    break
+                }
+
+                if let state {
+                    states[item] = state
+                }
+
+                outstanding -= 1
+                if outstanding == 0 {
+                    break
+                }
+            }
+
+            group.cancelAll()
+            return states
+        }
+    }
+
+    private func fetchState(for item: MagicItem) async -> (MagicItem, WidgetEntityState?) {
+        let serverId = item.serverId
+        let entityId = item.id
+
+        guard let domain = item.domain,
+              let server = Current.servers.all.first(where: { $0.identifier.rawValue == serverId }) else {
+            return (item, nil)
+        }
+
+        guard let state = await ControlEntityProvider(domains: [domain]).state(
+            server: server,
+            entityId: entityId
+        ) else {
+            Current.Log.error(
+                "Failed to get state for entity in \(logPrefix) widget, entityId: \(entityId), serverId: \(serverId)"
+            )
+            return (item, nil)
+        }
+
+        return (item, .init(
+            value: stateValueFormatter(state, serverId, entityId),
+            domainState: state.domainState,
+            rawState: state.rawState,
+            deviceClass: state.deviceClass,
+            liveColorHex: state.liveColor?.hex(),
+            groupMemberDomain: state.groupMemberDomain
+        ))
+    }
+
     private func readCache() -> WidgetEntitiesStateCache? {
         let fileURL = cacheURL()
+
+        // A widget that has never fetched has no cache file yet, which is not a failure worth
+        // logging on every first run.
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
         do {
             let data = try Data(contentsOf: fileURL)
             return try JSONDecoder().decode(WidgetEntitiesStateCache.self, from: data)

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -243,17 +243,20 @@ public final class ControlEntityProvider {
         private let lock = NSLock()
         private var continuation: CheckedContinuation<HAData?, Never>?
         private var token: HACancellable?
+        /// Whether the request has already been settled, by completing or by being cancelled.
+        /// `earlyResult` is only meaningful once this is true, which is what lets it stay a single
+        /// optional: a settled request with no result is a cancelled or failed one.
         private var isSettled = false
         /// A result that landed before `adopt` ran, which `send` is free to do by calling back
         /// synchronously.
-        private var earlyResult: HAData??
+        private var earlyResult: HAData?
 
         /// Takes ownership of the continuation and the in-flight request, resuming straight away if
         /// the request already settled while it was being handed over.
         func adopt(continuation: CheckedContinuation<HAData?, Never>, token: HACancellable) {
             lock.lock()
             guard !isSettled else {
-                let result = earlyResult ?? nil
+                let result = earlyResult
                 lock.unlock()
                 token.cancel()
                 continuation.resume(returning: result)
@@ -272,7 +275,7 @@ public final class ControlEntityProvider {
             }
             isSettled = true
             guard let continuation else {
-                earlyResult = .some(data)
+                earlyResult = data
                 lock.unlock()
                 return
             }

--- a/Sources/Shared/ControlEntityProvider.swift
+++ b/Sources/Shared/ControlEntityProvider.swift
@@ -176,19 +176,7 @@ public final class ControlEntityProvider {
             return nil
         }
 
-        let result = await withCheckedContinuation { continuation in
-            connection.send(.init(
-                type: .rest(.get, "states/\(entityId)"),
-                shouldRetry: true
-            )) { result in
-                continuation.resume(returning: result)
-            }
-        }
-
-        guard let data = try? result.get() else {
-            if case let .failure(error) = result {
-                Current.Log.error("Failed to get state: \(error)")
-            }
+        guard let data = await sendStateRequest(connection: connection, entityId: entityId) else {
             return nil
         }
 
@@ -215,6 +203,100 @@ public final class ControlEntityProvider {
             attributes: attributes,
             unitOfMeasurement: unitOfMeasurement
         )
+    }
+
+    /// Sends the `/states/<entity>` request in a way that honors task cancellation.
+    ///
+    /// HAKit drops a cancelled request's completion handler without calling it, and logs-and-discards
+    /// a response whose invocation is no longer active, so a bare `withCheckedContinuation` around
+    /// `send` can be left unresumed forever. Callers that bound how long they are willing to wait —
+    /// the widgets fetch every tile's state against a deadline — would hang on that instead of giving
+    /// up, which is worse than the slow request they were guarding against.
+    private func sendStateRequest(connection: HAConnection, entityId: String) async -> HAData? {
+        let request = PendingStateRequest()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<HAData?, Never>) in
+                let token = connection.send(.init(
+                    type: .rest(.get, "states/\(entityId)"),
+                    shouldRetry: true
+                )) { result in
+                    switch result {
+                    case let .success(data):
+                        request.finish(with: data)
+                    case let .failure(error):
+                        Current.Log.error("Failed to get state: \(error)")
+                        request.finish(with: nil)
+                    }
+                }
+
+                request.adopt(continuation: continuation, token: token)
+            }
+        } onCancel: {
+            request.cancel()
+        }
+    }
+
+    /// Shared one-shot ownership of a state request's continuation, so exactly one of HAKit's
+    /// completion handler and the cancellation handler resumes it — whichever gets there first.
+    private final class PendingStateRequest: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<HAData?, Never>?
+        private var token: HACancellable?
+        private var isSettled = false
+        /// A result that landed before `adopt` ran, which `send` is free to do by calling back
+        /// synchronously.
+        private var earlyResult: HAData??
+
+        /// Takes ownership of the continuation and the in-flight request, resuming straight away if
+        /// the request already settled while it was being handed over.
+        func adopt(continuation: CheckedContinuation<HAData?, Never>, token: HACancellable) {
+            lock.lock()
+            guard !isSettled else {
+                let result = earlyResult ?? nil
+                lock.unlock()
+                token.cancel()
+                continuation.resume(returning: result)
+                return
+            }
+            self.continuation = continuation
+            self.token = token
+            lock.unlock()
+        }
+
+        func finish(with data: HAData?) {
+            lock.lock()
+            guard !isSettled else {
+                lock.unlock()
+                return
+            }
+            isSettled = true
+            guard let continuation else {
+                earlyResult = .some(data)
+                lock.unlock()
+                return
+            }
+            self.continuation = nil
+            token = nil
+            lock.unlock()
+            continuation.resume(returning: data)
+        }
+
+        func cancel() {
+            lock.lock()
+            guard !isSettled else {
+                lock.unlock()
+                return
+            }
+            isSettled = true
+            let continuation = continuation
+            let token = token
+            self.continuation = nil
+            self.token = nil
+            lock.unlock()
+            token?.cancel()
+            continuation?.resume(returning: nil)
+        }
     }
 
     private func buildState(


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Widgets sometimes loaded states for only the first few tiles and left the rest blank until the widget was reloaded by hand.

States were fetched one entity at a time, so a refresh cost the sum of every round trip and the tiles at the end of the list ran out of WidgetKit's budget. Whatever that round managed to get was then cached and rendered as if it were complete, and a tile whose fetch failed looked exactly like one that has no state at all.

- Fetch a widget's states concurrently, bounded by a deadline for the batch.
- Reuse a tile's cached state when its fetch fails, instead of rendering it blank.
- Honor task cancellation in the state request, so the deadline can actually give up on a stalled one.

## Screenshots

Not a visual change: the same tiles render, with their state present instead of missing.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant# (not applicable, bug fix with no functionality change)

## Any other notes

No behaviour change when every fetch succeeds.
