### PR TITLE
Keep the watch app alive across wrist-down for Assist and database sync

### DIFF
--- a/Sources/WatchApp/Assist/WatchAssistView.swift
+++ b/Sources/WatchApp/Assist/WatchAssistView.swift
@@ -69,6 +69,7 @@ struct WatchAssistView: View {
             // unsubscribes the view model from responses, and without this the screen comes back
             // permanently deaf: TTS may still play elsewhere but the chat never updates.
             viewModel.reconnectObserver()
+            viewModel.beginExtendedRuntime()
             // Avoid re-trigger when coming back from audio volume screen
             if isInitialAppearance {
                 isInitialAppearance = false

--- a/Sources/WatchApp/Assist/WatchAssistViewModel.swift
+++ b/Sources/WatchApp/Assist/WatchAssistViewModel.swift
@@ -35,6 +35,7 @@ final class WatchAssistViewModel: ObservableObject {
     private let audioPlayer: any AudioPlayerProtocol
     private let immediateCommunicatorService: ImmediateCommunicatorService
     private let runtimeSessions: WatchExtendedRuntimeSessionHolding
+    private var isHoldingRuntimeSession = false
     /// Written prompt of an Assist prompt item: the session sends it instead of listening. `nil`
     /// for a regular voice session.
     private let prompt: String?
@@ -100,6 +101,8 @@ final class WatchAssistViewModel: ObservableObject {
     }
 
     func beginExtendedRuntime() {
+        guard !isHoldingRuntimeSession else { return }
+        isHoldingRuntimeSession = true
         runtimeSessions.begin(.assist)
     }
 
@@ -108,6 +111,12 @@ final class WatchAssistViewModel: ObservableObject {
         assistService.endRoutine()
         timer?.invalidate()
         immediateCommunicatorService.removeObserver(self)
+        endExtendedRuntime()
+    }
+
+    private func endExtendedRuntime() {
+        guard isHoldingRuntimeSession else { return }
+        isHoldingRuntimeSession = false
         runtimeSessions.end(.assist)
     }
 

--- a/Sources/WatchApp/Assist/WatchAssistViewModel.swift
+++ b/Sources/WatchApp/Assist/WatchAssistViewModel.swift
@@ -34,6 +34,7 @@ final class WatchAssistViewModel: ObservableObject {
     private let audioRecorder: any WatchAudioRecorderProtocol
     private let audioPlayer: any AudioPlayerProtocol
     private let immediateCommunicatorService: ImmediateCommunicatorService
+    private let runtimeSessions: WatchExtendedRuntimeSessionHolding
     /// Written prompt of an Assist prompt item: the session sends it instead of listening. `nil`
     /// for a regular voice session.
     private let prompt: String?
@@ -45,10 +46,12 @@ final class WatchAssistViewModel: ObservableObject {
         audioRecorder: any WatchAudioRecorderProtocol,
         audioPlayer: any AudioPlayerProtocol,
         immediateCommunicatorService: ImmediateCommunicatorService,
+        runtimeSessions: WatchExtendedRuntimeSessionHolding = WatchExtendedRuntimeSessionManager.shared,
         prompt: String? = nil
     ) {
         self.audioRecorder = audioRecorder
         self.immediateCommunicatorService = immediateCommunicatorService
+        self.runtimeSessions = runtimeSessions
         self.assistService = assistService
         self.audioPlayer = audioPlayer
         self.prompt = prompt
@@ -96,11 +99,16 @@ final class WatchAssistViewModel: ObservableObject {
         immediateCommunicatorService.addObserver(.init(delegate: self))
     }
 
+    func beginExtendedRuntime() {
+        runtimeSessions.begin(.assist)
+    }
+
     func endRoutine() {
         stopRecording()
         assistService.endRoutine()
         timer?.invalidate()
         immediateCommunicatorService.removeObserver(self)
+        runtimeSessions.end(.assist)
     }
 
     func assist() {

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -59,6 +59,7 @@ final class WatchHomeViewModel: ObservableObject {
 
     /// Registration for background (`transferUserInfo`) config responses from the phone.
     private var guaranteedObserver: HAWatchConnectivity.ObservationToken?
+    private let runtimeSessions: WatchExtendedRuntimeSessionHolding
 
     /// Minimum time each `loadingStatus` value stays on screen, so rapid chunk progress doesn't blink
     /// through numbers too fast to read.
@@ -91,7 +92,8 @@ final class WatchHomeViewModel: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + (Self.minStatusDisplay - elapsed), execute: work)
     }
 
-    init() {
+    init(runtimeSessions: WatchExtendedRuntimeSessionHolding = WatchExtendedRuntimeSessionManager.shared) {
+        self.runtimeSessions = runtimeSessions
         // The phone answers a background config pull with a guaranteed message; route it through the
         // same conflict-aware reconcile as the interactive reply so offline edits aren't clobbered.
         self.guaranteedObserver = Communicator.shared.guaranteedMessage.observe { [weak self] message in
@@ -182,6 +184,7 @@ final class WatchHomeViewModel: ObservableObject {
         }
         isSyncInFlight = true
         isSyncUserInitiated = userInitiated
+        runtimeSessions.begin(.databaseSync)
         isLoading = true
         clearError()
         setLoadingStatus(L10n.Watch.Sync.starting)
@@ -207,6 +210,7 @@ final class WatchHomeViewModel: ObservableObject {
         // keeps this abandoned sync from blocking a later reload.
         isLoading = false
         isSyncInFlight = false
+        runtimeSessions.end(.databaseSync)
         loadCache()
         setLoadingStatus(L10n.Watch.Home.Sync.waiting)
         enqueueGuaranteedConfigPull()
@@ -823,6 +827,7 @@ final class WatchHomeViewModel: ObservableObject {
                 // Loading is over — the sync (if any) has reached a terminal state, so a new reload may
                 // start.
                 self?.isSyncInFlight = false
+                self?.runtimeSessions.end(.databaseSync)
                 self?.syncProgress = nil
                 if clearStatus {
                     // Cancel any pending throttled status update and clear immediately.

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -60,6 +60,7 @@ final class WatchHomeViewModel: ObservableObject {
     /// Registration for background (`transferUserInfo`) config responses from the phone.
     private var guaranteedObserver: HAWatchConnectivity.ObservationToken?
     private let runtimeSessions: WatchExtendedRuntimeSessionHolding
+    private var isHoldingRuntimeSession = false
 
     /// Minimum time each `loadingStatus` value stays on screen, so rapid chunk progress doesn't blink
     /// through numbers too fast to read.
@@ -105,6 +106,19 @@ final class WatchHomeViewModel: ObservableObject {
         if let guaranteedObserver {
             Communicator.shared.guaranteedMessage.unobserve(guaranteedObserver)
         }
+        endExtendedRuntime()
+    }
+
+    private func beginExtendedRuntime() {
+        guard !isHoldingRuntimeSession else { return }
+        isHoldingRuntimeSession = true
+        runtimeSessions.begin(.databaseSync)
+    }
+
+    private func endExtendedRuntime() {
+        guard isHoldingRuntimeSession else { return }
+        isHoldingRuntimeSession = false
+        runtimeSessions.end(.databaseSync)
     }
 
     @MainActor
@@ -184,7 +198,7 @@ final class WatchHomeViewModel: ObservableObject {
         }
         isSyncInFlight = true
         isSyncUserInitiated = userInitiated
-        runtimeSessions.begin(.databaseSync)
+        beginExtendedRuntime()
         isLoading = true
         clearError()
         setLoadingStatus(L10n.Watch.Sync.starting)
@@ -210,7 +224,7 @@ final class WatchHomeViewModel: ObservableObject {
         // keeps this abandoned sync from blocking a later reload.
         isLoading = false
         isSyncInFlight = false
-        runtimeSessions.end(.databaseSync)
+        endExtendedRuntime()
         loadCache()
         setLoadingStatus(L10n.Watch.Home.Sync.waiting)
         enqueueGuaranteedConfigPull()
@@ -827,7 +841,7 @@ final class WatchHomeViewModel: ObservableObject {
                 // Loading is over — the sync (if any) has reached a terminal state, so a new reload may
                 // start.
                 self?.isSyncInFlight = false
-                self?.runtimeSessions.end(.databaseSync)
+                self?.endExtendedRuntime()
                 self?.syncProgress = nil
                 if clearStatus {
                     // Cancel any pending throttled status update and clear immediately.

--- a/Sources/WatchApp/Info.plist
+++ b/Sources/WatchApp/Info.plist
@@ -53,6 +53,10 @@
 	</array>
 	<key>WKApplication</key>
 	<true/>
+	<key>WKBackgroundModes</key>
+	<array>
+		<string>self-care</string>
+	</array>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>$(BUNDLE_ID_PREFIX).HomeAssistant$(BUNDLE_ID_SUFFIX)</string>
 </dict>

--- a/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionHolding.swift
+++ b/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionHolding.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol WatchExtendedRuntimeSessionHolding: AnyObject {
+    func begin(_ reason: WatchExtendedRuntimeSessionManager.Reason)
+    func end(_ reason: WatchExtendedRuntimeSessionManager.Reason)
+}

--- a/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
+++ b/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
@@ -31,10 +31,10 @@ final class WatchExtendedRuntimeSessionManager: NSObject {
     private func startSessionIfNeeded() {
         guard !holders.isEmpty, session == nil else { return }
         guard WKApplication.shared().applicationState == .active else {
-            Current.Log.info("Extended runtime session deferred until the app is active")
             observeActivation()
             return
         }
+        stopObservingActivation()
         let session = makeSession()
         session.delegate = self
         self.session = session
@@ -44,6 +44,7 @@ final class WatchExtendedRuntimeSessionManager: NSObject {
 
     private func observeActivation() {
         guard didBecomeActiveObserver == nil else { return }
+        Current.Log.info("Extended runtime session deferred until the app is active")
         didBecomeActiveObserver = NotificationCenter.default.addObserver(
             forName: WKApplication.didBecomeActiveNotification,
             object: nil,
@@ -51,6 +52,12 @@ final class WatchExtendedRuntimeSessionManager: NSObject {
         ) { [weak self] _ in
             self?.startSessionIfNeeded()
         }
+    }
+
+    private func stopObservingActivation() {
+        guard let didBecomeActiveObserver else { return }
+        NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+        self.didBecomeActiveObserver = nil
     }
 
     private var heldReasons: [String] {
@@ -79,11 +86,15 @@ extension WatchExtendedRuntimeSessionManager: WatchExtendedRuntimeSessionHolding
 
 extension WatchExtendedRuntimeSessionManager: WKExtendedRuntimeSessionDelegate {
     func extendedRuntimeSessionDidStart(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
-        Current.Log.info("Extended runtime session started for \(heldReasons)")
+        onMain { [self] in
+            Current.Log.info("Extended runtime session started for \(heldReasons)")
+        }
     }
 
     func extendedRuntimeSessionWillExpire(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
-        Current.Log.info("Extended runtime session about to expire; held by \(heldReasons)")
+        onMain { [self] in
+            Current.Log.info("Extended runtime session about to expire; held by \(heldReasons)")
+        }
     }
 
     func extendedRuntimeSession(
@@ -91,9 +102,12 @@ extension WatchExtendedRuntimeSessionManager: WKExtendedRuntimeSessionDelegate {
         didInvalidateWith reason: WKExtendedRuntimeSessionInvalidationReason,
         error: Error?
     ) {
-        guard extendedRuntimeSession === session else { return }
-        session = nil
-        let detail = error.map { " (\($0.localizedDescription))" } ?? ""
-        Current.Log.info("Extended runtime session invalidated: \(reason.rawValue)\(detail); held by \(heldReasons)")
+        onMain { [self] in
+            guard extendedRuntimeSession === session else { return }
+            session = nil
+            let detail = error.map { " (\($0.localizedDescription))" } ?? ""
+            Current.Log
+                .info("Extended runtime session invalidated: \(reason.rawValue)\(detail); held by \(heldReasons)")
+        }
     }
 }

--- a/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
+++ b/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
@@ -10,7 +10,7 @@ final class WatchExtendedRuntimeSessionManager: NSObject {
 
     static let shared = WatchExtendedRuntimeSessionManager()
 
-    private var holders: Set<Reason> = []
+    private var holders: [Reason: Int] = [:]
     private var session: WKExtendedRuntimeSession?
     private let makeSession: () -> WKExtendedRuntimeSession
     private var didBecomeActiveObserver: NSObjectProtocol?
@@ -61,22 +61,25 @@ final class WatchExtendedRuntimeSessionManager: NSObject {
     }
 
     private var heldReasons: [String] {
-        holders.map(\.rawValue).sorted()
+        holders.keys.map(\.rawValue).sorted()
     }
 }
 
 extension WatchExtendedRuntimeSessionManager: WatchExtendedRuntimeSessionHolding {
     func begin(_ reason: Reason) {
         onMain { [self] in
-            holders.insert(reason)
+            holders[reason, default: 0] += 1
             startSessionIfNeeded()
         }
     }
 
     func end(_ reason: Reason) {
         onMain { [self] in
-            holders.remove(reason)
-            guard holders.isEmpty, let session else { return }
+            guard let count = holders[reason] else { return }
+            holders[reason] = count > 1 ? count - 1 : nil
+            guard holders.isEmpty else { return }
+            stopObservingActivation()
+            guard let session else { return }
             Current.Log.info("Ending extended runtime session after \(reason.rawValue)")
             self.session = nil
             session.invalidate()

--- a/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
+++ b/Sources/WatchApp/Utilities/WatchExtendedRuntimeSessionManager.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Shared
+import WatchKit
+
+final class WatchExtendedRuntimeSessionManager: NSObject {
+    enum Reason: String {
+        case assist
+        case databaseSync
+    }
+
+    static let shared = WatchExtendedRuntimeSessionManager()
+
+    private var holders: Set<Reason> = []
+    private var session: WKExtendedRuntimeSession?
+    private let makeSession: () -> WKExtendedRuntimeSession
+    private var didBecomeActiveObserver: NSObjectProtocol?
+
+    init(makeSession: @escaping () -> WKExtendedRuntimeSession = { WKExtendedRuntimeSession() }) {
+        self.makeSession = makeSession
+        super.init()
+    }
+
+    private func onMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
+    }
+
+    private func startSessionIfNeeded() {
+        guard !holders.isEmpty, session == nil else { return }
+        guard WKApplication.shared().applicationState == .active else {
+            Current.Log.info("Extended runtime session deferred until the app is active")
+            observeActivation()
+            return
+        }
+        let session = makeSession()
+        session.delegate = self
+        self.session = session
+        Current.Log.info("Starting extended runtime session for \(heldReasons)")
+        session.start()
+    }
+
+    private func observeActivation() {
+        guard didBecomeActiveObserver == nil else { return }
+        didBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: WKApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.startSessionIfNeeded()
+        }
+    }
+
+    private var heldReasons: [String] {
+        holders.map(\.rawValue).sorted()
+    }
+}
+
+extension WatchExtendedRuntimeSessionManager: WatchExtendedRuntimeSessionHolding {
+    func begin(_ reason: Reason) {
+        onMain { [self] in
+            holders.insert(reason)
+            startSessionIfNeeded()
+        }
+    }
+
+    func end(_ reason: Reason) {
+        onMain { [self] in
+            holders.remove(reason)
+            guard holders.isEmpty, let session else { return }
+            Current.Log.info("Ending extended runtime session after \(reason.rawValue)")
+            self.session = nil
+            session.invalidate()
+        }
+    }
+}
+
+extension WatchExtendedRuntimeSessionManager: WKExtendedRuntimeSessionDelegate {
+    func extendedRuntimeSessionDidStart(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
+        Current.Log.info("Extended runtime session started for \(heldReasons)")
+    }
+
+    func extendedRuntimeSessionWillExpire(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
+        Current.Log.info("Extended runtime session about to expire; held by \(heldReasons)")
+    }
+
+    func extendedRuntimeSession(
+        _ extendedRuntimeSession: WKExtendedRuntimeSession,
+        didInvalidateWith reason: WKExtendedRuntimeSessionInvalidationReason,
+        error: Error?
+    ) {
+        guard extendedRuntimeSession === session else { return }
+        session = nil
+        let detail = error.map { " (\($0.localizedDescription))" } ?? ""
+        Current.Log.info("Extended runtime session invalidated: \(reason.rawValue)\(detail); held by \(heldReasons)")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On watchOS the app is suspended seconds after the display goes dark, which stalls an Assist round-trip mid-pipeline and freezes a database sync until the wrist is raised again.

This holds a `WKExtendedRuntimeSession` (self-care type) while the Assist screen is open and while a database sync is in flight, so the process keeps running with the screen off and raising the wrist returns to the app instead of the watch face.

A single refcounted manager owns the session, defers the start until the app is active, and drops a session the system ends early.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Self-care sessions are capped at ten minutes by the system.