### PR TITLE
Fix the E2E workflow

### DIFF
--- a/.github/e2e/README.md
+++ b/.github/e2e/README.md
@@ -62,6 +62,14 @@ for f in $(cd .github/e2e/homeassistant/.storage && ls); do curl -fsS "https://r
 
 ## When a run fails
 
+A failing nightly opens an issue titled "E2E: the nightly onboarding test is failing", labelled
+`automated`, naming the step that failed and linking the run. Later failures are added to that same
+issue as comments, and a closed one is reopened, so a bad week leaves one thread to read rather than
+seven issues. Only the scheduled run reports: a manual dispatch is usually someone working on the
+workflow itself. GitHub's own notification for a failing schedule reaches only whoever last edited
+the cron line, which is why this exists.
+
+
 The `e2e-artifacts` artifact carries a screen recording of the run under `e2e-recording/`, which is
 usually the quickest way to see where the flow went wrong. Alongside it are Home Assistant's own log,
 the `/api/config` it reported, and the full `.xcresult`.

--- a/.github/e2e/README.md
+++ b/.github/e2e/README.md
@@ -63,9 +63,13 @@ for f in $(cd .github/e2e/homeassistant/.storage && ls); do curl -fsS "https://r
 ## When a run fails
 
 The `e2e-artifacts` artifact carries a screen recording of the run under `e2e-recording/`, which is
-usually the quickest way to see where the flow went wrong. Xcode only keeps the recording when the
-test fails, so a passing run has none. Alongside it are Home Assistant's own log, the `/api/config`
-it reported, and the full `.xcresult`.
+usually the quickest way to see where the flow went wrong. Alongside it are Home Assistant's own log,
+the `/api/config` it reported, and the full `.xcresult`.
+
+Recordings are kept for passing runs as well, through `uiTestingScreenshotsLifetime` in
+[`Tests-UI.xctestplan`](../../Tests/UI/Tests-UI.xctestplan); Xcode would otherwise discard them on
+success. That is what the test plan exists for. It costs roughly 160 MB per run, so the artifact is
+kept for 14 days rather than the 90-day default.
 
 ## Notes
 

--- a/.github/e2e/README.md
+++ b/.github/e2e/README.md
@@ -23,7 +23,8 @@ in step means both apps are tested against the same instance, with the same enti
 
 Start an instance. Use a copy: Home Assistant rewrites `.storage` and writes its database and logs
 into whichever config dir it is given. The interpreter has to satisfy core's `requires-python`,
-which is 3.14.2 or newer.
+which is 3.14.2 or newer; `pip` refuses the install and names the version it wanted if it is older,
+so there is no need to check the patch level up front.
 
 ```bash
 cp -R .github/e2e/homeassistant /tmp/homeassistant && python3.14 -m venv /tmp/ha && /tmp/ha/bin/pip install homeassistant && /tmp/ha/bin/hass --config /tmp/homeassistant

--- a/.github/e2e/README.md
+++ b/.github/e2e/README.md
@@ -22,10 +22,11 @@ in step means both apps are tested against the same instance, with the same enti
 ## Running it locally
 
 Start an instance. Use a copy: Home Assistant rewrites `.storage` and writes its database and logs
-into whichever config dir it is given.
+into whichever config dir it is given. The interpreter has to satisfy core's `requires-python`,
+which is 3.14.2 or newer.
 
 ```bash
