### PR TITLE
Require 90% test coverage on the lines a pull request changes

### DIFF
--- a/.agents/skills/ha-ios-workflow-ci/SKILL.md
+++ b/.agents/skills/ha-ios-workflow-ci/SKILL.md
@@ -51,5 +51,40 @@ CI runs on GitHub Actions (`.github/workflows/ci.yml`):
 - **Linting**: SwiftFormat, SwiftLint, Rubocop, YamlLint
 - **Unit Tests**: Runs the `Tests-Unit` scheme
 - **Build Verification**: Ensures the app builds cleanly
+- **Patch coverage**: At least 90% of the lines a PR changes must be covered by the unit tests
 
 All lint checks and tests must pass before a PR can be merged.
+
+### The 90% patch coverage gate
+
+The `patch-coverage` job measures how much of a pull request's *own* diff the unit tests
+execute — not the coverage of the project as a whole, which is tracked separately by the
+Codecov statuses in `codecov.yaml`. Below 90%, the job fails and `github-actions[bot]`
+submits a **changes-requested review** naming the shortfall; the per-file breakdown and the
+list of changed lines no test runs are in the run's job summary.
+
+`Tools/diff_coverage.py` computes the number from the LCOV tracefile that
+`Tools/xccov_to_lcov.py` writes out of the test run's `.xcresult`, and the same script
+reproduces the CI verdict locally:
+
+```bash
+bundle exec fastlane test
+python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult \
+  --lcov fastlane/test_output/coverage.lcov
+python3 Tools/diff_coverage.py fastlane/test_output/coverage.lcov --base origin/main
+```
+
+What counts, and what does not:
+
+- Only lines the coverage report marks executable count, so comments, declarations and
+  braces never drag the number down.
+- Files no target in the `Tests-Unit` scheme builds have no coverage data and are skipped
+  entirely — a watchOS-only or widget-only file cannot fail the gate.
+- `Tests`, `Sources/SharedTesting` and the `Resources` directories are excluded, matching
+  the `ignore` list in `codecov.yaml`. Keep the two lists in step.
+- A pull request that changes nothing coverable (docs, assets, project settings) passes.
+
+Pushing tests that cover the missing lines dismisses the review automatically. When new
+code genuinely cannot be unit tested — UIKit plumbing, a system framework wrapper — a
+maintainer dismisses the review to let the change land; write the reason into the PR
+description so the next reader knows why.

--- a/.agents/skills/ha-ios-workflow-ci/SKILL.md
+++ b/.agents/skills/ha-ios-workflow-ci/SKILL.md
@@ -83,6 +83,8 @@ What counts, and what does not:
 - `Tests`, `Sources/SharedTesting` and the `Resources` directories are excluded, matching
   the `ignore` list in `codecov.yaml`. Keep the two lists in step.
 - A pull request that changes nothing coverable (docs, assets, project settings) passes.
+- A run with no tracefile to read, because the tests or the conversion failed, skips the
+  gate and dismisses any request an earlier run left behind.
 
 Pushing tests that cover the missing lines dismisses the review automatically. When new
 code genuinely cannot be unit tested — UIKit plumbing, a system framework wrapper — a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,10 @@ jobs:
           path: fastlane/test_output
 
       # Coverage that could not be measured must not block: when the conversion or the
-      # artifact is missing, this step is skipped, no output is set, and every step
-      # below no-ops rather than requesting changes nobody can act on. The step itself
-      # is `continue-on-error` because the script exits nonzero to report the shortfall.
+      # artifact is missing, this step is skipped and sets no output, which leaves the
+      # gate reporting nothing and dismisses any request an earlier run left behind,
+      # rather than blocking on a number nobody can act on. The step itself is
+      # `continue-on-error` because the script exits nonzero to report the shortfall.
       - name: Measure patch coverage
         id: coverage
         if: steps.tracefile.outcome == 'success'
