### PR TITLE
Run Focus filter when the app is in the background

### DIFF
--- a/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
+++ b/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
@@ -6,7 +6,14 @@ import Shared
 /// The Focus Filter the user adds to a Focus in Settings › Focus, picking one of the names they
 /// created in the app. iOS runs this when that Focus activates, which is the only moment it tells
 /// us anything about _which_ Focus is running.
-struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent {
+///
+/// `LiveActivityIntent` is not about Live Activities here: a plain `SetFocusFilterIntent` is only
+/// reliably performed while the app is in the foreground, and silently skipped when iOS would have
+/// to launch the app to run it — which is every Focus that starts with the app closed, so the
+/// filter misses exactly the moments it exists for. The conformance opts the intent into being run
+/// in the app's process in the background, which is what makes it run at all.
+@available(iOS 17.0, *)
+struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent, LiveActivityIntent {
     static let title: LocalizedStringResource = .init(
         "app_intents.focus_filter.title",
         defaultValue: "Report Focus name"

--- a/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
+++ b/Sources/App/Settings/Focus/FocusNameFocusFilterAppIntent.swift
@@ -6,14 +6,7 @@ import Shared
 /// The Focus Filter the user adds to a Focus in Settings › Focus, picking one of the names they
 /// created in the app. iOS runs this when that Focus activates, which is the only moment it tells
 /// us anything about _which_ Focus is running.
-///
-/// `LiveActivityIntent` is not about Live Activities here: a plain `SetFocusFilterIntent` is only
-/// reliably performed while the app is in the foreground, and silently skipped when iOS would have
-/// to launch the app to run it — which is every Focus that starts with the app closed, so the
-/// filter misses exactly the moments it exists for. The conformance opts the intent into being run
-/// in the app's process in the background, which is what makes it run at all.
-@available(iOS 17.0, *)
-struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent, LiveActivityIntent {
+struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent {
     static let title: LocalizedStringResource = .init(
         "app_intents.focus_filter.title",
         defaultValue: "Report Focus name"
@@ -75,3 +68,14 @@ struct FocusNameFocusFilterAppIntent: SetFocusFilterIntent, LiveActivityIntent {
         return .result()
     }
 }
+
+/// `LiveActivityIntent` is not about Live Activities here: a plain `SetFocusFilterIntent` is only
+/// reliably performed while the app is in the foreground, and silently skipped when iOS would have
+/// to launch the app to run it — which is every Focus that starts with the app closed, so the
+/// filter misses exactly the moments it exists for. The conformance opts the intent into being run
+/// in the app's process in the background, which is what makes it run at all.
+///
+/// Declared here rather than on the type so the filter itself stays available on the iOS versions
+/// below the one that introduced the protocol.
+@available(iOS 17.0, *)
+extension FocusNameFocusFilterAppIntent: LiveActivityIntent {}


### PR DESCRIPTION
## AI Policy
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
A plain `SetFocusFilterIntent` is only reliably performed while the app is in the foreground, and is skipped when iOS would have to launch the app to run it. That means a Focus starting with the app closed never reports its name, and `focus_name` blanks instead. Conforming the intent to `LiveActivityIntent` opts it into running in the app's process in the background, which is the known workaround for this (see [FB14715113](https://developer.apple.com/forums/thread/761593)).

That protocol is iOS 17+, so the conformance sits in an availability-gated extension and the filter itself stays available below iOS 17.

Related to #5467.

## Screenshots
Not a UI change.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant# N/A

## Any other notes
The other option Apple documents for this is hosting the filter in an App Intents extension so no app launch is needed. That needs a new extension target, a new App ID and a provisioning profile, so it is not in this PR.
