### PR TITLE
Add spacing above deeplink sheet's Include server section

### DIFF
--- a/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
+++ b/Sources/App/Frontend/EntityDeeplink/DeeplinkView.swift
@@ -64,6 +64,13 @@ struct DeeplinkView: View {
                                 viewModel.includeServerChanged()
                             }
                     }
+                    .modify { view in
+                        if #available(iOS 17.0, *) {
+                            view.listSectionSpacing(DesignSystem.Spaces.two)
+                        } else {
+                            view
+                        }
+                    }
                 }
             }
             .modify { view in


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The deeplink sheet zeroes the list section spacing so the header sits tight against the deeplink row, which also left the "Include server" section glued to it. That section now sets its own spacing so it reads as a separate group.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
