### PR TITLE
Improve stand-by dismissal and native sidebar performance on Mac

### DIFF
--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantView.swift
@@ -76,8 +76,13 @@ struct HomeAssistantView: View, WebFrontendView {
                     .opacity(viewModel.webViewContentOpacity)
                 pullToRefreshIndicator
                 macTitleBar
-                    .opacity(viewModel.webViewContentOpacity)
             }
+            // Covering fades, uncovering does not: the overlay is opaque, so a second full-screen opacity
+            // animation over a web view buys nothing and is what makes the hand-off stutter on Mac.
+            .animation(
+                viewModel.isWebViewCoveredByStandBy ? DesignSystem.Animation.default : nil,
+                value: viewModel.isWebViewCoveredByStandBy
+            )
             noActiveURLState
             standByView
         }

--- a/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
+++ b/Sources/App/Frontend/WebView/HomeAssistantView/HomeAssistantViewModel.swift
@@ -38,6 +38,9 @@ final class HomeAssistantViewModel: ObservableObject {
     @Published var contentOpacity: Double = 0
     @Published var isFullScreenLoaderMounted = true
     @Published var isFullScreenLoaderVisible = true
+    /// Separate from `isFullScreenLoaderVisible` so `HomeAssistantView` can uncover the frontend without
+    /// animating its opacity, which the overlay's own fade already covers for.
+    @Published var isWebViewCoveredByStandBy = true
     @Published var loaderMinimumDurationElapsed = false
     @Published var pullToRefreshProgress: CGFloat = 0
     @Published var isPullToRefreshActive = false
@@ -115,7 +118,7 @@ final class HomeAssistantViewModel: ObservableObject {
     }
 
     var webViewContentOpacity: Double {
-        if overlayState.emptyState != nil || isFullScreenLoaderVisible || isPullToRefreshActive {
+        if overlayState.emptyState != nil || isWebViewCoveredByStandBy || isPullToRefreshActive {
             return 0
         }
 
@@ -265,6 +268,7 @@ final class HomeAssistantViewModel: ObservableObject {
         isFullScreenLoaderMounted = true
         withAnimation(DesignSystem.Animation.default) {
             isFullScreenLoaderVisible = true
+            isWebViewCoveredByStandBy = true
         }
         loaderMinimumDurationElapsed = false
         overlayState.connectionState = .unknown
@@ -288,6 +292,7 @@ final class HomeAssistantViewModel: ObservableObject {
         if hasEmptyState ?? (overlayState.emptyState != nil) {
             withAnimation(DesignSystem.Animation.default) {
                 isFullScreenLoaderVisible = true
+                isWebViewCoveredByStandBy = true
             }
             return
         }
@@ -296,6 +301,7 @@ final class HomeAssistantViewModel: ObservableObject {
               didReachLoaderReadyState(connectionState ?? overlayState.connectionState) else { return }
 
         let finishingCycleID = loaderCycleID
+        isWebViewCoveredByStandBy = false
         withAnimation(DesignSystem.Animation.default) {
             isFullScreenLoaderVisible = false
         }
@@ -339,6 +345,7 @@ final class HomeAssistantViewModel: ObservableObject {
         loaderMinimumDurationTask?.cancel()
         loaderWatchdogTask?.cancel()
         loaderMinimumDurationElapsed = true
+        isWebViewCoveredByStandBy = false
         withAnimation(DesignSystem.Animation.default) {
             isFullScreenLoaderVisible = false
         }

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshot.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshot.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Shared
+
+/// Everything `MacSidebarItemsBuilder` needs to lay out the sidebar, as the last window resolved it.
+/// Cached per server by `MacSidebarSnapshotStore`: the panels, the sidebar preferences and the user's role
+/// each arrive in their own asynchronous reply, so a view model starting from nothing rebuilds the list
+/// several times over and the rows visibly rearrange under the user.
+struct MacSidebarSnapshot: Codable, Equatable {
+    var panels: [HAPanel] = []
+    var panelOrder: [String]?
+    var hiddenPanels: [String]?
+    var legacyPanelOrder: [String]?
+    var legacyHiddenPanels: [String]?
+    var legacyDefaultPanel: String?
+    var userDefaultPanel: String?
+    var systemDefaultPanel: String?
+    var isAdmin = false
+    var userName: String?
+}

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshotStore.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshotStore.swift
@@ -8,7 +8,7 @@ import Shared
 final class MacSidebarSnapshotStore {
     static let shared = MacSidebarSnapshotStore()
 
-    private static let storageKey = "macSidebarSnapshots"
+    static let storageKey = "macSidebarSnapshots"
 
     private let userDefaults: UserDefaults
     private var snapshots: [String: MacSidebarSnapshot]
@@ -34,6 +34,9 @@ final class MacSidebarSnapshotStore {
             return try JSONDecoder().decode([String: MacSidebarSnapshot].self, from: data)
         } catch {
             Current.Log.error("Failed to decode cached native sidebar snapshots: \(error)")
+            // Dropped rather than left behind, so the cache heals on the next write instead of failing to
+            // decode for every window from here on.
+            userDefaults.removeObject(forKey: storageKey)
             return [:]
         }
     }

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshotStore.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarSnapshotStore.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Shared
+
+/// Per-server cache of the native sidebar's last resolved layout, shared by every window and persisted so
+/// the first window of a launch starts from it too. Writes are skipped when the snapshot is unchanged,
+/// which is the common case once the sidebar has settled.
+@MainActor
+final class MacSidebarSnapshotStore {
+    static let shared = MacSidebarSnapshotStore()
+
+    private static let storageKey = "macSidebarSnapshots"
+
+    private let userDefaults: UserDefaults
+    private var snapshots: [String: MacSidebarSnapshot]
+
+    init(userDefaults: UserDefaults = UserDefaults(suiteName: AppConstants.AppGroupID) ?? .standard) {
+        self.userDefaults = userDefaults
+        self.snapshots = Self.persistedSnapshots(in: userDefaults)
+    }
+
+    func snapshot(for serverId: String) -> MacSidebarSnapshot? {
+        snapshots[serverId]
+    }
+
+    func store(_ snapshot: MacSidebarSnapshot, for serverId: String) {
+        guard snapshots[serverId] != snapshot else { return }
+        snapshots[serverId] = snapshot
+        persist()
+    }
+
+    private static func persistedSnapshots(in userDefaults: UserDefaults) -> [String: MacSidebarSnapshot] {
+        guard let data = userDefaults.data(forKey: storageKey) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: MacSidebarSnapshot].self, from: data)
+        } catch {
+            Current.Log.error("Failed to decode cached native sidebar snapshots: \(error)")
+            return [:]
+        }
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(snapshots)
+            userDefaults.set(data, forKey: Self.storageKey)
+        } catch {
+            Current.Log.error("Failed to cache native sidebar snapshots: \(error)")
+        }
+    }
+}

--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarViewModel.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarViewModel.swift
@@ -34,15 +34,26 @@ final class MacSidebarViewModel: ObservableObject {
     private var legacyHiddenPanels: [String]?
     private var legacyDefaultPanel: String?
     private var coreUserData = FrontendDefaultPanelData()
-    private var userDefaultPanel: String? { coreUserData.defaultPanel }
+    /// Stands in for `coreUserData.defaultPanel` until the live `core` value arrives, which is the only thing
+    /// that clears it: a cached default must not outlive one the user has since removed.
+    private var cachedUserDefaultPanel: String?
+    private var userDefaultPanel: String? { coreUserData.defaultPanel ?? cachedUserDefaultPanel }
     private var systemDefaultPanel: String?
+    private var isAdmin = false
+    private var userName: String?
     private var notificationIds: Set<String> = []
     private var currentPath: String?
     private var tokens: [HACancellable] = []
     private var cancellables = Set<AnyCancellable>()
+    private let snapshotStore: MacSidebarSnapshotStore
 
-    init(server: Server, overlayState: WebFrontendOverlayState) {
+    init(
+        server: Server,
+        overlayState: WebFrontendOverlayState,
+        snapshotStore: MacSidebarSnapshotStore = .shared
+    ) {
         self.server = server
+        self.snapshotStore = snapshotStore
 
         overlayState.$currentPath
             .receive(on: DispatchQueue.main)
@@ -60,7 +71,7 @@ final class MacSidebarViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        loadCachedPanels()
+        restoreSnapshot()
         rebuild()
     }
 
@@ -81,6 +92,8 @@ final class MacSidebarViewModel: ObservableObject {
         tokens.append(connection.caches.user.subscribe { [weak self] _, user in
             Task { @MainActor [weak self] in
                 self?.user = user
+                self?.isAdmin = user.isAdmin
+                self?.userName = user.name
                 self?.rebuild()
             }
         })
@@ -108,6 +121,7 @@ final class MacSidebarViewModel: ObservableObject {
             guard case let .success(data) = result else { return }
             Task { @MainActor [weak self] in
                 self?.coreUserData = data
+                self?.cachedUserDefaultPanel = nil
                 self?.rebuild()
             }
         })
@@ -272,6 +286,44 @@ final class MacSidebarViewModel: ObservableObject {
         })
     }
 
+    private func restoreSnapshot() {
+        if let snapshot = snapshotStore.snapshot(for: server.identifier.rawValue) {
+            panels = snapshot.panels
+            sidebarUserData = FrontendSidebarUserData(
+                panelOrder: snapshot.panelOrder,
+                hiddenPanels: snapshot.hiddenPanels
+            )
+            legacyPanelOrder = snapshot.legacyPanelOrder
+            legacyHiddenPanels = snapshot.legacyHiddenPanels
+            legacyDefaultPanel = snapshot.legacyDefaultPanel
+            cachedUserDefaultPanel = snapshot.userDefaultPanel
+            systemDefaultPanel = snapshot.systemDefaultPanel
+            isAdmin = snapshot.isAdmin
+            userName = snapshot.userName
+        }
+        if panels.isEmpty {
+            loadCachedPanels()
+        }
+    }
+
+    private func storeSnapshot() {
+        snapshotStore.store(
+            MacSidebarSnapshot(
+                panels: panels,
+                panelOrder: sidebarUserData.panelOrder,
+                hiddenPanels: sidebarUserData.hiddenPanels,
+                legacyPanelOrder: legacyPanelOrder,
+                legacyHiddenPanels: legacyHiddenPanels,
+                legacyDefaultPanel: legacyDefaultPanel,
+                userDefaultPanel: userDefaultPanel,
+                systemDefaultPanel: systemDefaultPanel,
+                isAdmin: isAdmin,
+                userName: userName
+            ),
+            for: server.identifier.rawValue
+        )
+    }
+
     private func loadCachedPanels() {
         do {
             panels = try AppPanel.panels(serverId: server.identifier.rawValue)?.map { panel in
@@ -295,30 +347,42 @@ final class MacSidebarViewModel: ObservableObject {
             panels: panels
         )
         let userData = effectiveUserData
-        mainItems = MacSidebarItemsBuilder.mainItems(
+        let mainItems = MacSidebarItemsBuilder.mainItems(
             panels: panels,
             defaultPanelPath: defaultPanelPath,
             panelOrder: userData.panelOrder ?? [],
             hiddenPanels: userData.hiddenPanels ?? []
         )
-        hiddenItems = MacSidebarItemsBuilder.hiddenItems(
+        let hiddenItems = MacSidebarItemsBuilder.hiddenItems(
             panels: panels,
             defaultPanelPath: defaultPanelPath,
             panelOrder: userData.panelOrder ?? [],
             hiddenPanels: userData.hiddenPanels ?? []
         )
-        fixedItems = MacSidebarItemsBuilder.fixedItems(
+        let fixedItems = MacSidebarItemsBuilder.fixedItems(
             panels: panels,
-            isAdmin: user?.isAdmin ?? false,
-            userName: user?.name,
+            isAdmin: isAdmin,
+            userName: userName,
             notificationsCount: notificationIds.count
         )
+        if self.mainItems != mainItems {
+            self.mainItems = mainItems
+        }
+        if self.hiddenItems != hiddenItems {
+            self.hiddenItems = hiddenItems
+        }
+        if self.fixedItems != fixedItems {
+            self.fixedItems = fixedItems
+        }
         updateSelection()
+        storeSnapshot()
     }
 
     private func updateSelection() {
         let itemId = MacSidebarItemsBuilder.itemId(forPath: currentPath)
         let knownIds = Set((mainItems + fixedItems).map(\.id))
-        selectedItemId = itemId.flatMap { knownIds.contains($0) ? $0 : nil }
+        let selectedItemId = itemId.flatMap { knownIds.contains($0) ? $0 : nil }
+        guard self.selectedItemId != selectedItemId else { return }
+        self.selectedItemId = selectedItemId
     }
 }

--- a/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
+++ b/Sources/App/Frontend/WebView/MacWebViewTitleBar.swift
@@ -83,13 +83,20 @@ extension MacWebViewTitleBar {
         private var server: Server?
         private var macToolbarItems: [MagicItem] = []
         private var macToolbarConfigObserver: NSObjectProtocol?
+        private var serverPickerSignature: String?
 
+        /// Runs on every SwiftUI update of the host view, and the frontend publishes state throughout a page
+        /// load, so anything expensive here (a database read, a re-rendered toolbar item) has to be skipped
+        /// when nothing changed rather than landing on top of the stand-by fade.
         func update(server: Server, webViewController: WebViewController?) {
+            let isFirstUpdate = self.server == nil
             self.server = server
             self.webViewController = webViewController
 
-            loadMacToolbarItems()
-            observeMacToolbarConfigChanges()
+            if isFirstUpdate {
+                loadMacToolbarItems()
+                observeMacToolbarConfigChanges()
+            }
 
             refreshToolbarState()
         }
@@ -362,6 +369,7 @@ extension MacWebViewTitleBar {
             }
 
             serverPickerItem = item
+            serverPickerSignature = nil
             updateServerPicker()
             return item
         }
@@ -369,6 +377,13 @@ extension MacWebViewTitleBar {
         private func updateServerPicker() {
             guard let serverPickerItem else { return }
             let title = server?.info.name ?? L10n.WebView.ServerSelection.title
+            let signature = (
+                [server?.identifier.rawValue ?? "", title]
+                    + Current.servers.all.map { "\($0.identifier.rawValue)\t\($0.info.name)" }
+            )
+            .joined(separator: "\n")
+            guard serverPickerSignature != signature else { return }
+            serverPickerSignature = signature
             serverPickerItem.label = title
             serverPickerItem.paletteLabel = L10n.ServersSelection.title
             serverPickerItem.toolTip = title

--- a/Sources/HAIconic/Sources/IconDrawable.swift
+++ b/Sources/HAIconic/Sources/IconDrawable.swift
@@ -131,6 +131,19 @@ extension IconDrawable {
 
     public func image(ofSize size: CGSize, color: UIColor?, edgeInsets: UIEdgeInsets) -> UIImage {
 
+        return IconImageCache.shared.image(
+            familyName: Self.familyName,
+            name: name,
+            size: size,
+            color: color,
+            edgeInsets: edgeInsets
+        ) {
+            renderedImage(ofSize: size, color: color, edgeInsets: edgeInsets)
+        }
+    }
+
+    private func renderedImage(ofSize size: CGSize, color: UIColor?, edgeInsets: UIEdgeInsets) -> UIImage {
+
         let pointSize = min(size.width, size.height)
         let aString = attributedString(ofSize: pointSize, color: color)
         let mString = NSMutableAttributedString(attributedString: aString)

--- a/Sources/HAIconic/Sources/IconImageCache.swift
+++ b/Sources/HAIconic/Sources/IconImageCache.swift
@@ -80,8 +80,11 @@ final class IconImageCache: @unchecked Sendable {
         return nil
     }
 
+    /// Capped at the whole budget, both because no single entry can be worth more than that and because an
+    /// unbounded `Int` conversion would trap.
     private static func cost(of image: UIImage) -> Int {
         let bytes = image.size.width * image.scale * image.size.height * image.scale * 4
-        return bytes.isFinite ? Int(bytes) : 0
+        guard bytes.isFinite, bytes > 0 else { return 0 }
+        return Int(min(bytes, CGFloat(totalCostLimit)))
     }
 }

--- a/Sources/HAIconic/Sources/IconImageCache.swift
+++ b/Sources/HAIconic/Sources/IconImageCache.swift
@@ -1,0 +1,87 @@
+import UIKit
+
+/// Memoizes the bitmaps behind `IconDrawable.image(ofSize:color:edgeInsets:)`, which rasterizes a glyph
+/// through TextKit on every call. Callers ask for the same glyph repeatedly: a SwiftUI row re-renders for
+/// reasons that have nothing to do with its icon (hover, selection), and lists draw the same handful of
+/// icons at the same size for every row.
+final class IconImageCache: @unchecked Sendable {
+    static let shared = IconImageCache()
+
+    private static let countLimit = 256
+    private static let totalCostLimit = 2 * 1024 * 1024
+    private static let fontProbeSize: CGFloat = 10
+
+    private let cache = NSCache<NSString, UIImage>()
+
+    private init() {
+        cache.countLimit = Self.countLimit
+        cache.totalCostLimit = Self.totalCostLimit
+    }
+
+    func image(
+        familyName: String,
+        name: String,
+        size: CGSize,
+        color: UIColor?,
+        edgeInsets: UIEdgeInsets,
+        render: () -> UIImage
+    ) -> UIImage {
+        guard let key = Self.key(
+            familyName: familyName,
+            name: name,
+            size: size,
+            color: color,
+            edgeInsets: edgeInsets
+        ) else {
+            return render()
+        }
+
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let image = render()
+        // Until the font is registered every glyph draws as the same missing-character box, and a cached one
+        // of those would outlive the registration.
+        guard UIFont(name: familyName, size: Self.fontProbeSize) != nil else { return image }
+        cache.setObject(image, forKey: key, cost: Self.cost(of: image))
+        return image
+    }
+
+    private static func key(
+        familyName: String,
+        name: String,
+        size: CGSize,
+        color: UIColor?,
+        edgeInsets: UIEdgeInsets
+    ) -> NSString? {
+        guard let colorKey = colorKey(color) else { return nil }
+        let insets = "\(edgeInsets.top),\(edgeInsets.left),\(edgeInsets.bottom),\(edgeInsets.right)"
+        return "\(familyName)|\(name)|\(size.width)x\(size.height)|\(insets)|\(colorKey)" as NSString
+    }
+
+    /// Reading a dynamic color's components resolves it against the current trait collection, exactly as
+    /// drawing the glyph does, so the resolved components are what the bitmap really depends on: keying on the
+    /// color object would hand a light-mode bitmap back in dark mode. Nil (a pattern color, whose components
+    /// cannot be read) skips the cache.
+    private static func colorKey(_ color: UIColor?) -> String? {
+        guard let color else { return "default" }
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        if color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+            return "\(red),\(green),\(blue),\(alpha)"
+        }
+        var white: CGFloat = 0
+        if color.getWhite(&white, alpha: &alpha) {
+            return "w\(white),\(alpha)"
+        }
+        return nil
+    }
+
+    private static func cost(of image: UIImage) -> Int {
+        let bytes = image.size.width * image.scale * image.size.height * image.scale * 4
+        return bytes.isFinite ? Int(bytes) : 0
+    }
+}

--- a/Tests/App/Utilities/IconImageCaching.test.swift
+++ b/Tests/App/Utilities/IconImageCaching.test.swift
@@ -1,0 +1,62 @@
+@testable import Shared
+import Testing
+import UIKit
+
+/// Runs in the app-hosted Tests-App target: rasterizing a glyph needs the Material Design icon font, which
+/// the hostless Tests-Shared target cannot load.
+@MainActor
+struct IconImageCachingTests {
+    private let size = CGSize(width: 20, height: 20)
+
+    @Test func repeatedRequestsForTheSameGlyphReuseOneBitmap() {
+        MaterialDesignIcons.register()
+
+        let first = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .white)
+        let second = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .white)
+
+        #expect(first === second)
+    }
+
+    @Test func iconColorAndSizeEachChangeTheBitmap() {
+        MaterialDesignIcons.register()
+        let larger = CGSize(width: 24, height: 24)
+
+        let white = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .white)
+
+        #expect(white !== MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .black))
+        #expect(white !== MaterialDesignIcons.lightbulbIcon.image(ofSize: larger, color: .white))
+        #expect(white !== MaterialDesignIcons.thermometerIcon.image(ofSize: size, color: .white))
+    }
+
+    /// A dynamic color draws as a different color per appearance, so a light-mode bitmap must not be the one
+    /// handed back in dark mode.
+    @Test func aDynamicColorIsNotSharedAcrossAppearances() {
+        MaterialDesignIcons.register()
+        var light: UIImage?
+        var dark: UIImage?
+
+        UITraitCollection(userInterfaceStyle: .light).performAsCurrent {
+            light = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .label)
+        }
+        UITraitCollection(userInterfaceStyle: .dark).performAsCurrent {
+            dark = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .label)
+        }
+
+        #expect(light !== dark)
+        #expect(light?.pngData() != dark?.pngData())
+    }
+
+    @Test func edgeInsetsChangeTheBitmap() {
+        MaterialDesignIcons.register()
+
+        let flush = MaterialDesignIcons.lightbulbIcon.image(ofSize: size, color: .white, edgeInsets: .zero)
+        let inset = MaterialDesignIcons.lightbulbIcon.image(
+            ofSize: size,
+            color: .white,
+            edgeInsets: .init(top: 2, left: 2, bottom: 2, right: 2)
+        )
+
+        #expect(flush !== inset)
+        #expect(flush.size != inset.size)
+    }
+}

--- a/Tests/App/WebView/HomeAssistantViewTests.swift
+++ b/Tests/App/WebView/HomeAssistantViewTests.swift
@@ -194,6 +194,54 @@ final class HomeAssistantViewTests: XCTestCase {
         XCTAssertTrue(sut.isFullScreenLoaderVisible)
     }
 
+    func testDismissingStandbyLoaderUncoversTheFrontendWebView() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: .frontendLoadedExternalBus),
+            overlayState: overlayState
+        )
+        sut.fade(to: 1, reduceMotion: true)
+        sut.loaderMinimumDurationElapsed = true
+        XCTAssertTrue(sut.isWebViewCoveredByStandBy)
+        XCTAssertEqual(sut.webViewContentOpacity, 0)
+
+        overlayState.connectionState = .loaded
+
+        XCTAssertFalse(sut.isWebViewCoveredByStandBy)
+        XCTAssertEqual(sut.webViewContentOpacity, 1)
+    }
+
+    func testANewLoadCycleCoversTheFrontendWebViewAgain() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: .frontendLoadedExternalBus),
+            overlayState: overlayState
+        )
+        sut.fade(to: 1, reduceMotion: true)
+        sut.loaderMinimumDurationElapsed = true
+        overlayState.connectionState = .loaded
+        XCTAssertFalse(sut.isWebViewCoveredByStandBy)
+
+        overlayState.isLoading = true
+
+        XCTAssertTrue(sut.isWebViewCoveredByStandBy)
+        XCTAssertEqual(sut.webViewContentOpacity, 0)
+    }
+
+    func testForceDismissUncoversTheFrontendWebView() {
+        let overlayState = WebFrontendOverlayState()
+        let sut = HomeAssistantViewModel(
+            server: server(version: .frontendLoadedExternalBus),
+            overlayState: overlayState
+        )
+        sut.fade(to: 1, reduceMotion: true)
+
+        sut.forceDismissStandByView()
+
+        XCTAssertFalse(sut.isWebViewCoveredByStandBy)
+        XCTAssertEqual(sut.webViewContentOpacity, 1)
+    }
+
     func testForceDismissHidesStandbyLoaderRegardlessOfConnectionState() {
         let overlayState = WebFrontendOverlayState()
         let sut = HomeAssistantViewModel(

--- a/Tests/App/WebView/MacSidebarCachingTests.swift
+++ b/Tests/App/WebView/MacSidebarCachingTests.swift
@@ -101,4 +101,15 @@ struct MacSidebarCachingTests {
         #expect(restored.snapshot(for: "server-1") == snapshot)
         #expect(restored.snapshot(for: "server-2") == nil)
     }
+
+    @Test("A cache that cannot be decoded is dropped rather than kept around failing")
+    func undecodableCacheIsDiscarded() {
+        let defaults = makeUserDefaults("undecodable")
+        defaults.set(Data("not a snapshot".utf8), forKey: MacSidebarSnapshotStore.storageKey)
+
+        let store = MacSidebarSnapshotStore(userDefaults: defaults)
+
+        #expect(store.snapshot(for: "server-1") == nil)
+        #expect(defaults.data(forKey: MacSidebarSnapshotStore.storageKey) == nil)
+    }
 }

--- a/Tests/App/WebView/MacSidebarCachingTests.swift
+++ b/Tests/App/WebView/MacSidebarCachingTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+@testable import HomeAssistant
+import Shared
+import Testing
+
+@MainActor
+struct MacSidebarCachingTests {
+    private func panel(
+        _ path: String,
+        component: String = "lovelace",
+        title: String? = nil
+    ) -> HAPanel {
+        HAPanel(
+            icon: nil,
+            title: title ?? path,
+            path: path,
+            component: component,
+            showInSidebar: true,
+            defaultVisible: nil,
+            rawTitle: title
+        )
+    }
+
+    private var cachedPanels: [HAPanel] {
+        [
+            panel("home", component: "home", title: "Overview"),
+            panel("alpha", title: "Alpha"),
+            panel("zeta", title: "Zeta"),
+            panel("config", component: "config", title: "Settings"),
+        ]
+    }
+
+    private func makeUserDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "MacSidebarCachingTests.\(name)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeSnapshotStore(_ name: String) -> MacSidebarSnapshotStore {
+        MacSidebarSnapshotStore(userDefaults: makeUserDefaults(name))
+    }
+
+    @Test("A new window renders the cached arrangement instead of rebuilding it from nothing")
+    func startsFromTheCachedArrangement() {
+        let server = ServerFixture.standard
+        let store = makeSnapshotStore("cachedArrangement")
+        store.store(
+            MacSidebarSnapshot(
+                panels: cachedPanels,
+                panelOrder: ["home", "zeta"],
+                hiddenPanels: ["alpha"],
+                isAdmin: true,
+                userName: "Bruno"
+            ),
+            for: server.identifier.rawValue
+        )
+
+        let sut = MacSidebarViewModel(
+            server: server,
+            overlayState: WebFrontendOverlayState(),
+            snapshotStore: store
+        )
+
+        #expect(sut.mainItems.map(\.id) == ["home", "zeta"])
+        #expect(sut.hiddenItems.map(\.id) == ["alpha"])
+        #expect(sut.fixedItems.map(\.id) == ["config", "notifications", "profile"])
+        #expect(sut.fixedItems.last?.title == "Bruno")
+    }
+
+    @Test("A cached non-admin keeps the settings row out instead of having it appear later")
+    func startsWithoutTheSettingsRowForANonAdmin() {
+        let server = ServerFixture.standard
+        let store = makeSnapshotStore("nonAdmin")
+        store.store(MacSidebarSnapshot(panels: cachedPanels), for: server.identifier.rawValue)
+
+        let sut = MacSidebarViewModel(
+            server: server,
+            overlayState: WebFrontendOverlayState(),
+            snapshotStore: store
+        )
+
+        #expect(sut.fixedItems.map(\.id) == ["notifications", "profile"])
+    }
+
+    @Test("Cached arrangements outlive the window that resolved them")
+    func persistsAcrossStoreInstances() {
+        let defaults = makeUserDefaults("persistence")
+        let snapshot = MacSidebarSnapshot(
+            panels: cachedPanels,
+            panelOrder: ["home", "zeta"],
+            hiddenPanels: ["alpha"],
+            legacyDefaultPanel: "zeta",
+            isAdmin: true,
+            userName: "Bruno"
+        )
+
+        MacSidebarSnapshotStore(userDefaults: defaults).store(snapshot, for: "server-1")
+
+        let restored = MacSidebarSnapshotStore(userDefaults: defaults)
+        #expect(restored.snapshot(for: "server-1") == snapshot)
+        #expect(restored.snapshot(for: "server-2") == nil)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Three performance fixes on Mac:

- The stand-by overlay is opaque, so the frontend is now revealed under it instead of cross-fading its own full-screen opacity at the same time. That second animation, over a web view, is what made the dismissal stutter.
- The App Labs native sidebar caches its resolved layout per server, so a new window renders the last known arrangement instead of rearranging as panels, sidebar preferences and the user's role arrive.
- Material Design icon glyphs are rasterized once and reused, instead of on every view body evaluation.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The Mac titlebar toolbar also stopped doing a database read and re-rendering its server picker on every SwiftUI update, which was main-thread work landing on the stand-by fade.
