### PR TITLE
Report code coverage on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,6 @@ jobs:
 
       - name: Run tests
         run: bundle exec fastlane test
-        env:
-          CI_ENABLE_COVERAGE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
       # Save the warmed DerivedData only from `main`, and only on a fresh key,
       # so PR runs never evict the shared base cache other PRs restore from.
@@ -211,12 +209,25 @@ jobs:
             env.DEVELOPER_DIR,
             hashFiles('Package.resolved')) }}
 
+      # `xcrun xccov` is the only source of truth for Xcode coverage: the uploader's
+      # own Swift plugin globs DerivedData and pairs profdata with the wrong binaries,
+      # which reported ~0% for the whole project. Convert the result bundle ourselves
+      # and hand Codecov a plain LCOV tracefile instead.
+      - name: Build coverage report
+        # Tests gate merges; coverage reporting must not. A broken report shows up as a
+        # failed step (and a missing Codecov comment) without blocking the pull request.
+        continue-on-error: true
+        run: >-
+          python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult
+          --lcov fastlane/test_output/coverage.lcov
+          --summary "$GITHUB_STEP_SUMMARY"
+
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         name: "Upload Code Coverage"
-        if: github.ref == 'refs/heads/main'
         with:
-          xcode: true
-          xcode_archive_path: fastlane/test_output/Tests-Unit.xcresult
+          files: fastlane/test_output/coverage.lcov
+          disable_search: true
+          plugins: noop
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload Test Logs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,9 +213,12 @@ jobs:
       # own Swift plugin globs DerivedData and pairs profdata with the wrong binaries,
       # which reported ~0% for the whole project. Convert the result bundle ourselves
       # and hand Codecov a plain LCOV tracefile instead.
+      #
+      # Both steps below are `continue-on-error`: tests gate merges, coverage reporting
+      # must not. `fail_ci_if_error` covers only the upload result, not the uploader's
+      # own setup steps (dependency checks, CLI download, signature verification), which
+      # exit nonzero on their own, so the action needs the same treatment.
       - name: Build coverage report
-        # Tests gate merges; coverage reporting must not. A broken report shows up as a
-        # failed step (and a missing Codecov comment) without blocking the pull request.
         continue-on-error: true
         run: >-
           python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult
@@ -224,6 +227,7 @@ jobs:
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         name: "Upload Code Coverage"
+        continue-on-error: true
         with:
           files: fastlane/test_output/coverage.lcov
           disable_search: true

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -23,6 +23,26 @@ python3 Tools/detect_unused_strings.py
 - `0`: No unused strings found
 - `1`: Unused strings detected (normal for reporting)
 
+### xccov_to_lcov.py
+
+Converts Xcode code coverage from an `.xcresult` bundle into an LCOV tracefile, which is
+what Codecov consumes. CI runs it after `fastlane test` so pull requests get a coverage
+report; the uploader's own Swift plugin cannot read Xcode result bundles reliably.
+
+**Usage:**
+```bash
+python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult --lcov coverage.lcov
+```
+
+**What it does:**
+1. Dumps per-line execution counts with `xcrun xccov view --archive --json`
+2. Rewrites absolute source paths as repository-relative paths, dropping anything outside the repository
+3. Writes an LCOV tracefile, and optionally appends a Markdown coverage summary to `--summary`
+
+**Exit codes:**
+- `0`: Coverage written
+- `1`: `xccov` failed, or the bundle covered no repository sources
+
 ## Shell Scripts
 
 ### BuildMaterialDesignIconsFont.sh

--- a/Tools/xccov_to_lcov.py
+++ b/Tools/xccov_to_lcov.py
@@ -31,7 +31,13 @@ class FileCoverage(NamedTuple):
 
 
 def read_archive(xcresult: Path) -> Dict[str, list]:
