### PR TITLE
Show what a control command actually did

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		11EE9B4C24C5181A00404AF8 /* ModelManager.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EE9B4B24C5181A00404AF8 /* ModelManager.test.swift */; };
 		13E4D63B90C14B0DA25F2827 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = C8FA7E5B23954D258050DD72 /* SFSafeSymbols */; };
 		17200629C6080FA329C8F802 /* Domain.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5459C05BEB77340680D8C6 /* Domain.test.swift */; };
+		42DA0000000000010000AF01 /* DomainStatesAfter.test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42DA0000000000020000AF02 /* DomainStatesAfter.test.swift */; };
 		17D9A7F5BB5024E854D46278 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DDD36A352E3698887FBF85D9 /* RealmSwift */; };
 		1A7E45C09B3D22E8F5A6B701 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4C014BAFE0BC019E4055ED11 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A7E45C09B3D22E8F5A6B702 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 3402A10CAEE631B133C57DBE /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -701,6 +702,7 @@
 		D0C8845F211ED11900CCB501 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		D0EEF300214D8EAB00D1D360 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		DA5459C05BEB77340680D8C6 /* Domain.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.test.swift; sourceTree = "<group>"; };
+		42DA0000000000020000AF02 /* DomainStatesAfter.test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainStatesAfter.test.swift; sourceTree = "<group>"; };
 		FA11C0DE0000000000000100 /* BackgroundRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshManager.swift; sourceTree = "<group>"; };
 		FD3BC66629BA003B00B19FBE /* HAEntity+CarPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HAEntity+CarPlay.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3093,6 +3095,7 @@
 				42AB77012FBD10010051FC9B /* SettingsStoreRestoreLastURL.test.swift */,
 				42EEEFE42E2792B20080E973 /* Service.test.swift */,
 				DA5459C05BEB77340680D8C6 /* Domain.test.swift */,
+				42DA0000000000020000AF02 /* DomainStatesAfter.test.swift */,
 				42AA0007300100010001AAA1 /* EntityIconColorProvider.test.swift */,
 				42C11A0031AC500011AABB00 /* ClimateControlState.test.swift */,
 				42C11A0431AC500011AABB04 /* VacuumCapabilities.test.swift */,
@@ -4548,6 +4551,7 @@
 				1165707C2702BAF5003906A7 /* DiskCache.test.swift in Sources */,
 				42EEEFE52E2792B20080E973 /* Service.test.swift in Sources */,
 				17200629C6080FA329C8F802 /* Domain.test.swift in Sources */,
+				42DA0000000000010000AF01 /* DomainStatesAfter.test.swift in Sources */,
 				42AA0008300100010001AAA1 /* EntityIconColorProvider.test.swift in Sources */,
 				42C11A0131AC500011AABB01 /* ClimateControlState.test.swift in Sources */,
 				42C11A0531AC500011AABB05 /* VacuumCapabilities.test.swift in Sources */,

--- a/Sources/Extensions/AppIntents/Control/ControlEntityIntentRunner+Snippet.swift
+++ b/Sources/Extensions/AppIntents/Control/ControlEntityIntentRunner+Snippet.swift
@@ -15,12 +15,13 @@ extension ControlEntityIntentRunner {
         _ action: Action,
         on entity: ControllableEntityAppEntity
     ) async throws -> (dialog: String, state: HAEntityStateAppEntity?) {
-        let dialog = try await perform(action, on: entity)
+        let service = try await callService(action, on: entity)
         let state = await ControlResultSnippet.state(
             of: entity,
             serverId: entity.serverId,
-            iconName: entity.iconName
+            iconName: entity.iconName,
+            settlingOn: entity.domain?.statesAfter(service) ?? []
         )
-        return (dialog, state)
+        return (dialog(for: service, entityName: entity.displayString), state)
     }
 }