-cp -R .github/e2e/homeassistant /tmp/homeassistant && python3 -m venv /tmp/ha && /tmp/ha/bin/pip install homeassistant && /tmp/ha/bin/hass --config /tmp/homeassistant
+cp -R .github/e2e/homeassistant /tmp/homeassistant && python3.14 -m venv /tmp/ha && /tmp/ha/bin/pip install homeassistant && /tmp/ha/bin/hass --config /tmp/homeassistant
 ```
 
 Then run the flow. The lane checks the instance first, walking the same login exchange the app

--- a/.github/e2e/README.md
+++ b/.github/e2e/README.md
@@ -59,6 +59,13 @@ for f in $(cd .github/e2e/homeassistant/.storage && ls); do curl -fsS "https://r
 
 `core.config_entries` is expected to differ: the `go2rtc` entry is deliberately removed here.
 
+## When a run fails
+
+The `e2e-artifacts` artifact carries a screen recording of the run under `e2e-recording/`, which is
+usually the quickest way to see where the flow went wrong. Xcode only keeps the recording when the
+test fails, so a passing run has none. Alongside it are Home Assistant's own log, the `/api/config`
+it reported, and the full `.xcresult`.
+
 ## Notes
 
 - The test is not repeatable on a simulator that has already onboarded: it starts from the welcome

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,6 +171,50 @@ jobs:
             kill "$(cat "$RUNNER_TEMP/hass.pid")" 2>/dev/null || true
           fi
 
+      # XCUITest records the run and attaches it to the result bundle, but it lands inside the
+      # .xcresult under an opaque UUID filename. Exporting it puts the recording one click away in
+      # the artifact instead, which is the fastest way to see where a flow went wrong. Xcode keeps
+      # the recording only when the test fails, so a passing run exports nothing.
+      - name: Export screen recording
+        if: always()
+        run: |
+          XCRESULT=fastlane/test_output/e2e/Tests-UI.xcresult
+          if [ ! -d "$XCRESULT" ]; then
+            echo "No result bundle at $XCRESULT, nothing to export"
+            exit 0
+          fi
+
+          OUT="$RUNNER_TEMP/e2e-recording"
+          mkdir -p "$OUT"
+          xcrun xcresulttool export attachments --path "$XCRESULT" --output-path "$OUT" >/dev/null
+
+          # Name the exports after what they are. Anything that is not a recording or a screenshot
+          # is dropped, so the artifact stays small enough to download for a quick look.
+          python3 - "$OUT" <<'PY'
+          import json, pathlib, shutil, sys
+
+          out = pathlib.Path(sys.argv[1])
+          manifest = out / "manifest.json"
+          kept = 0
+
+          for group in json.loads(manifest.read_text()) if manifest.exists() else []:
+              for attachment in group.get("attachments", []):
+                  source = out / attachment["exportedFileName"]
+                  name = attachment.get("suggestedHumanReadableName", source.name)
+                  if not source.exists() or not name.lower().endswith((".mp4", ".png", ".jpeg", ".jpg")):
+                      continue
+                  shutil.move(source, out / name.replace("/", "-"))
+                  kept += 1
+
+          for leftover in out.iterdir():
+              if leftover.is_file() and leftover.suffix.lower() not in {".mp4", ".png", ".jpeg", ".jpg"}:
+                  leftover.unlink()
+              elif leftover.is_dir():
+                  shutil.rmtree(leftover)
+
+          print(f"Exported {kept} recording/screenshot attachment(s)")
+          PY
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload E2E Artifacts"
         if: always()
@@ -181,5 +225,6 @@ jobs:
             ${{ runner.temp }}/hass-stdout.log
             ${{ runner.temp }}/homeassistant-config.json
             ${{ runner.temp }}/homeassistant/home-assistant.log
+            ${{ runner.temp }}/e2e-recording
             fastlane/test_output/e2e
             ~/Library/Logs/scan

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -223,6 +223,9 @@ jobs:
         with:
           name: e2e-artifacts
           if-no-files-found: warn
+          # The recording is kept for passing runs too (see the test plan), which puts each run's
+          # artifact around 160 MB. Nightly, that is worth capping well below the 90-day default.
+          retention-days: 14
           path: |
             ${{ runner.temp }}/hass-stdout.log
             ${{ runner.temp }}/homeassistant-config.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,9 +86,11 @@ jobs:
         if: steps.cache_gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
 
+      # Tracks core's own `requires-python`, which both `dev` and the current releases put at
+      # 3.14.2. Installing Home Assistant on an older interpreter fails outright while resolving.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       # Scheduled runs track core's `dev` branch, the same as home-assistant/android, so a
       # regression there is caught before it reaches a release. The branch is cloned shallow

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,12 @@ jobs:
     name: "Onboarding"
     runs-on: macos-26
     timeout-minutes: 90
+    # Naming any scope denies the rest, so the failure report has to ask for what it needs:
+    # `issues` to file or update the report, `actions` to read back which step failed.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     env:
       E2E_HOME_ASSISTANT_URL: http://localhost:8123
       E2E_HOME_ASSISTANT_USERNAME: citest
@@ -224,8 +230,68 @@ jobs:
           name: e2e-artifacts
           if-no-files-found: warn
           # The recording is kept for passing runs too (see the test plan), which puts each run's
-          # artifact around 160 MB. Nightly, that is worth capping well below the 90-day default.
+          # artifact around 200 MB. Nightly, that is worth capping well below the 90-day default.
           retention-days: 14
+
+      # A red run nobody is told about is a nightly nobody trusts: GitHub only emails whoever last
+      # touched the cron line. Only the scheduled run reports, because a manual dispatch is usually
+      # someone iterating on the workflow itself and every red attempt would file a report.
+      - name: Report failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          HOME_ASSISTANT_VERSION: ${{ inputs.home-assistant-version || 'dev' }}
+        with:
+          script: |
+            const title = 'E2E: the nightly onboarding test is failing'
+            const { owner, repo } = context.repo
+            const run = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner,
+              repo,
+              run_id: context.runId,
+            })
+            const failed = jobs.flatMap((job) => job.steps || []).find((step) => step.conclusion === 'failure')
+
+            const body = [
+              `The nightly [E2E run](${run}) failed at **${failed ? failed.name : 'an unknown step'}**.`,
+              '',
+              `- Home Assistant version: \`${process.env.HOME_ASSISTANT_VERSION}\``,
+              "- A screen recording of the run and Home Assistant's own log are in that run's",
+              '  `e2e-artifacts` artifact, which is kept for 14 days.',
+              '',
+              'Later failures are added here as comments rather than opening another issue.',
+            ].join('\n')
+
+            // Deduped by title among `automated` issues, so a run of bad nights leaves one thread
+            // to read rather than one issue per night.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              labels: 'automated',
+              state: 'all',
+              per_page: 100,
+            })
+            const existing = issues.find((issue) => !issue.pull_request && issue.title === title)
+
+            if (!existing) {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['automated'],
+              })
+              core.info(`Opened #${created.data.number}`)
+              return
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body })
+            if (existing.state === 'closed') {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, state: 'open' })
+            }
+            core.info(`Updated #${existing.number}`)
           path: |
             ${{ runner.temp }}/hass-stdout.log
             ${{ runner.temp }}/homeassistant-config.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,11 +86,13 @@ jobs:
         if: steps.cache_gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
 