@@ -364,9 +365,12 @@ jobs:
             await github.rest.pulls.createReview({ owner, repo, pull_number, event: 'REQUEST_CHANGES', body })
             core.info(`Requested changes: patch coverage ${process.env.COVERAGE}% is below ${threshold}%`)
 
-      - name: Dismiss the coverage review once it is met
+      # Runs whether coverage met the bar or could not be measured at all, so a
+      # request from an earlier run is never left blocking a pull request whose
+      # coverage this run has no number for.
+      - name: Dismiss an outstanding coverage review
         if: >-
-          steps.coverage.outputs.passed == 'true' &&
+          steps.coverage.outputs.passed != 'false' &&
           github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
@@ -387,9 +391,11 @@ jobs:
               (review) => review.state === 'CHANGES_REQUESTED' && (review.body || '').includes(marker),
             )
 
-            const message =
-              `Patch coverage is now ${process.env.COVERAGE}%, at or above the ` +
-              `${process.env.COVERAGE_THRESHOLD}% threshold.`
+            const coverage = process.env.COVERAGE
+            const message = coverage
+              ? `Patch coverage is now ${coverage}%, at or above the ` +
+                `${process.env.COVERAGE_THRESHOLD}% threshold.`
+              : 'Patch coverage could not be measured on this run, so the gate no longer applies.'
 
             for (const review of outstanding) {
               await github.rest.pulls.dismissReview({ owner, repo, pull_number, review_id: review.id, message })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,12 @@ jobs:
   patch-coverage:
     name: Patch coverage
     needs: test
-    if: github.event_name == 'pull_request'
+    # Runs even when the tests failed, which leaves no tracefile behind: the job has
+    # nothing to measure then, and its own cleanup below is what keeps a request from
+    # an earlier run from outliving the coverage it was about.
+    if: >-
+      !cancelled() &&
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -398,8 +403,14 @@ jobs:
               : 'Patch coverage could not be measured on this run, so the gate no longer applies.'
 
             for (const review of outstanding) {
-              await github.rest.pulls.dismissReview({ owner, repo, pull_number, review_id: review.id, message })
-              core.info(`Dismissed review ${review.id}`)
+              try {
+                await github.rest.pulls.dismissReview({ owner, repo, pull_number, review_id: review.id, message })
+                core.info(`Dismissed review ${review.id}`)
+              } catch (error) {
+                // A request nobody can dismiss blocks the pull request for good, so say
+                // so loudly enough that a maintainer can dismiss it by hand.
+                core.warning(`Could not dismiss review ${review.id}, dismiss it by hand: ${error.message}`)
+              }
             }
 
       - name: Fail below the threshold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,16 @@ jobs:
           disable_search: true
           plugins: noop
 
+      # Handed to the `patch-coverage` job below, which runs on Linux so the mac
+      # runner is free the moment the tests are done.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        name: "Upload Code Coverage Tracefile"
+        continue-on-error: true
+        with:
+          name: coverage-lcov
+          path: fastlane/test_output/coverage.lcov
+          if-no-files-found: ignore
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         name: "Upload Test Logs"
         if: ${{ always() }}
@@ -248,3 +258,148 @@ jobs:
         with:
           name: ios-simulator
           path: ~/Library/Developer/Xcode/DerivedData/HomeAssistant-*/Build/Products/Debug-iphonesimulator/*.app
+
+  # A pull request has to test the code it brings: at least 90% of the lines it adds
+  # or changes, and that the unit tests are able to run at all, must actually be run
+  # by them. Falling short is a changes-requested review rather than only a red check,
+  # so the reason lands where the discussion is. The review is dismissed automatically
+  # as soon as a push clears the bar, and a maintainer can dismiss it to land a change
+  # whose new code genuinely cannot be unit tested.
+  patch-coverage:
+    name: Patch coverage
+    needs: test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    env:
+      COVERAGE_THRESHOLD: "90"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0  # Fetch all history to diff against the merge base
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        name: "Download Code Coverage Tracefile"
+        id: tracefile
+        continue-on-error: true
+        with:
+          name: coverage-lcov
+          path: fastlane/test_output
+
+      # Coverage that could not be measured must not block: when the conversion or the
+      # artifact is missing, this step is skipped, no output is set, and every step
+      # below no-ops rather than requesting changes nobody can act on. The step itself
+      # is `continue-on-error` because the script exits nonzero to report the shortfall.
+      - name: Measure patch coverage
+        id: coverage
+        if: steps.tracefile.outcome == 'success'
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "+$BASE_REF:refs/remotes/origin/$BASE_REF"
+          python3 Tools/diff_coverage.py fastlane/test_output/coverage.lcov \
+            --base "origin/$BASE_REF" \
+            --threshold "$COVERAGE_THRESHOLD" \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --github-output "$GITHUB_OUTPUT"
+
+      # Only same-repository pull requests: a fork's token cannot review, and the run
+      # would fail on the API call instead of on the coverage it is reporting.
+      - name: Request changes below the threshold
+        if: >-
+          steps.coverage.outputs.passed == 'false' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+          COVERED: ${{ steps.coverage.outputs.covered }}
+          CHANGED: ${{ steps.coverage.outputs.changed }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const pull_number = context.payload.pull_request.number
+            const run = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const threshold = process.env.COVERAGE_THRESHOLD
+
+            // Marks the review as this job's, so the dismissal below leaves other bots alone.
+            const marker = '<!-- patch-coverage -->'
+
+            const body = [
+              marker,
+              `### Test coverage of this pull request is below ${threshold}%`,
+              '',
+              `The unit tests run **${process.env.COVERAGE}%** of the lines this pull request`,
+              `adds or changes (${process.env.COVERED} of ${process.env.CHANGED} coverable lines).`,
+              '',
+              'The per-file breakdown, and the changed lines no test runs, are in the',
+              `[job summary](${run}). Adding tests for those lines and pushing dismisses this`,
+              'review automatically.',
+              '',
+              'Lines that carry no executable code, and files the unit test targets do not',
+              'build, are not counted. If the new code genuinely cannot be unit tested, a',
+              'maintainer can dismiss this review.',
+            ].join('\n')
+
+            // A push that leaves coverage exactly where it was would otherwise stack an
+            // identical review on every run, so repeat the request only when it changed.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            })
+            const outstanding = reviews.findLast(
+              (review) => review.state === 'CHANGES_REQUESTED' && (review.body || '').includes(marker),
+            )
+
+            if (outstanding && outstanding.body === body) {
+              core.info('The outstanding coverage review already says this, leaving it alone')
+              return
+            }
+
+            await github.rest.pulls.createReview({ owner, repo, pull_number, event: 'REQUEST_CHANGES', body })
+            core.info(`Requested changes: patch coverage ${process.env.COVERAGE}% is below ${threshold}%`)
+
+      - name: Dismiss the coverage review once it is met
+        if: >-
+          steps.coverage.outputs.passed == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const pull_number = context.payload.pull_request.number
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            })
+            const marker = '<!-- patch-coverage -->'
+            const outstanding = reviews.filter(
+              (review) => review.state === 'CHANGES_REQUESTED' && (review.body || '').includes(marker),
+            )
+
+            const message =
+              `Patch coverage is now ${process.env.COVERAGE}%, at or above the ` +
+              `${process.env.COVERAGE_THRESHOLD}% threshold.`
+
+            for (const review of outstanding) {
+              await github.rest.pulls.dismissReview({ owner, repo, pull_number, review_id: review.id, message })
+              core.info(`Dismissed review ${review.id}`)
+            }
+
+      - name: Fail below the threshold
+        if: steps.coverage.outputs.passed == 'false'
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+        run: |
+          echo "::error::Patch coverage $COVERAGE% is below the required $COVERAGE_THRESHOLD%"
+          exit 1

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -43,6 +43,27 @@ python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult --lcov c
 - `0`: Coverage written
 - `1`: `xccov` failed, or the bundle covered no repository sources
 
+### diff_coverage.py
+
+Measures how much of a pull request's own diff the unit tests cover, out of the LCOV
+tracefile `xccov_to_lcov.py` writes. CI's `patch-coverage` job gates on it: below 90%, it
+fails and requests changes on the pull request.
+
+**Usage:**
+```bash
+python3 Tools/diff_coverage.py fastlane/test_output/coverage.lcov --base origin/main
+```
+
+**What it does:**
+1. Reads the LCOV tracefile as per-line execution counts
+2. Takes the lines the branch adds or changes from `git diff --unified=0 <base>...HEAD`
+3. Keeps the changed lines that coverage marks executable, dropping ignored paths
+4. Reports the covered share, a per-file table, and which changed lines no test runs
+
+**Exit codes:**
+- `0`: Coverage of the changed lines is at or above `--threshold` (default 90%)
+- `1`: Coverage is below the threshold, or the tracefile is missing
+
 ## Shell Scripts
 
 ### BuildMaterialDesignIconsFont.sh

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -47,7 +47,9 @@ python3 Tools/xccov_to_lcov.py fastlane/test_output/Tests-Unit.xcresult --lcov c
 
 Measures how much of a pull request's own diff the unit tests cover, out of the LCOV
 tracefile `xccov_to_lcov.py` writes. CI's `patch-coverage` job gates on it: below 90%, it
-fails and requests changes on the pull request.
+fails and requests changes on the pull request. When the tracefile is missing, because the
+test run or the conversion failed, that job skips the gate instead of blocking on a number
+it could not measure.
 
 **Usage:**
 ```bash

--- a/Tools/diff_coverage.py
+++ b/Tools/diff_coverage.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Measure how well tested the lines a pull request changes are.
+
+Codecov calls this "patch coverage": of the executable lines a branch adds or
+edits, the share the test suite actually runs. This computes the same number
+from the LCOV tracefile `Tools/xccov_to_lcov.py` writes, so CI can gate on it
+directly instead of depending on a third-party upload round-tripping in time.
+
+Only lines the coverage report knows about are counted. A changed line carrying
+no executable code (a comment, a brace, a type declaration) is not coverable,
+and a file none of the tested targets compile has no coverage data at all;
+neither is held against the pull request.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, NamedTuple, Sequence, Set, Tuple
+
+# Kept in sync with the `ignore` list in codecov.yaml: generated resources, the
+# testing helpers and the tests themselves are not what the threshold is about.
+DEFAULT_IGNORED_PATHS = (
+    'Sources/Shared/Resources',
+    'Sources/App/Resources',
+    'Sources/SharedTesting',
+    'Tests',
+)
+
+HUNK_HEADER = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+
+
+class FileResult(NamedTuple):
+    """The changed lines of one file, split by whether the tests execute them."""
+    path: str
+    covered: List[int]
+    uncovered: List[int]
+
+    @property
+    def changed(self) -> int:
+        return len(self.covered) + len(self.uncovered)
+
+
+def parse_lcov(tracefile: Path) -> Dict[str, Dict[int, int]]:
+    """Read an LCOV tracefile as {repository-relative path: {line: execution count}}."""
+    files: Dict[str, Dict[int, int]] = {}
+    lines: Dict[int, int] = {}
+
+    for record in tracefile.read_text(encoding='utf-8').splitlines():
+        if record.startswith('SF:'):
+            lines = files.setdefault(record[3:].strip(), {})
+        elif record.startswith('DA:'):
+            number, _, count = record[3:].partition(',')
+            lines[int(number)] = int(count or 0)
+
+    return files
+
+
+def read_diff(base: str, repo_root: Path) -> str:
+    """
+    Dump the pull request's own diff against the commit it branched from.
+
+    `base...HEAD` diffs against the merge base, so commits landing on the base
+    branch after the pull request opened are not counted as its changes. Deleted
+    files are excluded — they have no lines left to cover.
+    """
+    result = subprocess.run(
+        ['git', 'diff', '--unified=0', '--diff-filter=d', f"{base}...HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    if result.returncode != 0:
+        print(f"git diff against {base} failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    return result.stdout
+
+
+def parse_diff(diff: str) -> Dict[str, Set[int]]:
+    """
+    Collect the line numbers each file gains, keyed by its path after the change.
+
+    With `--unified=0` every hunk header covers added lines and nothing else, so
+    the header ranges are the changed lines. A `+++` line only starts a new file
+    when it follows a `---` line, so an added source line that happens to begin
+    with `++ ` cannot be mistaken for a file header.
+    """
+    files: Dict[str, Set[int]] = {}
+    path = None
+    previous = ''
+
+    for line in diff.splitlines():
+        if line.startswith('+++ ') and previous.startswith('--- '):
+            target = line[4:].strip()
+            path = None if target == '/dev/null' else re.sub(r'^b/', '', target)
+        elif path is not None:
+            hunk = HUNK_HEADER.match(line)
+
+            if hunk:
+                start, count = int(hunk.group(1)), int(hunk.group(2) or 1)
+                files.setdefault(path, set()).update(range(start, start + count))
+
+        previous = line
+
+    return files
+
+
+def is_ignored(path: str, ignored: Sequence[str]) -> bool:
+    return any(path == prefix or path.startswith(f"{prefix}/") for prefix in ignored)
+
+
+def measure(
+    coverage: Dict[str, Dict[int, int]],
+    changed: Dict[str, Set[int]],
+    ignored: Sequence[str],
+) -> List[FileResult]:
+    """Split every changed, coverable line into covered and uncovered, per file."""
+    results = []
+
+    for path, lines in sorted(changed.items()):
+        if is_ignored(path, ignored):
+            continue
+
+        counts = coverage.get(path)
+
+        if not counts:
+            continue
+
+        executable = sorted(line for line in lines if line in counts)
+        result = FileResult(
+            path=path,
+            covered=[line for line in executable if counts[line] > 0],
+            uncovered=[line for line in executable if counts[line] == 0],
+        )
+
+        if result.changed:
+            results.append(result)
+
+    return results
+
+
+def totals(results: Iterable[FileResult]) -> Tuple[int, int]:
+    """Return (covered, changed) across all files."""
+    results = list(results)
+    return sum(len(result.covered) for result in results), sum(result.changed for result in results)
+
+
+def percentage(covered: int, changed: int) -> float:
+    """A pull request with nothing coverable to measure is treated as fully covered."""
+    return covered / changed * 100 if changed else 100.0
+
+
+def format_ranges(lines: Sequence[int]) -> str:
+    """Collapse consecutive line numbers into `12-18, 42` so long lists stay readable."""
+    ranges: List[List[int]] = []
+
+    for line in lines:
+        if ranges and line == ranges[-1][1] + 1:
+            ranges[-1][1] = line
+        else:
+            ranges.append([line, line])
+
+    return ', '.join(str(first) if first == last else f"{first}-{last}" for first, last in ranges)
+
+
+def markdown_summary(results: List[FileResult], threshold: float) -> str:
+    """Render the verdict, a per-file table, and where the uncovered lines are."""
+    covered, changed = totals(results)
+    ratio = percentage(covered, changed)
+    passed = ratio >= threshold
+
+    if not changed:
+        headline = (
+            "This pull request changes no lines the test suite can cover, "
+            f"so the {threshold:g}% threshold does not apply."
+        )
+    else:
+        verdict = "meets" if passed else "is below"
+        headline = (
+            f"**{ratio:.2f}%** of the {changed} changed lines that tests can cover are covered "
+            f"— that {verdict} the required {threshold:g}%."
+        )
+
+    rows = [
+        "| File | Coverage | Covered | Changed |",
+        "| --- | --- | --- | --- |",
+    ]
+    rows += [
+        f"| `{result.path}` | {percentage(len(result.covered), result.changed):.2f}% "
+        f"| {len(result.covered)} | {result.changed} |"
+        for result in sorted(results, key=lambda result: percentage(len(result.covered), result.changed))
+    ]
+
+    uncovered = [result for result in results if result.uncovered]
+    details = []
+
+    if uncovered:
+        details = [
+            '',
+            '<details>',
+            '<summary>Changed lines no test runs</summary>',
+            '',
+        ]
+        details += [f"- `{result.path}`: {format_ranges(result.uncovered)}" for result in uncovered]
+        details += ['', '</details>']
+
+    return '\n'.join([
+        "## Patch coverage",
+        '',
+        headline,
+        '',
+        *(rows if changed else []),
+        *details,
+        '',
+    ])
+
+
+def write_github_output(destination: Path, values: Dict[str, str]) -> None:
+    """Append `key=value` pairs for later workflow steps to read."""
+    with open(destination, 'a', encoding='utf-8') as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('lcov', type=Path, help="LCOV tracefile written by Tools/xccov_to_lcov.py")
+    parser.add_argument('--base', default='origin/main', help="branch or commit the pull request targets")
+    parser.add_argument('--threshold', type=float, default=90.0, help="required coverage of changed lines")
+    parser.add_argument('--summary', type=Path, help="Markdown summary to append to")
+    parser.add_argument('--github-output', type=Path, help="GitHub Actions output file to append results to")
+    parser.add_argument('--ignore', nargs='*', default=list(DEFAULT_IGNORED_PATHS), help="paths to exclude")
+    parser.add_argument('--repo-root', type=Path, default=Path.cwd(), help="repository the diff is taken in")
+    arguments = parser.parse_args()
+
+    if not arguments.lcov.is_file():
+        print(f"No coverage tracefile at {arguments.lcov}", file=sys.stderr)
+        sys.exit(1)
+
+    results = measure(
+        parse_lcov(arguments.lcov),
+        parse_diff(read_diff(arguments.base, arguments.repo_root)),
+        arguments.ignore,
+    )
+
+    covered, changed = totals(results)
+    ratio = percentage(covered, changed)
+    passed = ratio >= arguments.threshold
+
+    summary = markdown_summary(results, arguments.threshold)
+    print(summary)
+
+    if arguments.summary:
+        with open(arguments.summary, 'a', encoding='utf-8') as handle:
+            handle.write(summary)
+
+    if arguments.github_output:
+        write_github_output(arguments.github_output, {
+            'passed': str(passed).lower(),
+            'coverage': f"{ratio:.2f}",
+            'covered': str(covered),
+            'changed': str(changed),
+        })
+
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,6 +11,11 @@ coverage:
         informational: true
     patch:
       default:
+        # Enforcement lives in the `patch-coverage` job of .github/workflows/ci.yml,
+        # which requests changes on a pull request whose changed lines fall below
+        # this bar. Codecov reports the same number so its comment and status agree
+        # with the gate, but stays informational rather than blocking merges twice.
+        target: 90%
         informational: true
 
 # Report coverage on every pull request, updating one comment in place rather


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Coverage was reported but never enforced, so a pull request could add untested code and still come back green.

A new `patch-coverage` CI job measures how much of a pull request's own diff the unit tests run. Below 90% it fails and requests changes, and it dismisses that review once a push clears the bar. `Tools/diff_coverage.py` computes the number from the LCOV tracefile the test run already produces.

Only coverable lines count: comments and declarations carry no execution count, files the unit test targets never build have no coverage data, and `Tests`, `Sources/SharedTesting` and the resource directories are excluded to match `codecov.yaml`. A change with nothing coverable in it passes, and a missing tracefile leaves the gate quiet rather than blocking on a number it could not measure.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A, this only changes CI.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: N/A, no user-facing functionality changes.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Making the job a required check is a branch protection setting, so it needs to be enabled in repository settings. Until then the changes-requested review is what blocks the merge, and a maintainer can dismiss it for code that genuinely cannot be unit tested.