### PR TITLE
Disable the tests that hang CI

### DIFF
--- a/Tests/App/Auth/OnboardingAuthStepDeviceNaming.test.swift
+++ b/Tests/App/Auth/OnboardingAuthStepDeviceNaming.test.swift
@@ -53,14 +53,16 @@ final class OnboardingAuthStepDeviceNamingTests: XCTestCase {
         XCTAssertTrue(OnboardingAuthStepDeviceNaming.supportedPoints.contains(.beforeRegister))
     }
 
-    func testNoWebSocketResponseWithoutError() {
+    func testNoWebSocketResponseWithoutError() throws {
+        try XCTSkipIf(true, "Hangs the test run waiting on the zero-second timeout; re-enabled once the wait is fixed")
         step.timeout = 0
         XCTAssertThrowsError(try hang(step.perform(point: .beforeRegister))) { error in
             XCTAssertEqual((error as? OnboardingAuthError)?.kind, .invalidURL)
         }
     }
 
-    func testNoWebSocketResponseWithError() {
+    func testNoWebSocketResponseWithError() throws {
+        try XCTSkipIf(true, "Hangs the test run waiting on the zero-second timeout; re-enabled once the wait is fixed")
         step.timeout = 0
         connection
             .setState(.disconnected(reason: .waitingToReconnect(

--- a/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
+++ b/Tests/App/Utilities/OpenCloseEntityAppIntentTests.swift
@@ -62,7 +62,8 @@ struct OpenCloseEntityAppIntentTests {
         try await body(server, connection)
     }
 
-    @Test func openCallsOpenCover() async throws {
+    @Test(.disabled("Hangs CI when the request lands after the one second poll"))
+    func openCallsOpenCover() async throws {
         try await withMockedServer { server, connection in
             let intent = OpenCloseEntityAppIntent()
             intent.action = .open
@@ -75,7 +76,8 @@ struct OpenCloseEntityAppIntentTests {
         }
     }
 
-    @Test func closeCallsCloseCover() async throws {
+    @Test(.disabled("Hangs CI when the request lands after the one second poll"))
+    func closeCallsCloseCover() async throws {
         try await withMockedServer { server, connection in
             let intent = OpenCloseEntityAppIntent()
             intent.action = .close

--- a/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
+++ b/Tests/App/Utilities/ReadableEntityAppEntityQueryTests.swift
@@ -170,7 +170,8 @@ struct GetEntityStateAppIntentTests {
         try await body(server, connection)
     }
 
-    @Test func readingAStateAsksTheServerAndKeepsTheContext() async throws {
+    @Test(.disabled("Hangs CI when a request lands after the poll"))
+    func readingAStateAsksTheServerAndKeepsTheContext() async throws {
         try await withMockedServer { server, connection in
             var intent = GetEntityStateAppIntent()
             intent.entity = Self.entity(serverId: server.identifier.rawValue)

--- a/Tests/App/Utilities/TurnOnOffEntityAppIntentTests.swift
+++ b/Tests/App/Utilities/TurnOnOffEntityAppIntentTests.swift
@@ -73,7 +73,8 @@ struct TurnOnOffEntityAppIntentTests {
         return first?.data["service"] as? String
     }
 
-    @Test func onSendsTurnOn() async throws {
+    @Test(.disabled("Hangs CI when a request lands after the poll"))
+    func onSendsTurnOn() async throws {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .on)
             intent.entity = Self.entity(serverId: server.identifier.rawValue)
@@ -82,7 +83,8 @@ struct TurnOnOffEntityAppIntentTests {
         }
     }
 
-    @Test func offSendsTurnOff() async throws {
+    @Test(.disabled("Hangs CI when a request lands after the poll"))
+    func offSendsTurnOff() async throws {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .off)
             intent.entity = Self.entity(serverId: server.identifier.rawValue)
@@ -92,7 +94,8 @@ struct TurnOnOffEntityAppIntentTests {
     }
 
     /// The service still comes from the domain, so the same intent opens a cover.
-    @Test func onOpensACover() async throws {
+    @Test(.disabled("Hangs CI when a request lands after the poll"))
+    func onOpensACover() async throws {
         try await withMockedServer { server, connection in
             var intent = TurnOnOffEntityAppIntent(action: .on)
             intent.entity = Self.entity(serverId: server.identifier.rawValue, entityId: "cover.curtain")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Since this morning the `test` job hangs on every branch in `OnboardingAuthStepDeviceNamingTests`: `testNoWebSocketResponseWithError` never returns and the job is cancelled at the 60 minute limit. The two `testNoWebSocketResponse*` tests race a zero-second timeout against a mock connection that never answers and wait on the run loop; they used to take milliseconds, and now take about a minute when they finish at all.

Both are skipped with `XCTSkip` until the wait is fixed.

With those skipped the run got further and then hung in `OpenCloseEntityAppIntentTests`: `openCallsOpenCover` and `closeCallsCloseCover` poll for the mock request for one second and then await the intent with no bound, so a slow network refresh stalls the run the same way. Both are disabled too, and so are the tests with the same shape that hung on the next attempt or would next: `onSendsTurnOn`, `offSendsTurnOff` and `onOpensACover` in `TurnOnOffEntityAppIntentTests`, and `readingAStateAsksTheServerAndKeepsTheContext` in `ReadableEntityAppEntityQueryTests`.

The re-enabling PR is linked below.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Re-enabling PR: https://github.com/home-assistant/iOS/pull/5698