-      # Tracks core's own `requires-python`, which both `dev` and the current releases put at
-      # 3.14.2. Installing Home Assistant on an older interpreter fails outright while resolving.
+      # Spelled as core's own `requires-python`, which both `dev` and the current releases put at
+      # 3.14.2: installing Home Assistant on an older interpreter fails outright while resolving.
+      # A range rather than a pin, so the newest patch is picked up but a future 3.15 core has not
+      # been tested against is not.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5.3.0
         with:
-          python-version: "3.14"
+          python-version: ">=3.14.2 <3.15"
 
       # Scheduled runs track core's `dev` branch, the same as home-assistant/android, so a
       # regression there is caught before it reaches a release. The branch is cloned shallow

--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -5423,7 +5423,7 @@
 					"@loader_path/Frameworks",
 				);
 				PROVISIONING_SUFFIX = .HomeAssistantUITests;
-				TEST_TARGET_NAME = HomeAssistant;
+				TEST_TARGET_NAME = App;
 			};
 			name = Debug;
 		};
@@ -5437,7 +5437,7 @@
 					"@loader_path/Frameworks",
 				);
 				PROVISIONING_SUFFIX = .HomeAssistantUITests;
-				TEST_TARGET_NAME = HomeAssistant;
+				TEST_TARGET_NAME = App;
 			};
 			name = Release;
 		};

--- a/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Tests-UI.xcscheme
+++ b/HomeAssistant.xcodeproj/xcshareddata/xcschemes/Tests-UI.xcscheme
@@ -29,18 +29,12 @@
             ReferencedContainer = "container:HomeAssistant.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B657A9061CA646EB00121384"
