### PR TITLE
Improve tab bar experiment

### DIFF
--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarButtonLocator.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarButtonLocator.swift
@@ -2,8 +2,12 @@ import UIKit
 
 /// Finds where the tab bar draws a tab, in window coordinates, so a presentation can zoom out of it.
 enum NativeTabBarButtonLocator {
+    static func tabBar(in window: UIWindow) -> UITabBar? {
+        firstView(in: window, where: { $0 is UITabBar }) as? UITabBar
+    }
+
     static func frame(ofButtonTitled title: String, trailing: Bool, in window: UIWindow? = keyWindow) -> CGRect? {
-        guard let window, let tabBar = firstView(in: window, where: { $0 is UITabBar }) else { return nil }
+        guard let window, let tabBar = tabBar(in: window) else { return nil }
         let button = firstView(in: tabBar, where: { ($0 as? UILabel)?.text == title }).map(control(enclosing:))
             ?? (trailing ? trailingControl(in: tabBar) : nil)
         guard let button else { return nil }

--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarContainerView.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarContainerView.swift
@@ -10,6 +10,7 @@ struct NativeTabBarContainerView<FrontendOverlay: View>: View {
     }
 
     @ObservedObject var viewModel: NativeTabBarViewModel
+    @Environment(\.serverSelectionNamespace) private var transitionNamespace
     let webViewController: WebViewController?
     let frontendOpacity: Double
     let frontendIgnoredSafeAreaEdges: Edge.Set
@@ -96,6 +97,31 @@ struct NativeTabBarContainerView<FrontendOverlay: View>: View {
         }
         .tabViewSearchActivation(.searchTabSelection)
         .tabBarMinimizeBehavior(.onScrollDown)
+        .background(NativeTabBarLongPressInstaller {
+            viewModel.showCustomize(zoomingFromButton: false)
+        })
+        .sheet(isPresented: $viewModel.showsCustomize) {
+            NavigationStack {
+                NativeTabBarCustomizeView(viewModel: viewModel)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            CloseButton {
+                                viewModel.showsCustomize = false
+                            }
+                        }
+                    }
+            }
+            .modify { view in
+                if viewModel.customizeZoomsFromButton, let transitionNamespace {
+                    view.navigationTransition(.zoom(
+                        sourceID: NativeTabBarViewModel.customizeTransitionID,
+                        in: transitionNamespace
+                    ))
+                } else {
+                    view
+                }
+            }
+        }
         .onAppear { viewModel.start() }
         .onDisappear { viewModel.stop() }
     }

--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarLongPressInstaller.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarLongPressInstaller.swift
@@ -1,0 +1,62 @@
+import Shared
+import SwiftUI
+import UIKit
+
+/// Opens Customize Tabs on a long press anywhere on the tab bar, which SwiftUI's `Tab` offers no hook for.
+struct NativeTabBarLongPressInstaller: UIViewRepresentable {
+    let onLongPress: () -> Void
+
+    func makeUIView(context: Context) -> InstallerView {
+        let view = InstallerView()
+        view.onLongPress = onLongPress
+        return view
+    }
+
+    func updateUIView(_ view: InstallerView, context: Context) {
+        view.onLongPress = onLongPress
+    }
+
+    final class InstallerView: UIView, UIGestureRecognizerDelegate {
+        static let minimumPressDuration: TimeInterval = 0.5
+
+        var onLongPress: (() -> Void)?
+        private(set) weak var recognizer: UILongPressGestureRecognizer?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            installIfNeeded()
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            installIfNeeded()
+        }
+
+        func installIfNeeded(in window: UIWindow? = nil) {
+            guard recognizer == nil, let window = window ?? self.window,
+                  let tabBar = NativeTabBarButtonLocator.tabBar(in: window) else { return }
+            let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(handle(_:)))
+            recognizer.minimumPressDuration = Self.minimumPressDuration
+            recognizer.delegate = self
+            tabBar.addGestureRecognizer(recognizer)
+            self.recognizer = recognizer
+        }
+
+        func handle(state: UIGestureRecognizer.State) {
+            guard state == .began else { return }
+            Current.impactFeedback.impactOccurred(style: .light)
+            onLongPress?()
+        }
+
+        @objc private func handle(_ recognizer: UILongPressGestureRecognizer) {
+            handle(state: recognizer.state)
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+    }
+}

