### PR TITLE
Cover the open and close parameter summary

### DIFF
--- a/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
+++ b/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
@@ -118,4 +118,12 @@ struct OpenCloseEntityAppIntentTests {
             #expect(OpenCloseActionAppEnum.caseDisplayRepresentations[action] != nil)
         }
     }
+
+    /// Reading the summary runs the builder that lays the command out in the Shortcuts editor.
+    /// Nothing else in these tests reaches it, and a summary that names a parameter the intent no
+    /// longer has stops the editor from drawing it.
+    @Test func theSummaryBuilds() {
+        #expect(!String(describing: OpenCloseEntityAppIntent.parameterSummary).isEmpty)
+        #expect(!String(localized: OpenCloseEntityAppIntent.title).isEmpty)
+    }
 }

--- a/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
+++ b/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
@@ -124,6 +124,5 @@ struct OpenCloseEntityAppIntentTests {
     /// longer has stops the editor from drawing it.
     @Test func theSummaryBuilds() {
         #expect(!String(describing: OpenCloseEntityAppIntent.parameterSummary).isEmpty)
-        #expect(!String(localized: OpenCloseEntityAppIntent.title).isEmpty)
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Follows #5666, which landed at 97.75% patch coverage. The two lines left uncovered were the open and close command's parameter summary — the builder that lays it out in the Shortcuts editor, which no other test reaches. A summary naming a parameter the intent no longer has stops the editor from drawing it, so it is worth a test.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Tests only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behaviour change.
