### PR TITLE
Fix Quick Access items switching server when entity ids collide

### DIFF
--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -154,8 +154,6 @@ struct CarPlayConfigurationView: View {
                     layoutPickerOption(layout).tag(layout)
                 }
             }
-            // Keyed by server unique id, not the bare entity id: two servers can hold the same
-            // entity id, and duplicate identities make the rows render each other's content.
             ForEach(viewModel.config.quickAccessItems, id: \.serverUniqueId) { item in
                 makeListItem(item: item)
             }

--- a/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
+++ b/Sources/App/Settings/CarPlay/CarPlayConfigurationView.swift
@@ -154,7 +154,9 @@ struct CarPlayConfigurationView: View {
                     layoutPickerOption(layout).tag(layout)
                 }
             }
-            ForEach(viewModel.config.quickAccessItems, id: \.id) { item in
+            // Keyed by server unique id, not the bare entity id: two servers can hold the same
+            // entity id, and duplicate identities make the rows render each other's content.
+            ForEach(viewModel.config.quickAccessItems, id: \.serverUniqueId) { item in
                 makeListItem(item: item)
             }
             .onMove { indices, newOffset in

--- a/Sources/Shared/MagicItem/MagicItem+Migration.swift
+++ b/Sources/Shared/MagicItem/MagicItem+Migration.swift
@@ -83,12 +83,12 @@ extension MagicItemProvider {
         // Sorted so the pick stays stable when more than one server holds the entity id; dictionary
         // iteration order is not.
         for serverId in entitiesPerServer.keys.sorted() {
-            guard let similarEntityInCache = entitiesPerServer[serverId]?
-                .first(where: { $0.entityId == item.id }) else { continue }
+            let entities = entitiesPerServer[serverId] ?? []
+            guard let similarEntity = entities.first(where: { $0.entityId == item.id }) else { continue }
 
             return .init(
-                id: similarEntityInCache.entityId,
-                serverId: similarEntityInCache.serverId,
+                id: similarEntity.entityId,
+                serverId: similarEntity.serverId,
                 type: item.type,
                 customization: item.customization
             )

--- a/Sources/Shared/MagicItem/MagicItem+Migration.swift
+++ b/Sources/Shared/MagicItem/MagicItem+Migration.swift
@@ -74,11 +74,15 @@ extension MagicItemProvider {
     /// orphaning every item that referenced the old one.
     ///
     /// Nothing is re-pointed while the item's server is still configured. Two servers can hold the
-    /// same entity id (two homes, each with a `cover.garage_door`), and there an item that doesn't
-    /// resolve means that entity is gone from *its* server — the identically named one next door is
-    /// a different device, not a replacement.
+    /// same entity id — two homes, each with a `cover.garage_door` — so an item that doesn't resolve
+    /// means that entity is gone from its own server. The identically named one next door is a
+    /// different device, not a replacement.
+    ///
+    /// Whether the server is gone is asked of the server list rather than of the entity cache: a
+    /// server whose entities simply failed to load has no entry there either, and an item must not
+    /// move to another server because of a failed read.
     private func getSimilarItem(for item: MagicItem) -> MagicItem? {
-        guard entitiesPerServer[item.serverId] == nil else { return nil }
+        guard Current.servers.server(for: .init(rawValue: item.serverId)) == nil else { return nil }
 
         // Sorted so the pick stays stable when more than one server holds the entity id; dictionary
         // iteration order is not.

--- a/Sources/Shared/MagicItem/MagicItem+Migration.swift
+++ b/Sources/Shared/MagicItem/MagicItem+Migration.swift
@@ -5,10 +5,13 @@ import GRDB
 
 extension MagicItemProvider {
     /*
-     In case items in watch config are referencing a server that no longer
-     matches with server Id's available in the app, migration will try to find the
-     first server with that entityID available and replace the item with that server ID.
-     This can happen when the user deletes the server and add it back again.
+     In case items in a config are referencing a server that no longer matches any server Id
+     available in the app, migration will try to find a server that has that entityID available and
+     replace the item with that server ID. This can happen when the user deletes the server and adds
+     it back again.
+
+     Items whose server is still configured are left alone, even when their entity no longer
+     resolves — see `getSimilarItem(for:)`.
      */
     func migrateItemsIfNeeded(items: [MagicItem]) -> [MagicItem] {
         var items = removingUnsupportedItems(from: items)
@@ -20,17 +23,22 @@ extension MagicItemProvider {
             item.items = migrateItemsIfNeeded(items: folderItems)
             return item
         }
-        let infos = items.compactMap { getInfo(for: $0) }
 
-        if infos.count == items.count {
+        // `MagicItem.Info.id` is the item's *server*-unique id ("serverId-entityId"), so an item
+        // only counts as resolved when an info carries its own server's id. Matching on the bare
+        // entity id instead made every entity-backed item look unresolved the moment one of them
+        // was, and then re-pointed each of them — by entity id alone — at whichever server held
+        // that id first, silently moving an item to the identically named entity on another server.
+        let resolvedIds = Set(items.compactMap { getInfo(for: $0)?.id })
+
+        guard items.contains(where: { !resolvedIds.contains($0.serverUniqueId) }) else {
             return items
         }
 
-        let missingItems = items.filter { item in
-            !infos.contains { $0.id == item.id }
-        }
+        // Replace missing items with similar items
+        return items.map { item in
+            guard !resolvedIds.contains(item.serverUniqueId) else { return item }
 
-        let replacementItems = missingItems.compactMap { item -> MagicItem? in
             switch item.type {
             case .assistPipeline, .assistPrompt, .area:
                 // Assist items and areas are not entity-backed, so there is no entity to re-point
@@ -41,16 +49,9 @@ extension MagicItemProvider {
                 // similar item to re-point them at. `getInfo` already dropped the ones whose config
                 // is gone; the rest are kept as-is.
                 return item
-            case .unsupported:
-                return nil
             default:
-                return getSimilarItem(for: item)
+                return getSimilarItem(for: item) ?? item
             }
-        }
-
-        // Replace missing items with similar items
-        return items.map { item in
-            replacementItems.first(where: { $0.id == item.id }) ?? item
         }
     }
 
@@ -68,20 +69,31 @@ extension MagicItemProvider {
         }
     }
 
+    /// The same entity on another server, for an item whose own server is gone — the case this
+    /// migration exists for: a server that is removed and added back comes back with a new id,
+    /// orphaning every item that referenced the old one.
+    ///
+    /// Nothing is re-pointed while the item's server is still configured. Two servers can hold the
+    /// same entity id (two homes, each with a `cover.garage_door`), and there an item that doesn't
+    /// resolve means that entity is gone from *its* server — the identically named one next door is
+    /// a different device, not a replacement.
     private func getSimilarItem(for item: MagicItem) -> MagicItem? {
-        if let similarEntityInCache = entitiesPerServer.first(where: { dict in
-            dict.value.contains { $0.entityId == item.id }
-        }).flatMap(\.value)?.first(where: { entity in
-            entity.entityId == item.id
-        }) {
+        guard entitiesPerServer[item.serverId] == nil else { return nil }
+
+        // Sorted so the pick stays stable when more than one server holds the entity id; dictionary
+        // iteration order is not.
+        for serverId in entitiesPerServer.keys.sorted() {
+            guard let similarEntityInCache = entitiesPerServer[serverId]?
+                .first(where: { $0.entityId == item.id }) else { continue }
+
             return .init(
                 id: similarEntityInCache.entityId,
                 serverId: similarEntityInCache.serverId,
                 type: item.type,
                 customization: item.customization
             )
-        } else {
-            return nil
         }
+
+        return nil
     }
 }

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -198,8 +198,8 @@ final class MagicItemProvider: MagicItemProviderProtocol {
         // Rebuilt on every load so complication renames and deletions surface without a relaunch.
         complicationConfigIndex = Self.loadComplicationConfigIndex()
         // Drop servers that are no longer configured: a long-lived provider (the CarPlay template
-        // keeps one) would otherwise keep resolving their entities, and `getSimilarItem` reads the
-        // absence of a server here as "this item's server is gone" before re-pointing an item.
+        // keeps one) would otherwise keep resolving their entities, which makes an item pointing at
+        // a removed server look resolved and stops the migration from re-pointing it.
         let configuredServerIds = Set(servers.map(\.identifier.rawValue))
         entitiesPerServer = entitiesPerServer.filter { configuredServerIds.contains($0.key) }
         areasPerServer = areasPerServer.filter { configuredServerIds.contains($0.key) }

--- a/Sources/Shared/MagicItem/MagicItemProvider.swift
+++ b/Sources/Shared/MagicItem/MagicItemProvider.swift
@@ -197,6 +197,14 @@ final class MagicItemProvider: MagicItemProviderProtocol {
         areasByIdPerServer = [:]
         // Rebuilt on every load so complication renames and deletions surface without a relaunch.
         complicationConfigIndex = Self.loadComplicationConfigIndex()
+        // Drop servers that are no longer configured: a long-lived provider (the CarPlay template
+        // keeps one) would otherwise keep resolving their entities, and `getSimilarItem` reads the
+        // absence of a server here as "this item's server is gone" before re-pointing an item.
+        let configuredServerIds = Set(servers.map(\.identifier.rawValue))
+        entitiesPerServer = entitiesPerServer.filter { configuredServerIds.contains($0.key) }
+        areasPerServer = areasPerServer.filter { configuredServerIds.contains($0.key) }
+        devicesPerServer = devicesPerServer.filter { configuredServerIds.contains($0.key) }
+        floorNamesPerServer = floorNamesPerServer.filter { configuredServerIds.contains($0.key) }
         guard !servers.isEmpty else {
             completion()
             return

--- a/Tests/App/MagicItem/MagicItemProviderTests.swift
+++ b/Tests/App/MagicItem/MagicItemProviderTests.swift
@@ -1,6 +1,8 @@
 @testable import Shared
 import Testing
 
+/// Serialized because the tests share the database and swap the servers in `Current`.
+@Suite(.serialized)
 struct MagicItemProviderTests {
     private var sut: MagicItemProvider
 
@@ -135,21 +137,23 @@ struct MagicItemProviderTests {
             try carPlayConfig.insert(db)
         }
 
+        let garageDoorOnServerOne = Self.entity(
+            entityId: "cover.garage_door",
+            domain: "cover",
+            name: "Garage Door",
+            icon: nil,
+            serverId: "1"
+        )
+        let garageDoorOnServerTwo = Self.entity(
+            entityId: "cover.garage_door",
+            domain: "cover",
+            name: "Garage Door",
+            icon: nil,
+            serverId: "2"
+        )
         sut.entitiesPerServer = [
-            "1": [Self.entity(
-                entityId: "cover.garage_door",
-                domain: "cover",
-                name: "Garage Door",
-                icon: nil,
-                serverId: "1"
-            )],
-            "2": [Self.entity(
-                entityId: "cover.garage_door",
-                domain: "cover",
-                name: "Garage Door",
-                icon: nil,
-                serverId: "2"
-            )],
+            "1": [garageDoorOnServerOne],
+            "2": [garageDoorOnServerTwo],
         ]
 
         await withCheckedContinuation { continuation in
@@ -162,6 +166,57 @@ struct MagicItemProviderTests {
         // item points at is untouched.
         let newCarPlayConfig = try CarPlayConfig.config()
         #expect(newCarPlayConfig?.quickAccessItems == expectedItems)
+    }
+
+    /// Items that aren't entity-backed have no entity to be re-pointed at, so an area or a
+    /// complication that no longer resolves is kept as it is rather than dropped or moved.
+    @Test mutating func migrateKeepsNonEntityBackedItemsThatCannotResolve() async throws {
+        var watchConfig = WatchConfig()
+        let expectedItems: [MagicItem] = [
+            .init(id: "area-gone", serverId: "areas-test-server", type: .area),
+            .init(id: "complication-gone", serverId: "areas-test-server", type: .complication),
+        ]
+        watchConfig.items = expectedItems
+
+        try await Current.database().write { [watchConfig] db in
+            try WatchConfig.deleteAll(db)
+            try watchConfig.insert(db)
+        }
+
+        await withCheckedContinuation { continuation in
+            sut.migrateWatchConfig {
+                continuation.resume()
+            }
+        }
+
+        let newWatchConfig = try WatchConfig.config()
+        #expect(newWatchConfig?.items == expectedItems)
+    }
+
+    /// Entities cached for a server that has since been removed must not linger: the absence of a
+    /// server's entities is what tells the migration an item's server is gone and its entity can be
+    /// looked for elsewhere.
+    @Test mutating func loadInformationForgetsServersThatAreNoLongerConfigured() async {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+
+        let servers = FakeServerManager()
+        let server = servers.addFake()
+        Current.servers = servers
+
+        let entityOnRemovedServer = Self.entity(
+            entityId: "light.one",
+            domain: "light",
+            name: "Light One",
+            icon: nil,
+            serverId: "removed-server"
+        )
+        sut.entitiesPerServer = ["removed-server": [entityOnRemovedServer]]
+
+        _ = await sut.loadInformation()
+
+        #expect(sut.entitiesPerServer["removed-server"] == nil)
+        #expect(sut.entitiesPerServer[server.identifier.rawValue] != nil)
     }
 
     /// `getInfo` resolves entity-backed items through the per-server entity index rather than scanning

--- a/Tests/App/MagicItem/MagicItemProviderTests.swift
+++ b/Tests/App/MagicItem/MagicItemProviderTests.swift
@@ -122,13 +122,21 @@ struct MagicItemProviderTests {
     /// identically named entity next door, and it must not drag the items that *did* resolve along
     /// with it.
     @Test mutating func migrateKeepsItemsOnTheirOwnServerWhenServersShareEntityIds() async throws {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+
+        let servers = FakeServerManager()
+        let firstServerId = servers.addFake().identifier.rawValue
+        let secondServerId = servers.addFake().identifier.rawValue
+        Current.servers = servers
+
         var carPlayConfig = CarPlayConfig()
         let expectedItems: [MagicItem] = [
-            .init(id: "cover.garage_door", serverId: "1", type: .entity),
-            .init(id: "cover.garage_door", serverId: "2", type: .entity),
-            // Gone from server 2, so nothing resolves it: this is the item whose absence used to
-            // send every other item to whichever server held its entity id first.
-            .init(id: "light.gone", serverId: "2", type: .entity),
+            .init(id: "cover.garage_door", serverId: firstServerId, type: .entity),
+            .init(id: "cover.garage_door", serverId: secondServerId, type: .entity),
+            // Gone from the second server, so nothing resolves it: this is the item whose absence
+            // used to send every other item to whichever server held its entity id first.
+            .init(id: "light.gone", serverId: secondServerId, type: .entity),
         ]
         carPlayConfig.quickAccessItems = expectedItems
 
@@ -137,23 +145,23 @@ struct MagicItemProviderTests {
             try carPlayConfig.insert(db)
         }
 
-        let garageDoorOnServerOne = Self.entity(
+        let garageDoorOnFirstServer = Self.entity(
             entityId: "cover.garage_door",
             domain: "cover",
             name: "Garage Door",
             icon: nil,
-            serverId: "1"
+            serverId: firstServerId
         )
-        let garageDoorOnServerTwo = Self.entity(
+        let garageDoorOnSecondServer = Self.entity(
             entityId: "cover.garage_door",
             domain: "cover",
             name: "Garage Door",
             icon: nil,
-            serverId: "2"
+            serverId: secondServerId
         )
         sut.entitiesPerServer = [
-            "1": [garageDoorOnServerOne],
-            "2": [garageDoorOnServerTwo],
+            firstServerId: [garageDoorOnFirstServer],
+            secondServerId: [garageDoorOnSecondServer],
         ]
 
         await withCheckedContinuation { continuation in

--- a/Tests/App/MagicItem/MagicItemProviderTests.swift
+++ b/Tests/App/MagicItem/MagicItemProviderTests.swift
@@ -8,11 +8,17 @@ struct MagicItemProviderTests {
         self.sut = MagicItemProvider()
     }
 
-    private static func entity(entityId: String, domain: String, name: String, icon: String?) -> HAAppEntity {
+    private static func entity(
+        entityId: String,
+        domain: String,
+        name: String,
+        icon: String?,
+        serverId: String = "1"
+    ) -> HAAppEntity {
         .init(
-            id: "1-\(entityId)",
+            id: "\(serverId)-\(entityId)",
             entityId: entityId,
-            serverId: "1",
+            serverId: serverId,
             domain: domain,
             name: name,
             icon: icon,
@@ -107,6 +113,55 @@ struct MagicItemProviderTests {
             // No replacement provided so item stays the same
             .init(id: "light.one", serverId: "1", type: .entity),
         ])
+    }
+
+    /// Two servers can hold the same entity id — two homes, each with a `cover.garage_door`. An item
+    /// that can't be resolved must stay on its own server rather than being re-pointed at the
+    /// identically named entity next door, and it must not drag the items that *did* resolve along
+    /// with it.
+    @Test mutating func migrateKeepsItemsOnTheirOwnServerWhenServersShareEntityIds() async throws {
+        var carPlayConfig = CarPlayConfig()
+        let expectedItems: [MagicItem] = [
+            .init(id: "cover.garage_door", serverId: "1", type: .entity),
+            .init(id: "cover.garage_door", serverId: "2", type: .entity),
+            // Gone from server 2, so nothing resolves it: this is the item whose absence used to
+            // send every other item to whichever server held its entity id first.
+            .init(id: "light.gone", serverId: "2", type: .entity),
+        ]
+        carPlayConfig.quickAccessItems = expectedItems
+
+        try await Current.database().write { [carPlayConfig] db in
+            try CarPlayConfig.deleteAll(db)
+            try carPlayConfig.insert(db)
+        }
+
+        sut.entitiesPerServer = [
+            "1": [Self.entity(
+                entityId: "cover.garage_door",
+                domain: "cover",
+                name: "Garage Door",
+                icon: nil,
+                serverId: "1"
+            )],
+            "2": [Self.entity(
+                entityId: "cover.garage_door",
+                domain: "cover",
+                name: "Garage Door",
+                icon: nil,
+                serverId: "2"
+            )],
+        ]
+
+        await withCheckedContinuation { continuation in
+            sut.migrateCarPlayConfig {
+                continuation.resume()
+            }
+        }
+
+        // `MagicItem`'s equality compares id, serverId and type, so this asserts the server each
+        // item points at is untouched.
+        let newCarPlayConfig = try CarPlayConfig.config()
+        #expect(newCarPlayConfig?.quickAccessItems == expectedItems)
     }
 
     /// `getInfo` resolves entity-backed items through the per-server entity index rather than scanning


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #5689.

When two servers have an entity with the same `entity_id` (two homes, each with a `cover.garage_door`), items added to CarPlay Quick Access from the second server turned into the first server's items.

Two causes:

1. `migrateItemsIfNeeded` compared `MagicItem.Info.id` (which is `"serverId-entityId"`) against `MagicItem.id` (the bare `entity_id`), so entity-backed items never matched. As soon as one item failed to resolve, every other item was treated as orphaned and re-pointed — by bare entity id — at whichever server came first, and the result was written back to the config. Items are now resolved by their server-unique id, and only re-pointed when their own server is actually gone (the removed-and-re-added case the migration exists for).
2. The CarPlay configuration screen keyed its Quick Access `ForEach` on the bare entity id, so two servers' garage doors shared one SwiftUI identity and rendered each other's content. It now uses `serverUniqueId`, matching the Watch, widget and app icon shortcut screens.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — no visual change; the rows just show the correct entity now.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The same migration runs for the Watch, app icon shortcuts and custom widgets, so those were affected too.
