### PR TITLE
Keep last-known network state when Wi-Fi info is unreadable

### DIFF
--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -81,15 +81,38 @@ public class ConnectivityWrapper {
         }
     }
 
-    /// Records a state that a fetch actually returned. Unlike a state re-applied from the cache by
-    /// `refreshNetworkInformation()`, this is what `emptyNetworkStateGrace` measures from.
-    private func recordFetchedNetworkState(_ state: NetworkState) {
+    /// Applies a state a fetch actually returned, deciding whether to believe an empty result under the
+    /// same lock as the write: `currentNetworkState()` has many concurrent callers, and deciding against
+    /// one snapshot and writing against another lets an empty result overwrite a populated one that
+    /// landed in between. Returns what the caller should see, and whether the fetched state was dropped
+    /// in favour of the last-known one.
+    private func applyFetchedNetworkState(_ state: NetworkState) -> (state: NetworkState, keptLastKnown: Bool) {
+        guard state == NetworkState() else {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            cachedNetworkState = state
+            lastPopulatedNetworkStateDate = Current.date()
+            return (state, false)
+        }
+
+        // On cellular there is genuinely no Wi-Fi to report, and switching to the external URL right
+        // away is the correct response to leaving the network. Read before taking the lock: it does not
+        // touch the cache, and the path monitor should not be called with `stateLock` held.
+        let isOnCellular = simpleNetworkType() == .cellular
+
         stateLock.lock()
         defer { stateLock.unlock() }
-        cachedNetworkState = state
-        if state != NetworkState() {
-            lastPopulatedNetworkStateDate = Current.date()
+
+        if !isOnCellular, let lastPopulated = lastPopulatedNetworkStateDate,
+           Current.date().timeIntervalSince(lastPopulated) < emptyNetworkStateGrace {
+            return (cachedNetworkState, true)
         }
+
+        cachedNetworkState = state
+        // Believing an empty state leaves nothing for the grace to measure from, so the next empty read
+        // is believed straight away rather than preserving a cache that is already empty.
+        lastPopulatedNetworkStateDate = nil
+        return (state, false)
     }
 
     private func readLastKnownNetworkState() -> NetworkState {
@@ -98,7 +121,9 @@ public class ConnectivityWrapper {
         return cachedNetworkState
     }
 
-    private func readLastPopulatedNetworkStateDate() -> Date? {
+    /// When the last fetch that reported a network landed, which `emptyNetworkStateGrace` measures from.
+    /// Internal so tests can assert it never disagrees with the cache.
+    func lastPopulatedNetworkStateDateForTests() -> Date? {
         stateLock.lock()
         defer { stateLock.unlock() }
         return lastPopulatedNetworkStateDate
@@ -153,30 +178,11 @@ public class ConnectivityWrapper {
             return readLastKnownNetworkState()
         }
 
-        guard state != NetworkState() || shouldBelieveEmptyNetworkState() else {
+        let applied = applyFetchedNetworkState(state)
+        if applied.keptLastKnown {
             Current.Log.info("network information came back unreadable; keeping last-known network state")
-            return readLastKnownNetworkState()
         }
-
-        recordFetchedNetworkState(state)
-        return state
-    }
-
-    /// Whether a fetch reporting no network describes the network the device is actually on, rather
-    /// than a read that failed while it was between access points.
-    private func shouldBelieveEmptyNetworkState() -> Bool {
-        // On cellular there is genuinely no Wi-Fi to report, and switching to the external URL right
-        // away is the correct response to leaving the network.
-        if simpleNetworkType() == .cellular {
-            return true
-        }
-
-        guard let lastPopulated = readLastPopulatedNetworkStateDate() else {
-            // Nothing was ever read successfully, so there is no earlier network to hold on to.
-            return true
-        }
-
-        return Current.date().timeIntervalSince(lastPopulated) >= emptyNetworkStateGrace
+        return applied.state
     }
 
     #if targetEnvironment(macCatalyst)

--- a/Sources/Shared/Environment/ConnectivityWrapper.swift
+++ b/Sources/Shared/Environment/ConnectivityWrapper.swift
@@ -63,6 +63,7 @@ public class ConnectivityWrapper {
 
     private let stateLock = NSLock()
     private var cachedNetworkState = NetworkState()
+    private var lastPopulatedNetworkStateDate: Date?
 
     private let notificationLock = NSLock()
     private var lastNotifiedNetworkType: NetworkType?
@@ -74,6 +75,21 @@ public class ConnectivityWrapper {
         stateLock.lock()
         defer { stateLock.unlock() }
         cachedNetworkState = state
+        if state == NetworkState() {
+            // Deliberately resetting to no network leaves nothing for `emptyNetworkStateGrace` to hold on to.
+            lastPopulatedNetworkStateDate = nil
+        }
+    }
+
+    /// Records a state that a fetch actually returned. Unlike a state re-applied from the cache by
+    /// `refreshNetworkInformation()`, this is what `emptyNetworkStateGrace` measures from.
+    private func recordFetchedNetworkState(_ state: NetworkState) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        cachedNetworkState = state
+        if state != NetworkState() {
+            lastPopulatedNetworkStateDate = Current.date()
+        }
     }
 
     private func readLastKnownNetworkState() -> NetworkState {
@@ -82,9 +98,24 @@ public class ConnectivityWrapper {
         return cachedNetworkState
     }
 
+    private func readLastPopulatedNetworkStateDate() -> Date? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return lastPopulatedNetworkStateDate
+    }
+
     /// Maximum time to await a network-info fetch before falling back to the last-known state.
     /// Overridable in tests.
     var networkFetchTimeout: TimeInterval = 3
+
+    /// How long a fetch that reports no network at all keeps deferring to the last-known state while
+    /// the device is not on cellular. `NEHotspotNetwork.fetchCurrent` reports nothing for reasons other
+    /// than being off Wi-Fi, most commonly a roam between access points on the same SSID, which leaves
+    /// the device with no readable network while it re-associates. Believing that flips the active URL
+    /// to the external one and reloads the whole frontend, then reloads it again once the read recovers.
+    /// Bounded rather than indefinite so a read that never recovers (location access denied, say) is
+    /// eventually believed. Overridable in tests.
+    var emptyNetworkStateGrace: TimeInterval = 60
 
     /// The underlying network-info fetch, before the timeout guard in `fetchNetworkState()`.
     /// Overridable in tests to simulate a fetch that never completes.
@@ -122,8 +153,30 @@ public class ConnectivityWrapper {
             return readLastKnownNetworkState()
         }
 
-        updateLastKnownNetworkState(state)
+        guard state != NetworkState() || shouldBelieveEmptyNetworkState() else {
+            Current.Log.info("network information came back unreadable; keeping last-known network state")
+            return readLastKnownNetworkState()
+        }
+
+        recordFetchedNetworkState(state)
         return state
+    }
+
+    /// Whether a fetch reporting no network describes the network the device is actually on, rather
+    /// than a read that failed while it was between access points.
+    private func shouldBelieveEmptyNetworkState() -> Bool {
+        // On cellular there is genuinely no Wi-Fi to report, and switching to the external URL right
+        // away is the correct response to leaving the network.
+        if simpleNetworkType() == .cellular {
+            return true
+        }
+
+        guard let lastPopulated = readLastPopulatedNetworkStateDate() else {
+            // Nothing was ever read successfully, so there is no earlier network to hold on to.
+            return true
+        }
+
+        return Current.date().timeIntervalSince(lastPopulated) >= emptyNetworkStateGrace
     }
 
     #if targetEnvironment(macCatalyst)

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -8,6 +8,8 @@ class ConnectivityWrapperTests: XCTestCase {
     private var previousPerformNetworkStateFetch: (() async -> NetworkState)!
     private var previousNetworkFetchTimeout: TimeInterval!
     private var previousSimpleNetworkType: (() -> NetworkType)!
+    private var previousEmptyNetworkStateGrace: TimeInterval!
+    private var previousDate: (() -> Date)!
 
     override func setUp() {
         super.setUp()
@@ -17,6 +19,9 @@ class ConnectivityWrapperTests: XCTestCase {
         previousPerformNetworkStateFetch = Current.connectivity.performNetworkStateFetch
         previousNetworkFetchTimeout = Current.connectivity.networkFetchTimeout
         previousSimpleNetworkType = Current.connectivity.simpleNetworkType
+        previousEmptyNetworkStateGrace = Current.connectivity.emptyNetworkStateGrace
+        previousDate = Current.date
+        Current.connectivity.updateLastKnownNetworkState(NetworkState())
     }
 
     override func tearDown() {
@@ -26,6 +31,9 @@ class ConnectivityWrapperTests: XCTestCase {
         Current.connectivity.performNetworkStateFetch = previousPerformNetworkStateFetch
         Current.connectivity.networkFetchTimeout = previousNetworkFetchTimeout
         Current.connectivity.simpleNetworkType = previousSimpleNetworkType
+        Current.connectivity.emptyNetworkStateGrace = previousEmptyNetworkStateGrace
+        Current.date = previousDate
+        Current.connectivity.updateLastKnownNetworkState(NetworkState())
         super.tearDown()
     }
 
@@ -207,5 +215,112 @@ class ConnectivityWrapperTests: XCTestCase {
         XCTAssertEqual(state.ssid, "fresh-ssid")
         XCTAssertEqual(state.bssid, "fresh-bssid")
         XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "fresh-ssid")
+    }
+
+    func testEmptyFetchWhileStillOnWiFiKeepsLastKnownNetwork() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home", bssid: "ap-a") }
+        _ = await Current.connectivity.fetchNetworkState()
+
+        // Roaming to another access point on the same SSID: NEHotspotNetwork reports nothing while the
+        // device re-associates, which must not read as having left the network.
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+
+        let state = await Current.connectivity.fetchNetworkState()
+
+        XCTAssertEqual(state.ssid, "home")
+        XCTAssertEqual(state.bssid, "ap-a")
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "home")
+    }
+
+    func testEmptyFetchOnCellularClearsLastKnownNetwork() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home", bssid: "ap-a") }
+        _ = await Current.connectivity.fetchNetworkState()
+
+        Current.connectivity.simpleNetworkType = { .cellular }
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+
+        let state = await Current.connectivity.fetchNetworkState()
+
+        XCTAssertNil(state.ssid)
+        XCTAssertNil(Current.connectivity.lastKnownNetworkState().ssid)
+    }
+
+    func testEmptyFetchIsBelievedOnceTheGraceElapses() async {
+        var now = Date(timeIntervalSince1970: 1_000_000)
+        Current.date = { now }
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.emptyNetworkStateGrace = 60
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home") }
+        _ = await Current.connectivity.fetchNetworkState()
+
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+        now = now.addingTimeInterval(59)
+        let withinGrace = await Current.connectivity.fetchNetworkState()
+        XCTAssertEqual(withinGrace.ssid, "home")
+
+        now = now.addingTimeInterval(2)
+        let pastGrace = await Current.connectivity.fetchNetworkState()
+        XCTAssertNil(pastGrace.ssid)
+    }
+
+    func testRepeatedEmptyFetchesDoNotExtendTheGrace() async {
+        var now = Date(timeIntervalSince1970: 1_000_000)
+        Current.date = { now }
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.emptyNetworkStateGrace = 60
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home") }
+        _ = await Current.connectivity.fetchNetworkState()
+
+        // The grace is measured from the last fetch that actually reported a network, so preserving the
+        // cached one must not push the deadline out on every retry.
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+        for _ in 0 ..< 6 {
+            now = now.addingTimeInterval(10)
+            _ = await Current.connectivity.fetchNetworkState()
+        }
+
+        XCTAssertNil(Current.connectivity.lastKnownNetworkState().ssid)
+    }
+
+    func testEmptyFetchWithNoPriorNetworkIsBelieved() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+
+        let state = await Current.connectivity.fetchNetworkState()
+
+        XCTAssertNil(state.ssid)
+    }
+
+    func testRefreshingWhileTheNetworkIsUnreadableKeepsReportingTheSameNetwork() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { await Current.connectivity.fetchNetworkState() }
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home", bssid: "ap-a") }
+        await Current.connectivity.refreshNetworkInformation()
+
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+        await Current.connectivity.refreshNetworkInformation()
+
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "home")
+    }
+
+    func testPathUpdateWhileRoamingDoesNotPostConnectivityChange() async {
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.currentNetworkState = { await Current.connectivity.fetchNetworkState() }
+        Current.connectivity.performNetworkStateFetch = { NetworkState(ssid: "home", bssid: "ap-a") }
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+        let expectation = expectation(
+            forNotification: Current.connectivity.connectivityDidChangeNotification(),
+            object: nil
+        )
+        expectation.isInverted = true
+
+        await Current.connectivity.handleNetworkPathUpdate()
+
+        await fulfillment(of: [expectation], timeout: 0.5)
+        XCTAssertEqual(Current.connectivity.lastKnownNetworkState().ssid, "home")
     }
 }

