### PR TITLE
Enable widgets "Show states" by default and remove BETA label

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2749,7 +2749,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.custom.show_last_update_time.param.title" = "Show last update time";
 "widgets.custom.show_states.description" = "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information.";
 "widgets.custom.show_states.param.title" = "Show states (BETA)";
-"widgets.custom.show_states.param.title_v2" = "Show states";
+"widgets.custom.show_states.param.title_no_beta" = "Show states";
 "widgets.custom.show_update_time.title" = "Last update:";
 "widgets.custom.subtitle" = "Create widgets with your own style";
 "widgets.custom.title" = "Custom widgets";

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -2749,6 +2749,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "widgets.custom.show_last_update_time.param.title" = "Show last update time";
 "widgets.custom.show_states.description" = "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information.";
 "widgets.custom.show_states.param.title" = "Show states (BETA)";
+"widgets.custom.show_states.param.title_v2" = "Show states";
 "widgets.custom.show_update_time.title" = "Last update:";
 "widgets.custom.subtitle" = "Create widgets with your own style";
 "widgets.custom.title" = "Custom widgets";

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesAppIntent.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesAppIntent.swift
@@ -23,7 +23,7 @@ struct WidgetCommonlyUsedEntitiesAppIntent: AppIntent, WidgetConfigurationIntent
     var showLastUpdateTime: Bool
 
     @Parameter(
-        title: .init("widgets.custom.show_states.param.title_v2", defaultValue: "Show states"),
+        title: .init("widgets.custom.show_states.param.title_no_beta", defaultValue: "Show states"),
         description: .init(
             "widgets.custom.show_states.description",
             defaultValue: "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information."

--- a/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesAppIntent.swift
+++ b/Sources/Extensions/Widgets/CommonlyUsedEntities/WidgetCommonlyUsedEntitiesAppIntent.swift
@@ -23,7 +23,7 @@ struct WidgetCommonlyUsedEntitiesAppIntent: AppIntent, WidgetConfigurationIntent
     var showLastUpdateTime: Bool
 
     @Parameter(
-        title: .init("widgets.custom.show_states.param.title", defaultValue: "Show states (BETA)"),
+        title: .init("widgets.custom.show_states.param.title_v2", defaultValue: "Show states"),
         description: .init(
             "widgets.custom.show_states.description",
             defaultValue: "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information."

--- a/Sources/Extensions/Widgets/Custom/WidgetCustomTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/Custom/WidgetCustomTimelineProvider.swift
@@ -154,12 +154,12 @@ struct WidgetCustomAppIntent: AppIntent, WidgetConfigurationIntent {
     var showLastUpdateTime: Bool
 
     @Parameter(
-        title: .init("widgets.custom.show_states.param.title", defaultValue: "Show states (BETA)"),
+        title: .init("widgets.custom.show_states.param.title_v2", defaultValue: "Show states"),
         description: .init(
             "widgets.custom.show_states.description",
             defaultValue: "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information."
         ),
-        default: false
+        default: true
     )
     var showStates: Bool
 

--- a/Sources/Extensions/Widgets/Custom/WidgetCustomTimelineProvider.swift
+++ b/Sources/Extensions/Widgets/Custom/WidgetCustomTimelineProvider.swift
@@ -154,7 +154,7 @@ struct WidgetCustomAppIntent: AppIntent, WidgetConfigurationIntent {
     var showLastUpdateTime: Bool
 
     @Parameter(
-        title: .init("widgets.custom.show_states.param.title_v2", defaultValue: "Show states"),
+        title: .init("widgets.custom.show_states.param.title_no_beta", defaultValue: "Show states"),
         description: .init(
             "widgets.custom.show_states.description",
             defaultValue: "Displaying latest states is not 100% guaranteed, you can give it a try and check the companion App documentation for more information."

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -8883,6 +8883,8 @@ public enum L10n {
         public enum Param {
           /// Show states (BETA)
           public static var title: String { return L10n.tr("Localizable", "widgets.custom.show_states.param.title") }
+          /// Show states
+          public static var titleV2: String { return L10n.tr("Localizable", "widgets.custom.show_states.param.title_v2") }
         }
       }
       public enum ShowUpdateTime {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -8884,7 +8884,7 @@ public enum L10n {
           /// Show states (BETA)
           public static var title: String { return L10n.tr("Localizable", "widgets.custom.show_states.param.title") }
           /// Show states
-          public static var titleV2: String { return L10n.tr("Localizable", "widgets.custom.show_states.param.title_v2") }
+          public static var titleNoBeta: String { return L10n.tr("Localizable", "widgets.custom.show_states.param.title_no_beta") }
         }
       }
       public enum ShowUpdateTime {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
"Show states" in the custom widget configuration now defaults to on (the common controls widget already did), and the parameter title no longer says "(BETA)". The new title uses a new localized key so the beta-labelled translations are not reused.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The old key `widgets.custom.show_states.param.title` is now unused and can be removed from Lokalise.