--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarMoreView.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarMoreView.swift
@@ -13,7 +13,7 @@ struct NativeTabBarMoreView: View {
 
     @ObservedObject var viewModel: NativeTabBarViewModel
     @State private var rowFrames: [String: CGRect] = [:]
-    @Environment(\.serverSelectionNamespace) private var settingsTransitionNamespace
+    @Environment(\.serverSelectionNamespace) private var transitionNamespace
 
     var body: some View {
         List {
@@ -55,10 +55,10 @@ struct NativeTabBarMoreView: View {
                 }
                 .buttonStyle(.plain)
                 .modify { view in
-                    if let settingsTransitionNamespace {
+                    if let transitionNamespace {
                         view.matchedTransitionSource(
                             id: NativeTabBarViewModel.customizeTransitionID,
-                            in: settingsTransitionNamespace
+                            in: transitionNamespace
                         )
                     } else {
                         view
@@ -163,10 +163,10 @@ struct NativeTabBarMoreView: View {
                 }
                 .accessibilityLabel(L10n.Mac.Sidebar.settings)
                 .modify { view in
-                    if let settingsTransitionNamespace {
+                    if let transitionNamespace {
                         view.matchedTransitionSource(
                             id: NativeTabBarViewModel.appSettingsTransitionID,
-                            in: settingsTransitionNamespace
+                            in: transitionNamespace
                         )
                     } else {
                         view

--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarMoreView.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarMoreView.swift
@@ -11,12 +11,8 @@ struct NativeTabBarMoreView: View {
         static let badgeOffset: CGFloat = 6
     }
 
-    private static let customizeTransitionID = "customizeTabs"
-
     @ObservedObject var viewModel: NativeTabBarViewModel
-    @State private var showsCustomize = false
     @State private var rowFrames: [String: CGRect] = [:]
-    @Namespace private var customizeNamespace
     @Environment(\.serverSelectionNamespace) private var settingsTransitionNamespace
 
     var body: some View {
@@ -45,7 +41,7 @@ struct NativeTabBarMoreView: View {
             }
             Section {
                 Button {
-                    showsCustomize = true
+                    viewModel.showCustomize(zoomingFromButton: true)
                 } label: {
                     HStack(spacing: DesignSystem.Spaces.one) {
                         Image(systemSymbol: .pencil)
@@ -58,7 +54,16 @@ struct NativeTabBarMoreView: View {
                     .background(Capsule().fill(Color(uiColor: .secondarySystemFill)))
                 }
                 .buttonStyle(.plain)
-                .matchedTransitionSource(id: Self.customizeTransitionID, in: customizeNamespace)
+                .modify { view in
+                    if let settingsTransitionNamespace {
+                        view.matchedTransitionSource(
+                            id: NativeTabBarViewModel.customizeTransitionID,
+                            in: settingsTransitionNamespace
+                        )
+                    } else {
+                        view
+                    }
+                }
                 .frame(maxWidth: .infinity)
                 .listRowBackground(Color.clear)
                 .listRowInsets(EdgeInsets())
@@ -168,19 +173,6 @@ struct NativeTabBarMoreView: View {
                     }
                 }
             }
-        }
-        .sheet(isPresented: $showsCustomize) {
-            NavigationStack {
-                NativeTabBarCustomizeView(viewModel: viewModel)
-                    .toolbar {
-                        ToolbarItem(placement: .topBarTrailing) {
-                            CloseButton {
-                                showsCustomize = false
-                            }
-                        }
-                    }
-            }
-            .navigationTransition(.zoom(sourceID: Self.customizeTransitionID, in: customizeNamespace))
         }
     }
 }

--- a/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarViewModel.swift
+++ b/Sources/App/Frontend/WebView/NativeTabBar/NativeTabBarViewModel.swift
@@ -7,6 +7,7 @@ import Shared
 final class NativeTabBarViewModel: ObservableObject {
     static let maximumTabs = 4
     static let appSettingsTransitionID = "nativeTabBarAppSettings"
+    static let customizeTransitionID = "nativeTabBarCustomize"
 
     @Published private(set) var tabItems: [NativeTabBarItem] = []
     /// Entries that did not make it into the bar, in list order.
@@ -16,6 +17,8 @@ final class NativeTabBarViewModel: ObservableObject {
     @Published private(set) var selection: NativeTabBarTab
     /// The More tab shows its list until the user opens a page from it, then the frontend takes over.
     @Published private(set) var moreShowsFrontend = false
+    @Published var showsCustomize = false
+    private(set) var customizeZoomsFromButton = true
 
     let sidebar: MacSidebarViewModel
     /// Opens the frontend's own quick search; the Search tab is an action, never a selected tab.
@@ -221,6 +224,12 @@ final class NativeTabBarViewModel: ObservableObject {
     }
 
     // MARK: - Customisation
+
+    /// Opens Customize Tabs, zooming out of the More tab's button when that is what was tapped.
+    func showCustomize(zoomingFromButton: Bool) {
+        customizeZoomsFromButton = zoomingFromButton
+        showsCustomize = true
+    }
 
     func moveItems(fromOffsets source: IndexSet, toOffset destination: Int) {
         var items = tabItems + moreItems

--- a/Tests/App/WebView/NativeTabBarLongPressInstallerTests.swift
+++ b/Tests/App/WebView/NativeTabBarLongPressInstallerTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import HomeAssistant
+import Testing
+import UIKit
+
+@MainActor
+struct NativeTabBarLongPressInstallerTests {
+    @Test("A long press on the tab bar opens Customize once per press and never blocks the bar's own gestures")
+    func longPressOpensCustomize() throws {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let controller = UITabBarController()
+        controller.viewControllers = [UIViewController(), UIViewController()]
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        var presses = 0
+        let installer = NativeTabBarLongPressInstaller.InstallerView()
+        installer.onLongPress = { presses += 1 }
+        installer.installIfNeeded(in: window)
+        installer.installIfNeeded(in: window)
+
+        let recognizer = try #require(installer.recognizer)
+        #expect(controller.tabBar.gestureRecognizers?.filter { $0 === recognizer }.count == 1)
+        #expect(recognizer.minimumPressDuration == NativeTabBarLongPressInstaller.InstallerView.minimumPressDuration)
+        #expect(installer.gestureRecognizer(recognizer, shouldRecognizeSimultaneouslyWith: UITapGestureRecognizer()))
+
+        installer.handle(state: .began)
+        installer.handle(state: .changed)
+        installer.handle(state: .ended)
+        #expect(presses == 1)
+
+        let detached = NativeTabBarLongPressInstaller.InstallerView()
+        detached.installIfNeeded(in: UIWindow(frame: .zero))
+        #expect(detached.recognizer == nil)
+    }
+}

--- a/Tests/App/WebView/NativeTabBarLongPressInstallerTests.swift
+++ b/Tests/App/WebView/NativeTabBarLongPressInstallerTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 @testable import HomeAssistant
 import Testing
 import UIKit

--- a/Tests/App/WebView/NativeTabBarViewModelTests.swift
+++ b/Tests/App/WebView/NativeTabBarViewModelTests.swift
@@ -453,6 +453,21 @@ struct NativeTabBarViewModelTests {
         #expect(coordinator.openedServers.map(\.identifier) == [other.identifier, other.identifier])
     }
 
+    @Test("Customize opens from the More button with a zoom and from a long press without one")
+    func showCustomize() {
+        let sut = makeFixture("customize").sut
+        #expect(!sut.showsCustomize)
+
+        sut.showCustomize(zoomingFromButton: false)
+        #expect(sut.showsCustomize)
+        #expect(!sut.customizeZoomsFromButton)
+
+        sut.showsCustomize = false
+        sut.showCustomize(zoomingFromButton: true)
+        #expect(sut.showsCustomize)
+        #expect(sut.customizeZoomsFromButton)
+    }
+
     @Test("Without an injected list the servers are the app's registered servers")
     func defaultServers() {
         let overlayState = WebFrontendOverlayState()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Follow-up to #5705 for the App Labs native tab bar, TestFlight only.

A long press anywhere on the tab bar opens Customize Tabs, with a light haptic. SwiftUI's `Tab` has no long-press hook, so a long-press recognizer is attached to the tab bar UIKit renders; it recognizes alongside the bar's own gestures, so taps keep working. The Customize sheet moves from the More tab to the tab bar container so it can open from any tab; the More tab's Customize button still zooms into it.

Everything is behind the App Labs flag; with it off the flow is unchanged.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
App Labs feature, TestFlight only.
