### PR TITLE
Keep kiosk camera overlay and screensaver from conflicting

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -1217,6 +1217,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				CameraPlayer/CameraMJPEGPlayerView.swift,
+				CameraPlayer/CameraOverlayPresenter.swift,
 				CameraPlayer/CameraPlayerView.swift,
 				CameraPlayer/CameraStreamHLSView.swift,
 				CameraPlayer/WebRTC/CameraZoomGestureOverlay.swift,

--- a/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
@@ -80,7 +80,7 @@ final class CameraOverlayPresenter {
         }
     }
 
-    private func overlayDidDisappear(_ camera: Camera) {
+    func overlayDidDisappear(_ camera: Camera) {
         guard displayedCamera == camera else { return }
         clearState()
     }

--- a/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
@@ -1,0 +1,93 @@
+import Shared
+import SwiftUI
+import UIKit
+
+final class CameraOverlayPresenter {
+    static let shared = CameraOverlayPresenter()
+
+    struct Camera: Equatable {
+        let entityId: String
+        let serverIdentifier: Identifier<Server>
+    }
+
+    private(set) var displayedCamera: Camera?
+    private weak var overlayController: UIViewController?
+    private var isDismissing = false
+    private var pendingShow: (() -> Void)?
+    private let kiosk: KioskModeManager
+
+    init(kiosk: KioskModeManager = Current.kiosk) {
+        self.kiosk = kiosk
+    }
+
+    func isDisplaying(_ camera: Camera, on webViewController: WebViewControllerProtocol) -> Bool {
+        guard displayedCamera == camera, let overlayController else { return false }
+        return webViewController.overlayedController === overlayController
+    }
+
+    func show(
+        entityId: String,
+        server: Server,
+        cameraName: String? = nil,
+        on webViewController: WebViewControllerProtocol
+    ) {
+        let camera = Camera(entityId: entityId, serverIdentifier: server.identifier)
+
+        if isDismissing {
+            if webViewController.overlayedController != nil {
+                Current.Log.info("Camera \(entityId) requested while another overlay is dismissing, deferring")
+                pendingShow = { [weak self] in
+                    self?.show(entityId: entityId, server: server, cameraName: cameraName, on: webViewController)
+                }
+                return
+            }
+            isDismissing = false
+        }
+
+        guard !isDisplaying(camera, on: webViewController) else {
+            Current.Log.info("Camera \(entityId) is already on display, ignoring show request")
+            return
+        }
+
+        let controller = CameraPlayerView(server: server, cameraEntityId: entityId, cameraName: cameraName)
+            .onDisappear { [weak self] in
+                self?.overlayDidDisappear(camera)
+            }
+            .embeddedInHostingController()
+        controller.modalPresentationStyle = .overFullScreen
+
+        overlayController = controller
+        displayedCamera = camera
+        kiosk.setCameraOverlayVisible(true)
+        webViewController.presentOverlayController(controller: controller, animated: true)
+    }
+
+    func hide(on webViewController: WebViewControllerProtocol) {
+        guard let overlayController, webViewController.overlayedController === overlayController else {
+            Current.Log.info("No camera is on display, ignoring hide request")
+            clearState()
+            return
+        }
+
+        isDismissing = true
+        webViewController.dismissOverlayController(animated: true) { [weak self] in
+            guard let self else { return }
+            isDismissing = false
+            clearState()
+            let deferredShow = pendingShow
+            pendingShow = nil
+            deferredShow?()
+        }
+    }
+
+    private func overlayDidDisappear(_ camera: Camera) {
+        guard displayedCamera == camera else { return }
+        clearState()
+    }
+
+    private func clearState() {
+        overlayController = nil
+        displayedCamera = nil
+        kiosk.setCameraOverlayVisible(false)
+    }
+}

--- a/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
+++ b/Sources/App/Cameras/CameraPlayer/CameraOverlayPresenter.swift
@@ -31,12 +31,14 @@ final class CameraOverlayPresenter {
         cameraName: String? = nil,
         on webViewController: WebViewControllerProtocol
     ) {
+        precondition(Thread.isMainThread)
         let camera = Camera(entityId: entityId, serverIdentifier: server.identifier)
 
         if isDismissing {
             if webViewController.overlayedController != nil {
                 Current.Log.info("Camera \(entityId) requested while another overlay is dismissing, deferring")
-                pendingShow = { [weak self] in
+                pendingShow = { [weak self, weak webViewController] in
+                    guard let webViewController else { return }
                     self?.show(entityId: entityId, server: server, cameraName: cameraName, on: webViewController)
                 }
                 return
@@ -63,6 +65,7 @@ final class CameraOverlayPresenter {
     }
 
     func hide(on webViewController: WebViewControllerProtocol) {
+        precondition(Thread.isMainThread)
         guard let overlayController, webViewController.overlayedController === overlayController else {
             Current.Log.info("No camera is on display, ignoring hide request")
             clearState()

--- a/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/WebViewExternalMessageHandler.swift
@@ -654,13 +654,12 @@ final class WebViewExternalMessageHandler: @preconcurrency WebViewExternalMessag
             return
         }
 
-        let view = CameraPlayerView(
+        CameraOverlayPresenter.shared.show(
+            entityId: entityId,
             server: webViewController.server,
-            cameraEntityId: entityId,
-            cameraName: cameraName
-        ).embeddedInHostingController()
-        view.modalPresentationStyle = .overFullScreen
-        webViewController.presentOverlayController(controller: view, animated: true)
+            cameraName: cameraName,
+            on: webViewController
+        )
     }
 }
 

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -75,7 +75,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
         }
 
         Current.sceneManager.webViewControllerPromise
-            .done { [weak self] webViewController in
+            .done(on: .main) { [weak self] webViewController in
                 guard let self else { return }
                 let server = cameraServer(from: userInfo, fallback: webViewController.server)
                 CameraOverlayPresenter.shared.show(entityId: entityId, server: server, on: webViewController)
@@ -135,7 +135,7 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
     private func hideCamera() {
         Current.sceneManager.webViewControllerPromise
-            .done { webViewController in
+            .done(on: .main) { webViewController in
                 CameraOverlayPresenter.shared.hide(on: webViewController)
             }.catch { error in
                 Current.Log.error("Failed to hide camera from push command: \(error)")

--- a/Sources/App/Notifications/NotificationManager.swift
+++ b/Sources/App/Notifications/NotificationManager.swift
@@ -32,8 +32,6 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
     }()
 
     var commandManager = NotificationCommandManager()
-    private weak var cameraOverlayController: UIViewController?
-    private var displayedCamera: (entityId: String, serverIdentifier: Identifier<Server>)?
 
     /// Hidden, off-screen volume view; `MPVolumeView` only drives the hardware volume while in a window.
     private lazy var volumeControlView = MPVolumeView(frame: CGRect(x: -2000, y: -2000, width: 1, height: 1))
@@ -80,42 +78,8 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
             .done { [weak self] webViewController in
                 guard let self else { return }
                 let server = cameraServer(from: userInfo, fallback: webViewController.server)
-
-                if let displayedCamera,
-                   displayedCamera.entityId == entityId,
-                   displayedCamera.serverIdentifier == server.identifier,
-                   cameraOverlayController != nil {
-                    Current.Log
-                        .info("Ignoring kiosk_show_camera command because camera \(entityId) is already on display")
-                    return
-                }
-
-                let view = CameraPlayerView(
-                    server: server,
-                    cameraEntityId: entityId
-                )
-                .onDisappear { [weak self] in
-                    guard let self else { return }
-                    // Only clear state if this overlay is still the active one. When switching
-                    // directly from one camera to another, the old overlay's onDisappear fires
-                    // after displayedCamera has already been updated for the new camera, so
-                    // clearing unconditionally would wipe the new state and desync the flag.
-                    guard displayedCamera?.entityId == entityId,
-                          displayedCamera?.serverIdentifier == server.identifier else {
-                        return
-                    }
-                    displayedCamera = nil
-                    Current.kiosk.setCameraOverlayVisible(false)
-                }
-                .embeddedInHostingController()
-                cameraOverlayController = view
-                displayedCamera = (entityId: entityId, serverIdentifier: server.identifier)
-                view.modalPresentationStyle = .overFullScreen
-                Current.kiosk.setCameraOverlayVisible(true)
-                webViewController.presentOverlayController(controller: view, animated: true)
-            }.catch { [weak self] error in
-                self?.displayedCamera = nil
-                Current.kiosk.setCameraOverlayVisible(false)
+                CameraOverlayPresenter.shared.show(entityId: entityId, server: server, on: webViewController)
+            }.catch { error in
                 Current.Log.error("Failed to show camera from push command: \(error)")
             }
     }
@@ -171,19 +135,8 @@ class NotificationManager: NSObject, LocalPushManagerDelegate {
 
     private func hideCamera() {
         Current.sceneManager.webViewControllerPromise
-            .done { [weak self] webViewController in
-                guard let cameraOverlayController = self?.cameraOverlayController,
-                      webViewController.overlayedController === cameraOverlayController else {
-                    Current.Log.info("Ignoring kiosk_hide_camera command because no camera is on display")
-                    Current.kiosk.setCameraOverlayVisible(false)
-                    return
-                }
-
-                webViewController.dismissOverlayController(animated: true) { [weak self] in
-                    self?.cameraOverlayController = nil
-                    self?.displayedCamera = nil
-                    Current.kiosk.setCameraOverlayVisible(false)
-                }
+            .done { webViewController in
+                CameraOverlayPresenter.shared.hide(on: webViewController)
             }.catch { error in
                 Current.Log.error("Failed to hide camera from push command: \(error)")
             }

--- a/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
+++ b/Sources/App/Settings/Kiosk/KioskScreensaverView.swift
@@ -146,12 +146,17 @@ final class KioskScreensaverController: ObservableObject {
         didSet {
             guard oldValue != isActive else { return }
             // Mirror visibility into the shared kiosk manager so the kiosk screensaver sensor can report it.
-            Current.kiosk.setScreensaverVisible(isActive)
+            kiosk.setScreensaverVisible(isActive)
         }
     }
 
     @Published private(set) var screensaver = KioskScreensaverSettings()
 
+    var isIdleTimerArmed: Bool {
+        idleTimer != nil
+    }
+
+    private let kiosk: KioskModeManager
     private var isEnabled = false
     private var isCameraOverlayVisible = false
     private var brightnessBeforeDimming: CGFloat?
@@ -160,8 +165,10 @@ final class KioskScreensaverController: ObservableObject {
     private var isMotionObserving = false
     private var isMotionDetected = false
 
-    init() {
-        Current.kiosk.settingsPublisher
+    init(kiosk: KioskModeManager = Current.kiosk) {
+        self.kiosk = kiosk
+
+        kiosk.settingsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.apply($0) }
             .store(in: &cancellables)
@@ -179,15 +186,15 @@ final class KioskScreensaverController: ObservableObject {
             }
             .store(in: &cancellables)
 
-        Current.kiosk.cameraOverlayVisiblePublisher
+        kiosk.cameraOverlayVisiblePublisher
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] visible in
-                self?.isCameraOverlayVisible = visible
-                self?.updateBrightness()
+                self?.cameraOverlayVisibilityChanged(visible)
             }
             .store(in: &cancellables)
 
-        Current.kiosk.screensaverCommandPublisher
+        kiosk.screensaverCommandPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] command in
                 switch command {
@@ -203,7 +210,7 @@ final class KioskScreensaverController: ObservableObject {
         restoreBrightness()
         Current.motionDetection.unregister(observer: self)
         // The screensaver is no longer on screen once this controller goes away (e.g. kiosk mode disabled).
-        Current.kiosk.setScreensaverVisible(false)
+        kiosk.setScreensaverVisible(false)
     }
 
     func recordActivity() {
@@ -213,6 +220,10 @@ final class KioskScreensaverController: ObservableObject {
 
     func show() {
         guard isEnabled else { return }
+        guard !isCameraOverlayVisible else {
+            Current.Log.info("Kiosk: ignoring screensaver show request while a camera is on display")
+            return
+        }
         idleTimer?.invalidate()
         idleTimer = nil
         isActive = true
@@ -223,6 +234,21 @@ final class KioskScreensaverController: ObservableObject {
         isActive = false
         updateBrightness()
         restartIdleTimer()
+    }
+
+    private func cameraOverlayVisibilityChanged(_ visible: Bool) {
+        isCameraOverlayVisible = visible
+        if visible {
+            idleTimer?.invalidate()
+            idleTimer = nil
+            if isActive {
+                Current.Log.info("Kiosk: camera on display, hiding screensaver")
+                isActive = false
+            }
+        } else {
+            restartIdleTimer()
+        }
+        updateBrightness()
     }
 
     private func apply(_ settings: KioskSettings) {
@@ -260,7 +286,7 @@ final class KioskScreensaverController: ObservableObject {
         idleTimer = nil
         // Never arm the idle timer while motion is ongoing: it restarts (with the full
         // interval) once the motion detector reports clear.
-        guard isEnabled, !isActive, !isMotionDetected,
+        guard isEnabled, !isActive, !isMotionDetected, !isCameraOverlayVisible,
               let interval = screensaver.timeToStart.timeInterval else { return }
         idleTimer = Timer.scheduledTimer(
             withTimeInterval: interval,

--- a/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
+++ b/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
@@ -1,0 +1,140 @@
+import GRDB
+@testable import HomeAssistant
+@testable import Shared
+import UIKit
+import XCTest
+
+@MainActor
+final class CameraOverlayPresenterTests: XCTestCase {
+    private var previousDatabase: (() -> DatabaseQueue)!
+    private var kiosk: KioskModeManager!
+    private var presenter: CameraOverlayPresenter!
+    private var webViewController: MockWebViewController!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try KioskSettingsTable().createIfNeeded(database: database)
+        previousDatabase = Current.database
+        Current.database = { database }
+        SensorEnablementStore.resetForTesting()
+
+        kiosk = KioskModeManager()
+        presenter = CameraOverlayPresenter(kiosk: kiosk)
+        webViewController = MockWebViewController()
+    }
+
+    override func tearDown() {
+        Current.database = previousDatabase
+        SensorEnablementStore.resetForTesting()
+        super.tearDown()
+    }
+
+    private var server: Server {
+        webViewController.server
+    }
+
+    private var frontDoor: CameraOverlayPresenter.Camera {
+        .init(entityId: "camera.front_door", serverIdentifier: server.identifier)
+    }
+
+    private var backyard: CameraOverlayPresenter.Camera {
+        .init(entityId: "camera.backyard", serverIdentifier: server.identifier)
+    }
+
+    private func show(_ camera: CameraOverlayPresenter.Camera) {
+        presenter.show(entityId: camera.entityId, server: server, on: webViewController)
+    }
+
+    func testShowPresentsCameraAndFlagsOverlayVisible() {
+        show(frontDoor)
+
+        XCTAssertTrue(webViewController.presentOverlayControllerCalled)
+        XCTAssertEqual(webViewController.overlayedController?.modalPresentationStyle, .overFullScreen)
+        XCTAssertEqual(presenter.displayedCamera, frontDoor)
+        XCTAssertTrue(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+
+    func testShowingTheDisplayedCameraAgainDoesNothing() {
+        show(frontDoor)
+        let presented = webViewController.overlayedController
+        webViewController.presentOverlayControllerCalled = false
+
+        show(frontDoor)
+
+        XCTAssertFalse(webViewController.presentOverlayControllerCalled)
+        XCTAssertIdentical(webViewController.overlayedController, presented)
+        XCTAssertEqual(presenter.displayedCamera, frontDoor)
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+
+    func testShowingAnotherCameraReplacesTheDisplayedOne() {
+        show(frontDoor)
+        let presented = webViewController.overlayedController
+
+        show(backyard)
+
+        XCTAssertNotIdentical(webViewController.overlayedController, presented)
+        XCTAssertEqual(presenter.displayedCamera, backyard)
+        XCTAssertTrue(presenter.isDisplaying(backyard, on: webViewController))
+        XCTAssertFalse(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+
+    func testHideDismissesTheCameraAndClearsState() {
+        show(frontDoor)
+
+        presenter.hide(on: webViewController)
+
+        XCTAssertTrue(webViewController.dismissOverlayControllerCalled)
+        XCTAssertTrue(webViewController.dismissOverlayControllerLastAnimated)
+
+        webViewController.overlayedController = nil
+        webViewController.dismissOverlayControllerLastCompletion?()
+
+        XCTAssertNil(presenter.displayedCamera)
+        XCTAssertFalse(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertFalse(kiosk.isCameraOverlayVisible)
+    }
+
+    func testHideWithoutCameraOnDisplayDoesNotDismissAnything() {
+        kiosk.setCameraOverlayVisible(true)
+
+        presenter.hide(on: webViewController)
+
+        XCTAssertFalse(webViewController.dismissOverlayControllerCalled)
+        XCTAssertNil(presenter.displayedCamera)
+        XCTAssertFalse(kiosk.isCameraOverlayVisible)
+    }
+
+    func testHideLeavesAnOverlayThatIsNotTheCameraAlone() {
+        show(frontDoor)
+        webViewController.overlayedController = UIViewController()
+
+        presenter.hide(on: webViewController)
+
+        XCTAssertFalse(webViewController.dismissOverlayControllerCalled)
+        XCTAssertNil(presenter.displayedCamera)
+        XCTAssertFalse(kiosk.isCameraOverlayVisible)
+    }
+
+    func testShowWhileDismissingIsDeferredUntilDismissalCompletes() {
+        show(frontDoor)
+        presenter.hide(on: webViewController)
+        webViewController.presentOverlayControllerCalled = false
+
+        show(frontDoor)
+
+        XCTAssertFalse(webViewController.presentOverlayControllerCalled)
+
+        webViewController.overlayedController = nil
+        webViewController.dismissOverlayControllerLastCompletion?()
+
+        XCTAssertTrue(webViewController.presentOverlayControllerCalled)
+        XCTAssertEqual(presenter.displayedCamera, frontDoor)
+        XCTAssertTrue(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+}

--- a/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
+++ b/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
@@ -120,6 +120,40 @@ final class CameraOverlayPresenterTests: XCTestCase {
         XCTAssertFalse(kiosk.isCameraOverlayVisible)
     }
 
+    func testOverlayDisappearingClearsStateForTheDisplayedCamera() {
+        show(frontDoor)
+
+        presenter.overlayDidDisappear(frontDoor)
+
+        XCTAssertNil(presenter.displayedCamera)
+        XCTAssertFalse(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertFalse(kiosk.isCameraOverlayVisible)
+    }
+
+    func testOverlayDisappearingForAnotherCameraIsIgnored() {
+        show(frontDoor)
+
+        presenter.overlayDidDisappear(backyard)
+
+        XCTAssertEqual(presenter.displayedCamera, frontDoor)
+        XCTAssertTrue(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+
+    func testShowAfterDismissalFinishedWithoutCompletionPresents() {
+        show(frontDoor)
+        presenter.hide(on: webViewController)
+        webViewController.overlayedController = nil
+        webViewController.presentOverlayControllerCalled = false
+
+        show(frontDoor)
+
+        XCTAssertTrue(webViewController.presentOverlayControllerCalled)
+        XCTAssertEqual(presenter.displayedCamera, frontDoor)
+        XCTAssertTrue(presenter.isDisplaying(frontDoor, on: webViewController))
+        XCTAssertTrue(kiosk.isCameraOverlayVisible)
+    }
+
     func testShowWhileDismissingIsDeferredUntilDismissalCompletes() {
         show(frontDoor)
         presenter.hide(on: webViewController)

--- a/Tests/App/Kiosk/KioskScreensaverControllerTests.swift
+++ b/Tests/App/Kiosk/KioskScreensaverControllerTests.swift
@@ -1,0 +1,116 @@
+import GRDB
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+@MainActor
+final class KioskScreensaverControllerTests: XCTestCase {
+    private var database: DatabaseQueue!
+    private var previousDatabase: (() -> DatabaseQueue)!
+    private var kiosk: KioskModeManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try KioskSettingsTable().createIfNeeded(database: database)
+        self.database = database
+        previousDatabase = Current.database
+        Current.database = { database }
+        SensorEnablementStore.resetForTesting()
+    }
+
+    override func tearDown() {
+        Current.database = previousDatabase
+        SensorEnablementStore.resetForTesting()
+        super.tearDown()
+    }
+
+    func testShowCommandActivatesScreensaver() throws {
+        let controller = try makeController()
+
+        kiosk.requestScreensaver(.show)
+
+        waitUntil("screensaver active") { controller.isActive }
+        XCTAssertTrue(kiosk.isScreensaverVisible)
+    }
+
+    func testShowCommandIsIgnoredWhileCameraIsOnDisplay() throws {
+        let controller = try makeController()
+        kiosk.setCameraOverlayVisible(true)
+        pumpMainQueue()
+
+        kiosk.requestScreensaver(.show)
+        pumpMainQueue()
+
+        XCTAssertFalse(controller.isActive)
+        XCTAssertFalse(kiosk.isScreensaverVisible)
+    }
+
+    func testCameraAppearingDismissesActiveScreensaver() throws {
+        let controller = try makeController()
+        kiosk.requestScreensaver(.show)
+        waitUntil("screensaver active") { controller.isActive }
+
+        kiosk.setCameraOverlayVisible(true)
+
+        waitUntil("screensaver dismissed") { !controller.isActive }
+        XCTAssertFalse(kiosk.isScreensaverVisible)
+    }
+
+    func testScreensaverCanShowAgainOnceCameraIsHidden() throws {
+        let controller = try makeController()
+        kiosk.setCameraOverlayVisible(true)
+        pumpMainQueue()
+        kiosk.requestScreensaver(.show)
+        pumpMainQueue()
+        XCTAssertFalse(controller.isActive)
+
+        kiosk.setCameraOverlayVisible(false)
+        pumpMainQueue()
+        kiosk.requestScreensaver(.show)
+
+        waitUntil("screensaver active") { controller.isActive }
+    }
+
+    func testIdleTimerIsHeldWhileCameraIsOnDisplay() throws {
+        let controller = try makeController(timeToStart: .seconds30)
+        waitUntil("idle timer armed") { controller.isIdleTimerArmed }
+
+        kiosk.setCameraOverlayVisible(true)
+        waitUntil("idle timer held") { !controller.isIdleTimerArmed }
+
+        kiosk.setCameraOverlayVisible(false)
+        waitUntil("idle timer re-armed") { controller.isIdleTimerArmed }
+    }
+
+    // MARK: - Helpers
+
+    private func makeController(
+        timeToStart: KioskScreensaverTimeout = .pushNotificationControlled
+    ) throws -> KioskScreensaverController {
+        try database.write { db in
+            var settings = KioskSettings()
+            settings.enabled = true
+            settings.screensaver.enabled = true
+            settings.screensaver.timeToStart = timeToStart
+            try settings.insert(db, onConflict: .replace)
+        }
+        kiosk = KioskModeManager()
+        let controller = KioskScreensaverController(kiosk: kiosk)
+        waitUntil("screensaver settings applied") { controller.screensaver.enabled }
+        return controller
+    }
+
+    private func pumpMainQueue(for interval: TimeInterval = 0.2) {
+        RunLoop.current.run(until: Date().addingTimeInterval(interval))
+    }
+
+    private func waitUntil(_ what: String, timeout: TimeInterval = 5, condition: () -> Bool) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTAssertTrue(condition(), "timed out waiting for \(what)")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
In kiosk mode, a camera shown with `kiosk_show_camera` and the screensaver could fight each other: the screensaver still activated underneath a visible camera, so the screensaver sensor reported on and the user landed on the screensaver once the camera was hidden. Cameras opened from the dashboard were also invisible to the kiosk commands, and a `kiosk_show_camera` arriving while a hide was animating was dropped.

- The screensaver now treats a visible camera as a block: the idle timer is held, `kiosk_show_screensaver` is ignored, and an active screensaver is dismissed when a camera appears. The timer re-arms once the camera goes away.
- Camera overlay bookkeeping moved into `CameraOverlayPresenter`, shared by the push command and the frontend `camera/show` message. Showing the camera that is already on display does nothing, and a show requested during a dismissal is replayed once it completes.

## Screenshots

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
