### PR TITLE
Open cameras from widgets in the frontend more-info dialog

### DIFF
--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -25,7 +25,6 @@ class IncomingURLHandler {
         case navigate
         case invite
         case createCustomWidget = "createcustomwidget"
-        case camera
     }
 
     // swiftlint:disable cyclomatic_complexity
@@ -74,32 +73,6 @@ class IncomingURLHandler {
                     message: L10n.UrlHandler.SendLocation.Confirm.message,
                     handler: { self.sendLocationURLHandler() }
                 )
-            case .camera:
-                guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                    return false
-                }
-                components.scheme = nil
-                components.host = nil
-
-                let queryParameters = components.queryItems
-                let serverId = queryParameters?.first(where: { $0.name == "serverId" })?.value
-                let entityId = queryParameters?.first(where: { $0.name == "entityId" })?.value
-
-                guard let entityId,
-                      let server = Current.servers.all.first(where: { server in
-                          server.identifier.rawValue == serverId
-                      }) else {
-                    Current.Log.error("No server found for open camera URL: \(url)")
-                    return false
-                }
-                presentOverFrontend { webViewController in
-                    let view = CameraPlayerView(
-                        server: server,
-                        cameraEntityId: entityId
-                    ).embeddedInHostingController()
-                    view.modalPresentationStyle = .overFullScreen
-                    webViewController.present(view, animated: true)
-                }
             case .navigate: // homeassistant://navigate/lovelace/dashboard
                 guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                     return false

--- a/Sources/App/Frontend/IncomingURLHandler.swift
+++ b/Sources/App/Frontend/IncomingURLHandler.swift
@@ -25,6 +25,7 @@ class IncomingURLHandler {
         case navigate
         case invite
         case createCustomWidget = "createcustomwidget"
+        case camera
     }
 
     // swiftlint:disable cyclomatic_complexity
@@ -73,6 +74,16 @@ class IncomingURLHandler {
                     message: L10n.UrlHandler.SendLocation.Confirm.message,
                     handler: { self.sendLocationURLHandler() }
                 )
+            case .camera:
+                guard let entityId = serviceData["entityId"],
+                      let destination = AppConstants.openEntityDestinationURL(
+                          entityId: entityId,
+                          serverId: serviceData["serverId"] ?? ""
+                      ) else {
+                    Current.Log.error("No entity found for open camera URL: \(url)")
+                    return false
+                }
+                return handle(url: destination)
             case .navigate: // homeassistant://navigate/lovelace/dashboard
                 guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                     return false

--- a/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
+++ b/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
@@ -2,7 +2,7 @@ import AppIntents
 import Foundation
 import Shared
 
-/// Opens an entity's more-info dialog in the frontend (or the native player, for cameras).
+/// Opens an entity's more-info dialog in the frontend.
 ///
 /// Spotlight runs this intent when someone taps one of the indexed entities, which is why it exists
 /// separately from the widget control's `OpenEntityAppIntent`: only an `OpenIntent` with a `target`
