### PR TITLE
Fix launch crash on iOS 16 from nested navigation stacks

### DIFF
--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -83,12 +83,8 @@ struct ContainerView: View {
         }
     }
 
-    /// The frontend, and the navigation stack Settings is pushed onto when the frontend's external bus asks
-    /// for it. The stack deliberately wraps only this screen: onboarding hosts a `NavigationStack` of its
-    /// own, and nesting two of them makes SwiftUI compare their differently-typed paths and fatally error
-    /// (`AnyNavigationPath.Error.comparisonTypeMismatch`) as the app lays out for the first time on iOS 16.
-    /// It stays out of the size-class branch it used to live in — rebuilding it on rotation reloaded the
-    /// frontend.
+    /// The frontend, in the stack Settings is pushed onto. Only this screen: onboarding brings its own
+    /// `NavigationStack`, and SwiftUI crashes on the two nested.
     private func frontend(server: Server, initialPath: String?) -> some View {
         NavigationStack(path: $appSettings.pushPath) {
             HomeAssistantView(server: server, initialPath: initialPath) { webViewController in

--- a/Sources/App/Container/ContainerView.swift
+++ b/Sources/App/Container/ContainerView.swift
@@ -6,6 +6,7 @@ import UIKit
 struct ContainerView: View {
     @StateObject private var state = OnboardingStateObservable()
     @StateObject private var viewModel = ContainerViewModel()
+    @ObservedObject private var appSettings = AppSettingsPresenter.shared
     @State private var coordinator = AppContainerCoordinator()
 
     var body: some View {
@@ -15,11 +16,7 @@ struct ContainerView: View {
                 OnboardingNavigationView(onboardingStyle: style)
                     .id(style)
             case let .webView(server, initialPath):
-                HomeAssistantView(server: server, initialPath: initialPath) { webViewController in
-                    coordinator.setFrontend(webViewController)
-                    Current.sceneManager.setWebViewController(webViewController)
-                }
-                .id(server.identifier.rawValue)
+                frontend(server: server, initialPath: initialPath)
             case .recoveredServerImport:
                 RecoveredServersImportView(onImport: { state.completeRecoveredServerImport() })
             case let .recoveredServerReauth(server):
@@ -82,6 +79,33 @@ struct ContainerView: View {
                 }
                 .navigationViewStyle(.stack)
                 .injectingViewControllerProvider()
+            }
+        }
+    }
+
+    /// The frontend, and the navigation stack Settings is pushed onto when the frontend's external bus asks
+    /// for it. The stack deliberately wraps only this screen: onboarding hosts a `NavigationStack` of its
+    /// own, and nesting two of them makes SwiftUI compare their differently-typed paths and fatally error
+    /// (`AnyNavigationPath.Error.comparisonTypeMismatch`) as the app lays out for the first time on iOS 16.
+    /// It stays out of the size-class branch it used to live in — rebuilding it on rotation reloaded the
+    /// frontend.
+    private func frontend(server: Server, initialPath: String?) -> some View {
+        NavigationStack(path: $appSettings.pushPath) {
+            HomeAssistantView(server: server, initialPath: initialPath) { webViewController in
+                coordinator.setFrontend(webViewController)
+                Current.sceneManager.setWebViewController(webViewController)
+            }
+            .id(server.identifier.rawValue)
+            .toolbar(.hidden, for: .navigationBar)
+            .navigationDestination(for: AppSettingsPushRoute.self) { route in
+                switch route {
+                case .settings:
+                    SettingsView(embedInOwnNavigation: false)
+                        .injectingViewControllerProvider()
+                case let .item(item):
+                    item.destinationView
+                        .injectingViewControllerProvider()
+                }
             }
         }
     }

--- a/Sources/App/Settings/Kiosk/KioskView.swift
+++ b/Sources/App/Settings/Kiosk/KioskView.swift
@@ -10,25 +10,14 @@ struct ConditionalContainerView: View {
     @State private var showKioskSettings = false
     @Namespace private var serverSelectionNamespace
 
+    // The navigation stack Settings is pushed onto lives in `ContainerView`, around the frontend alone:
+    // it is the only screen anything is ever pushed over, and a stack here would also enclose
+    // onboarding's own — two nested `NavigationStack`s crash SwiftUI on iOS 16.
     var body: some View {
-        // Always present: branching on the size class here rebuilt the frontend on every rotation.
-        NavigationStack(path: $appSettings.pushPath) {
-            content
-                .toolbar(.hidden, for: .navigationBar)
-                .navigationDestination(for: AppSettingsPushRoute.self) { route in
-                    switch route {
-                    case .settings:
-                        SettingsView(embedInOwnNavigation: false)
-                            .injectingViewControllerProvider()
-                    case let .item(item):
-                        item.destinationView
-                            .injectingViewControllerProvider()
-                    }
-                }
-        }
-        .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {
-            settingsSheet
-        }
+        content
+            .sheet(isPresented: $appSettings.isSheetPresented, onDismiss: appSettings.sheetDismissed) {
+                settingsSheet
+            }
     }
 
     /// One sheet, two sizes: the servers at the medium detent, Settings once it is expanded. Settings is

--- a/Sources/App/Settings/Settings/SettingsView.swift
+++ b/Sources/App/Settings/Settings/SettingsView.swift
@@ -112,7 +112,7 @@ struct SettingsView: View {
     // MARK: - iOS List View
 
     // When pushed onto the container's stack (`embedInOwnNavigation == false`) items are pushed as
-    // `AppSettingsPushRoute.item` instead, resolved by `ConditionalContainerView`: that path must stay
+    // `AppSettingsPushRoute.item` instead, resolved by `ContainerView`: that path must stay
     // single-typed or SwiftUI's path diffing can fatally error comparing elements of different types.
     @ViewBuilder
     private var iOSView: some View {

--- a/Tests/App/Container/ContainerNavigationTests.swift
+++ b/Tests/App/Container/ContainerNavigationTests.swift
@@ -1,0 +1,103 @@
+@testable import HomeAssistant
+@testable import Shared
+import SwiftUI
+import UIKit
+import XCTest
+
+/// The container hosts the frontend inside the navigation stack app Settings is pushed onto, and hosts
+/// onboarding — which runs a `NavigationStack` of its own — outside it. Nesting the two made SwiftUI
+/// force-try a comparison of their differently-typed paths and raise an unexpected error: on a push for
+/// iOS 17 and later, and on the app's very first layout on iOS 16.
+@MainActor
+final class ContainerNavigationTests: XCTestCase {
+    private var previousServers: ServerManager!
+    private var window: UIWindow?
+
+    override func setUp() {
+        super.setUp()
+        previousServers = Current.servers
+        AppSettingsPresenter.shared.pushPath = NavigationPath()
+    }
+
+    override func tearDown() {
+        window?.isHidden = true
+        window?.rootViewController = nil
+        window = nil
+        AppSettingsPresenter.shared.pushPath = NavigationPath()
+        Current.servers = previousServers
+        super.tearDown()
+    }
+
+    func testOnboardingIsHostedOutsideTheSettingsNavigationStack() {
+        Current.servers = FakeServerManager(initial: 0)
+
+        let window = hostContainer()
+
+        XCTAssertLessThanOrEqual(
+            navigationControllerCount(under: window.rootViewController),
+            1,
+            "Onboarding brings its own NavigationStack; a second one around it is what crashes SwiftUI"
+        )
+    }
+
+    func testFrontendHostsSettingsPushesWithoutNestingNavigationStacks() {
+        Current.servers = FakeServerManager(initial: 1)
+
+        let window = hostContainer()
+
+        XCTAssertLessThanOrEqual(
+            navigationControllerCount(under: window.rootViewController),
+            1,
+            "The frontend is shown inside the one stack Settings is pushed onto"
+        )
+
+        // What the frontend's external bus asks for, and what used to crash on the way in.
+        AppSettingsPresenter.shared.isPushPresented = true
+        settle(window)
+
+        XCTAssertEqual(AppSettingsPresenter.shared.pushPath.count, 1)
+
+        // Settings pushes its own screens onto the same path, as `AppSettingsPushRoute.item`.
+        AppSettingsPresenter.shared.pushPath.append(AppSettingsPushRoute.item(.help))
+        settle(window)
+
+        XCTAssertEqual(AppSettingsPresenter.shared.pushPath.count, 2)
+
+        AppSettingsPresenter.shared.isPushPresented = false
+        settle(window)
+
+        XCTAssertTrue(AppSettingsPresenter.shared.pushPath.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Puts the real app root on screen, so the screens below it lay out exactly as they do at launch.
+    private func hostContainer() -> UIWindow {
+        let controller = UIHostingController(rootView: ConditionalContainerView())
+        // On the host app's scene, so the window is a real one that reports appearance; a window
+        // without a scene never appears, and the screens are only built once they do.
+        let scene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        let window = scene.map { UIWindow(windowScene: $0) } ?? UIWindow()
+        window.frame = CGRect(origin: .zero, size: CGSize(width: 390, height: 844))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+        settle(window)
+        self.window = window
+        return window
+    }
+
+    /// Lets SwiftUI apply the pending state change and lay the result out before it is inspected.
+    private func settle(_ window: UIWindow) {
+        window.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
+        window.layoutIfNeeded()
+    }
+
+    private func navigationControllerCount(under controller: UIViewController?) -> Int {
+        guard let controller else { return 0 }
+        let own = controller is UINavigationController ? 1 : 0
+        return controller.children.reduce(own) { $0 + navigationControllerCount(under: $1) }
+    }
+}

--- a/Tests/UI/OnboardingE2ETests.swift
+++ b/Tests/UI/OnboardingE2ETests.swift
@@ -145,14 +145,11 @@ final class OnboardingE2ETests: XCTestCase {
     }
 
     private func openNativeSettingsFromFrontend() {
-        // Relaunched because asking the frontend for the settings screen in the same session that just
-        // onboarded crashes the app: SwiftUI raises an unexpected error from
-        // `NavigationColumnState.boundPathChange` the moment `AppSettingsPresenter.pushPath` gains its
-        // first element. Onboarding runs its own `NavigationStack` inside the container's, and the
-        // container's stack does not survive that nesting. Reproduces on iOS 26.5 and iOS 27; a
-        // relaunched app pushes the same screen without complaint.
-        app.terminate()
-        app.launch()
+        // Deliberately runs in the same session that just onboarded: that is the case the settings stack
+        // used to crash in. It was nested inside onboarding's own `NavigationStack`, and SwiftUI raised an
+        // unexpected error from `NavigationColumnState.boundPathChange` as soon as
+        // `AppSettingsPresenter.pushPath` gained its first element (and, on iOS 16, at the very first
+        // layout). The stack now wraps only the frontend, so nothing is nested and no relaunch is needed.
 
         // The toggle reports a successful tap even when the page swallows it, so the sidebar opening
         // is the only thing worth believing.


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
The container wrapped everything it shows in the `NavigationStack` that Settings is pushed onto, including onboarding, which runs a `NavigationStack` of its own. SwiftUI does not survive that nesting: it force-tries a comparison of the two differently-typed paths, and `AnyNavigationPath.Error.comparisonTypeMismatch` escapes as an unexpected error from `NavigationColumnState`.

On iOS 17+ that only fires once something is pushed, which is why the end-to-end test relaunched the app before asking the frontend for the settings screen. On iOS 16 it fires as the app lays out for the first time, so the app crashes on every launch before anything is on screen.

The stack now wraps only the frontend, the one screen anything is ever pushed over, so nothing nests. The end-to-end test drops its relaunch and covers the case that used to crash.

Fixes #5691
Fixes #5650

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
Nesting arrived in 2026.8.0: before it, the container had no stack of its own and onboarding used a `NavigationView`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012SduL9cgZdrTSb1wsqZtLB)_