### PR TITLE
Fix Assist keyboard button not responding to taps

### DIFF
--- a/Sources/App/Assist/AssistView.swift
+++ b/Sources/App/Assist/AssistView.swift
@@ -506,6 +506,7 @@ struct AssistView: View {
                 .font(.system(size: Constants.keyboardIconFontSize, weight: .medium))
                 .foregroundStyle(.primary)
                 .frame(width: Constants.keyboardButtonSize, height: Constants.keyboardButtonSize)
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .modify { view in


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While Assist is listening on iPhone, tapping the keyboard button did nothing.

Its label is an 18pt symbol padded out to 44pt by a `frame`, and hit testing only covers what a label draws, so the tappable area was just the glyph in the middle of the circle. Adding `contentShape(Circle())` makes the whole visible circle tappable, matching what `ModalReusableButton` already does.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change, only the hit area.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The mic and send buttons in the input row share the same arrangement, with the glass applied outside the button, so their hit area is the icon rather than the circle too. They are large enough to be usable, so they are left alone here.
