### PR TITLE
Make App Labs available on every build

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1342,7 +1342,6 @@ Home Assistant is open source, advocates for privacy and runs locally in your ho
 "settings.app_labs.header.subtitle" = "App Labs are experimental features that can change or be removed at any time. Use them at your own risk.";
 "settings.app_labs.mac_native_sidebar.footer" = "Replaces the Home Assistant sidebar with a native macOS sidebar. The page reloads when you change this setting.";
 "settings.app_labs.mac_native_sidebar.title" = "Native sidebar";
-"settings.app_labs.testflight_only.body" = "App Labs is only available on TestFlight builds.";
 "settings.app_labs.title" = "App Labs";
 "settings.connection_section.activate_server" = "Activate";
 "settings.connection_section.add_server" = "Add Server";

--- a/Sources/App/Settings/AppLabs/AppLabsFeature.swift
+++ b/Sources/App/Settings/AppLabs/AppLabsFeature.swift
@@ -6,9 +6,8 @@ enum AppLabsFeature: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    // App Labs is limited to TestFlight builds while its features mature.
     static var isLabsAvailable: Bool {
-        Current.isTestFlight
+        true
     }
 
     var title: String {

--- a/Sources/App/Settings/AppLabs/AppLabsView.swift
+++ b/Sources/App/Settings/AppLabs/AppLabsView.swift
@@ -1,4 +1,3 @@
-import SFSafeSymbols
 import Shared
 import SwiftUI
 
@@ -12,17 +11,6 @@ struct AppLabsView: View {
                 title: L10n.Settings.AppLabs.title,
                 subtitle: L10n.Settings.AppLabs.Header.subtitle
             )
-
-            Section {
-                Label {
-                    Text(L10n.Settings.AppLabs.TestflightOnly.body)
-                        .font(.callout)
-                        .foregroundColor(.secondary)
-                } icon: {
-                    Image(systemSymbol: .infoCircle)
-                        .foregroundColor(.haPrimary)
-                }
-            }
 
             let features = AppLabsFeature.availableFeatures
             if features.isEmpty {

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4491,10 +4491,6 @@ public enum L10n {
         /// Native sidebar
         public static var title: String { return L10n.tr("Localizable", "settings.app_labs.mac_native_sidebar.title") }
       }
-      public enum TestflightOnly {
-        /// App Labs is only available on TestFlight builds.
-        public static var body: String { return L10n.tr("Localizable", "settings.app_labs.testflight_only.body") }
-      }
     }
     public enum ConnectionSection {
       /// Activate

--- a/Tests/App/Settings/AppLabsView.test.swift
+++ b/Tests/App/Settings/AppLabsView.test.swift
@@ -8,13 +8,12 @@ struct AppLabsViewTests {
         assertLightDarkSnapshots(of: AppLabsView())
     }
 
-    @Test func appLabsIsHiddenOutsideTestFlight() {
+    @Test func appLabsIsAvailableOnEveryBuild() {
         let previousIsTestFlight = Current.isTestFlight
         defer { Current.isTestFlight = previousIsTestFlight }
 
         Current.isTestFlight = false
-        #expect(!SettingsItem.appLabs.isVisible)
-        #expect(!AppLabsFeature.macNativeSidebar.isEnabled)
+        #expect(SettingsItem.appLabs.isVisible)
 
         Current.isTestFlight = true
         #expect(SettingsItem.appLabs.isVisible)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Removes the TestFlight gate from App Labs so the Settings entry is available on every build.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Ungating counterpart of #5596. Keep as draft until App Labs has been validated on TestFlight.
