### PR TITLE
Create macOS release when a release tag is pushed

### DIFF
--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -7,6 +7,9 @@ on:
         description: Release tag to publish, for example release/2026.5.0/2026.1985
         required: true
         type: string
+  push:
+    tags:
+      - 'release/*/*'
 
 permissions:
   actions: read


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
`release_macos.yml` only ran on `workflow_dispatch`, so a release tag pushed by hand or created in the GitHub UI produced no release. This adds a `push` trigger on `release/*/*` tags.

The workflow already supported this: it falls back to `GITHUB_REF_NAME` when no `release_tag` input is given, and its concurrency group already references `github.ref_name`. Only the trigger was missing.

Tagging through `tag_macos_release.yml` is unaffected. That workflow pushes the tag with `GITHUB_TOKEN`, which does not start new workflow runs, so it still produces exactly one release run via its explicit dispatch.

Note that a tag push runs the workflow file as it exists at the tagged commit, so this applies to tags pointing at commits that include this change.

## Screenshots
N/A, no user-facing change.

## Link to pull request in Documentation repository
Documentation: N/A, internal release workflow only.

## Any other notes
None.
