### PR TITLE
Fix watch entity states not updating

### DIFF
--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -170,7 +170,11 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
         let image = icon.carPlayIcon(color: iconColor)
 
         var detailText: String?
-        if !entityHasIrrelevantState {
+        if entityHasIrrelevantState {
+            // No state worth showing, but where the item lives still is: keep the area on its own
+            // rather than dropping the line entirely.
+            detailText = area
+        } else {
             var renderedDetailText = getContextualStateDescription()
             if let area, !renderedDetailText.isEmpty {
                 renderedDetailText += Self.detailTextSeparator + area

--- a/Sources/Shared/Domain/Domain.swift
+++ b/Sources/Shared/Domain/Domain.swift
@@ -600,10 +600,12 @@ public enum Domain: String, CaseIterable {
         [.cover, .inputBoolean, .light, .lock, .switch].contains(self)
     }
 
-    /// Whether the domain's state adds no value in list UIs — scripts and scenes just report
-    /// their last-triggered time.
+    /// Whether the domain's state adds no value in list UIs — scripts and scenes just report their
+    /// last-triggered time, and an automation reports whether it is *enabled*, never the state of
+    /// the light or fan it actually drives. Rows for these domains show where the item lives
+    /// (server, area) instead of a state the user can't read anything into.
     public var hasIrrelevantState: Bool {
-        [.script, .scene].contains(self)
+        [.automation, .scene, .script].contains(self)
     }
 
     public func localizedState(for state: String) -> String {

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRow.swift
@@ -6,11 +6,19 @@ struct WatchMagicViewRow: View {
     @StateObject private var viewModel: WatchMagicViewRowViewModel
     @Environment(\.watchNavigate) private var navigate
     private let subtitle: String?
+    private let areaName: String?
     private let layout: WatchLayout
 
-    init(item: MagicItem, itemInfo: MagicItem.Info, subtitle: String? = nil, layout: WatchLayout = .list) {
+    init(
+        item: MagicItem,
+        itemInfo: MagicItem.Info,
+        subtitle: String? = nil,
+        areaName: String? = nil,
+        layout: WatchLayout = .list
+    ) {
         self._viewModel = .init(wrappedValue: .init(item: item, itemInfo: itemInfo))
         self.subtitle = subtitle
+        self.areaName = areaName
         self.layout = layout
     }
 
@@ -166,8 +174,13 @@ struct WatchMagicViewRow: View {
         )
     }
 
+    /// A row whose domain reports a meaningful state leads with it, followed by the server name the
+    /// caller passes (multi-server configs only). The domains whose state says nothing about what
+    /// the item controls — a script's last-triggered time, an automation's enabled flag — show where
+    /// the item lives instead: server and area, whichever exist.
     private var subtitleToDisplay: String? {
-        let combined = [viewModel.stateText, subtitle].compactMap { $0 }.joined(separator: " • ")
+        let parts = viewModel.displaysState ? [viewModel.stateText, subtitle] : [subtitle, areaName]
+        let combined = parts.compactMap { $0 }.joined(separator: " • ")
         return combined.isEmpty ? nil : combined
     }
 
@@ -272,6 +285,13 @@ struct WatchMagicViewRow: View {
         WatchMagicViewRow(
             item: .init(id: "scene.one", serverId: "1", type: .scene),
             itemInfo: .init(id: "1", name: "New scene", iconName: "earth")
+        )
+        // No state worth showing: the subtitle carries where the item lives instead.
+        WatchMagicViewRow(
+            item: .init(id: "automation.bedroom_light_control", serverId: "1", type: .entity),
+            itemInfo: .init(id: "1", name: "Bedroom light", iconName: "mdi:ceiling-light"),
+            subtitle: "Home",
+            areaName: "Bedroom"
         )
         WatchMagicViewRow(
             item: .init(id: "sensor.living_room_temperature", serverId: "1", type: .entity),

--- a/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
+++ b/Sources/WatchApp/Home/MagicItemRow/WatchMagicViewRowViewModel.swift
@@ -174,8 +174,9 @@ final class WatchMagicViewRowViewModel: ObservableObject {
     }
 
     /// State is only fetched for entity items whose domain reports a meaningful state — same
-    /// rule as CarPlay.
-    private var displaysState: Bool {
+    /// rule as CarPlay. The rows this excludes (scripts, scenes, automations) show the item's
+    /// server and area instead, so they still carry a context line.
+    var displaysState: Bool {
         guard item.type == .entity, let domain = item.domain else { return false }
         return !domain.hasIrrelevantState
     }

--- a/Sources/WatchApp/Home/WatchFolderContentView.swift
+++ b/Sources/WatchApp/Home/WatchFolderContentView.swift
@@ -141,7 +141,8 @@ struct WatchFolderContentView: View {
             WatchMagicViewRow(
                 item: item,
                 itemInfo: viewModel.info(for: item),
-                subtitle: viewModel.serverName(for: item)
+                subtitle: viewModel.serverName(for: item),
+                areaName: viewModel.areaName(for: item)
             )
         }
     }

--- a/Sources/WatchApp/Home/WatchHomeView.swift
+++ b/Sources/WatchApp/Home/WatchHomeView.swift
@@ -470,7 +470,8 @@ struct WatchHomeView: View {
             WatchMagicViewRow(
                 item: item,
                 itemInfo: viewModel.info(for: item),
-                subtitle: viewModel.serverName(for: item)
+                subtitle: viewModel.serverName(for: item),
+                areaName: viewModel.areaName(for: item)
             )
         }
     }

--- a/Sources/WatchApp/Home/WatchHomeViewModel.swift
+++ b/Sources/WatchApp/Home/WatchHomeViewModel.swift
@@ -268,6 +268,15 @@ final class WatchHomeViewModel: ObservableObject {
         return .init(id: magicItem.id, name: magicItem.id, iconName: "")
     }
 
+    /// The area the item's entity belongs to, or `nil` when it has none (or isn't an entity at all).
+    /// Rows whose domain has no state worth showing put this under the name instead, so a script or
+    /// automation still says where it lives. Resolved from the same registry the provider already
+    /// loaded for `info(for:)`, so it costs no extra database read.
+    func areaName(for magicItem: MagicItem) -> String? {
+        guard magicItem.type != .folder, !magicItem.serverId.isEmpty else { return nil }
+        return magicItemProvider.getAreaName(for: magicItem)
+    }
+
     // MARK: - Offline-aware config reconciliation
 
     /// Handle the phone's reply to a config pull, deciding whether to adopt it, push local offline

--- a/Sources/WatchWidgets/Info.plist
+++ b/Sources/WatchWidgets/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Tests/Shared/Domain.test.swift
+++ b/Tests/Shared/Domain.test.swift
@@ -305,7 +305,7 @@ struct DomainMappingTests {
     }
 
     @Test func irrelevantStateMembership() {
-        let expected: Set<Domain> = [.script, .scene]
+        let expected: Set<Domain> = [.automation, .scene, .script]
         for domain in Domain.allCases {
             #expect(
                 domain.hasIrrelevantState == expected.contains(domain),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Two reasons a watch shows entity states that never move.

**Complications froze on http-only servers.** The watch widget extension refreshes its own values (`POST /auth/token`, then `GET /api/states/{entity}`), but its `Info.plist` was the only network-using bundle without the arbitrary-loads App Transport Security exception the app, the watch app and every other extension carry. ATS is per process, so on a server reachable only over plain http every request failed before leaving the device. Those failures degrade silently by design, keeping the stored snapshot, so the face only ever moved while the watch app itself ran.

**Scripts and automations showed a state that says nothing.** A script reports its last-triggered time and an automation whether it is *enabled*, never the state of the light or fan it actually drives, which is what someone putting one on the watch is looking at. `Domain.hasIrrelevantState` already covered scripts and scenes; automations join them, and those rows now show the item's server (multi-server configs only, as before) and its area instead. The watch also stops polling REST for them. CarPlay reads the same rule and used to drop its whole detail line for these domains, area included; it now keeps the area on its own.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
With no live entity behind them, script and automation rows now take their icon colour from the item's own customization (or white) instead of the frontend's state colour.
