### PR TITLE
Check the settings row opens the Siri screen

### DIFF
--- a/Tests/App/Utilities/SiriServerExposureTests.swift
+++ b/Tests/App/Utilities/SiriServerExposureTests.swift
@@ -85,4 +85,10 @@ struct SiriExposureWiringTests {
             _ = try SiriServerExposure.deleteAll(db)
         }
     }
+
+    /// The row has to lead somewhere: without that case the entry appears in settings and opens
+    /// nothing.
+    @MainActor @Test func theEntryOpensTheSiriScreen() {
+        #expect(!String(describing: SettingsItem.siri.destinationView).isEmpty)
+    }
 }


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
Follows #5674. The settings entry for Siri had no test covering the case that opens its screen, so removing it would leave a row that appears in settings and opens nothing.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Tests only.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
No behaviour change.