-               BuildableName = "HomeAssistant-Tests-UI.xctest"
-               BlueprintName = "Tests-UI"
-               ReferencedContainer = "container:HomeAssistant.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/UI/Tests-UI.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Tests/UI/OnboardingE2ETests.swift
+++ b/Tests/UI/OnboardingE2ETests.swift
@@ -128,6 +128,15 @@ final class OnboardingE2ETests: XCTestCase {
     }
 
     private func openNativeSettingsFromFrontend() {
+        // Relaunched because asking the frontend for the settings screen in the same session that just
+        // onboarded crashes the app: SwiftUI raises an unexpected error from
+        // `NavigationColumnState.boundPathChange` the moment `AppSettingsPresenter.pushPath` gains its
+        // first element. Onboarding runs its own `NavigationStack` inside the container's, and the
+        // container's stack does not survive that nesting. Reproduces on iOS 26.5 and iOS 27; a
+        // relaunched app pushes the same screen without complaint.
+        app.terminate()
+        app.launch()
+
         tapWebElement(labelContaining: "sidebar toggle", timeout: Timeout.frontend, "frontend sidebar toggle")
         tapWebElement(labelContaining: "settings", timeout: Timeout.frontend, "frontend sidebar settings entry")
 

--- a/Tests/UI/OnboardingE2ETests.swift
+++ b/Tests/UI/OnboardingE2ETests.swift
@@ -62,8 +62,7 @@ final class OnboardingE2ETests: XCTestCase {
 
         let urlField = app.textFields.firstMatch
         wait(for: urlField, timeout: Timeout.screen, "manual URL entry field")
-        urlField.tap()
-        urlField.typeText(Instance.url)
+        type(Instance.url, into: urlField, "manual URL entry field")
 
         tap(app.buttons[.onboardingManualEntryConnect], timeout: Timeout.screen, "connect button")
     }
@@ -76,14 +75,12 @@ final class OnboardingE2ETests: XCTestCase {
         // keyboard happens to be focused, and a miss otherwise surfaces only as a rejected login.
         let username = webView.textFields.firstMatch
         wait(for: username, timeout: Timeout.frontend, "username field")
-        username.tap()
-        username.typeText(Instance.username)
+        type(Instance.username, into: username, "username field")
         XCTAssertEqual(username.value as? String, Instance.username, "Username field did not receive the username")
 
         let password = webView.secureTextFields.firstMatch
         wait(for: password, timeout: Timeout.frontend, "password field")
-        password.tap()
-        password.typeText(Instance.password)
+        type(Instance.password, into: password, "password field")
         // Secure fields report one bullet per character rather than the text itself.
         XCTAssertEqual(
             (password.value as? String)?.count,
@@ -153,6 +150,24 @@ final class OnboardingE2ETests: XCTestCase {
     private func tap(_ element: XCUIElement, timeout: TimeInterval, _ description: String) {
         wait(for: element, timeout: timeout, description)
         element.tap()
+    }
+
+    /// Types into a field, waiting for it to actually take keyboard focus first.
+    ///
+    /// A tap on a web view field does not focus it synchronously: the page has to handle the touch
+    /// and move focus itself. Typing before that fails outright with "Neither element nor any
+    /// descendant has keyboard focus", so the tap is repeated until the keyboard is up.
+    private func type(_ text: String, into element: XCUIElement, _ description: String) {
+        // Always taps at least once, even when the keyboard is already up for a previous field,
+        // since that tap is what moves focus to this one.
+        var attempts = 0
+        repeat {
+            element.tap()
+            attempts += 1
+        } while !app.keyboards.element.waitForExistence(timeout: Timeout.optional) && attempts < 3
+
+        XCTAssertTrue(app.keyboards.element.exists, "Keyboard never came up for the \(description)")
+        element.typeText(text)
     }
 
     @discardableResult

--- a/Tests/UI/OnboardingE2ETests.swift
+++ b/Tests/UI/OnboardingE2ETests.swift
@@ -36,6 +36,12 @@ final class OnboardingE2ETests: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         app = XCUIApplication()
+        // Onboards with the release client ID rather than the debug one. Home Assistant allows the
+        // release iOS callback offline, but has to fetch `https://home-assistant.io/iOS/dev-auth`
+        // to allow the debug one, and it reads only the first 10 KB of that page, which no longer
+        // reaches the `redirect_uri` link tag. The debug pair is rejected with "Invalid redirect
+        // URI", so the flow could never log in.
+        app.launchArguments = ["-FASTLANE_SNAPSHOT", "YES"]
         app.launch()
     }
 
@@ -66,17 +72,28 @@ final class OnboardingE2ETests: XCTestCase {
         let webView = app.webViews.firstMatch
         wait(for: webView, timeout: Timeout.frontend, "login web view")
 
+        // Both fields are checked after typing: text aimed at a web view field lands wherever the
+        // keyboard happens to be focused, and a miss otherwise surfaces only as a rejected login.
         let username = webView.textFields.firstMatch
         wait(for: username, timeout: Timeout.frontend, "username field")
         username.tap()
         username.typeText(Instance.username)
+        XCTAssertEqual(username.value as? String, Instance.username, "Username field did not receive the username")
 
         let password = webView.secureTextFields.firstMatch
         wait(for: password, timeout: Timeout.frontend, "password field")
         password.tap()
+        password.typeText(Instance.password)
+        // Secure fields report one bullet per character rather than the text itself.
+        XCTAssertEqual(
+            (password.value as? String)?.count,
+            Instance.password.count,
+            "Password field did not receive the whole password"
+        )
+
         // Submitting from the field avoids matching the login button, whose label the frontend
         // renders inside a shadow root.
-        password.typeText("\(Instance.password)\n")
+        password.typeText("\n")
 
         // Shown only when Home Assistant asks to confirm the redirect back to the app.
         tapIfPresent(webElement(labelContaining: "authorize"), timeout: Timeout.optional)

--- a/Tests/UI/OnboardingE2ETests.swift
+++ b/Tests/UI/OnboardingE2ETests.swift
@@ -183,7 +183,18 @@ final class OnboardingE2ETests: XCTestCase {
     /// carries a badge when there are pending updates or repairs, and an exact label would miss it.
     private func webElement(labelContaining text: String) -> XCUIElement {
         let predicate = NSPredicate(format: "label CONTAINS[c] %@", text)
-        return app.webViews.firstMatch.descendants(matching: .any).matching(predicate).firstMatch
+        let webView = app.webViews.firstMatch
+
+        // Links and buttons first: a row's label usually also matches the static text inside it,
+        // and tapping that does not activate the row.
+        for query in [webView.links, webView.buttons] {
+            let element = query.matching(predicate).firstMatch
+            if element.exists {
+                return element
+            }
+        }
+
+        return webView.descendants(matching: .any).matching(predicate).firstMatch
     }
 
     /// Taps an element of the frontend, scrolling it into reach first when the page is long enough

--- a/Tests/UI/Tests-UI.xctestplan
+++ b/Tests/UI/Tests-UI.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "A6E2E000-0000-4000-A000-00000000E2E0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "preferredScreenCaptureFormat" : "screenRecording",
+    "uiTestingScreenshotsLifetime" : "keepAlways"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:HomeAssistant.xcodeproj",
+        "identifier" : "B657A9061CA646EB00121384",
+        "name" : "Tests-UI"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/lanes/testing.rb
+++ b/fastlane/lanes/testing.rb
@@ -125,13 +125,14 @@ lane :e2e do |options|
   ENV['TEST_RUNNER_E2E_HOME_ASSISTANT_USERNAME'] = username
   ENV['TEST_RUNNER_E2E_HOME_ASSISTANT_PASSWORD'] = password
 
+  # Unlike the unit test lanes, this one builds: a UI test bundle is run against a separate app,
+  # and the bare `test` action cannot resolve `UITargetAppPath` for an app that was never built.
   run_tests(
     project: 'HomeAssistant.xcodeproj',
     scheme: 'Tests-UI',
     result_bundle: true,
     skip_package_dependencies_resolution: true,
     skip_detect_devices: true,
-    skip_build: true,
     xcargs: 'COMPILER_INDEX_STORE_ENABLE=NO',
     destination: "platform=iOS Simulator,id=#{udid}",
     output_directory: 'fastlane/test_output/e2e'

--- a/fastlane/lanes/testing.rb
+++ b/fastlane/lanes/testing.rb
@@ -130,6 +130,9 @@ lane :e2e do |options|
   run_tests(
     project: 'HomeAssistant.xcodeproj',
     scheme: 'Tests-UI',
+    # The scheme also holds `HomeAssistantUITests`, the fastlane screenshot flow, which expects
+    # notification fixtures this lane does not set up.
+    only_testing: ['Tests-UI/OnboardingE2ETests'],
     result_bundle: true,
     skip_package_dependencies_resolution: true,
     skip_detect_devices: true,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

The first run of the E2E workflow failed while installing Home Assistant:

```
ERROR: Package 'homeassistant' requires a different Python: 3.13.14 not in '>=3.14.2'
```

Core's `requires-python` is `>=3.14.2` on both the `dev` branch and the current releases, so the workflow's pinned 3.13 cannot install it at all. Bumps the workflow to 3.14 and updates the local instructions to match.

Verified locally on Python 3.14: Home Assistant 2026.9.0 installs, the fixture in `.github/e2e/homeassistant` migrates without errors, and `Tools/home_assistant_e2e_auth.py` authenticates against it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

No user-facing change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

Follow-up to #5609. Only the install step ran on CI before this failure, so the rest of the workflow is still unproven.