@@ -20,7 +20,7 @@ struct ShowEntityDetailsAppIntent: OpenIntent {
     var target: HAAppEntityAppIntentEntity
 
     func perform() async throws -> some IntentResult {
-        guard let url = AppConstants.openEntityDestinationURL(
+        guard let url = AppConstants.openEntityDeeplinkURL(
             entityId: target.entityId,
             serverId: target.serverId
         ) else {

--- a/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
+++ b/Sources/App/Utilities/Spotlight/ShowEntityDetailsAppIntent.swift
@@ -20,7 +20,7 @@ struct ShowEntityDetailsAppIntent: OpenIntent {
     var target: HAAppEntityAppIntentEntity
 
     func perform() async throws -> some IntentResult {
-        guard let url = AppConstants.openEntityDeeplinkURL(
+        guard let url = AppConstants.openEntityDestinationURL(
             entityId: target.entityId,
             serverId: target.serverId
         ) else {

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -187,22 +187,9 @@ public enum AppConstants {
         pageDeeplinkURL(path: path)?.appending(queryItems: [URLQueryItem(name: "server", value: serverName)])
     }
 
-    /// Where tapping an entity lands: the native camera player for cameras, the frontend's more-info
-    /// dialog for everything else.
+    /// Where tapping an entity lands: the frontend's more-info dialog, cameras included.
     public static func openEntityDestinationURL(entityId: String, serverId: String) -> URL? {
-        if Domain(entityId: entityId) == .camera {
-            return openCameraDeeplinkURL(entityId: entityId, serverId: serverId)
-        }
-        return openEntityDeeplinkURL(entityId: entityId, serverId: serverId)
-    }
-
-    /// The deep link host that opens the native camera player.
-    public static let cameraDeeplinkHost = "camera"
-
-    public static func openCameraDeeplinkURL(entityId: String, serverId: String) -> URL? {
-        URL(
-            string: "\(AppConstants.deeplinkURL.absoluteString)\(cameraDeeplinkHost)/?entityId=\(entityId)&serverId=\(serverId)&\(AppConstants.QueryItems.isComingFromAppIntent.rawValue)=true"
-        )
+        openEntityDeeplinkURL(entityId: entityId, serverId: serverId)
     }
 
     public static func todoListAddItemURL(listId: String, serverId: String) -> URL? {

--- a/Sources/Shared/MagicItem/MagicItem.swift
+++ b/Sources/Shared/MagicItem/MagicItem.swift
@@ -313,8 +313,7 @@ public struct MagicItem: Codable, Equatable, Hashable {
     /// `Domain.isActionable` domain the domain's own action — its main action where it names one
     /// ("Press", "Activate", "Run", "Trigger"), its toggle otherwise, which covers the
     /// state-aware pairs so a locked lock unlocks and a closed cover opens. Every other entity
-    /// only opens: its more-info dialog, or the native camera player for a camera. An Assist
-    /// pipeline starts Assist.
+    /// only opens its more-info dialog. An Assist pipeline starts Assist.
     public var defaultIconAction: ItemAction {
         if type == .assistPipeline {
             return .assist(serverId, assistPipelineId ?? id, true)
@@ -455,8 +454,7 @@ public struct MagicItem: Codable, Equatable, Hashable {
         return .widgetURL(url)
     }
 
-    /// Opens this item's entity where tapping it lands: the native camera player for a camera,
-    /// its more-info dialog in the app's web view for everything else.
+    /// Opens this item's entity where tapping it lands: its more-info dialog in the app's web view.
     private func openEntityIntent() -> WidgetInteractionType {
         navigateIntent(url: AppConstants.openEntityDestinationURL(
             entityId: id,

--- a/Sources/Shared/WidgetInteractionType.swift
+++ b/Sources/Shared/WidgetInteractionType.swift
@@ -4,18 +4,14 @@ public enum WidgetInteractionType: Hashable, Encodable {
     case widgetURL(URL)
     case appIntent(WidgetIntentType)
 
-    /// Whether this only opens the entity in the app — its more-info dialog, or the native camera
-    /// player a camera opens in instead — the one interaction a tile never asks to confirm, since
-    /// it changes nothing.
+    /// Whether this only opens the entity's more-info dialog in the app, the one interaction a tile
+    /// never asks to confirm, since it changes nothing.
     public var opensEntityInApp: Bool {
         guard case let .widgetURL(url) = self,
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let scheme = components.scheme,
               AppConstants.deeplinkSchemes.contains(scheme) else {
             return false
-        }
-        if components.host == AppConstants.cameraDeeplinkHost {
-            return true
         }
         return components.queryItems?
             .contains { $0.name == AppConstants.QueryItems.openMoreInfoDialog.rawValue } == true

--- a/Tests/App/AppConstants.test.swift
+++ b/Tests/App/AppConstants.test.swift
@@ -76,6 +76,17 @@ struct AppConstantsTests {
         )
     }
 
+    @Test func testOpenEntityDestinationURLOpensMoreInfoDialogForEveryDomain() async throws {
+        let serverId = "server123"
+        for entityId in ["camera.porch", "light.living_room", "sensor.temperature"] {
+            let result = AppConstants.openEntityDestinationURL(entityId: entityId, serverId: serverId)
+            #expect(result != nil, "\(entityId) should have a destination")
+            #expect(result == AppConstants.openEntityDeeplinkURL(entityId: entityId, serverId: serverId))
+            #expect(result?.host == "navigate")
+            #expect(result?.absoluteString.contains("more-info-entity-id=\(entityId)") == true)
+        }
+    }
+
     @Test func testOpenEntityMoreInfoDeeplinkURL() async throws {
         let entityId = "light.living_room"
         let result = AppConstants.openEntityMoreInfoDeeplinkURL(entityId: entityId)?.absoluteString

--- a/Tests/App/MagicItem/MagicItemWidgetInteraction.test.swift
+++ b/Tests/App/MagicItem/MagicItemWidgetInteraction.test.swift
@@ -430,9 +430,9 @@ struct MagicItemWidgetInteractionTests {
         #expect(item.widgetTapInteractionType.opensEntityInApp)
     }
 
-    /// A camera opens in the app's own player rather than the frontend's more-info dialog, and that
-    /// is still only opening the entity, so it is exempt from confirmation too.
-    @Test func cameraOpensTheNativePlayer() {
+    /// A camera opens the frontend's more-info dialog like any other entity, and that is only
+    /// opening the entity, so it is exempt from confirmation too.
+    @Test func cameraOpensTheMoreInfoDialog() {
         let camera = MagicItem(id: "camera.porch", serverId: "1", type: .entity)
 
         #expect(camera.defaultIconAction == .moreInfoDialog)
@@ -444,8 +444,8 @@ struct MagicItemWidgetInteractionTests {
             Issue.record("Expected a deep link, got \(camera.widgetInteractionType)")
             return
         }
-        #expect(url.host == AppConstants.cameraDeeplinkHost)
-        #expect(url.absoluteString.contains("entityId=camera.porch"))
+        #expect(url.host == "navigate")
+        #expect(url.absoluteString.contains("\(AppConstants.QueryItems.openMoreInfoDialog.rawValue)=camera.porch"))
     }
 
     /// A `url` action opens exactly what was typed, and an address typed without a scheme still

--- a/Tests/App/WebView/IncomingURLHandler.test.swift
+++ b/Tests/App/WebView/IncomingURLHandler.test.swift
@@ -1,0 +1,46 @@
+@testable import HomeAssistant
+@testable import Shared
+import Testing
+
+/// The `camera` deep link used to open the native camera player; it now lands on the entity's
+/// more-info dialog, so links created before the change keep working.
+struct IncomingURLHandlerTests {
+    private func withFakeServer(_ body: (Server, MockAppCoordinator, IncomingURLHandler) throws -> Void) throws {
+        let previousServers = Current.servers
+        defer { Current.servers = previousServers }
+        let manager = FakeServerManager(initial: 0)
+        let server = manager.addFake()
+        Current.servers = manager
+
+        let coordinator = MockAppCoordinator()
+        let handler = IncomingURLHandler(coordinator: coordinator)
+        try body(server, coordinator, handler)
+    }
+
+    @Test func cameraDeeplinkOpensTheMoreInfoDialog() throws {
+        try withFakeServer { server, coordinator, handler in
+            let url = try #require(URL(
+                string: "\(AppConstants.deeplinkURL.absoluteString)camera/?entityId=camera.porch&serverId=\(server.identifier.rawValue)"
+            ))
+
+            #expect(handler.handle(url: url))
+
+            let opened = try #require(coordinator.openedDeeplinks.first)
+            #expect(opened.server.identifier == server.identifier)
+            #expect(opened.urlString.contains("\(AppConstants.QueryItems.openMoreInfoDialog.rawValue)=camera.porch"))
+            #expect(coordinator.openedDeeplinksSelectingServer.isEmpty)
+        }
+    }
+
+    @Test func cameraDeeplinkWithoutEntityIsRejected() throws {
+        try withFakeServer { server, coordinator, handler in
+            let url = try #require(URL(
+                string: "\(AppConstants.deeplinkURL.absoluteString)camera/?serverId=\(server.identifier.rawValue)"
+            ))
+
+            #expect(!handler.handle(url: url))
+            #expect(coordinator.openedDeeplinks.isEmpty)
+            #expect(coordinator.openedDeeplinksSelectingServer.isEmpty)
+        }
+    }
+}

--- a/Tests/App/WebView/Mocks/MockAppCoordinator.swift
+++ b/Tests/App/WebView/Mocks/MockAppCoordinator.swift
@@ -10,6 +10,8 @@ final class MockAppCoordinator: AppCoordinator {
     private(set) var showAssistSettingsCalled = false
     private(set) var dismissPresentedContentCallCount = 0
     private(set) var activatedServers: [Server] = []
+    private(set) var openedDeeplinks: [(server: Server, urlString: String)] = []
+    private(set) var openedDeeplinksSelectingServer: [String] = []
     var onShowSettings: (() -> Void)?
     var onShowAssistSettings: (() -> Void)?
 
@@ -52,7 +54,9 @@ final class MockAppCoordinator: AppCoordinator {
         skipConfirm: Bool,
         avoidUnnecessaryReload: Bool,
         isComingFromAppIntent: Bool
-    ) {}
+    ) {
+        openedDeeplinks.append((server, urlString))
+    }
 
     func openSelectingServer(
         from: OpenSource,
@@ -60,7 +64,9 @@ final class MockAppCoordinator: AppCoordinator {
         skipConfirm: Bool,
         queryParameters: [URLQueryItem]?,
         isComingFromAppIntent: Bool
-    ) {}
+    ) {
+        openedDeeplinksSelectingServer.append(urlString)
+    }
 
     func dismissPresentedContent(completion: (() -> Void)?) {
         dismissPresentedContentCallCount += 1


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Widgets, controls, Spotlight results and app icon shortcuts that open a camera currently open the native camera player. Its quality is not where we want it yet, so for now cameras open the frontend's more-info dialog again, like every other entity.

The `camera` deep link that only existed to reach the native player from those places now redirects to the same more-info dialog, so links created before this change keep working.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The native player stays in place for the kiosk camera overlay and the frontend's own `camera/show` external bus message; only the entity deep link destination changes.
