### PR TITLE
Explain why the In Bed health sensor can be unavailable

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1991,6 +1991,7 @@ Importing replaces every category listed on this screen, including app settings.
 "settings_sensors.health.error.unavailable" = "Apple Health is not available on this device.";
 "settings_sensors.health.footer" = "Apple Health sensors use the existing per-sensor controls below. Health data is read only during normal sensor updates.";
 "settings_sensors.health.header" = "Apple Health";
+"settings_sensors.health.metric.in_bed.footer" = "Apple Watch records sleep stages but not time in bed, so this stays unavailable until a source writes it. Turn on “Track Time in Bed with iPhone” in Health > Sleep > Options, or use a sleep tracking app that records time in bed.";
 "settings_sensors.health.reload" = "Reload Sensors";
 "settings_sensors.health.request_access" = "Request Apple Health Access";
 "settings_sensors.health.sensors.enable_all" = "Enable all Apple Health sensors";

--- a/Sources/App/Settings/Sensors/Health/HealthSensorRow.swift
+++ b/Sources/App/Settings/Sensors/Health/HealthSensorRow.swift
@@ -20,20 +20,29 @@ struct HealthSensorRow: View {
     }
 
     var body: some View {
-        Toggle(isOn: $isEnabled) {
-            HStack(spacing: DesignSystem.Spaces.two) {
-                Image(uiImage: icon)
-                    .renderingMode(.template)
-                    .foregroundColor(isEnabled ? .accentColor : .secondary)
-                VStack(alignment: .leading) {
-                    Text(metric.name)
-                        .foregroundColor(isEnabled ? .primary : .secondary)
-                    if let subtitle {
-                        Text(subtitle)
-                            .foregroundColor(.secondary)
-                            .font(.subheadline)
+        VStack(alignment: .leading, spacing: DesignSystem.Spaces.one) {
+            Toggle(isOn: $isEnabled) {
+                HStack(spacing: DesignSystem.Spaces.two) {
+                    Image(uiImage: icon)
+                        .renderingMode(.template)
+                        .foregroundColor(isEnabled ? .accentColor : .secondary)
+                    VStack(alignment: .leading) {
+                        Text(metric.name)
+                            .foregroundColor(isEnabled ? .primary : .secondary)
+                        if let subtitle {
+                            Text(subtitle)
+                                .foregroundColor(.secondary)
+                                .font(.subheadline)
+                        }
                     }
                 }
+            }
+            // A footer under the row rather than under the section: it explains this one sensor, and the
+            // section holds every sleep sensor.
+            if let footer = metric.footer {
+                Text(footer.text)
+                    .foregroundColor(.secondary)
+                    .font(DesignSystem.Font.footnote)
             }
         }
     }
@@ -43,6 +52,9 @@ struct HealthSensorRow: View {
     List {
         HealthSensorRow(metric: .restingHeartRate, stateDescription: "62 bpm", isEnabled: .constant(true))
         HealthSensorRow(metric: .restingHeartRate, stateDescription: nil, isEnabled: .constant(false))
+        if let inBed = HealthKitMetric.metric(uniqueID: "health_sleep_in_bed") {
+            HealthSensorRow(metric: inBed, stateDescription: "unavailable", isEnabled: .constant(true))
+        }
     }
 }
 #endif

--- a/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric+Sleep.swift
+++ b/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric+Sleep.swift
@@ -12,7 +12,13 @@ public extension HealthKitMetric {
             icon: "mdi:sleep",
             stages: HealthKitSleepStage.asleepStages
         ),
-        sleepMetric(uniqueID: "health_sleep_in_bed", name: "In Bed", icon: "mdi:bed", stages: [.inBed]),
+        sleepMetric(
+            uniqueID: "health_sleep_in_bed",
+            name: "In Bed",
+            icon: "mdi:bed",
+            stages: [.inBed],
+            footer: .timeInBedSource
+        ),
         sleepMetric(uniqueID: "health_sleep_awake", name: "Awake", icon: "mdi:eye", stages: [.awake]),
         sleepMetric(uniqueID: "health_sleep_core", name: "Core Sleep", icon: "mdi:sleep", stages: [.core]),
         sleepMetric(uniqueID: "health_sleep_deep", name: "Deep Sleep", icon: "mdi:sleep", stages: [.deep]),
@@ -23,13 +29,15 @@ public extension HealthKitMetric {
         uniqueID: String,
         name: String,
         icon: String,
-        stages: Set<HealthKitSleepStage>
+        stages: Set<HealthKitSleepStage>,
+        footer: HealthKitMetricFooter? = nil
     ) -> HealthKitMetric {
         HealthKitMetric(
             uniqueID: uniqueID,
             identifier: HealthKitSleepStage.sleepAnalysisIdentifier,
             name: name,
             icon: icon,
+            footer: footer,
             unit: "min",
             queryUnit: .minute,
             aggregation: .sleep(stages: stages),

--- a/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric.swift
+++ b/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetric.swift
@@ -17,6 +17,8 @@ public struct HealthKitMetric: Equatable, Hashable, Sendable {
     public let name: String
     /// Material Design icon name, including the `mdi:` prefix.
     public let icon: String
+    /// Explanation shown under the sensor in settings, `nil` for a metric that needs none.
+    public let footer: HealthKitMetricFooter?
     /// Unit of measurement reported to Home Assistant, `nil` for unitless metrics.
     public let unit: String?
     /// Unit the samples are read in, which is also what `unit` describes. A `.sleep` metric has no
@@ -41,6 +43,7 @@ public struct HealthKitMetric: Equatable, Hashable, Sendable {
         identifier: String,
         name: String,
         icon: String,
+        footer: HealthKitMetricFooter? = nil,
         unit: String?,
         queryUnit: HealthKitMetricUnit,
         aggregation: HealthKitMetricAggregation,
@@ -56,6 +59,7 @@ public struct HealthKitMetric: Equatable, Hashable, Sendable {
         self.identifier = identifier
         self.name = name
         self.icon = icon
+        self.footer = footer
         self.unit = unit
         self.queryUnit = queryUnit
         self.aggregation = aggregation

--- a/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetricFooter.swift
+++ b/Sources/Shared/API/Webhook/Sensors/Health/HealthKitMetricFooter.swift
@@ -1,0 +1,21 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+import Foundation
+
+/// Explanatory text shown under one sensor in the Apple Health sensor list, for a metric whose
+/// availability depends on something the user has to set up outside this app.
+///
+/// A case rather than a string, so the metric catalog stays plain data — like
+/// `HealthKitMetricCategory`, the wording is resolved in the user's current language when it's read.
+public enum HealthKitMetricFooter: String, CaseIterable, Sendable {
+    /// Nothing writes `inBed` samples on its own: Apple Watch records the sleep stages but not time in
+    /// bed, so "In Bed" reads as unavailable until the user turns iPhone tracking on or installs a
+    /// sleep app that records it.
+    case timeInBedSource
+
+    public var text: String {
+        switch self {
+        case .timeInBedSource: return L10n.SettingsSensors.Health.Metric.InBed.footer
+        }
+    }
+}
+#endif

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -6526,6 +6526,12 @@ public enum L10n {
         /// Apple Health is not available on this device.
         public static var unavailable: String { return L10n.tr("Localizable", "settings_sensors.health.error.unavailable") }
       }
+      public enum Metric {
+        public enum InBed {
+          /// Apple Watch records sleep stages but not time in bed, so this stays unavailable until a source writes it. Turn on “Track Time in Bed with iPhone” in Health > Sleep > Options, or use a sleep tracking app that records time in bed.
+          public static var footer: String { return L10n.tr("Localizable", "settings_sensors.health.metric.in_bed.footer") }
+        }
+      }
       public enum Sensors {
         /// Enable all Apple Health sensors
         public static var enableAll: String { return L10n.tr("Localizable", "settings_sensors.health.sensors.enable_all") }

--- a/Tests/Shared/Sensors/HealthKitMetricCatalog.test.swift
+++ b/Tests/Shared/Sensors/HealthKitMetricCatalog.test.swift
@@ -89,6 +89,17 @@ class HealthKitMetricCatalogTests: XCTestCase {
         }
     }
 
+    func testOnlyInBedCarriesAFooter() throws {
+        // Nothing writes `inBed` samples on its own, so it's the one metric whose sensor needs the list
+        // to say where its samples have to come from.
+        let inBed = try XCTUnwrap(HealthKitMetric.metric(uniqueID: "health_sleep_in_bed"))
+        XCTAssertEqual(inBed.footer, .timeInBedSource)
+
+        for metric in HealthKitMetric.all where metric.uniqueID != inBed.uniqueID {
+            XCTAssertNil(metric.footer, metric.uniqueID)
+        }
+    }
+
     func testUnitsAreCompatibleWithTheirQuantityType() {
         for metric in HealthKitMetric.all where isAvailableOnThisOS(metric) && !isSleepMetric(metric) {
             guard let type = quantityType(for: metric), let unit = metric.queryUnit.hkUnit else { continue }


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The In Bed sleep sensor reports `unavailable` whenever nothing writes `inBed` samples to Apple Health. Apple Watch records the sleep stages but not time in bed, so on a Watch-only setup this one sensor looks broken while the other sleep sensors report a duration.

A metric can now carry an optional footer, shown under its row in the Apple Health sensor list. In Bed uses it to say where its samples have to come from: turn on "Track Time in Bed with iPhone" in Health > Sleep > Options, or use a sleep tracking app that records it.

## Screenshots

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

## Any other notes
The footer is an enum case rather than a stored string, so the metric catalog stays plain data and the wording resolves in the user's current language.
