### PR TITLE
Fix mTLS camera streams on Apple Watch

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1BD4D48734DB8B6FDE329FCD /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DC7A63D910AB3EEAC50BE210 /* RealmSwift */; };
 		1C9E83AFBC3E48D5AD9C7741 /* ClientCertificate.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */; };
+		42C11A2031AC500011AABB20 /* MJPEGStreamerSessionDelegate.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C11A2131AC500011AABB21 /* MJPEGStreamerSessionDelegate.test.swift */; };
 		223B508E6D6C41C599FC6838 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = 294DFA6C65284F6E95CC08F1 /* SFSafeSymbols */; };
 		2ACC292CBD70CA7E061DE1D9 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AB784C585C188EB65EA62A21 /* RealmSwift */; };
 		3B5B2D52F2408473F8BFA79C /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 70600C4E2473CC736B505F6D /* RealmSwift */; };
@@ -663,6 +664,7 @@
 		46C62B882D8A3687002C0001 /* SharedTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SharedTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		46C62BA82D8A3AC5002C0001 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/iOSSupport/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
 		480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCertificate.test.swift; sourceTree = "<group>"; };
+		42C11A2131AC500011AABB21 /* MJPEGStreamerSessionDelegate.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MJPEGStreamerSessionDelegate.test.swift; sourceTree = "<group>"; };
 		5C50FA39BF16AD0BD782D0D7 /* Database/GRDB+Initialization.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database/GRDB+Initialization.test.swift"; sourceTree = "<group>"; };
 		6F482639B10AA7F76717F84F /* WatchConnectivity.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivity.test.swift; sourceTree = "<group>"; };
 		892F0EF22A0B9F20AAEE4CCA /* Database/DatabaseMigration.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database/DatabaseMigration.test.swift; sourceTree = "<group>"; };
@@ -2954,6 +2956,7 @@
 				11B38EDE275BE29F00205C7B /* ConnectionInfo.test.swift */,
 				42F1C0223140B00011AACC01 /* ConnectivityWrapper.test.swift */,
 				480E9A5D40714BBAA81B15F7 /* ClientCertificate.test.swift */,
+				42C11A2131AC500011AABB21 /* MJPEGStreamerSessionDelegate.test.swift */,
 				6F482639B10AA7F76717F84F /* WatchConnectivity.test.swift */,
 				114CBAEA2839FC2500A9BAFF /* SecurityExceptions.test.swift */,
 				114CBAEC283AB92D00A9BAFF /* SecTrust+TestAdditions.swift */,
@@ -4389,6 +4392,7 @@
 				11B38EDF275BE29F00205C7B /* ConnectionInfo.test.swift in Sources */,
 				42F1C0323140B00011AACC02 /* ConnectivityWrapper.test.swift in Sources */,
 				1C9E83AFBC3E48D5AD9C7741 /* ClientCertificate.test.swift in Sources */,
+				42C11A2031AC500011AABB20 /* MJPEGStreamerSessionDelegate.test.swift in Sources */,
 				6DC7361D22E7972F8C24B259 /* WatchConnectivity.test.swift in Sources */,
 				42164BB9301320720077A903 /* ComplicationFormula.test.swift in Sources */,
 				11883CC524C12C8A0036A6C6 /* CLLocation+Extensions.test.swift in Sources */,

