### PR TITLE
Fix frontend reloading on rotation

### DIFF
--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -31,8 +31,7 @@ struct ContainerView: View {
             coordinator.onOpenServer = { state.showWebView(for: $0) }
             coordinator.onSetup = { state.reevaluate() }
             coordinator.onShowSettings = { [weak coordinator] pushOntoNavigationStack in
-                // Pushing lands on `ConditionalContainerView`'s compact-only navigation stack, so the
-                // decision reads the same size class it does — from the window, at presentation time.
+                // Push only in compact width, read from the window at presentation time.
                 let sizeClass = coordinator?.window?.traitCollection.horizontalSizeClass
                 if pushOntoNavigationStack, sizeClass == .compact {
                     AppSettingsPresenter.shared.isPushPresented = true

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -7,40 +7,27 @@ struct ConditionalContainerView: View {
     @StateObject private var kiosk = Current.kiosk
     @ObservedObject private var appSettings = AppSettingsPresenter.shared
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showKioskSettings = false
     @Namespace private var serverSelectionNamespace
 
     var body: some View {
-        if horizontalSizeClass == .compact {
-            // Driven entirely by `appSettings.pushPath` so Settings and the screens it pushes share one
-            // value-based mechanism: the boolean `navigationDestination(isPresented:)` used here before
-            // made SwiftUI push Settings again in place of the screen that was tapped. The path is also
-            // single-typed, because SwiftUI's path diffing fatally errors comparing elements of
-            // different types at the same position: Settings' own pushes arrive wrapped as
-            // `AppSettingsPushRoute.item` instead of raw `SettingsItem` values.
-            NavigationStack(path: $appSettings.pushPath) {
-                content
-                    .toolbar(.hidden, for: .navigationBar)
-                    .navigationDestination(for: AppSettingsPushRoute.self) { route in
-                        switch route {
-                        case .settings:
-                            SettingsView(embedInOwnNavigation: false)
-                                .injectingViewControllerProvider()
-                        case let .item(item):
-                            item.destinationView
-                                .injectingViewControllerProvider()
-                        }
-                    }
-            }
-            .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {
-                settingsSheet
-            }
-        } else {
+        // Always present: branching on the size class here rebuilt the frontend on every rotation.
+        NavigationStack(path: $appSettings.pushPath) {
             content
-                .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {
-                    settingsSheet
+                .toolbar(.hidden, for: .navigationBar)
+                .navigationDestination(for: AppSettingsPushRoute.self) { route in
+                    switch route {
+                    case .settings:
+                        SettingsView(embedInOwnNavigation: false)
+                            .injectingViewControllerProvider()
+                    case let .item(item):
+                        item.destinationView
+                            .injectingViewControllerProvider()
+                    }
                 }
+        }
+        .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {
+            settingsSheet
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
`ConditionalContainerView` switched between a `NavigationStack` and bare content based on the horizontal size class. The two branches have different identities, so every size class change rebuilt the frontend: new `WebViewController`, full reload, back to the default dashboard. Plus/Max/Air-sized iPhones change size class on every rotation, which is why only those devices were affected.

The stack is now always present. Whether Settings pushes or opens as a sheet is still decided in `ContainerView` from the window's size class.

Fixes #5636

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Worth checking on iPad Split View and Mac Catalyst, which now also sit inside the stack at regular width.