-    """Dump the per-line coverage archive of an .xcresult bundle as JSON."""
+    """
+    Dump the per-line coverage archive of an .xcresult bundle as JSON.
+
+    `--archive` maps each absolute source path to its list of lines. This is not
+    the `--report` format, which nests files under targets and carries no
+    per-line execution counts, so it cannot produce LCOV.
+    """
     result = subprocess.run(
         ['xcrun', 'xccov', 'view', '--archive', '--json', str(xcresult)],
         capture_output=True,
@@ -42,7 +48,17 @@ def read_archive(xcresult: Path) -> Dict[str, list]:
         print(f"xccov failed for {xcresult}:\n{result.stderr}", file=sys.stderr)
         sys.exit(1)
 
-    return json.loads(result.stdout)
+    archive = json.loads(result.stdout)
+
+    if not isinstance(archive, dict) or not all(isinstance(lines, list) for lines in archive.values()):
+        print(
+            "Unexpected xccov archive format: expected a mapping of source path to lines. "
+            "If a future Xcode changed it, this script needs updating.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return archive
 
 
 def parse_coverage(archive: Dict[str, list], repo_root: Path) -> List[FileCoverage]:

--- a/Tools/xccov_to_lcov.py
+++ b/Tools/xccov_to_lcov.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Convert Xcode code coverage from an .xcresult bundle into LCOV.
+
+`xcrun xccov view --archive --json` reports per-line execution counts keyed by
+absolute source path. Codecov cannot read that format, so this script rewrites
+it as LCOV with repository-relative paths, and optionally renders a Markdown
+summary for the GitHub Actions job summary.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Tuple
+
+
+class FileCoverage(NamedTuple):
+    """Per-line hit counts for one source file, keyed by repository-relative path."""
+    path: str
+    lines: List[Tuple[int, int]]
+
+    @property
+    def executable(self) -> int:
+        return len(self.lines)
+
+    @property
+    def covered(self) -> int:
+        return sum(1 for _, count in self.lines if count > 0)
+
+
+def read_archive(xcresult: Path) -> Dict[str, list]:
+    """Dump the per-line coverage archive of an .xcresult bundle as JSON."""
+    result = subprocess.run(
+        ['xcrun', 'xccov', 'view', '--archive', '--json', str(xcresult)],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"xccov failed for {xcresult}:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    return json.loads(result.stdout)
+
+
+def parse_coverage(archive: Dict[str, list], repo_root: Path) -> List[FileCoverage]:
+    """
+    Turn the xccov archive into repository-relative per-file coverage.
+
+    Files outside the repository (dependency checkouts inside DerivedData) are
+    dropped, since Codecov can only map paths that exist in the repository.
+    """
+    files = []
+
+    for absolute_path, lines in sorted(archive.items()):
+        try:
+            relative_path = Path(absolute_path).resolve().relative_to(repo_root)
+        except ValueError:
+            continue
+
+        executable = [
+            (line['line'], line.get('executionCount', 0))
+            for line in lines
+            if line.get('isExecutable')
+        ]
+
+        if executable:
+            files.append(FileCoverage(relative_path.as_posix(), executable))
+
+    return files
+
+
+def write_lcov(files: List[FileCoverage], destination: Path) -> None:
+    """Write the coverage as an LCOV tracefile."""
+    records = []
+
+    for file in files:
+        record = [f"SF:{file.path}"]
+        record += [f"DA:{line},{count}" for line, count in file.lines]
+        record.append(f"LF:{file.executable}")
+        record.append(f"LH:{file.covered}")
+        record.append('end_of_record')
+        records.append('\n'.join(record))
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text('\n'.join(records) + '\n', encoding='utf-8')
+
+
+def percentage(covered: int, executable: int) -> str:
+    return f"{covered / executable * 100:.2f}%" if executable else "n/a"
+
+
+def markdown_summary(files: List[FileCoverage], depth: int = 2) -> str:
+    """
+    Render a Markdown table of overall coverage plus a row per source group.
+
+    Groups are the first `depth` path components (`Sources/Shared`,
+    `Sources/App`, …), which is the same granularity the Codecov path-based
+    statuses in codecov.yaml use.
+    """
+    groups: Dict[str, List[int]] = {}
+
+    for file in files:
+        group = '/'.join(file.path.split('/')[:depth])
+        totals = groups.setdefault(group, [0, 0])
+        totals[0] += file.covered
+        totals[1] += file.executable
+
+    covered = sum(file.covered for file in files)
+    executable = sum(file.executable for file in files)
+
+    rows = [
+        "| Area | Coverage | Covered | Executable |",
+        "| --- | --- | --- | --- |",
+        f"| **Total** | **{percentage(covered, executable)}** | {covered} | {executable} |",
+    ]
+    rows += [
+        f"| `{group}` | {percentage(*groups[group])} | {groups[group][0]} | {groups[group][1]} |"
+        for group in sorted(groups)
+    ]
+
+    return '\n'.join(["## Code coverage", '', *rows, ''])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('xcresult', type=Path, help="path to the .xcresult bundle")
+    parser.add_argument('--lcov', type=Path, required=True, help="LCOV tracefile to write")
+    parser.add_argument('--summary', type=Path, help="Markdown summary to append to")
+    parser.add_argument(
+        '--repo-root',
+        type=Path,
+        default=Path.cwd(),
+        help="repository root that coverage paths are made relative to",
+    )
+    arguments = parser.parse_args()
+
+    files = parse_coverage(read_archive(arguments.xcresult), arguments.repo_root.resolve())
+
+    if not files:
+        print(f"No repository sources covered in {arguments.xcresult}", file=sys.stderr)
+        sys.exit(1)
+
+    write_lcov(files, arguments.lcov)
+
+    summary = markdown_summary(files)
+    print(summary)
+
+    if arguments.summary:
+        with open(arguments.summary, 'a', encoding='utf-8') as handle:
+            handle.write(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -12,9 +12,21 @@ coverage:
     patch:
       default:
         informational: true
+
+# Report coverage on every pull request, updating one comment in place rather
+# than adding a new one per push.
+comment:
+  layout: "condensed_header, diff, files, condensed_footer"
+  behavior: default
+  require_changes: false
+
+# Statuses and the comment carry the report; per-line annotations on the diff
+# are pure noise while most of the project is uncovered.
+github_checks:
+  annotations: false
+
 ignore:
   - Sources/Shared/Resources
   - Sources/App/Resources
   - Sources/SharedTesting
   - Tests
-  - Pods

--- a/fastlane/lanes/testing.rb
+++ b/fastlane/lanes/testing.rb
@@ -36,7 +36,6 @@ end
 
 desc 'Run tests'
 lane :test do
-  code_coverage = ENV.key?('CI_ENABLE_COVERAGE') ? (ENV['CI_ENABLE_COVERAGE'] == 'true') : nil
   run_tests(
     project: 'HomeAssistant.xcodeproj',
     scheme: 'Tests-Unit',
@@ -46,7 +45,6 @@ lane :test do
     # Run only the `test` action: `build test` compiles every SPM target twice
     # because the plain `build` action disables testability for packages.
     skip_build: true,
-    code_coverage: code_coverage,
     xcargs: 'COMPILER_INDEX_STORE_ENABLE=NO',
     destination: 'platform=iOS Simulator,name=iPhone 17,OS=latest'
   )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Brings code coverage results back to pull requests, and fixes the numbers being reported.

`codecov-action` v7 no longer accepts the `xcode` and `xcode_archive_path` inputs, so the upload fell back to the CLI's Swift plugin, which globs DerivedData and pairs profile data with the wrong binaries. `main` has been reporting 0.81% total and 0.00% for `Sources/Shared`, while `xcrun xccov` reports 19.81% for Shared and 3.20% for the app.

`Tools/xccov_to_lcov.py` now converts the result bundle to LCOV and Codecov uploads that file directly, on pull requests as well as `main`. The `comment` block in `codecov.yaml` is what makes the report show up on a pull request; diff annotations stay off, since most of the project is uncovered.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Reported coverage is 32.71% overall, 56.85% for `Sources/Shared` and 22.49% for `Sources/App`. That is not comparable to the ~52% shown before July, which counted only the files that had some coverage and ignored fully uncovered ones.

Coverage instrumentation is enabled on pull request runs again, which also makes their build flags match the DerivedData cache that `main` warms.

The report step is `continue-on-error`, so tests keep gating merges and a coverage tooling break cannot block a pull request.

