### PR TITLE
Persist entities from every domain

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -51,9 +51,7 @@ final class EntityAddToHandler {
                 #endif
 
                 // Widgets are available on all platforms
-                if domain != nil {
-                    actions.append(CustomWidgetAction())
-                }
+                actions.append(CustomWidgetAction())
 
                 // Mac titlebar/toolbar is available on Mac Catalyst for any entity
                 if Current.isCatalyst, domain != nil {

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -51,7 +51,7 @@ final class EntityAddToHandler {
                 #endif
 
                 // Widgets are available on all platforms
-                if let domain, !Domain.appDatabaseExcluded.contains(domain) {
+                if domain != nil {
                     actions.append(CustomWidgetAction())
                 }
 

--- a/Sources/Shared/API/Models/AppEntitiesModel.swift
+++ b/Sources/Shared/API/Models/AppEntitiesModel.swift
@@ -8,7 +8,6 @@ public protocol AppEntitiesModelProtocol {
 
 final class AppEntitiesModel: AppEntitiesModelProtocol {
     static var shared = AppEntitiesModel()
-    private static let excludedDomains = Set(Domain.appDatabaseExcluded.map(\.rawValue))
     /// ServerId: Date
     private var lastDatabaseUpdate: [String: Date] = [:]
     /// ServerId: Int
@@ -16,25 +15,20 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
 
     public func updateModel(_ entities: Set<HAEntity>, server: Server) async {
         // Only update database after a few seconds or if the entities count changed
-        // First check for time to avoid unnecessary filtering to check count
         if !checkLastDatabaseUpdateRecently(server: server) {
-            let appRelatedEntities = persistableEntities(entities)
             Current.Log
                 .verbose(
                     "Updating App Entities for \(server.info.name) checkLastDatabaseUpdateLessThanMinuteAgo false, lastDatabaseUpdate \(String(describing: lastDatabaseUpdate)) "
                 )
-            updateLastUpdate(entitiesCount: appRelatedEntities.count, server: server)
-            await handle(appRelatedEntities: appRelatedEntities, server: server)
-        } else {
-            let appRelatedEntities = persistableEntities(entities)
-            if lastEntitiesCount[server.identifier.rawValue] != appRelatedEntities.count {
-                Current.Log
-                    .verbose(
-                        "Updating App Entities for \(server.info.name) entities count diff, count: last \(lastEntitiesCount), new \(appRelatedEntities.count)"
-                    )
-                updateLastUpdate(entitiesCount: appRelatedEntities.count, server: server)
-                await handle(appRelatedEntities: appRelatedEntities, server: server)
-            }
+            updateLastUpdate(entitiesCount: entities.count, server: server)
+            await handle(fetchedEntities: entities, server: server)
+        } else if lastEntitiesCount[server.identifier.rawValue] != entities.count {
+            Current.Log
+                .verbose(
+                    "Updating App Entities for \(server.info.name) entities count diff, count: last \(lastEntitiesCount), new \(entities.count)"
+                )
+            updateLastUpdate(entitiesCount: entities.count, server: server)
+            await handle(fetchedEntities: entities, server: server)
         }
     }
 
@@ -43,17 +37,13 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
         lastDatabaseUpdate[server.identifier.rawValue] = Date()
     }
 
-    private func persistableEntities(_ entities: Set<HAEntity>) -> Set<HAEntity> {
-        entities.filter { !Self.excludedDomains.contains($0.domain) }
-    }
-
     // Avoid updating database too often
     private func checkLastDatabaseUpdateRecently(server: Server) -> Bool {
         guard let lastDate = lastDatabaseUpdate[server.identifier.rawValue] else { return false }
         return Date().timeIntervalSince(lastDate) < 15
     }
 
-    private func handle(appRelatedEntities: Set<HAEntity>, server: Server) async {
+    private func handle(fetchedEntities: Set<HAEntity>, server: Server) async {
         let serverId = server.identifier.rawValue
 
         // Resolve each entity's display name from the entity registry (`list_for_display` `en`) once,
@@ -96,7 +86,7 @@ final class AppEntitiesModel: AppEntitiesModelProtocol {
         // without a live connection. `nil` when the map isn't available (old server / not yet fetched).
         let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
 
-        let appEntities = appRelatedEntities.map { entity -> HAAppEntity in
+        let appEntities = fetchedEntities.map { entity -> HAAppEntity in
             let deviceClass = entity.attributes.dictionary["device_class"] as? String
             let resolvedIcon = componentIcons.flatMap { map in
                 EntityIconResolver.componentDefaultIcon(domain: entity.domain, deviceClass: deviceClass, map: map)

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -60,6 +60,13 @@ public enum Domain: String, CaseIterable {
     case weather
     case counter
     case timer
+    case aiTask = "ai_task"
+    case configurator
+    case imageProcessing = "image_processing"
+    case infrared
+    case plant
+    case radioFrequency = "radio_frequency"
+    case tag
 
     public init?(entityId: String) {
         let domainString = entityId.components(separatedBy: ".").first ?? ""
@@ -364,6 +371,20 @@ public enum Domain: String, CaseIterable {
             image = .counterIcon
         case .timer:
             image = .timerOutlineIcon
+        case .aiTask:
+            image = .starFourPointsIcon
+        case .configurator:
+            image = .cogIcon
+        case .imageProcessing:
+            image = .imageFilterFramesIcon
+        case .infrared:
+            image = .ledOnIcon
+        case .plant:
+            image = .flowerIcon
+        case .radioFrequency:
+            image = .radioTowerIcon
+        case .tag:
+            image = .tagOutlineIcon
         }
         return image
     }
@@ -522,7 +543,17 @@ public enum Domain: String, CaseIterable {
             return CoreStrings.componentWeatherTitle
         case .timer:
             return CoreStrings.componentTimerTitle
-        case .zone, .airQuality, .conversation, .stt, .tts, .wakeWord, .counter:
+        case .aiTask:
+            return CoreStrings.componentAiTaskTitle
+        case .configurator:
+            return CoreStrings.componentConfiguratorTitle
+        case .imageProcessing:
+            return CoreStrings.componentImageProcessingTitle
+        case .plant:
+            return CoreStrings.componentPlantTitle
+        case .tag:
+            return CoreStrings.componentTagTitle
+        case .zone, .airQuality, .conversation, .stt, .tts, .wakeWord, .counter, .infrared, .radioFrequency:
             return rawValue
         }
     }
@@ -698,17 +729,6 @@ public extension Domain {
         .deviceTracker,
         .update,
     ]
-
-    static let appDatabaseExcluded: [Domain] = [
-        .geoLocation,
-        .conversation,
-        .stt,
-        .tts,
-        .wakeWord,
-        .assistSatellite,
-        .notify,
-        .image,
-    ]
 }
 
 // MARK: - Main Action
@@ -733,7 +753,8 @@ public extension Domain {
              .dateTime, .deviceTracker, .event, .geoLocation, .group, .image, .inputDatetime, .inputNumber,
              .inputSelect, .inputText, .lawnMower, .mediaPlayer, .notify, .number, .remote, .schedule,
              .select, .siren, .stt, .sun, .text, .time, .tts, .update, .vacuum, .wakeWord, .waterHeater,
-             .weather, .counter, .timer:
+             .weather, .counter, .timer, .aiTask, .configurator, .imageProcessing, .infrared, .plant,
+             .radioFrequency, .tag:
             return nil // Read-only or complex domains
         }
     }

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -63,6 +63,13 @@ struct DomainTests {
             .weather: "weather",
             .counter: "counter",
             .timer: "timer",
+            .aiTask: "ai_task",
+            .configurator: "configurator",
+            .imageProcessing: "image_processing",
+            .infrared: "infrared",
+            .plant: "plant",
+            .radioFrequency: "radio_frequency",
+            .tag: "tag",
         ]
 
         #expect(
@@ -505,13 +512,6 @@ struct DomainFeatureSupportTests {
         #expect(Set(Domain.sensorWidgetSupported) == expected, "Domain.sensorWidgetSupported membership changed")
     }
 
-    @Test func appDatabaseExcludedMembership() {
-        let expected: Set<Domain> = [
-            .geoLocation, .conversation, .stt, .tts, .wakeWord, .assistSatellite, .notify, .image,
-        ]
-        #expect(Set(Domain.appDatabaseExcluded) == expected, "Domain.appDatabaseExcluded membership changed")
-    }
-
     @Test func groupsHaveNoDuplicates() {
         let groups: [(String, [Domain])] = [
             ("carPlaySupported", Domain.carPlaySupported),
@@ -520,26 +520,9 @@ struct DomainFeatureSupportTests {
             ("watchAddable", Domain.watchAddable),
             ("controlScreenDomains", Domain.controlScreenDomains),
             ("sensorWidgetSupported", Domain.sensorWidgetSupported),
-            ("appDatabaseExcluded", Domain.appDatabaseExcluded),
         ]
         for (name, group) in groups {
             #expect(group.count == Set(group).count, "\(name) contains duplicate domains")
-        }
-    }
-
-    @Test func supportedDomainsAreNotExcludedFromPersistence() {
-        let excluded = Set(Domain.appDatabaseExcluded)
-        let featureLists: [(String, [Domain])] = [
-            ("carPlaySupported", Domain.carPlaySupported),
-            ("watchSupported", Domain.watchSupported),
-            ("watchAddable", Domain.watchAddable),
-            ("controlScreenDomains", Domain.controlScreenDomains),
-            ("sensorWidgetSupported", Domain.sensorWidgetSupported),
-        ]
-        for (name, list) in featureLists {
-            for domain in list {
-                #expect(!excluded.contains(domain), "\(name) domain \(domain) must not be in appDatabaseExcluded")
-            }
         }
     }
 }

--- a/Tests/Shared/Models/EntityRegistry.test.swift
+++ b/Tests/Shared/Models/EntityRegistry.test.swift
@@ -41,7 +41,7 @@ struct EntityRegistryTests {
     }
 }
 
-@Suite("AppEntitiesModel display-name resolution")
+@Suite("AppEntitiesModel display-name resolution", .serialized)
 struct AppEntitiesModelNameResolutionTests {
     private func makeEntity(_ entityId: String, friendlyName: String?) throws -> HAEntity {
         var attributes: [String: Any] = [:]

--- a/Tests/Shared/Models/EntityRegistry.test.swift
+++ b/Tests/Shared/Models/EntityRegistry.test.swift
@@ -153,4 +153,45 @@ struct AppEntitiesModelNameResolutionTests {
         try #expect(row("light.visible").isHidden == nil)
         try #expect(row("light.unregistered").isHidden == nil)
     }
+
+    /// Persistence is domain-agnostic: Spotlight, the entity pickers and templating all read the
+    /// local database, so every domain the server reports is stored (including the assist, notify,
+    /// image and geo_location ones that used to be dropped, and domains the `Domain` enum
+    /// doesn't know). Features that support only some domains filter where they read.
+    @Test("every domain is persisted, including ones no feature supports")
+    func persistsEveryDomain() async throws {
+        let previousDatabase = Current.database
+        let database = try DatabaseQueue(path: ":memory:")
+        try HAppEntityTable().createIfNeeded(database: database)
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
+        Current.database = { database }
+        defer { Current.database = previousDatabase }
+
+        let serverId = "all-domains-test"
+        let server = Server.fake(identifier: .init(rawValue: serverId))
+
+        let entityIds = [
+            "light.kitchen",
+            "geo_location.nearby_fire",
+            "conversation.home_assistant",
+            "stt.whisper",
+            "tts.piper",
+            "wake_word.openwakeword",
+            "assist_satellite.kitchen_speaker",
+            "notify.mobile_app_iphone",
+            "image.doorbell_snapshot",
+            "some_custom_integration.thing",
+        ]
+        let entities = try Set(entityIds.map { try makeEntity($0, friendlyName: nil) })
+
+        await AppEntitiesModel().updateModel(entities, server: server)
+
+        let storedEntityIds = try await database.read { db in
+            try HAAppEntity
+                .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
+                .fetchAll(db)
+                .map(\.entityId)
+        }
+        #expect(Set(storedEntityIds) == Set(entityIds))
+    }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Entity persistence dropped a fixed list of domains (`geo_location`, `conversation`, `stt`, `tts`, `wake_word`, `assist_satellite`, `notify`, `image`). Now that entities are indexed in Spotlight, and since the entity pickers and templating also read the local database, a domain missing there is a domain the user can never find. Every domain the server reports is persisted, and the features that support only some domains keep filtering where they read.

`Domain.appDatabaseExcluded` had one other use, gating the frontend "Add to → Widget" action, which existed because those domains had no database row for the widget item to resolve. With rows present, that check is gone.

Also completes the `Domain` enum with the entity domains it was missing: `ai_task`, `configurator`, `image_processing`, `infrared`, `plant`, `radio_frequency` and `tag`.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI changes, only more entities available in the existing search and picker surfaces.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The missing domains were checked against `home-assistant/frontend`; `remember_the_milk` is the only entity domain left out, since the frontend does not reference it anywhere.

`geo_location` feed integrations recreate their entities on every poll, so each of those changes now rewrites the server's entity table, resyncs the watch mirror and reindexes Spotlight. The database updater is throttled to 120s and only runs on frontend loads, manual refresh and onboarding, so it does not add background work.
