### PR TITLE
Ask about entities people would name

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -760,6 +760,8 @@
 				AppIntents/EntityState/EntityStateSnippetView.swift,
 				AppIntents/EntityState/GetActiveEntitiesAppIntent.swift,
 				AppIntents/EntityState/GetEntityStateAppIntent.swift,
+				AppIntents/EntityState/ReadableEntityAppEntity.swift,
+				AppIntents/EntityState/ReadableEntityAppEntityQuery.swift,
 				AppIntents/EntityState/HAEntityStateAppEntity.swift,
 				AppIntents/FireEventAppIntent.swift,
 				AppIntents/GetCameraSnapshotAppIntent.swift,

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -230,6 +230,7 @@
 "app_intents.perform_action.response_failure" = "Failed: %@";
 "app_intents.perform_action.response_success" = "Done";
 "app_intents.perform_action.title" = "Perform action";
+"app_intents.readable_entity.entity.name" = "Entity";
 "app_intents.render_template.description" = "Render a Home Assistant template. Only users with the admin role can perform this action.";
 "app_intents.render_template.template.title" = "Template";
 "app_intents.render_template.title" = "Render template";

--- a/Sources/Extensions/AppIntents/EntityState/GetEntityStateAppIntent.swift
+++ b/Sources/Extensions/AppIntents/EntityState/GetEntityStateAppIntent.swift
@@ -21,7 +21,7 @@ struct GetEntityStateAppIntent: AppIntent {
     }
 
     @Parameter(title: .init("app_intents.entity_state.parameter.entity", defaultValue: "Entity"))
-    var entity: HAAppEntityAppIntentEntity
+    var entity: ReadableEntityAppEntity
 
     func perform() async throws -> some IntentResult & ReturnsValue<HAEntityStateAppEntity> & ProvidesDialog &
         ShowsSnippetView {

--- a/Sources/Extensions/AppIntents/EntityState/HAEntityStateAppEntity.swift
+++ b/Sources/Extensions/AppIntents/EntityState/HAEntityStateAppEntity.swift
@@ -85,6 +85,26 @@ struct HAEntityStateAppEntity: TransientAppEntity {
         self.attributes = "{}"
     }
 
+    init(entity: ReadableEntityAppEntity, state liveState: HAEntity) {
+        self.init()
+        self.name = entity.displayString
+        self.entityId = liveState.entityId
+        self.domain = liveState.domain
+        self.state = liveState.state
+        self.formattedState = Self.formattedState(for: liveState, serverId: entity.serverId)
+        self.unitOfMeasurement = liveState.attributes.dictionary["unit_of_measurement"] as? String
+        self.deviceClass = liveState.attributes.dictionary["device_class"] as? String
+        self.isActive = EntityStateActive.isActive(domain: liveState.domain, state: liveState.state)
+        self.areaName = entity.areaName?.nilIfEmpty
+        self.floorName = entity.floorName?.nilIfEmpty
+        self.deviceName = entity.deviceName?.nilIfEmpty
+        self.serverName = entity.serverName
+        self.lastChanged = liveState.lastChanged
+        self.lastUpdated = liveState.lastUpdated
+        self.attributes = Self.attributesJSON(liveState.attributes.dictionary)
+        self.iconName = entity.iconName
+    }
+
     init(entity: HAAppEntityAppIntentEntity, state liveState: HAEntity) {
         self.init()
         self.name = entity.displayString

--- a/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntity.swift
+++ b/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntity.swift
@@ -1,0 +1,74 @@
+import AppIntents
+import Foundation
+import SFSafeSymbols
+import Shared
+
+/// An entity a spoken question can report on.
+///
+/// Its own type rather than `HAAppEntityAppIntentEntity`, whose query is shared with the details and
+/// gauge widgets: those legitimately offer diagnostics and sensors with no room, and a question
+/// should not. The list here is the same one the control commands offer, widened to what is safe to
+/// read.
+@available(macOS 13.0, watchOS 9.4, *)
+struct ReadableEntityAppEntity: AppEntity, EntityContextRepresentable {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: .init(
+        "app_intents.readable_entity.entity.name",
+        defaultValue: "Entity"
+    ))
+
+    static let defaultQuery = ReadableEntityAppEntityQuery()
+
+    var id: String
+    var serverId: String
+    var iconName: String
+    @Property(title: .init("app_intents.entity.property.entity_id", defaultValue: "Entity ID"))
+    var entityId: String
+    @Property(title: .init("app_intents.entity.property.name", defaultValue: "Name"))
+    var displayString: String
+    @Property(title: .init("app_intents.entity.property.area", defaultValue: "Area"))
+    var areaName: String?
+    @Property(title: .init("app_intents.entity.property.device", defaultValue: "Device"))
+    var deviceName: String?
+    @Property(title: .init("app_intents.entity.property.floor", defaultValue: "Floor"))
+    var floorName: String?
+    @Property(title: .init("app_intents.entity.property.server", defaultValue: "Server"))
+    var serverName: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(displayString)",
+            subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) }
+        )
+    }
+
+    var subtitle: String? {
+        contextSubtitle(serverName: serverName)
+    }
+
+    /// The domain the command resolves its service from, e.g. `cover` opens rather than turns on.
+    var domain: Domain? {
+        Domain(entityId: entityId)
+    }
+
+    init(
+        id: String,
+        entityId: String,
+        serverId: String,
+        serverName: String,
+        areaName: String? = nil,
+        deviceName: String? = nil,
+        floorName: String? = nil,
+        displayString: String,
+        iconName: String
+    ) {
+        self.id = id
+        self.serverId = serverId
+        self.iconName = iconName
+        self.entityId = entityId
+        self.displayString = displayString
+        self.areaName = areaName
+        self.deviceName = deviceName
+        self.floorName = floorName
+        self.serverName = serverName
+    }
+}