--- a/Sources/Shared/API/HAAPI.swift
+++ b/Sources/Shared/API/HAAPI.swift
@@ -265,13 +265,12 @@ public class HomeAssistantAPI {
     }
 
     public func VideoStreamer() -> MJPEGStreamer {
-        #if !os(watchOS)
-        let delegate: SessionDelegate = server.info.connection.clientCertificate != nil
-            ? MJPEGCertificateSessionDelegate(server: server)
-            : MJPEGStreamerSessionDelegate()
-        #else
-        let delegate = MJPEGStreamerSessionDelegate()
-        #endif
+        // Attached unconditionally, on every platform, for the same reason the REST session's
+        // delegate is (see `makeCertificateAwareURLSession`): the delegate resolves the certificate
+        // fresh at challenge time, so a streamer built before the server config carries the
+        // certificate still presents it. Gating on the init-time snapshot left the watch's camera
+        // notification stream permanently without a certificate, and an mTLS server refuses it.
+        let delegate = MJPEGStreamerSessionDelegate(server: server)
         return MJPEGStreamer(manager: HomeAssistantAPI.configureSessionManager(
             delegate: delegate,
             interceptor: newInterceptor(),

--- a/Sources/Shared/API/MJPEGStreamer.swift
+++ b/Sources/Shared/API/MJPEGStreamer.swift
@@ -2,7 +2,12 @@ import Alamofire
 import Foundation
 import UIKit
 
-class MJPEGStreamerSessionDelegate: SessionDelegate, @unchecked Sendable {
+/// Combines MJPEG response-boundary notifications with mTLS client certificate handling.
+///
+/// Certificate handling is not iOS-only: the watch streams `camera_proxy_stream` for a camera
+/// notification's long look, and an mTLS server rejects that stream without the client certificate
+/// just as it rejects everything else.
+final class MJPEGStreamerSessionDelegate: ClientCertificateSessionDelegate, @unchecked Sendable {
     static let didReceiveResponse: Notification.Name = .init(rawValue: "MJPEGStreamerSessionDelegateDidReceiveResponse")
     static let taskUserInfoKey: AnyHashable = "taskUserInfoKey"
 
@@ -22,26 +27,6 @@ class MJPEGStreamerSessionDelegate: SessionDelegate, @unchecked Sendable {
         completionHandler(.allow)
     }
 }
-
-#if !os(watchOS)
-/// Combines MJPEG response-boundary notifications with mTLS client certificate handling.
-final class MJPEGCertificateSessionDelegate: ClientCertificateSessionDelegate, @unchecked Sendable {
-    override func urlSession(
-        _ session: URLSession,
-        dataTask: URLSessionDataTask,
-        didReceive response: URLResponse,
-        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
-    ) {
-        super.urlSession(session, dataTask: dataTask, didReceive: response, completionHandler: completionHandler)
-        NotificationCenter.default.post(
-            name: MJPEGStreamerSessionDelegate.didReceiveResponse,
-            object: self,
-            userInfo: [MJPEGStreamerSessionDelegate.taskUserInfoKey: dataTask]
-        )
-        completionHandler(.allow)
-    }
-}
-#endif
 
 enum MJPEGEvent: CustomStringConvertible {
     case data(Data)

--- a/Sources/WatchApp/ExtensionDelegate.swift
+++ b/Sources/WatchApp/ExtensionDelegate.swift
@@ -70,6 +70,11 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         // connection info doesn't carry the override across launches/syncs).
         WatchServerSync.applyURLOverrides()
 
+        // The persisted servers can reference an mTLS client certificate this Watch's Keychain no
+        // longer has; ask the phone to re-send it rather than failing every request until the user
+        // happens to hit refresh.
+        WatchServerSync.requestCertificatesIfMissing()
+
         // schedule the next background refresh
         Current.backgroundRefreshScheduler.schedule().cauterize()
 

--- a/Sources/WatchApp/WatchServerSync.swift
+++ b/Sources/WatchApp/WatchServerSync.swift
@@ -61,13 +61,32 @@ enum WatchServerSync {
         // Already off-main here, so the Keychain lookups (SecItemCopyMatching) can run inline.
         // Pushed mirrors also often arrive while the phone isn't immediately reachable, so the
         // follow-up request waits for reachability instead of being dropped.
-        let missingCertificate = Current.servers.all.contains { server in
+        guard hasMissingCertificate() else { return }
+        Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
+        DispatchQueue.main.async { requestWhenReachable() }
+    }
+
+    /// Whether any configured server references a client certificate this Watch's Keychain lacks.
+    /// Reads the Keychain, so it must not run on the main thread.
+    private static func hasMissingCertificate() -> Bool {
+        Current.servers.all.contains { server in
             guard let certificate = server.info.connection.clientCertificate else { return false }
             return !ClientCertificateManager.shared.hasIdentity(for: certificate)
         }
-        guard missingCertificate else { return }
-        Current.Log.info("[Watch] Mirrored servers reference a client certificate not in the Keychain")
-        DispatchQueue.main.async { requestWhenReachable() }
+    }
+
+    /// Pull the mTLS bundles from the phone when a configured server references a client certificate
+    /// this Watch's Keychain doesn't have. Called at launch as well as after each mirror apply: the
+    /// servers persisted from a previous run outlive the identity that went with them (the mirror is
+    /// sanitized of Keychain material, and a Watch restored from a backup keeps neither), and without
+    /// this every mTLS request fails with `certificateNotFound` for the process's whole lifetime with
+    /// nothing asking the phone to re-send.
+    static func requestCertificatesIfMissing() {
+        applyQueue.async {
+            guard hasMissingCertificate() else { return }
+            Current.Log.info("[Watch] A configured server references a client certificate not in the Keychain")
+            DispatchQueue.main.async { requestWhenReachable() }
+        }
     }
 
     /// One-shot reachability observation guarding the deferred certificate request. Main-thread only.

--- a/Tests/Shared/MJPEGStreamerSessionDelegate.test.swift
+++ b/Tests/Shared/MJPEGStreamerSessionDelegate.test.swift
@@ -1,0 +1,45 @@
+import Alamofire
+import Foundation
+@testable import Shared
+import Testing
+
+@Suite("MJPEGStreamerSessionDelegate Tests")
+struct MJPEGStreamerSessionDelegateTests {
+    /// The camera long look on Apple Watch (and the iOS notification content extension) streams
+    /// `camera_proxy_stream`, which an mTLS server refuses unless the session presents the client
+    /// certificate. The delegate resolves the certificate at challenge time, so it has to be
+    /// attached even when the server config carried none when the streamer was built — the watch
+    /// restores its servers from sources that don't carry Keychain material, and a snapshot taken
+    /// at that moment would leave the stream without a certificate for the process's lifetime.
+    @Test("Given no client certificate when building the video streamer then it still handles mTLS")
+    func videoStreamerAlwaysHandlesClientCertificateChallenges() {
+        var info = ServerInfo(
+            name: "mTLS Server",
+            connection: .init(
+                externalURL: URL(string: "https://external.example.com"),
+                internalURL: nil,
+                cloudhookURL: nil,
+                remoteUIURL: nil,
+                webhookID: "webhook-id",
+                webhookSecret: nil,
+                internalSSIDs: nil,
+                internalHardwareAddresses: nil,
+                isLocalPushEnabled: false,
+                securityExceptions: .init(exceptions: []),
+                connectionAccessSecurityLevel: .undefined
+            ),
+            token: .init(accessToken: "access-token", refreshToken: "refresh-token", expiration: Date()),
+            version: "2026.8.0"
+        )
+        #expect(info.connection.clientCertificate == nil)
+
+        let server = Server(identifier: "mjpeg-mtls", getter: { info }, setter: { newInfo in
+            info = newInfo
+            return true
+        })
+        let streamer = HomeAssistantAPI(server: server).VideoStreamer()
+
+        let delegate: SessionDelegate = streamer.manager.delegate
+        #expect(delegate is ClientCertificateSessionDelegate)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #4534.

A camera notification's long look on the Watch streams `camera_proxy_stream` through `VideoStreamer()`, but its session delegate had no mTLS handling on watchOS — `MJPEGCertificateSessionDelegate` sat behind `#if !os(watchOS)`. An mTLS server refuses that stream, so the long look shows "the server requires a client certificate" instead of the camera.

- The two near-identical MJPEG delegates collapse into one that handles both the response boundary and the client certificate challenge, on every platform. Nothing about it was iOS-only — token refresh already uses `ClientCertificateSessionDelegate` on watchOS.
- It is attached unconditionally instead of being gated on `clientCertificate != nil`, matching `makeCertificateAwareURLSession`. The delegate resolves the certificate at challenge time, and on the Watch the streamer is often built before the certificate-bearing server config has been applied.
- The Watch now asks the phone to re-send the certificate at launch when a server references one its Keychain doesn't have. Previously only a database mirror apply noticed that, so a cold launch failed every mTLS request with `certificateNotFound` until the user hit refresh.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — no UI change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Bug fix only, no documentation change needed. Adds a unit test asserting the video streamer's session always handles client certificate challenges.
