### PR TITLE
Improve App Labs features

### DIFF
--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarRow.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarRow.swift
@@ -17,7 +17,6 @@ struct MacSidebarRow: View {
         static let rowHeight: CGFloat = 32
         static let pinnedRowHeight: CGFloat = 40
         static let selectedFillOpacity: CGFloat = 0.12
-        static let hoverFillOpacity: CGFloat = 0.06
         static let badgeMinWidth: CGFloat = 28
     }
 
@@ -77,7 +76,7 @@ struct MacSidebarRow: View {
             .frame(maxWidth: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.one, style: .continuous)
-                    .fill(Color.primary.opacity(fillOpacity))
+                    .fill(fillColor)
             )
             .contentShape(Rectangle())
         }
@@ -85,13 +84,14 @@ struct MacSidebarRow: View {
         .onHover { isHovering = $0 }
     }
 
-    private var fillOpacity: CGFloat {
+    /// Hover uses the frontend's translucent primary tint so the sidebar reads like the web one.
+    private var fillColor: Color {
         if isSelected {
-            return Constants.selectedFillOpacity
+            return Color.primary.opacity(Constants.selectedFillOpacity)
         } else if isHovering {
-            return Constants.hoverFillOpacity
+            return FrontendColors.haButtonPrimaryLightColor.color
         } else {
-            return 0
+            return .clear
         }
     }
 }

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarRow.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarRow.swift
@@ -89,7 +89,7 @@ struct MacSidebarRow: View {
         if isSelected {
             return Color.primary.opacity(Constants.selectedFillOpacity)
         } else if isHovering {
-            return FrontendColors.haButtonPrimaryLightColor.color
+            return Color.haPrimaryLightFill
         } else {
             return .clear
         }

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarView.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarView.swift
@@ -92,7 +92,7 @@ struct MacSidebarView: View {
             }
             .background(.bar)
         }
-        .background(Color(uiColor: .secondarySystemBackground).ignoresSafeArea())
+        .background(Color(uiColor: .systemBackground).ignoresSafeArea())
         .onAppear { viewModel.start() }
         .onDisappear { viewModel.stop() }
     }

--- a/Sources/HADesignSystem/Sources/Colors/Color+Semantic.swift
+++ b/Sources/HADesignSystem/Sources/Colors/Color+Semantic.swift
@@ -115,6 +115,11 @@ public extension ShapeStyle where Self == Color {
         )
     }
 
+    /// The frontend's `--ha-button-primary-light-color` (`#4082a040`): a translucent primary tint for
+    /// hover states. The frontend declares it once, in its dark theme block, so it is the same in
+    /// both appearances here too.
+    static var haPrimaryLightFill: Color { srgb(0x40, 0x82, 0xA0, opacity: 0x40 / 255) }
+
     /// The frontend's `--disabled-color`: the unfilled part of a control's track, and the fill of a
     /// control that is off. The `ha-control-*` components draw it at 20%.
     static var haDisabled: Color {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Improves the App Labs features on Mac: the background now uses the system background color and hovered rows use the frontend's translucent primary tint.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Follow-up to #5596.
