### PR TITLE
Keep the Focus name when iOS reports a Focus it can't see

### DIFF
--- a/Sources/Shared/Environment/FocusReport.swift
+++ b/Sources/Shared/Environment/FocusReport.swift
@@ -5,9 +5,9 @@ import Foundation
 ///
 /// Two sources each know half of it and neither is complete on its own. The Focus Filter runs when
 /// a Focus *starts* and is the only thing that ever tells us its name. `INShareFocusStatusIntent`
-/// pushes whether any Focus is running, which is the only thing that tells us one ended — but
-/// asking iOS for that status back reports `false` for a Focus whose status the user doesn't
-/// share, and during a switch it still describes the Focus that just ended.
+/// pushes whether any Focus is running, which is the only thing that tells us one ended — but it
+/// says `false` for a Focus whose status the user doesn't share, whether pushed to us or asked
+/// for, and during a switch it still describes the Focus that just ended.
 ///
 /// The name is deliberately sticky: iOS wipes the filter's name on deactivation and skips
 /// re-running the filter for quick reactivations, so the last reported name is the best answer to
@@ -65,7 +65,8 @@ public struct FocusReport: Equatable {
             } ?? "<never ran>"
             let status = receivedStatus.map {
                 "isFocused(\(String(describing: $0.isFocused))) at(\($0.date)) " +
-                    "lastEnded(\(String(describing: $0.lastEndedDate)))"
+                    "lastEnded(\(String(describing: $0.lastEndedDate))) " +
+                    "lastStarted(\(String(describing: $0.lastStartedDate)))"
             } ?? "<never received>"
             return "focus report: \(report) from filter[\(filter)] status[\(status)]"
         }
