### PR TITLE
Detect TestFlight builds on Mac Catalyst

### DIFF
--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -483,7 +483,7 @@ public class AppEnvironment {
         print("⚠️ isTestFlight returns TRUE while debugging")
         return true
         #else
-        return Environment.isTestFlightReceipt()
+        return AppEnvironment.isTestFlightReceipt()
         #endif
     }()
 
@@ -596,7 +596,7 @@ public class AppEnvironment {
         )
 
         // Create a file log destination
-        let isTestFlight = Environment.isTestFlightReceipt()
+        let isTestFlight = AppEnvironment.isTestFlightReceipt()
         let fileDestination = AutoRotatingFileDestination(
             writeToFile: logPath,
             identifier: "advancedLogger.fileDestination",

--- a/Sources/Shared/Environment/Environment.swift
+++ b/Sources/Shared/Environment/Environment.swift
@@ -483,9 +483,23 @@ public class AppEnvironment {
         print("⚠️ isTestFlight returns TRUE while debugging")
         return true
         #else
-        return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        return Environment.isTestFlightReceipt()
         #endif
     }()
+
+    /// On iOS a TestFlight build gets a `sandboxReceipt` file. On Mac Catalyst the receipt is always
+    /// `_MASReceipt/receipt`, so the receipt type inside it (`ProductionSandbox` for TestFlight,
+    /// `Production` for the App Store) is what tells them apart; the payload is signed, not encrypted.
+    static func isTestFlightReceipt() -> Bool {
+        guard let url = Bundle.main.appStoreReceiptURL else { return false }
+        #if targetEnvironment(macCatalyst)
+        guard let receipt = try? Data(contentsOf: url),
+              let marker = "ProductionSandbox".data(using: .utf8) else { return false }
+        return receipt.range(of: marker) != nil
+        #else
+        return url.lastPathComponent == "sandboxReceipt"
+        #endif
+    }
 
     #if os(iOS)
     public var isAppExtension = AppConstants.BundleID != Bundle.main.bundleIdentifier
@@ -582,7 +596,7 @@ public class AppEnvironment {
         )
 
         // Create a file log destination
-        let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        let isTestFlight = Environment.isTestFlightReceipt()
         let fileDestination = AutoRotatingFileDestination(
             writeToFile: logPath,
             identifier: "advancedLogger.fileDestination",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
TestFlight detection only checked for the iOS `sandboxReceipt` file name. On Mac Catalyst the receipt is always `_MASReceipt/receipt`, so TestFlight-only features such as App Labs never showed up in Mac TestFlight builds. Catalyst now reads the receipt type from the receipt payload instead.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Follow-up to #5596.