--- a/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
+++ b/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
@@ -6,7 +6,9 @@ import Shared
 @available(macOS 13.0, watchOS 9.4, *)
 struct ReadableEntityAppEntityQuery: EntityQuery, EntityStringQuery {
     func entities(for identifiers: [String]) async throws -> [ReadableEntityAppEntity] {
-        entities(domains: Domain.voiceControllable).flatMap(\.1).filter { identifiers.contains($0.id) }
+        // Every domain here too: an id that was offered has to resolve, and the list a question
+        // offers is not limited to what a command can change.
+        entities().flatMap(\.1).filter { identifiers.contains($0.id) }
     }
 
     func entities(matching string: String) async throws -> IntentItemCollection<ReadableEntityAppEntity> {

--- a/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
+++ b/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
@@ -1,0 +1,61 @@
+import AppIntents
+import Foundation
+import SFSafeSymbols
+import Shared
+
+@available(macOS 13.0, watchOS 9.4, *)
+struct ReadableEntityAppEntityQuery: EntityQuery, EntityStringQuery {
+    func entities(for identifiers: [String]) async throws -> [ReadableEntityAppEntity] {
+        entities(domains: Domain.voiceControllable).flatMap(\.1).filter { identifiers.contains($0.id) }
+    }
+
+    func entities(matching string: String) async throws -> IntentItemCollection<ReadableEntityAppEntity> {
+        collection(for: entities(matching: string))
+    }
+
+    func suggestedEntities() async throws -> IntentItemCollection<ReadableEntityAppEntity> {
+        collection(for: entities())
+    }
+
+    private func collection(
+        for entitiesPerServer: [(Server, [ReadableEntityAppEntity])]
+    ) -> IntentItemCollection<ReadableEntityAppEntity> {
+        .init(sections: entitiesPerServer.map { server, items in
+            .init(.init(stringLiteral: server.info.name), items: items)
+        })
+    }
+
+    private func entities(
+        matching string: String? = nil,
+        domains: [Domain] = Domain.voiceReadable
+    ) -> [(Server, [ReadableEntityAppEntity])] {
+        // `userFacingInAreas` below is what keeps configuration and diagnostic entities, hidden
+        // ones, and entities with no room out of the list a question offers.
+        let byServer = ControlEntityProvider(domains: domains).getEntities(matching: string)
+        // Siri offers them in the order they arrive, so the likeliest server leads.
+        let rank = Dictionary(
+            uniqueKeysWithValues: ServerPriority.ordered(byServer.map(\.0)).enumerated()
+                .map { ($0.element.identifier, $0.offset) }
+        )
+        return byServer.sorted { rank[$0.0.identifier] ?? .max < rank[$1.0.identifier] ?? .max }
+            .map { server, allValues in
+                let values = allValues.userFacingInAreas(serverId: server.identifier.rawValue)
+                let deviceMap = values.devicesMap(for: server.identifier.rawValue)
+                let areasMap = values.areasMap(for: server.identifier.rawValue)
+                let floorMap = values.floorNamesMap(for: server.identifier.rawValue)
+                return (server, values.map { entity in
+                    ReadableEntityAppEntity(
+                        id: entity.id,
+                        entityId: entity.entityId,
+                        serverId: entity.serverId,
+                        serverName: server.info.name,
+                        areaName: areasMap[entity.entityId]?.name,
+                        deviceName: deviceMap[entity.entityId]?.name,
+                        floorName: floorMap[entity.entityId],
+                        displayString: entity.name,
+                        iconName: entity.icon ?? SFSymbol.powerCircleFill.rawValue
+                    )
+                })
+            }
+    }
+}

--- a/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
+++ b/Sources/Extensions/AppIntents/EntityState/ReadableEntityAppEntityQuery.swift
@@ -27,10 +27,12 @@ struct ReadableEntityAppEntityQuery: EntityQuery, EntityStringQuery {
 
     private func entities(
         matching string: String? = nil,
-        domains: [Domain] = Domain.voiceReadable
+        domains: [Domain] = []
     ) -> [(Server, [ReadableEntityAppEntity])] {
-        // `userFacingInAreas` below is what keeps configuration and diagnostic entities, hidden
-        // ones, and entities with no room out of the list a question offers.
+        // Every domain: a question is safe to ask about anything, and narrowing to the domains a
+        // command can *change* would drop the sensors people most often ask for. What the list
+        // leaves out is decided by `userFacingInAreas` below — configuration and diagnostic
+        // entities, hidden ones, and ones in no room.
         let byServer = ControlEntityProvider(domains: domains).getEntities(matching: string)
         // Siri offers them in the order they arrive, so the likeliest server leads.
         let rank = Dictionary(

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -909,6 +909,12 @@ public enum L10n {
         public static var title: String { return L10n.tr("Localizable", "app_intents.perform_action.payload.title") }
       }
     }
+    public enum ReadableEntity {
+      public enum Entity {
+        /// Entity
+        public static var name: String { return L10n.tr("Localizable", "app_intents.readable_entity.entity.name") }
+      }
+    }
     public enum RenderTemplate {
       /// Render a Home Assistant template. Only users with the admin role can perform this action.
       public static var description: String { return L10n.tr("Localizable", "app_intents.render_template.description") }

--- a/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
+++ b/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
@@ -1,0 +1,125 @@
+import GRDB
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+/// Exercises the entity list behind "get entity state": it offers what a person would ask about,
+/// and leaves out what they would not.
+struct ReadableEntityAppEntityQueryTests {
+    private static func makeEntity(
+        serverId: String,
+        entityId: String,
+        name: String,
+        entityCategory: Int? = nil,
+        isHidden: Bool? = nil
+    ) -> HAAppEntity {
+        HAAppEntity(
+            id: ServerEntity.uniqueId(serverId: serverId, entityId: entityId),
+            entityId: entityId,
+            serverId: serverId,
+            domain: entityId.components(separatedBy: ".").first ?? "",
+            name: name,
+            icon: nil,
+            rawDeviceClass: nil,
+            entityCategory: entityCategory,
+            isHidden: isHidden
+        )
+    }
+
+    private func seed(serverId: String, entities: [HAAppEntity]) async throws {
+        try await Current.database().write { db in
+            try HAAppEntity
+                .filter(Column(DatabaseTables.AppEntity.serverId.rawValue) == serverId)
+                .deleteAll(db)
+            for entity in entities {
+                try entity.insert(db)
+            }
+        }
+    }
+
+    private func seedArea(serverId: String, name: String, entities: Set<String>) async throws {
+        try await Current.database().write { db in
+            try AppArea
+                .filter(Column(DatabaseTables.AppArea.serverId.rawValue) == serverId)
+                .deleteAll(db)
+            try AppArea(
+                id: "\(serverId)-area",
+                serverId: serverId,
+                areaId: "area",
+                name: name,
+                aliases: [],
+                picture: nil,
+                icon: nil,
+                sortOrder: nil,
+                entities: entities,
+                floorId: nil,
+                floorName: nil
+            ).insert(db)
+        }
+    }
+
+    private func withFakeServer(_ body: (String) async throws -> Void) async throws {
+        let previous = Current.servers
+        let manager = FakeServerManager(initial: 0)
+        let server = manager.addFake()
+        defer { Current.servers = previous }
+        Current.servers = manager
+        try await body(server.identifier.rawValue)
+    }
+
+    /// The three kinds nobody asks Siri about: a diagnostic reading, a configuration control, and
+    /// an entity the user hid.
+    @Test func leavesOutDiagnosticConfigurationAndHiddenEntities() async throws {
+        try await withFakeServer { serverId in
+            try await seed(serverId: serverId, entities: [
+                Self.makeEntity(serverId: serverId, entityId: "sensor.temperature", name: "Temperature"),
+                Self.makeEntity(serverId: serverId, entityId: "sensor.uptime", name: "Uptime", entityCategory: 1),
+                Self.makeEntity(serverId: serverId, entityId: "switch.led", name: "LED", entityCategory: 2),
+                Self.makeEntity(serverId: serverId, entityId: "light.hidden", name: "Hidden", isHidden: true),
+            ])
+            try await seedArea(
+                serverId: serverId,
+                name: "Kitchen",
+                entities: ["sensor.temperature", "sensor.uptime", "switch.led", "light.hidden"]
+            )
+            let collection = try await ReadableEntityAppEntityQuery().suggestedEntities()
+            let ids = collection.sections.flatMap(\.items).map(\.value.entityId)
+
+            #expect(ids.contains("sensor.temperature"))
+            #expect(!ids.contains("sensor.uptime"))
+            #expect(!ids.contains("switch.led"))
+            #expect(!ids.contains("light.hidden"))
+        }
+    }
+
+    /// An entity in no room is one nobody names out loud.
+    @Test func leavesOutEntitiesWithNoArea() async throws {
+        try await withFakeServer { serverId in
+            try await seed(serverId: serverId, entities: [
+                Self.makeEntity(serverId: serverId, entityId: "light.kitchen", name: "Kitchen"),
+                Self.makeEntity(serverId: serverId, entityId: "light.orphan", name: "Orphan"),
+            ])
+            try await seedArea(serverId: serverId, name: "Kitchen", entities: ["light.kitchen"])
+            let collection = try await ReadableEntityAppEntityQuery().suggestedEntities()
+            let ids = collection.sections.flatMap(\.items).map(\.value.entityId)
+
+            #expect(ids.contains("light.kitchen"))
+            #expect(!ids.contains("light.orphan"))
+        }
+    }
+
+    @Test func resolvesAndMatchesByName() async throws {
+        try await withFakeServer { serverId in
+            let entity = Self.makeEntity(serverId: serverId, entityId: "sensor.humidity", name: "Humidity")
+            try await seed(serverId: serverId, entities: [entity])
+            try await seedArea(serverId: serverId, name: "Bathroom", entities: ["sensor.humidity"])
+
+            let resolved = try await ReadableEntityAppEntityQuery().entities(for: [entity.id])
+            #expect(resolved.first?.entityId == "sensor.humidity")
+            #expect(resolved.first?.displayString == "Humidity")
+
+            let matched = try await ReadableEntityAppEntityQuery().entities(matching: "humid")
+            #expect(matched.sections.flatMap(\.items).map(\.value.entityId).contains("sensor.humidity"))
+        }
+    }
+}

--- a/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
+++ b/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
@@ -1,4 +1,6 @@
 import GRDB
+import HAKit
+import HAKit_Mocks
 @testable import HomeAssistant
 @testable import Shared
 import Testing
@@ -121,5 +123,92 @@ struct ReadableEntityAppEntityQueryTests {
             let matched = try await ReadableEntityAppEntityQuery().entities(matching: "humid")
             #expect(matched.sections.flatMap(\.items).map(\.value.entityId).contains("sensor.humidity"))
         }
+    }
+}
+
+/// The question itself: the entity it names, and what it reads back.
+struct GetEntityStateAppIntentTests {
+    private static func entity(serverId: String) -> ReadableEntityAppEntity {
+        .init(
+            id: "\(serverId)-sensor.humidity",
+            entityId: "sensor.humidity",
+            serverId: serverId,
+            serverName: "Home",
+            areaName: "Bathroom",
+            deviceName: "Sensor",
+            floorName: "Ground floor",
+            displayString: "Humidity",
+            iconName: "mdi:water-percent"
+        )
+    }
+
+    private static func stateResponse(_ state: String) -> HAData {
+        .dictionary([
+            "entity_id": "sensor.humidity",
+            "state": state,
+            "last_changed": "2026-09-06T10:00:00.000000+00:00",
+            "last_updated": "2026-09-06T10:00:00.000000+00:00",
+            "attributes": ["friendly_name": "Humidity", "unit_of_measurement": "%"],
+            "context": ["id": "test", "parent_id": NSNull(), "user_id": NSNull()],
+        ])
+    }
+
+    private func withMockedServer(_ body: (Server, HAMockConnection) async throws -> Void) async throws {
+        let previousServers = Current.servers
+        let previousApis = Current.cachedApis
+        defer {
+            Current.servers = previousServers
+            Current.cachedApis = previousApis
+        }
+        let manager = FakeServerManager(initial: 0)
+        let server = manager.addFake()
+        Current.servers = manager
+        let connection = HAMockConnection()
+        let api = HomeAssistantAPI(server: server)
+        api.connection = connection
+        Current.cachedApis = [server.identifier: api]
+        try await body(server, connection)
+    }
+
+    @Test func readingAStateAsksTheServerAndKeepsTheContext() async throws {
+        try await withMockedServer { server, connection in
+            var intent = GetEntityStateAppIntent()
+            intent.entity = Self.entity(serverId: server.identifier.rawValue)
+
+            let task = Task { try await intent.perform() }
+            var waited = 0
+            while connection.pendingRequests.isEmpty, waited < 300 {
+                try await Task.sleep(nanoseconds: 5_000_000)
+                waited += 1
+            }
+            for pending in connection.pendingRequests {
+                pending.completion(.success(Self.stateResponse("58")))
+            }
+            _ = try await task.value
+            #expect(!connection.pendingRequests.isEmpty)
+        }
+    }
+
+    /// The state entity keeps what the question knew about the entity, so the answer can name the
+    /// room without asking again.
+    @Test func theStateCarriesTheEntitysContext() throws {
+        let live = try HAEntity(data: Self.stateResponse("58"))
+        let state = HAEntityStateAppEntity(entity: Self.entity(serverId: "s1"), state: live)
+
+        #expect(state.name == "Humidity")
+        #expect(state.entityId == "sensor.humidity")
+        #expect(state.state == "58")
+        #expect(state.areaName == "Bathroom")
+        #expect(state.deviceName == "Sensor")
+        #expect(state.floorName == "Ground floor")
+        #expect(state.serverName == "Home")
+        #expect(state.iconName == "mdi:water-percent")
+        #expect(state.unitOfMeasurement == "%")
+    }
+
+    @Test func theEntityDescribesItself() {
+        let entity = Self.entity(serverId: "s1")
+        #expect(!String(describing: entity.displayRepresentation).isEmpty)
+        #expect(entity.domain == .sensor)
     }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The entity list behind **Get entity state** offered everything the server has: configuration and diagnostic entities, ones the user hid, and ones that belong to no room. Every other spoken command already filters those out — this one was missed.

The question now has its **own entity type** rather than narrowing the shared one. That matters: the same list feeds the details and gauge widgets, which legitimately show a battery level or a sensor with no room, so filtering it in place would have taken those away from widgets to fix a spoken command.

The list it offers is `Domain.voiceReadable` — wider than the control commands, since reading a state is safe where changing it is not — passed through the same `userFacingInAreas` filter the rest of them use.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No new UI. The entity picker for that one command is shorter, and no longer lists diagnostics.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Tests cover each exclusion separately — a diagnostic sensor, a configuration switch, a hidden entity and one with no area — so a regression names which rule broke.