@@ -76,9 +77,18 @@ public struct FocusReport: Equatable {
     /// Whether iOS said every Focus had ended after the filter ran, which is what makes the name it
     /// reported stale. Checked against the last such moment rather than the current status, so a
     /// Focus that started without a filter can't inherit the name of the one before it.
+    ///
+    /// It only counts for a Focus iOS confirmed running after that filter run. Focus status is
+    /// shared per Focus, and the ones the user doesn't share read back as "not focused" for as
+    /// long as they run — repeatedly, since iOS re-shares that on its own — so without a
+    /// confirmation to pair it with, a status saying nothing is running says nothing about this
+    /// Focus. The filter's own reset run still ends those.
     private static func hasEnded(filterState: FocusFilterState, receivedStatus: FocusStatusState?) -> Bool {
-        guard let lastEndedDate = receivedStatus?.lastEndedDate else { return false }
-        return lastEndedDate > filterState.date.addingTimeInterval(switchGracePeriod)
+        guard let receivedStatus,
+              let lastEndedDate = receivedStatus.lastEndedDate,
+              lastEndedDate > filterState.date.addingTimeInterval(switchGracePeriod) else { return false }
+        guard let lastStartedDate = receivedStatus.lastStartedDate else { return false }
+        return lastStartedDate > filterState.date
     }
 
     /// Asking iOS directly, which only the app can do, and which only answers for Focuses whose

--- a/Sources/Shared/Environment/FocusReport.swift
+++ b/Sources/Shared/Environment/FocusReport.swift
@@ -88,7 +88,7 @@ public struct FocusReport: Equatable {
               let lastEndedDate = receivedStatus.lastEndedDate,
               lastEndedDate > filterState.date.addingTimeInterval(switchGracePeriod) else { return false }
         guard let lastStartedDate = receivedStatus.lastStartedDate else { return false }
-        return lastStartedDate > filterState.date
+        return lastStartedDate >= filterState.date
     }
 
     /// Asking iOS directly, which only the app can do, and which only answers for Focuses whose

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -107,6 +107,12 @@ public class FocusStatusWrapper {
 
         let now = Current.date()
         let isFocused = lastStatus?.isFocused
+        let previous = receivedStatus.value
+
+        // State persisted before `lastStartedDate` existed still carries the same evidence in its
+        // own `isFocused`: a status that said a Focus was running is the confirmation, so the
+        // first status after an upgrade doesn't have to be the one that establishes it.
+        let previousStartedDate = previous?.lastStartedDate ?? (previous?.isFocused == true ? previous?.date : nil)
 
         // Recorded rather than acted on: iOS runs the next Focus' filter before it tells us the
         // previous one ended, so which of the two is current is decided when they are read back
@@ -114,8 +120,8 @@ public class FocusStatusWrapper {
         receivedStatus.value = FocusStatusState(
             isFocused: isFocused,
             date: now,
-            lastEndedDate: isFocused == false ? now : receivedStatus.value?.lastEndedDate,
-            lastStartedDate: isFocused == true ? now : receivedStatus.value?.lastStartedDate
+            lastEndedDate: isFocused == false ? now : previous?.lastEndedDate,
+            lastStartedDate: isFocused == true ? now : previousStartedDate
         )
     }
 

--- a/Sources/Shared/Environment/FocusStatusWrapper.swift
+++ b/Sources/Shared/Environment/FocusStatusWrapper.swift
@@ -12,11 +12,17 @@ public struct FocusStatusState: Codable, Equatable {
     /// When iOS last said every Focus had ended, kept across later updates. A name the filter
     /// reported before that moment belongs to a Focus that is over; one reported after it doesn't.
     public var lastEndedDate: Date?
+    /// When iOS last said a Focus was running, kept across later updates. iOS reports "not
+    /// focused" for a Focus whose status the user doesn't share, so this is what says whether it
+    /// can see the running Focus at all: without it, a status saying nothing is running is
+    /// silence rather than an ending.
+    public var lastStartedDate: Date?
 
-    public init(isFocused: Bool?, date: Date, lastEndedDate: Date?) {
+    public init(isFocused: Bool?, date: Date, lastEndedDate: Date?, lastStartedDate: Date? = nil) {
         self.isFocused = isFocused
         self.date = date
         self.lastEndedDate = lastEndedDate
+        self.lastStartedDate = lastStartedDate
     }
 }
 
@@ -108,7 +114,8 @@ public class FocusStatusWrapper {
         receivedStatus.value = FocusStatusState(
             isFocused: isFocused,
             date: now,
-            lastEndedDate: isFocused == false ? now : receivedStatus.value?.lastEndedDate
+            lastEndedDate: isFocused == false ? now : receivedStatus.value?.lastEndedDate,
+            lastStartedDate: isFocused == true ? now : receivedStatus.value?.lastStartedDate
         )
     }
 

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -330,6 +330,23 @@ class FocusNameSensorTests: XCTestCase {
         XCTAssertEqual(Current.focusStatus.lastReceived()?.lastStartedDate, now.addingTimeInterval(60))
     }
 
+    /// Status persisted before it recorded when a Focus started still says one was running, and
+    /// that is the confirmation — otherwise the first status after an upgrade could never be the
+    /// one that ends the Focus it was talking about.
+    func testReceivedStatusBackfillsTheStartFromAPersistedFocusedStatus() throws {
+        Current.isAppExtension = true
+        Current.focusStatus.receivedStatus.value = FocusStatusState(
+            isFocused: true,
+            date: now.addingTimeInterval(-60),
+            lastEndedDate: nil
+        )
+
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
+
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastEndedDate, now)
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastStartedDate, now.addingTimeInterval(-60))
+    }
+
     /// A received status must not destroy the reported name: whether it is still current depends on
     /// when the filter ran, which is only known when the two are read back together.
     func testReceivedStatusKeepsTheReportedName() throws {

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -69,13 +69,15 @@ class FocusNameSensorTests: XCTestCase {
     private func received(
         isFocused: Bool?,
         at offset: TimeInterval,
-        lastEnded: TimeInterval? = nil
+        lastEnded: TimeInterval? = nil,
+        lastStarted: TimeInterval? = nil
     ) -> FocusStatusState {
         let date = now.addingTimeInterval(offset)
         return FocusStatusState(
             isFocused: isFocused,
             date: date,
-            lastEndedDate: lastEnded.map { now.addingTimeInterval($0) } ?? (isFocused == false ? date : nil)
+            lastEndedDate: lastEnded.map { now.addingTimeInterval($0) } ?? (isFocused == false ? date : nil),
+            lastStartedDate: lastStarted.map { now.addingTimeInterval($0) } ?? (isFocused == true ? date : nil)
         )
     }
 
@@ -157,11 +159,47 @@ class FocusNameSensorTests: XCTestCase {
     /// Knowing every Focus ended blanks the name rather than reporting a made-up state.
     func testReportsEmptyOnceEveryFocusEnded() throws {
         FocusName(name: "Work").save()
-        setUpDependencies(activeFocusName: "Work", receivedStatus: received(isFocused: false, at: -10))
+        setUpDependencies(
+            activeFocusName: "Work",
+            receivedStatus: received(isFocused: false, at: -10, lastStarted: -50)
+        )
 
         let sensors = try hang(FocusNameSensor(request: request).sensors())
         XCTAssertEqual(sensors[0].State as? String, "")
         XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, false)
+    }
+
+    /// The bug behind #5592: Focus status is shared per Focus, and the ones the user doesn't share
+    /// read back as "not focused" the whole time they run. Nothing ever confirmed this Focus, so
+    /// those statuses can't be what ended it — only the filter's own reset run can.
+    func testKeepsTheNameWhenTheEndedStatusNeverSawTheFocusStart() throws {
+        FocusName(name: "Work").save()
+        setUpDependencies(
+            activeFocusName: "Work",
+            filterRan: -3600,
+            receivedStatus: received(isFocused: false, at: -60),
+            liveIsFocused: false
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Work")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
+    }
+
+    /// Switching from a Focus iOS could see to one it can't: the confirmation belongs to the Focus
+    /// that ended, so it must not hand the statuses that follow the right to end the new one.
+    func testKeepsTheNameWhenOnlyThePreviousFocusWasEverConfirmed() throws {
+        FocusName(name: "Work").save()
+        setUpDependencies(
+            activeFocusName: "Work",
+            filterRan: -3600,
+            receivedStatus: received(isFocused: false, at: -60, lastStarted: -3610),
+            liveIsFocused: false
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "Work")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
     }
 
     /// A Focus without a filter starting after every Focus ended keeps the last reported name —
@@ -257,8 +295,9 @@ class FocusNameSensorTests: XCTestCase {
     }
 
     /// The received status is what every process reads back, so it has to survive the one that
-    /// received it going away — and it has to remember when a Focus last ended.
-    func testReceivedStatusIsStoredWithWhenEveryFocusLastEnded() throws {
+    /// received it going away — and it has to remember when a Focus last started and last ended,
+    /// which is what pairs a status with the Focus it is talking about.
+    func testReceivedStatusIsStoredWithWhenAFocusLastStartedAndEnded() throws {
         Current.isAppExtension = true
 
         Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
@@ -269,6 +308,12 @@ class FocusNameSensorTests: XCTestCase {
         Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: true))
         XCTAssertEqual(Current.focusStatus.lastReceived()?.isFocused, true)
         XCTAssertEqual(Current.focusStatus.lastReceived()?.lastEndedDate, now)
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastStartedDate, now.addingTimeInterval(60))
+
+        Current.date = { [now] in now.addingTimeInterval(120) }
+        Current.focusStatus.update(fromReceived: INFocusStatus(isFocused: false))
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastEndedDate, now.addingTimeInterval(120))
+        XCTAssertEqual(Current.focusStatus.lastReceived()?.lastStartedDate, now.addingTimeInterval(60))
     }
 
     /// A received status must not destroy the reported name: whether it is still current depends on

--- a/Tests/Shared/Sensors/FocusNameSensor.test.swift
+++ b/Tests/Shared/Sensors/FocusNameSensor.test.swift
@@ -186,6 +186,20 @@ class FocusNameSensorTests: XCTestCase {
         XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, true)
     }
 
+    /// A confirmation stamped at the same instant as the filter run belongs to that run: the two
+    /// come from different processes reading the same clock, so the boundary counts as seen.
+    func testReportsEmptyWhenTheFocusWasConfirmedAtTheFilterRunInstant() throws {
+        FocusName(name: "Work").save()
+        setUpDependencies(
+            activeFocusName: "Work",
+            receivedStatus: received(isFocused: false, at: -10, lastStarted: -60)
+        )
+
+        let sensors = try hang(FocusNameSensor(request: request).sensors())
+        XCTAssertEqual(sensors[0].State as? String, "")
+        XCTAssertEqual(sensors[0].Attributes?["Is focused"] as? Bool, false)
+    }
+
     /// Switching from a Focus iOS could see to one it can't: the confirmation belongs to the Focus
     /// that ended, so it must not hand the statuses that follow the right to end the new one.
     func testKeepsTheNameWhenOnlyThePreviousFocusWasEverConfirmed() throws {


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Focus status is shared per Focus. A Focus whose status the user doesn't share reads back as "not focused" for as long as it runs, and iOS pushes that repeatedly, which cleared the name the Focus Filter had reported: `sensor.focus_name` went empty and `binary_sensor.focus` went off while a Focus was running.

A pushed status saying nothing is running now only ends a Focus that the same status channel confirmed as running after that filter run. The filter's own reset run still ends the others.

## Screenshots
No UI changes.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Trade-off: if a Focus iOS can't see ends and the filter's reset run doesn't land, the name sticks instead of blanking. The name is sticky by design and reset runs do land in practice.
