### PR TITLE
Answer both requests the command sends

### DIFF
--- a/Tests/App/Utilities/TurnOnOffEntityAppIntentTests.swift
+++ b/Tests/App/Utilities/TurnOnOffEntityAppIntentTests.swift
@@ -35,29 +35,49 @@ struct TurnOnOffEntityAppIntentTests {
         try await body(server, connection)
     }
 
+    /// A state the read back can decode, so the command builds its card rather than dropping it.
+    private static func stateResponse(entityId: String) -> HAData {
+        .dictionary([
+            "entity_id": entityId,
+            "state": "on",
+            "last_changed": "2026-09-06T10:00:00.000000+00:00",
+            "last_updated": "2026-09-06T10:00:00.000000+00:00",
+            "attributes": ["friendly_name": "Ceiling"],
+            "context": ["id": "test", "parent_id": NSNull(), "user_id": NSNull()],
+        ])
+    }
+
+    /// The command sends two requests: the service, then the state it reads back to describe. Both
+    /// are answered, or the card is never built and half the command goes unexercised.
     private func serviceCalled(
         _ intent: TurnOnOffEntityAppIntent,
-        connection: HAMockConnection
+        connection: HAMockConnection,
+        entityId: String
     ) async throws -> String? {
         let task = Task { try await intent.perform() }
+        var answered = 0
         var waited = 0
-        while connection.pendingRequests.isEmpty, waited < 300 {
+        var first: HARequest?
+        while answered < 2, waited < 400 {
+            if connection.pendingRequests.count > answered {
+                let pending = connection.pendingRequests[answered]
+                if answered == 0 { first = pending.request }
+                pending.completion(.success(Self.stateResponse(entityId: entityId)))
+                answered += 1
+                continue
+            }
             try await Task.sleep(nanoseconds: 5_000_000)
             waited += 1
         }
-        let request = connection.pendingRequests.first?.request
-        for pending in connection.pendingRequests {
-            pending.completion(.success(.empty))
-        }
         _ = try? await task.value
-        return request?.data["service"] as? String
+        return first?.data["service"] as? String
     }
 
     @Test func onSendsTurnOn() async throws {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .on)
             intent.entity = Self.entity(serverId: server.identifier.rawValue)
-            let service = try await serviceCalled(intent, connection: connection)
+            let service = try await serviceCalled(intent, connection: connection, entityId: intent.entity.entityId)
             #expect(service == "turn_on")
         }
     }
@@ -66,7 +86,7 @@ struct TurnOnOffEntityAppIntentTests {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .off)
             intent.entity = Self.entity(serverId: server.identifier.rawValue)
-            let service = try await serviceCalled(intent, connection: connection)
+            let service = try await serviceCalled(intent, connection: connection, entityId: intent.entity.entityId)
             #expect(service == "turn_off")
         }
     }
@@ -76,7 +96,7 @@ struct TurnOnOffEntityAppIntentTests {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .on)
             intent.entity = Self.entity(serverId: server.identifier.rawValue, entityId: "cover.curtain")
-            let service = try await serviceCalled(intent, connection: connection)
+            let service = try await serviceCalled(intent, connection: connection, entityId: intent.entity.entityId)
             #expect(service == "open_cover")
         }
     }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Follows #5677, which landed at 84.61% patch coverage. The two uncovered lines were the ones that build the result card.

The command sends two requests — the service, then the state it reads back to describe — and the test answered only the first. The state read never completed, so the card was never built and the lines that build it never ran, while the assertion on the service still passed. The test now answers both.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Tests only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behaviour change.
