### PR TITLE
Fix the CI test job hanging after the kiosk tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
   test:
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b  # v1.321.0

--- a/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
+++ b/Tests/App/Kiosk/CameraOverlayPresenterTests.swift
@@ -7,6 +7,7 @@ import XCTest
 @MainActor
 final class CameraOverlayPresenterTests: XCTestCase {
     private var previousDatabase: (() -> DatabaseQueue)!
+    private var previousSensors: SensorContainer!
     private var kiosk: KioskModeManager!
     private var presenter: CameraOverlayPresenter!
     private var webViewController: MockWebViewController!
@@ -18,6 +19,8 @@ final class CameraOverlayPresenterTests: XCTestCase {
         try KioskSettingsTable().createIfNeeded(database: database)
         previousDatabase = Current.database
         Current.database = { database }
+        previousSensors = Current.sensors
+        Current.sensors = SensorContainer()
         SensorEnablementStore.resetForTesting()
 
         kiosk = KioskModeManager()
@@ -26,6 +29,7 @@ final class CameraOverlayPresenterTests: XCTestCase {
     }
 
     override func tearDown() {
+        Current.sensors = previousSensors
         Current.database = previousDatabase
         SensorEnablementStore.resetForTesting()
         super.tearDown()

--- a/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
+++ b/Tests/App/Kiosk/KioskModeManagerSensorSyncTests.swift
@@ -11,6 +11,7 @@ import XCTest
 final class KioskModeManagerSensorSyncTests: XCTestCase {
     private var database: DatabaseQueue!
     private var previousDatabase: (() -> DatabaseQueue)!
+    private var previousSensors: SensorContainer!
 
     private let kioskSensorIds = [WebhookSensorId.kioskBrightness, .kioskVolume, .kioskScreensaver]
 
@@ -22,11 +23,14 @@ final class KioskModeManagerSensorSyncTests: XCTestCase {
         self.database = database
         previousDatabase = Current.database
         Current.database = { database }
+        previousSensors = Current.sensors
+        Current.sensors = SensorContainer()
 
         SensorEnablementStore.resetForTesting()
     }
 
     override func tearDown() {
+        Current.sensors = previousSensors
         Current.database = previousDatabase
         SensorEnablementStore.resetForTesting()
         super.tearDown()

--- a/Tests/App/Kiosk/KioskScreensaverControllerTests.swift
+++ b/Tests/App/Kiosk/KioskScreensaverControllerTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class KioskScreensaverControllerTests: XCTestCase {
     private var database: DatabaseQueue!
     private var previousDatabase: (() -> DatabaseQueue)!
+    private var previousSensors: SensorContainer!
     private var kiosk: KioskModeManager!
 
     override func setUpWithError() throws {
@@ -17,10 +18,13 @@ final class KioskScreensaverControllerTests: XCTestCase {
         self.database = database
         previousDatabase = Current.database
         Current.database = { database }
+        previousSensors = Current.sensors
+        Current.sensors = SensorContainer()
         SensorEnablementStore.resetForTesting()
     }
 
     override func tearDown() {
+        Current.sensors = previousSensors
         Current.database = previousDatabase
         SensorEnablementStore.resetForTesting()
         super.tearDown()

--- a/Tests/App/WebView/WebViewControllerTests.swift
+++ b/Tests/App/WebView/WebViewControllerTests.swift
@@ -876,12 +876,15 @@ final class WebViewControllerTests: XCTestCase {
     func testPrefersStatusBarHiddenTracksKioskAndFullScreenSettings() throws {
         let previousDatabase = Current.database
         let previousKiosk = Current.kiosk
+        let previousSensors = Current.sensors
         let previousFullScreen = Current.settingsStore.fullScreen
         defer {
             Current.database = previousDatabase
             Current.kiosk = previousKiosk
+            Current.sensors = previousSensors
             Current.settingsStore.fullScreen = previousFullScreen
         }
+        Current.sensors = SensorContainer()
 
         let database = try DatabaseQueue()
         try KioskSettingsTable().createIfNeeded(database: database)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Since #5664 the `test` job hangs on most runs and is cancelled at the 60 minute limit, usually inside `OnboardingAuthStepDeviceNamingTests`.

The kiosk suites turn kiosk mode on, which enables the kiosk sensors through the shared `Current.sensors`. Every `HomeAssistantAPI` created by earlier suites is still alive as a sensor observer, so each of them registers sensors and uploads them over the webhook, and every one of those calls parks a dispatch worker on a background-task semaphore. With enough of them the pool is exhausted, `after(seconds:)` never fires, and whichever test is waiting on a promise next hangs forever.

The three kiosk suites, and the WebView status bar test that creates a `KioskModeManager` with kiosk enabled, now swap in a fresh `SensorContainer` for the duration of each test, the same way `SensorPermissionOnEnable.test.swift` already does, so flipping kiosk mode no longer reaches the rest of the run.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The `test` job also gets 90 minutes instead of 60: runs without the DerivedData cache have been taking most of the hour lately, so a slow but healthy run and a hung one were indistinguishable. A per-test execution time allowance in the fastlane test lane, so a hung test fails in minutes with a spindump instead of consuming the job, is a sensible follow-up but is left out here to keep this to the fix.