--- a/Tests/Shared/ConnectivityWrapper.test.swift
+++ b/Tests/Shared/ConnectivityWrapper.test.swift
@@ -11,6 +11,16 @@ class ConnectivityWrapperTests: XCTestCase {
     private var previousEmptyNetworkStateGrace: TimeInterval!
     private var previousDate: (() -> Date)!
 
+    /// Alternates between an unreadable read and a populated one so concurrent fetches interleave both.
+    private actor FetchResults {
+        private var count = 0
+
+        func next() -> Bool {
+            count += 1
+            return count.isMultiple(of: 2)
+        }
+    }
+
     override func setUp() {
         super.setUp()
         previousCurrentNetworkState = Current.connectivity.currentNetworkState
@@ -291,6 +301,39 @@ class ConnectivityWrapperTests: XCTestCase {
         let state = await Current.connectivity.fetchNetworkState()
 
         XCTAssertNil(state.ssid)
+    }
+
+    func testBelievingAnEmptyFetchLeavesNothingForTheGraceToPreserve() async {
+        Current.connectivity.simpleNetworkType = { .cellular }
+        Current.connectivity.performNetworkStateFetch = { NetworkState() }
+
+        _ = await Current.connectivity.fetchNetworkState()
+
+        // An empty cache must not be held on to as if it were a network worth preserving.
+        XCTAssertNil(Current.connectivity.lastPopulatedNetworkStateDateForTests())
+    }
+
+    func testConcurrentFetchesNeverLeaveAnEmptyCacheAnchoredToAPopulatedRead() async {
+        // The empty result is decided against the cache and written to it under one lock: deciding
+        // against one snapshot and writing against another lets an empty fetch land on top of a
+        // populated one that arrived in between, leaving the cache empty but still anchored, which
+        // makes every later empty read preserve the emptiness.
+        Current.connectivity.simpleNetworkType = { .wifi }
+        Current.connectivity.emptyNetworkStateGrace = 0
+        let results = FetchResults()
+        Current.connectivity.performNetworkStateFetch = {
+            await results.next() ? NetworkState() : NetworkState(ssid: "home")
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 200 {
+                group.addTask { _ = await Current.connectivity.fetchNetworkState() }
+            }
+        }
+
+        let cached = Current.connectivity.lastKnownNetworkState()
+        let anchor = Current.connectivity.lastPopulatedNetworkStateDateForTests()
+        XCTAssertFalse(cached == NetworkState() && anchor != nil)
     }
 
     func testRefreshingWhileTheNetworkIsUnreadableKeepsReportingTheSameNetwork() async {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
`NEHotspotNetwork.fetchCurrent` returns no network while the device re-associates between access points on the same SSID. There was no "unknown" state, so that read as "not on the internal network": the active URL flipped to the external one and the whole frontend reloaded, then reloaded again seconds later when the read recovered.

An empty fetch result is now only believed when the device is on cellular, or when 60s have passed since the last fetch that actually reported a network. Otherwise the last-known state is kept.

Fixes #5542

## Screenshots
N/A

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The grace period is bounded so a read that never recovers (location access denied, for instance) is eventually believed.
