### PR TITLE
Show add-on panels in the app's panel lists

### DIFF
--- a/Sources/App/Frontend/WebView/MacSidebar/MacSidebarItemsBuilder.swift
+++ b/Sources/App/Frontend/WebView/MacSidebar/MacSidebarItemsBuilder.swift
@@ -11,6 +11,7 @@ enum MacSidebarItemsBuilder {
 
     private static let fixedPanelPaths: Set<String> = [profilePanelPath, settingsPanelPath, "notfound"]
     private static let lovelaceComponent = "lovelace"
+    private static let ingressComponent = "app"
     private static let sortValueByPath: [String: Int] = [
         "energy": 1,
         "map": 2,
@@ -173,8 +174,14 @@ enum MacSidebarItemsBuilder {
         if let icon = iconByPath[panel.path] {
             return icon
         }
-        let fallback: MaterialDesignIcons = panel
-            .component == lovelaceComponent ? .viewDashboardIcon : .viewDashboardOutlineIcon
+        let fallback: MaterialDesignIcons
+        switch panel.component {
+        case lovelaceComponent: fallback = .viewDashboardIcon
+        // The frontend draws add-on ingress panels with a puzzle piece, see
+        // `computeIngressNavigationPathInfo` in `data/compute-navigation-path-info.ts`.
+        case ingressComponent: fallback = .puzzleIcon
+        default: fallback = .viewDashboardOutlineIcon
+        }
         guard let iconName = panel.icon, !iconName.isEmpty else { return fallback }
         return MaterialDesignIcons(serversideValueNamed: iconName, fallback: fallback)
     }

--- a/Sources/Shared/API/WebSocket/HAPanel.swift
+++ b/Sources/Shared/API/WebSocket/HAPanel.swift
@@ -42,7 +42,8 @@ public struct HAPanel: HADataDecodable, Codable, Equatable {
 
         // Servers before 2026.3 don't send a title for dashboards hidden from the sidebar; the
         // frontend falls back to the path for those, which reads better than the component name.
-        let rawTitle: String? = try? data.decode("title")
+        // An empty title counts as no title, the way the frontend's `!panel.title` check does.
+        let rawTitle: String? = (try? data.decode("title") as String).flatMap { $0.isEmpty ? nil : $0 }
         self.rawTitle = rawTitle
         let title = rawTitle ?? path
 
@@ -81,9 +82,11 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
 
     /// Panels the frontend never offers as a navigation target.
     /// `SYSTEM_PANELS` in https://github.com/home-assistant/frontend/blob/dev/src/data/panel.ts
-    private static let systemPanelPaths: Set<String> = ["_my_redirect", "notfound"]
-    /// Add-on ingress panels, which the frontend lists separately from its own panels.
-    private static let ingressPanelComponent = "app"
+    ///
+    /// `app` is the supervisor's untitled ingress host panel, which only serves `/app/<add-on slug>`.
+    /// Every add-on panel _also_ has `component_name: "app"`, but its url path is the add-on slug and
+    /// the frontend lists it in the sidebar like any other panel.
+    private static let systemPanelPaths: Set<String> = ["_my_redirect", "notfound", "app"]
     /// The built-in dashboard the frontend defaults to since core 2026.3.
     private static let overviewPath = "home"
     /// The other dashboards core 2026.3+ registers built in, none of which are in the sidebar.
@@ -105,7 +108,6 @@ public struct HAPanels: HADataDecodable, Codable, Equatable {
 
             do {
                 let panel = try HAPanel(data: .init(value: value))
-                guard panel.component != Self.ingressPanelComponent else { return nil }
                 return (key, panel)
             } catch {
                 Current.Log.error("Failed to decode panel \(key): \(error)")

--- a/Tests/App/WebView/MacSidebarItemsBuilderTests.swift
+++ b/Tests/App/WebView/MacSidebarItemsBuilderTests.swift
@@ -45,6 +45,28 @@ struct MacSidebarItemsBuilderTests {
         #expect(items.first?.navigationPath == "/home")
     }
 
+    @Test("Add-on ingress panels are listed like any other panel, with a puzzle fallback icon")
+    func addOnIngressPanels() {
+        let panels = [
+            panel("home", component: "home", title: "Overview"),
+            panel("45df7312_zigbee2mqtt", component: "app", title: "Zigbee2MQTT"),
+            panel("core_matter_server", component: "app", title: "Matter Server"),
+            panel("energy", component: "energy", title: "Energy"),
+        ]
+
+        let items = MacSidebarItemsBuilder.mainItems(
+            panels: panels,
+            defaultPanelPath: "home",
+            panelOrder: [],
+            hiddenPanels: []
+        )
+
+        #expect(items.map(\.id) == ["home", "energy", "core_matter_server", "45df7312_zigbee2mqtt"])
+        #expect(items.last?.navigationPath == "/45df7312_zigbee2mqtt")
+        #expect(items.last?.icon == .puzzleIcon)
+        #expect(items.last?.isDashboard == false)
+    }
+
     @Test("User panel order wins over the default order")
     func userOrder() {
         let panels = [

--- a/Tests/Shared/Models/HAPanels.test.swift
+++ b/Tests/Shared/Models/HAPanels.test.swift
@@ -79,11 +79,24 @@ struct HAPanelsTests {
         let panels = try HAPanels(data: HAData(value: [
             "_my_redirect": panel(component: "my", urlPath: "_my_redirect"),
             "notfound": panel(component: "notfound", urlPath: "notfound"),
-            "core_ssh": panel(component: "app", urlPath: "core_ssh", title: "Terminal"),
+            "app": panel(component: "app", urlPath: "app"),
             "lovelace": panel(component: "lovelace", urlPath: "lovelace", title: "Overview"),
         ]))
 
         #expect(panels.allPanels.map(\.path) == ["lovelace"])
+    }
+
+    @Test("Keeps the add-on panels the supervisor registers as ingress")
+    func keepsAddOnIngressPanels() throws {
+        let panels = try HAPanels(data: HAData(value: [
+            "app": panel(component: "app", urlPath: "app"),
+            "core_matter_server": panel(component: "app", urlPath: "core_matter_server", title: "Matter Server"),
+            "45df7312_zigbee2mqtt": panel(component: "app", urlPath: "45df7312_zigbee2mqtt", title: "Zigbee2MQTT"),
+            "lovelace": panel(component: "lovelace", urlPath: "lovelace", title: "Overview"),
+        ]))
+
+        #expect(panels.allPanels.map(\.path) == ["lovelace", "core_matter_server", "45df7312_zigbee2mqtt"])
+        #expect(panels.panelsByPath["core_matter_server"]?.title == "Matter Server")
     }
 
     @Test("A panel that can't be decoded doesn't drop the rest")
@@ -103,6 +116,16 @@ struct HAPanelsTests {
         ]))
 
         #expect(panels.panelsByPath["hidden-dashboard"]?.title == "hidden-dashboard")
+    }
+
+    @Test("An empty title counts as no title, so the sidebar leaves the panel out")
+    func treatsEmptyTitleAsMissing() throws {
+        let panels = try HAPanels(data: HAData(value: [
+            "blank": panel(component: "lovelace", urlPath: "blank", title: ""),
+        ]))
+
+        #expect(panels.panelsByPath["blank"]?.rawTitle == nil)
+        #expect(panels.panelsByPath["blank"]?.title == "blank")
     }
 
     @Test("Decodes default_visible, which older servers don't send")


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Add-on panels (Matter Server, Zigbee2MQTT, Studio Code Server, ...) were missing from the app's panel lists, including the native Mac sidebar.

Add-ons are registered with the component name `app` and the add-on slug as their url path, and we were skipping every panel with that component. The frontend only skips the url path `app`, the supervisor's untitled ingress host panel, so that is what we skip now.

Add-on panels without an icon fall back to a puzzle piece, which is what the frontend uses for ingress panels.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The panel list is shared, so add-ons are also back in the Open Page widget, App Shortcuts and Kiosk settings.
