### PR TITLE
Prevent clipboard writes from ingress panels (like Music Assistant) from silently failing

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/SafeScriptMessageHandler.swift
@@ -31,57 +31,6 @@ final class SafeScriptMessageHandler: NSObject, WKScriptMessageHandler {
     }
 
     func shouldAllowMessage(isMainFrame: Bool, scheme: String, host: String, port: Int) -> Bool {
-        guard isMainFrame, let origin = originKey(scheme: scheme, host: host, port: port) else {
-            return false
-        }
-
-        return allowedOrigins.contains(origin)
-    }
-
-    private var allowedOrigins: Set<String> {
-        let urls = [
-            server.info.connection.address(for: .internal),
-            server.info.connection.address(for: .external),
-            server.info.connection.address(for: .remoteUI),
-        ]
-
-        return Set(urls.compactMap(originKey(url:)))
-    }
-
-    private func originKey(url: URL?) -> String? {
-        guard let url, let scheme = url.scheme?.lowercased(), let host = url.host else {
-            return nil
-        }
-
-        return originKey(scheme: scheme, host: host, port: url.port)
-    }
-
-    private func originKey(scheme: String, host: String, port: Int?) -> String? {
-        guard let normalizedPort = normalizedPort(for: scheme, port: port) else {
-            return nil
-        }
-
-        return "\(scheme.lowercased())://\(normalizedHost(host)):\(normalizedPort)"
-    }
-
-    private func normalizedPort(for scheme: String, port: Int?) -> Int? {
-        if let port, port != 0 {
-            return port
-        }
-
-        switch scheme.lowercased() {
-        case "http": return 80
-        case "https": return 443
-        default: return port
-        }
-    }
-
-    private func normalizedHost(_ host: String) -> String {
-        let lowercasedHost = host.lowercased()
-        if lowercasedHost.hasPrefix("["), lowercasedHost.hasSuffix("]") {
-            return String(lowercasedHost.dropFirst().dropLast())
-        }
-
-        return lowercasedHost
+        isMainFrame && ServerOriginValidator(server: server).isAllowedOrigin(scheme: scheme, host: host, port: port)
     }
 }

--- a/Sources/App/Frontend/ExternalMessageBus/ServerOriginValidator.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/ServerOriginValidator.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Shared
+
+/// Validates that a WebKit security origin matches one of the server's configured base URLs.
+/// Ingress panels are included because they are served from the server origin under
+/// `/api/hassio_ingress/`.
+struct ServerOriginValidator {
+    let server: Server
+
+    /// WebKit reports the security origin port as 0 whenever the URL doesn't specify one, so a
+    /// 0 port is normalized to the scheme's default before comparing.
+    func isAllowedOrigin(scheme: String, host: String, port: Int?) -> Bool {
+        guard let origin = originKey(scheme: scheme, host: host, port: port) else {
+            return false
+        }
+
+        return allowedOrigins.contains(origin)
+    }
+
+    private var allowedOrigins: Set<String> {
+        let urls = [
+            server.info.connection.address(for: .internal),
+            server.info.connection.address(for: .external),
+            server.info.connection.address(for: .remoteUI),
+        ]
+
+        return Set(urls.compactMap(originKey(url:)))
+    }
+
+    private func originKey(url: URL?) -> String? {
+        guard let url, let scheme = url.scheme?.lowercased(), let host = url.host else {
+            return nil
+        }
+
+        return originKey(scheme: scheme, host: host, port: url.port)
+    }
+
+    private func originKey(scheme: String, host: String, port: Int?) -> String? {
+        guard let normalizedPort = normalizedPort(for: scheme, port: port) else {
+            return nil
+        }
+
+        return "\(scheme.lowercased())://\(normalizedHost(host)):\(normalizedPort)"
+    }
+
+    private func normalizedPort(for scheme: String, port: Int?) -> Int? {
+        if let port, port != 0 {
+            return port
+        }
+
+        switch scheme.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return port
+        }
+    }
+
+    private func normalizedHost(_ host: String) -> String {
+        let lowercasedHost = host.lowercased()
+        if lowercasedHost.hasPrefix("["), lowercasedHost.hasSuffix("]") {
+            return String(lowercasedHost.dropFirst().dropLast())
+        }
+
+        return lowercasedHost
+    }
+}