--- a/Sources/Extensions/AppIntents/Control/ControlEntityIntentRunner.swift
+++ b/Sources/Extensions/AppIntents/Control/ControlEntityIntentRunner.swift
@@ -14,6 +14,14 @@ enum ControlEntityIntentRunner {
     /// Performs `action` and returns the sentence Siri should speak.
     @available(macOS 13.0, watchOS 9.4, *)
     static func perform(_ action: Action, on entity: ControllableEntityAppEntity) async throws -> String {
+        let service = try await callService(action, on: entity)
+        return dialog(for: service, entityName: entity.displayString)
+    }
+
+    /// Performs `action` and returns the service it called, which is what says both how to word the
+    /// confirmation and which state the entity should settle on.
+    @available(macOS 13.0, watchOS 9.4, *)
+    static func callService(_ action: Action, on entity: ControllableEntityAppEntity) async throws -> Service {
         await Current.connectivity.refreshNetworkInformation()
         guard let server = Current.servers.server(for: .init(rawValue: entity.serverId)) else {
             throw ShortcutAppIntentError(L10n.AppIntents.Error.noServer)
@@ -30,7 +38,7 @@ enum ControlEntityIntentRunner {
             data: ["entity_id": entity.entityId],
             returnResponse: false
         )
-        return dialog(for: service, entityName: entity.displayString)
+        return service
     }
 
     @available(macOS 13.0, watchOS 9.4, *)

--- a/Sources/Extensions/AppIntents/Control/ControlResultSnippet.swift
+++ b/Sources/Extensions/AppIntents/Control/ControlResultSnippet.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import Foundation
+import HAKit
 import Shared
 
 /// Builds the card a control command shows once it has changed something.
@@ -9,15 +10,26 @@ import Shared
 /// claiming otherwise.
 @available(macOS 13.0, watchOS 9.4, *)
 enum ControlResultSnippet {
+    /// How long to keep reading the state back while it is still the one the action replaced. Long
+    /// enough for a device to report in, short enough that Siri isn't left waiting on one that never
+    /// will.
+    static let settleTimeout: TimeInterval = 2
+    private static let settleInterval: Duration = .milliseconds(250)
+
+    /// - Parameter expected: the states that would show the action took effect, from
+    ///   `Domain.statesAfter(_:)`. Passing them is what keeps a light that was just switched on from
+    ///   being drawn as off. Empty reads the state once, for an action that settles on nothing.
     static func state(
         of context: some EntityContextRepresentable,
         serverId: String,
-        iconName: String
+        iconName: String,
+        settlingOn expected: [String] = []
     ) async -> HAEntityStateAppEntity? {
         guard let server = Current.servers.server(for: .init(rawValue: serverId)),
-              let liveState = try? await AppIntentServerAPI.entityState(
-                  server: server,
-                  entityId: context.entityId
+              let liveState = await settledState(
+                  of: context.entityId,
+                  on: server,
+                  expecting: expected
               ) else {
             // The command already succeeded; failing to read the state back is not worth failing it,
             // so the spoken sentence stands on its own and no card is shown.
@@ -30,5 +42,29 @@ enum ControlResultSnippet {
             iconName: iconName,
             state: liveState
         )
+    }
+
+    /// Reads the state back until it is the one the action asked for, or until the deadline passes.
+    ///
+    /// A service call returns before the device has reported the change, so reading once hands back
+    /// the state the action replaced. Whatever the last read said is still what's returned, so a
+    /// device that refuses, or one slower than the deadline, reports what it really is rather than
+    /// what it was told to become.
+    private static func settledState(
+        of entityId: String,
+        on server: Server,
+        expecting expected: [String]
+    ) async -> HAEntity? {
+        let deadline = Date().addingTimeInterval(settleTimeout)
+        var latest: HAEntity?
+        repeat {
+            guard let read = try? await AppIntentServerAPI.entityState(server: server, entityId: entityId) else {
+                return latest
+            }
+            latest = read
+            guard !expected.isEmpty, !expected.contains(read.state) else { return read }
+            try? await Task.sleep(for: settleInterval)
+        } while Date() < deadline
+        return latest
     }
 }

--- a/Sources/Extensions/AppIntents/Control/ControlResultSnippetView.swift
+++ b/Sources/Extensions/AppIntents/Control/ControlResultSnippetView.swift
@@ -14,7 +14,7 @@ import UIKit
 struct ControlResultSnippetView: View {
     let state: HAEntityStateAppEntity
 
-    private static let iconSize: CGFloat = 44
+    private static let iconSize: CGFloat = 28
     private var accent: Color { Color(uiColor: AppConstants.tintColor) }
 
     var body: some View {
@@ -25,17 +25,22 @@ struct ControlResultSnippetView: View {
                 .padding(DesignSystem.Spaces.one)
                 .background(accent.opacity(0.15), in: Circle())
 
+            // Siri gives a snippet the full width of its own card and scales the type up with it,
+            // so the sizes here sit a step below what the same rows would use in the app.
             VStack(alignment: .leading, spacing: DesignSystem.Spaces.half) {
                 Text(state.name)
-                    .font(.headline)
-                Text(state.formattedState)
-                    .font(.title3)
+                    .font(.subheadline)
                     .fontWeight(.semibold)
+                    .lineLimit(1)
+                Text(state.formattedState)
+                    .font(.subheadline)
                     .foregroundStyle(accent)
+                    .lineLimit(1)
                 if let context {
                     Text(context)
-                        .font(.footnote)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
             }
             Spacer(minLength: 0)

--- a/Sources/Extensions/AppIntents/Control/LockEntityAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Control/LockEntityAppIntent.swift
@@ -31,7 +31,8 @@ struct LockEntityAppIntent: AppIntent {
         let state = await ControlResultSnippet.state(
             of: entity,
             serverId: entity.serverId,
-            iconName: entity.iconName
+            iconName: entity.iconName,
+            settlingOn: Domain.lock.statesAfter(.lock)
         )
         return .result(dialog: .init(stringLiteral: dialog)) {
             if let state {

--- a/Sources/Extensions/AppIntents/Control/OpenCloseEntityAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Control/OpenCloseEntityAppIntent.swift
@@ -38,19 +38,21 @@ struct OpenCloseEntityAppIntent: AppIntent {
 
     #if os(watchOS)
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        try await .result(dialog: .init(stringLiteral: move()))
+        let service = try await move()
+        return .result(dialog: .init(stringLiteral: dialog(for: service)))
     }
     #else
     // The card is app-only: the view and the entity it draws aren't built for the watch, where a
     // spoken answer is the whole interaction anyway.
     func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
-        let dialog = try await move()
+        let service = try await move()
         let state = await ControlResultSnippet.state(
             of: entity,
             serverId: entity.serverId,
-            iconName: entity.iconName
+            iconName: entity.iconName,
+            settlingOn: entity.domain?.statesAfter(service) ?? []
         )
-        return .result(dialog: .init(stringLiteral: dialog)) {
+        return .result(dialog: .init(stringLiteral: dialog(for: service))) {
             if let state {
                 ControlResultSnippetView(state: state)
             }
@@ -58,8 +60,8 @@ struct OpenCloseEntityAppIntent: AppIntent {
     }
     #endif
 
-    /// Opens or closes the cover, returning the sentence to speak.
-    private func move() async throws -> String {
+    /// Opens or closes the cover, returning the service it called.
+    private func move() async throws -> Service {
         await Current.connectivity.refreshNetworkInformation()
         guard let server = Current.servers.server(for: .init(rawValue: entity.serverId)) else {
             throw ShortcutAppIntentError(L10n.AppIntents.Error.noServer)
@@ -76,7 +78,12 @@ struct OpenCloseEntityAppIntent: AppIntent {
             data: ["entity_id": entity.entityId],
             returnResponse: false
         )
-        return action == .open
+        return service
+    }
+
+    /// The spoken confirmation, worded for the direction the cover moved.
+    private func dialog(for service: Service) -> String {
+        action == .open
             ? L10n.AppIntents.OpenClose.Dialog.opened(entity.displayString)
             : L10n.AppIntents.OpenClose.Dialog.closed(entity.displayString)
     }

--- a/Sources/Extensions/AppIntents/Control/SetBrightnessAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Control/SetBrightnessAppIntent.swift
@@ -40,7 +40,8 @@ struct SetBrightnessAppIntent: AppIntent {
         let state = await ControlResultSnippet.state(
             of: light,
             serverId: light.serverId,
-            iconName: light.iconName
+            iconName: light.iconName,
+            settlingOn: Domain.light.statesAfter(.turnOn)
         )
         return .result(dialog: .init(stringLiteral: dialog)) {
             if let state {

--- a/Sources/Extensions/AppIntents/Control/SetTemperatureAppIntent.swift
+++ b/Sources/Extensions/AppIntents/Control/SetTemperatureAppIntent.swift
@@ -40,6 +40,8 @@ struct SetTemperatureAppIntent: AppIntent {
     // spoken answer is the whole interaction anyway.
     func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         let dialog = try await apply()
+        // No state to settle on: setting a target temperature changes an attribute, and the
+        // thermostat goes on reading whatever mode it was already in.
         let state = await ControlResultSnippet.state(
             of: entity,
             serverId: entity.serverId,

--- a/Sources/Shared/Domain/Domain+StatesAfter.swift
+++ b/Sources/Shared/Domain/Domain+StatesAfter.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public extension Domain {
+    /// The states that show `service` took effect, including the one an entity passes through on
+    /// the way.
+    ///
+    /// Home Assistant answers a service call as soon as it has passed it on, not once the device
+    /// has reported back, so anything that wants to show the result has to know which states to
+    /// wait for. A curtain reads `closing` for as long as it is travelling and only reaches
+    /// `closed` at the end of it, which is far longer than anyone will wait for a card — but
+    /// `closing` already proves the command landed, so it counts.
+    ///
+    /// Empty where there is nothing worth waiting for: a scene or a button records the time it last
+    /// ran rather than a state, a script only reads `on` for as long as it is running, and a
+    /// service that changes an attribute leaves the state alone.
+    func statesAfter(_ service: Service) -> [String] {
+        switch self {
+        case .scene, .button, .inputButton, .script:
+            // These record when they last ran, not what they became.
+            return []
+        default:
+            break
+        }
+
+        switch service {
+        case .turnOn:
+            return ["on"]
+        case .turnOff:
+            return ["off"]
+        case .openCover, .openValve:
+            return ["open", "opening"]
+        case .closeCover, .closeValve:
+            return ["closed", "closing"]
+        case .lock:
+            return ["locked", "locking"]
+        case .unlock:
+            return ["unlocked", "unlocking"]
+        default:
+            return []
+        }
+    }
+}

--- a/Tests/App/Utilities/ControlResultSnippetTests.swift
+++ b/Tests/App/Utilities/ControlResultSnippetTests.swift
@@ -62,6 +62,26 @@ struct ControlResultSnippetTests {
         }
     }
 
+    /// Answers each state read the card makes, in order, until they stop coming. The last state
+    /// given answers every read after it, which is how a device that ignores the command behaves.
+    private func answerReads(_ connection: HAMockConnection, with states: [String]) async throws {
+        var answered = 0
+        var idle = 0
+        // The card waits a quarter second between reads, so a longer silence than that means it
+        // has stopped asking.
+        while idle < 120 {
+            guard connection.pendingRequests.count > answered else {
+                try await Task.sleep(nanoseconds: 5_000_000)
+                idle += 1
+                continue
+            }
+            let state = states[min(answered, states.count - 1)]
+            connection.pendingRequests[answered].completion(.success(Self.stateResponse(state)))
+            answered += 1
+            idle = 0
+        }
+    }
+
     @Test func describesTheEntityAsItStandsAfterwards() async throws {
         try await withMockedServer { server, connection in
             let entity = Self.light(serverId: server.identifier.rawValue)
@@ -82,6 +102,70 @@ struct ControlResultSnippetTests {
             #expect(state?.iconName == "mdi:ceiling-light")
             #expect(state?.areaName == "Kitchen")
             #expect(state?.serverName == server.info.name)
+        }
+    }
+
+    /// Home Assistant answers a service call before the device has reported back, so the first read
+    /// still says the light is off. The card waits for the state the action asked for rather than
+    /// drawing the one it replaced.
+    @Test func waitsForTheStateTheActionAskedFor() async throws {
+        try await withMockedServer { server, connection in
+            let entity = Self.light(serverId: server.identifier.rawValue)
+            let task = Task {
+                await ControlResultSnippet.state(
+                    of: entity,
+                    serverId: entity.serverId,
+                    iconName: entity.iconName,
+                    settlingOn: ["on"]
+                )
+            }
+            try await answerReads(connection, with: ["off", "on"])
+            let state = await task.value
+
+            #expect(state?.state == "on")
+            #expect(state?.isActive == true)
+        }
+    }
+
+    /// A device that ignores the command is reported as it is: the card gives up on the state it
+    /// was waiting for rather than claiming the light came on.
+    @Test func reportsTheStateADeviceThatRefusesIsLeftIn() async throws {
+        try await withMockedServer { server, connection in
+            let entity = Self.light(serverId: server.identifier.rawValue)
+            let task = Task {
+                await ControlResultSnippet.state(
+                    of: entity,
+                    serverId: entity.serverId,
+                    iconName: entity.iconName,
+                    settlingOn: ["on"]
+                )
+            }
+            try await answerReads(connection, with: ["off"])
+            let state = await task.value
+
+            #expect(state?.state == "off")
+            #expect(state?.isActive == false)
+        }
+    }
+
+    /// A curtain reads `closing` for as long as it travels, which outlasts any card. That state
+    /// already proves the command landed, so the card shows it rather than waiting out the deadline
+    /// on `closed` and reporting the curtain as still open.
+    @Test func takesAMovingCoverAsProofTheCommandLanded() async throws {
+        try await withMockedServer { server, connection in
+            let entity = Self.light(serverId: server.identifier.rawValue)
+            let task = Task {
+                await ControlResultSnippet.state(
+                    of: entity,
+                    serverId: entity.serverId,
+                    iconName: entity.iconName,
+                    settlingOn: Domain.cover.statesAfter(.closeCover)
+                )
+            }
+            try await answerReads(connection, with: ["open", "closing"])
+            let state = await task.value
+
+            #expect(state?.state == "closing")
         }
     }
 

--- a/Tests/Shared/DomainStatesAfter.test.swift
+++ b/Tests/Shared/DomainStatesAfter.test.swift
@@ -1,0 +1,55 @@
+@testable import Shared
+import Testing
+
+/// The state a confirmation waits for after each service, so a card reports what the action
+/// produced rather than the state it replaced.
+struct DomainStatesAfterTests {
+    @Test func eachServiceNamesTheStatesItProduces() {
+        #expect(Domain.light.statesAfter(.turnOn) == ["on"])
+        #expect(Domain.light.statesAfter(.turnOff) == ["off"])
+        #expect(Domain.switch.statesAfter(.turnOn) == ["on"])
+        #expect(Domain.cover.statesAfter(.openCover) == ["open", "opening"])
+        #expect(Domain.cover.statesAfter(.closeCover) == ["closed", "closing"])
+        #expect(Domain.valve.statesAfter(.openValve) == ["open", "opening"])
+        #expect(Domain.valve.statesAfter(.closeValve) == ["closed", "closing"])
+        #expect(Domain.lock.statesAfter(.lock) == ["locked", "locking"])
+        #expect(Domain.lock.statesAfter(.unlock) == ["unlocked", "unlocking"])
+    }
+
+    /// A curtain travels for far longer than a card will wait, so the state it holds while moving
+    /// has to count: it already proves the command landed. Without it the card reads "Open" for
+    /// the whole of a close.
+    @Test func whatMovesCountsAsSoonAsItStartsMoving() {
+        #expect(Domain.cover.statesAfter(.closeCover).contains("closing"))
+        #expect(Domain.cover.statesAfter(.openCover).contains("opening"))
+        #expect(Domain.lock.statesAfter(.lock).contains("locking"))
+        #expect(Domain.valve.statesAfter(.closeValve).contains("closing"))
+    }
+
+    /// The state a toggle reads as off has to be one the off services produce, or a card would
+    /// wait for a state the entity never reports.
+    @Test func theOffStatesAreTheOnesAToggleReadsAsOff() {
+        let offStates = [
+            Domain.light.statesAfter(.turnOff),
+            Domain.cover.statesAfter(.closeCover),
+            Domain.lock.statesAfter(.lock),
+        ]
+        #expect(offStates.allSatisfy { $0.contains(where: Domain.statesOff.contains) })
+    }
+
+    /// A scene and a button record the time they last ran, and a script only reads `on` while it
+    /// is running — waiting on any of those would just spend the deadline.
+    @Test func whatRunsRatherThanChangesWaitsForNothing() {
+        #expect(Domain.scene.statesAfter(.turnOn).isEmpty)
+        #expect(Domain.script.statesAfter(.turnOn).isEmpty)
+        #expect(Domain.button.statesAfter(.press).isEmpty)
+        #expect(Domain.inputButton.statesAfter(.press).isEmpty)
+    }
+
+    /// A service that changes an attribute leaves the state alone, so there is nothing to wait for.
+    @Test func aServiceThatChangesNoStateWaitsForNothing() {
+        #expect(Domain.climate.statesAfter(.setTemperature).isEmpty)
+        #expect(Domain.light.statesAfter(.toggle).isEmpty)
+        #expect(Domain.cover.statesAfter(.setCoverPosition).isEmpty)
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The card a control command shows in Siri reported the state the action replaced. Home Assistant answers a service call as soon as it has passed it on, not once the device has reported back, so a light that was just switched on drew as "Off".

The card now reads the state back until it shows the command landed, and draws whatever the last read said, so a device that refuses still reports the truth rather than what it was told to become. A cover holds `opening` or `closing` for longer than any card will wait, and that already proves the command landed, so those count too.

Also brings the card's type down a step. It is drawn at Siri's scale, where the sizes it used ran large enough to wrap the area line onto two rows.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not captured: the card only renders inside Siri, and the change is the state it shows plus a smaller type scale.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
`set_temperature` waits for nothing: it changes an attribute while the thermostat goes on reading whatever mode it was already in. Same for scenes, buttons and scripts, which record when they last ran rather than what they became.

`Tests/Shared` is only a synchronized group below its subfolders, so the new test file needed an explicit project entry to compile.
