### PR TITLE
Draw picker rows with SF Symbols

### DIFF
--- a/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
+++ b/Sources/Extensions/Widgets/HAAppEntityAppIntentEntity.swift
@@ -30,16 +30,22 @@ struct HAAppEntityAppIntentEntity: AppEntity, EntityContextRepresentable {
     /// groups entities under a per-server section.
     var includesServerContext: Bool
 
-    /// The icon is the entity's own Material Design glyph rather than an SF Symbol: Home Assistant
-    /// lets people choose an icon per entity, and mapping those onto SF Symbols would throw that
-    /// choice away. `EntityIconRenderer` memoizes by icon name, so a long picker redraws cheaply.
+    /// The icon is the domain's SF Symbol, not the entity's own Material Design glyph.
+    ///
+    /// Drawing the glyph here meant rendering an image per row as the list scrolled, which made the
+    /// Shortcuts app stutter. A symbol name costs nothing to pass and the system draws it. Spotlight
+    /// results still carry the real glyph, where it is rendered once per index pass.
     var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayString)",
             subtitle: subtitle.map { LocalizedStringResource(stringLiteral: $0) },
-            image: EntityIconRenderer.thumbnailData(iconName: iconName).map { .init(data: $0) }
+            image: .init(systemName: Domain(entityId: entityId)?.sfSymbolName ?? Self.fallbackSymbolName)
         )
     }
+
+    /// A domain the app does not model still gets a row, and an on/off glyph is the least wrong
+    /// thing to show for one.
+    static let fallbackSymbolName = SFSymbol.powerCircle.rawValue
 
     /// The `Server • Floor • Area • Device` line shown under the entity name.
     var subtitle: String? {

--- a/Sources/Shared/Domain/Domain+SFSymbol.swift
+++ b/Sources/Shared/Domain/Domain+SFSymbol.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SFSafeSymbols
+
+public extension Domain {
+    /// The SF Symbol that stands in for this domain in an App Intents picker.
+    ///
+    /// Pickers draw an icon per row as the list scrolls, and rendering the entity's own Material
+    /// Design glyph to an image there made the Shortcuts app stutter. A symbol name costs nothing
+    /// to pass and the system draws it, so the picker stays smooth. The trade is per-domain rather
+    /// than per-entity accuracy: an entity whose icon was customized in Home Assistant shows its
+    /// domain's symbol here. Spotlight results and the result card still draw the real glyph, where
+    /// the cost is paid once rather than per row.
+    var sfSymbolName: String {
+        symbol.rawValue
+    }
+
+    private var symbol: SFSymbol {
+        switch self {
+        case .light: .lightbulb
+        case .switch, .inputBoolean: .powerCircle
+        case .fan: .fanblades
+        case .cover: .blindsHorizontalClosed
+        case .valve: .spigot
+        case .lock: .lock
+        case .climate, .waterHeater: .thermometerMedium
+        case .humidifier: .humidity
+        case .mediaPlayer: .playCircle
+        case .camera: .videoCircle
+        case .scene: .moonStars
+        case .script, .automation: .playSquare
+        case .sensor, .binarySensor, .airQuality: .sensorTagRadiowavesForward
+        case .person, .deviceTracker: .personCircle
+        case .zone, .geoLocation: .mappinCircle
+        case .calendar, .schedule, .date, .dateTime, .time: .calendar
+        case .todo: .checklist
+        case .alarmControlPanel: .shield
+        case .siren, .alert: .bellBadge
+        case .vacuum, .lawnMower: .sparkles
+        case .weather, .sun: .cloudSun
+        case .update: .arrowTriangle2Circlepath
+        case .timer, .counter: .timer
+        case .button, .inputButton: .handTap
+        case .number, .inputNumber: .numberCircle
+        case .select, .inputSelect: .listBullet
+        case .text, .inputText, .inputDatetime: .characterCursorIbeam
+        case .group: .squareStack
+        case .remote: .avRemote
+        case .image, .imageProcessing: .photo
+        case .plant: .leaf
+        case .tag: .tag
+        case .conversation, .assistSatellite, .stt, .tts, .wakeWord, .aiTask: .bubbleLeftAndBubbleRight
+        case .notify: .bellCircle
+        case .event: .bolt
+        case .infrared, .radioFrequency: .dotRadiowavesLeftAndRight
+        case .configurator: .gearshape
+        }
+    }
+}

--- a/Tests/App/Utilities/DomainSFSymbolTests.swift
+++ b/Tests/App/Utilities/DomainSFSymbolTests.swift
@@ -1,0 +1,25 @@
+import SFSafeSymbols
+@testable import Shared
+import Testing
+import UIKit
+
+/// The picker draws these per row, so a name that resolves to nothing would leave the list blank.
+struct DomainSFSymbolTests {
+    @Test func everyDomainResolvesToASymbolTheSystemCanDraw() {
+        for domain in Domain.allCases {
+            let name = domain.sfSymbolName
+            #expect(!name.isEmpty, "\(domain.rawValue) has no symbol")
+            #expect(UIImage(systemName: name) != nil, "\(domain.rawValue) maps to \(name), which does not render")
+        }
+    }
+
+    /// The domains a spoken command reaches are the ones worth reading at a glance, so they get
+    /// something recognisable rather than the fallback.
+    @Test func theVoiceDomainsGetTheirOwnSymbol() {
+        #expect(Domain.light.sfSymbolName == SFSymbol.lightbulb.rawValue)
+        #expect(Domain.lock.sfSymbolName == SFSymbol.lock.rawValue)
+        #expect(Domain.cover.sfSymbolName == SFSymbol.blindsHorizontalClosed.rawValue)
+        #expect(Domain.climate.sfSymbolName == SFSymbol.thermometerMedium.rawValue)
+        #expect(Domain.fan.sfSymbolName == SFSymbol.fanblades.rawValue)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The entity picker rendered each row's Material Design glyph to an image as the list scrolled, and the Shortcuts app stuttered for it. Rows now carry an SF Symbol name and the system draws it.

The symbol comes from the entity's **domain**. Mapping every Material Design glyph would not be maintainable, and a domain is something every entity has. The trade is worth naming: an entity whose icon was customized in Home Assistant now shows its domain's symbol in the picker.

Spotlight results and the spoken-command result card still draw the real glyph — those render once rather than once per row, so they were never the cost.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Picker rows keep their icon; it is the domain's SF Symbol rather than the entity's own glyph. Scrolling no longer stutters.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
A test walks every `Domain` case and asserts the name actually resolves through `UIImage(systemName:)` — a symbol that exists in the enum but not on the deployment target would otherwise leave rows blank at runtime.