--- a/Sources/App/Frontend/WebView/ClipboardWriteMessageHandler.swift
+++ b/Sources/App/Frontend/WebView/ClipboardWriteMessageHandler.swift
@@ -1,0 +1,128 @@
+import Shared
+import UIKit
+@preconcurrency import WebKit
+
+/// WKWebView silently no-ops `navigator.clipboard.writeText` from ingress iframes, so this bridge
+/// performs the actual pasteboard write and replies afterwards. Deliberately scoped to the ingress
+/// path only — ordinary frontend and third-party frames keep WebKit's native clipboard behavior.
+final class ClipboardWriteMessageHandler: NSObject, WKScriptMessageHandlerWithReply {
+    static let messageName = "clipboardWrite"
+    static let ingressPathPrefix = "/api/hassio_ingress/"
+
+    /// Patches `navigator.clipboard.writeText` only in ingress documents and falls back to WebKit's
+    /// implementation when the native write is refused. In insecure contexts without a Clipboard
+    /// API, installs a write-only `navigator.clipboard` so ingress pages can still request a write.
+    static var userScript: WKUserScript {
+        WKUserScript(
+            source: """
+            (function() {
+                "use strict";
+                if (!window.location.pathname.startsWith("\(ingressPathPrefix)")) { return; }
+                const handler = window.webkit && window.webkit.messageHandlers
+                    && window.webkit.messageHandlers.\(messageName);
+                if (!handler) { return; }
+                const nativeWrite = function(text) {
+                    if (typeof text !== "string") {
+                        return Promise.reject(new TypeError("Clipboard text must be a string"));
+                    }
+                    return handler.postMessage({ text: text });
+                };
+                const clipboard = navigator.clipboard;
+                if (clipboard) {
+                    const original = typeof clipboard.writeText === "function"
+                        ? clipboard.writeText.bind(clipboard) : null;
+                    const patched = function(text) {
+                        return nativeWrite(text).catch(function(error) {
+                            return original ? original(text) : Promise.reject(error);
+                        });
+                    };
+                    try {
+                        Object.defineProperty(clipboard, "writeText", {
+                            value: patched,
+                            configurable: true,
+                            writable: true,
+                        });
+                    } catch (error) { /* keep WebKit's implementation */ }
+                } else {
+                    try {
+                        Object.defineProperty(navigator, "clipboard", {
+                            value: { writeText: nativeWrite },
+                            configurable: true,
+                        });
+                    } catch (error) { /* leave the page without a Clipboard API */ }
+                }
+            })();
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
+    }
+
+    private let server: Server
+    private let writeToPasteboard: (String) -> Void
+
+    init(server: Server, writeToPasteboard: @escaping (String) -> Void = { UIPasteboard.general.string = $0 }) {
+        self.server = server
+        self.writeToPasteboard = writeToPasteboard
+        super.init()
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage,
+        replyHandler: @escaping (Any?, String?) -> Void
+    ) {
+        handleMessage(
+            body: message.body,
+            requestURL: message.frameInfo.request.url,
+            scheme: message.frameInfo.securityOrigin.protocol,
+            host: message.frameInfo.securityOrigin.host,
+            port: message.frameInfo.securityOrigin.port,
+            replyHandler: replyHandler
+        )
+    }
+
+    func handleMessage(
+        body: Any,
+        requestURL: URL?,
+        scheme: String,
+        host: String,
+        port: Int,
+        replyHandler: @escaping (Any?, String?) -> Void
+    ) {
+        guard Self.isIngressURL(requestURL), shouldAllowMessage(scheme: scheme, host: host, port: port) else {
+            replyHandler(nil, "Origin or path is not allowed to write to the clipboard")
+            return
+        }
+
+        guard let body = body as? [String: Any] else {
+            Current.Log.error("clipboardWrite message with unexpected body type: \(type(of: body))")
+            replyHandler(nil, "Malformed clipboard message")
+            return
+        }
+
+        guard let text = body["text"] as? String else {
+            Current.Log.error("clipboardWrite message is missing a string text field")
+            replyHandler(nil, "Malformed clipboard message")
+            return
+        }
+
+        let writeAndReply = {
+            self.writeToPasteboard(text)
+            replyHandler(nil, nil)
+        }
+        if Thread.isMainThread {
+            writeAndReply()
+        } else {
+            DispatchQueue.main.sync(execute: writeAndReply)
+        }
+    }
+
+    static func isIngressURL(_ url: URL?) -> Bool {
+        url?.path.hasPrefix(ingressPathPrefix) == true
+    }
+
+    func shouldAllowMessage(scheme: String, host: String, port: Int) -> Bool {
+        ServerOriginValidator(server: server).isAllowedOrigin(scheme: scheme, host: host, port: port)
+    }
+}

--- a/Sources/App/Frontend/WebView/ClipboardWriteMessageHandler.swift
+++ b/Sources/App/Frontend/WebView/ClipboardWriteMessageHandler.swift
@@ -22,10 +22,10 @@ final class ClipboardWriteMessageHandler: NSObject, WKScriptMessageHandlerWithRe
                     && window.webkit.messageHandlers.\(messageName);
                 if (!handler) { return; }
                 const nativeWrite = function(text) {
-                    if (typeof text !== "string") {
-                        return Promise.reject(new TypeError("Clipboard text must be a string"));
+                    if (!navigator.userActivation || !navigator.userActivation.isActive) {
+                        return Promise.reject(new DOMException("User activation is required", "NotAllowedError"));
                     }
-                    return handler.postMessage({ text: text });
+                    return handler.postMessage({ text: String(text) });
                 };
                 const clipboard = navigator.clipboard;
                 if (clipboard) {

--- a/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebViewSetup.swift
+++ b/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebViewSetup.swift
@@ -14,6 +14,16 @@ extension WebViewController {
         userContentController.add(safeScriptMessageHandler, name: "updateThemeColors")
         userContentController.add(safeScriptMessageHandler, name: "logError")
         userContentController.add(safeScriptMessageHandler, name: "frontendRestored")
+
+        // Route clipboard writes through the native bridge so iframe calls update the pasteboard reliably.
+        // Install it in every frame so ingress panels use the same path and receive the native result.
+        userContentController.addScriptMessageHandler(
+            ClipboardWriteMessageHandler(server: server),
+            contentWorld: .page,
+            name: ClipboardWriteMessageHandler.messageName
+        )
+        userContentController.addUserScript(ClipboardWriteMessageHandler.userScript)
+
         return userContentController
     }
 

--- a/Tests/App/WebView/ClipboardWriteMessageHandlerTests.swift
+++ b/Tests/App/WebView/ClipboardWriteMessageHandlerTests.swift
@@ -1,0 +1,103 @@
+@testable import HomeAssistant
+import Shared
+import Testing
+import WebKit
+
+struct ClipboardWriteMessageHandlerTests {
+    @Test func writesTextAndRepliesSuccessfullyForIngressFromConfiguredOrigin() {
+        ServerFixture.reset()
+        var writtenText: String?
+        var replyError: String?
+        let handler = ClipboardWriteMessageHandler(
+            server: ServerFixture.withRemoteConnection,
+            writeToPasteboard: { writtenText = $0 }
+        )
+
+        handler.handleMessage(
+            body: ["text": "copied from Music Assistant"],
+            requestURL: URL(string: "https://external.example.com/api/hassio_ingress/music_assistant")!,
+            scheme: "https",
+            host: "external.example.com",
+            port: 443,
+            replyHandler: { _, error in replyError = error }
+        )
+
+        #expect(writtenText == "copied from Music Assistant")
+        #expect(replyError == nil)
+    }
+
+    @Test func rejectsOrdinaryFrontendURLWithoutWritingOrReplyingSuccess() {
+        ServerFixture.reset()
+        var didWrite = false
+        var replyError: String?
+        let handler = ClipboardWriteMessageHandler(
+            server: ServerFixture.withRemoteConnection,
+            writeToPasteboard: { _ in didWrite = true }
+        )
+
+        handler.handleMessage(
+            body: ["text": "should not be copied"],
+            requestURL: URL(string: "https://external.example.com/lovelace/music")!,
+            scheme: "https",
+            host: "external.example.com",
+            port: 443,
+            replyHandler: { _, error in replyError = error }
+        )
+
+        #expect(!didWrite)
+        #expect(replyError == "Origin or path is not allowed to write to the clipboard")
+    }
+
+    @Test func rejectsIngressFromOriginOutsideConfiguredServerOrigins() {
+        ServerFixture.reset()
+        var didWrite = false
+        var replyError: String?
+        let handler = ClipboardWriteMessageHandler(
+            server: ServerFixture.withRemoteConnection,
+            writeToPasteboard: { _ in didWrite = true }
+        )
+
+        handler.handleMessage(
+            body: ["text": "should not be copied"],
+            requestURL: URL(string: "https://evil.example.com/api/hassio_ingress/music_assistant")!,
+            scheme: "https",
+            host: "evil.example.com",
+            port: 443,
+            replyHandler: { _, error in replyError = error }
+        )
+
+        #expect(!didWrite)
+        #expect(replyError == "Origin or path is not allowed to write to the clipboard")
+    }
+
+    @Test func rejectsMalformedIngressMessageWithoutWriting() {
+        ServerFixture.reset()
+        var didWrite = false
+        var replyError: String?
+        let handler = ClipboardWriteMessageHandler(
+            server: ServerFixture.withRemoteConnection,
+            writeToPasteboard: { _ in didWrite = true }
+        )
+
+        handler.handleMessage(
+            body: ["text": 123],
+            requestURL: URL(string: "https://external.example.com/api/hassio_ingress/music_assistant")!,
+            scheme: "https",
+            host: "external.example.com",
+            port: 443,
+            replyHandler: { _, error in replyError = error }
+        )
+
+        #expect(!didWrite)
+        #expect(replyError == "Malformed clipboard message")
+    }
+
+    @Test @MainActor func userScriptOnlyInstallsClipboardShimForIngressDocuments() {
+        let script = ClipboardWriteMessageHandler.userScript
+
+        #expect(script.injectionTime == .atDocumentStart)
+        #expect(!script.isForMainFrameOnly)
+        #expect(script.source.contains("window.location.pathname.startsWith(\"/api/hassio_ingress/\")"))
+        #expect(script.source.contains("writable: true"))
+    }
+}

--- a/Tests/App/WebView/ClipboardWriteMessageHandlerTests.swift
+++ b/Tests/App/WebView/ClipboardWriteMessageHandlerTests.swift
@@ -98,6 +98,8 @@ struct ClipboardWriteMessageHandlerTests {
         #expect(script.injectionTime == .atDocumentStart)
         #expect(!script.isForMainFrameOnly)
         #expect(script.source.contains("window.location.pathname.startsWith(\"/api/hassio_ingress/\")"))
+        #expect(script.source.contains("navigator.userActivation.isActive"))
+        #expect(script.source.contains("text: String(text)"))
         #expect(script.source.contains("writable: true"))
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [X] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [X] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

When viewing the Music Assistant app via the sidebar in the HA app, copy/paste (specifically for the webrtc / remote access code) would *appear* to work (the little toast saying it was successful appears) but would not actually inject the code into the local copy buffer. This change adds a clipboardWrite bridge that lets that actually work. Tested on a local build under macOS 26.6.2.

## Screenshots

No user-facing change.

## Link to pull request in Documentation repository

No documentation change needed.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
