### PR TITLE
Make flaky unit tests deterministic

### DIFF
--- a/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
+++ b/Sources/App/Settings/EntityPicker/EntityPickerViewModel.swift
@@ -88,6 +88,12 @@ final class EntityPickerViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        $entities
+            .sink { [weak self] _ in
+                self?.cachedEntitiesByServer.removeAll()
+            }
+            .store(in: &cancellables)
+
         // Recompute area-based caches when area data changes
         $areaData
             .sink { [weak self] _ in

--- a/Tests/App/Cameras/WebRTCViewPlayerViewModelSignalingTests.swift
+++ b/Tests/App/Cameras/WebRTCViewPlayerViewModelSignalingTests.swift
@@ -17,7 +17,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
 
     private let timing = WebRTCViewPlayerViewModel.Timing(
         connectionTimeout: 0.2,
-        disconnectedGracePeriod: 0.1,
+        disconnectedGracePeriod: 1.0,
         signalingStallTimeout: 0.2,
         connectionWaitTimeout: 1.0,
         backgroundTeardownDelay: 60
@@ -400,7 +400,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
     private func flushMainQueue() {
         let flushed = expectation(description: "main queue flushed")
         DispatchQueue.main.async { flushed.fulfill() }
-        wait(for: [flushed], timeout: 2)
+        wait(for: [flushed], timeout: 10.0)
     }
 
     private func spinMain(for interval: TimeInterval) {

--- a/Tests/App/Cameras/WebRTCViewPlayerViewModelTests.swift
+++ b/Tests/App/Cameras/WebRTCViewPlayerViewModelTests.swift
@@ -173,6 +173,6 @@ final class WebRTCViewPlayerViewModelTests: XCTestCase {
     private func flushMainQueue() {
         let flushed = expectation(description: "main queue flushed")
         DispatchQueue.main.async { flushed.fulfill() }
-        wait(for: [flushed], timeout: 2)
+        wait(for: [flushed], timeout: 10.0)
     }
 }

--- a/Tests/App/CarPlay/CarPlayVacuumControlViewModel.test.swift
+++ b/Tests/App/CarPlay/CarPlayVacuumControlViewModel.test.swift
@@ -143,7 +143,7 @@ final class CarPlayVacuumControlViewModelTests: XCTestCase {
         let request = try XCTUnwrap(connection.pendingRequests.first)
         request.completion(.success(.dictionary(["area_ids": []])))
 
-        wait(for: [finished], timeout: 2)
+        wait(for: [finished], timeout: 10.0)
         XCTAssertFalse(sut.isLoadingAreas)
     }
 
@@ -156,7 +156,7 @@ final class CarPlayVacuumControlViewModelTests: XCTestCase {
         let request = try XCTUnwrap(connection.pendingRequests.first)
         request.completion(.failure(.internal(debugDescription: "nope")))
 
-        wait(for: [finished], timeout: 2)
+        wait(for: [finished], timeout: 10.0)
         XCTAssertFalse(sut.isLoadingAreas)
     }
 }

--- a/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
+++ b/Tests/App/EntityPicker/EntityPickerViewModel.test.swift
@@ -43,7 +43,7 @@ private extension AppArea {
     }
 }
 
-@Suite("EntityPickerViewModel")
+@Suite("EntityPickerViewModel", .serialized)
 struct EntityPickerViewModelTests {
     private func makeVM(
         domainFilter: [Domain]? = nil,

--- a/Tests/App/WebView/EntityAddToHandlerTests.swift
+++ b/Tests/App/WebView/EntityAddToHandlerTests.swift
@@ -12,7 +12,7 @@ final class EntityAddToHandlerTests: XCTestCase {
         sut.execute(action: DeeplinkAction(), entityId: "light.kitchen").done {
             executed.fulfill()
         }.cauterize()
-        wait(for: [executed], timeout: 2)
+        wait(for: [executed], timeout: 10.0)
 
         XCTAssertTrue(webView.presentOverlayControllerCalled)
         let controller = try XCTUnwrap(webView.overlayedController)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The `test` job fails on a different test most runs, on `main` as well as on pull requests. Four failures observed across three recent runs of the same code:

| Test | Failure |
| --- | --- |
| `CarPlayVacuumControlViewModelTests.testLoadingAreasFinishesWhenTheMappingRequestFails` | Exceeded timeout of 2 seconds |
| `EntityAddToHandlerTests.testDeeplinkActionPresentsTheDeeplinkSheetForTheEntity` | Exceeded timeout of 2 seconds |
| `WebRTCViewPlayerViewModelSignalingTests.testAConnectionThatRecoversWithinTheGracePeriodIsNotRebuilt` | `("2") is not equal to ("1")` |
| `EntityPickerViewModel` / "Selectable domains are scoped to the selected server" | `(vm.selectableDomains → []) == ["light"]` |

Three causes:

**Waits too tight for a loaded runner.** Two of them do nothing but wait 2 seconds for a callback that normally arrives in milliseconds. Raised to 10 seconds, which is the timeout most of the suite already uses. A healthy test still finishes immediately; only a genuinely broken one waits.

**A 100ms grace period straddling a queue hop.** The WebRTC test disconnects, hops the main queue, and reconnects, expecting to land inside `disconnectedGracePeriod` so the stream is not rebuilt. That hop can take longer than 100ms under load, the grace timer fires, and the stream is rebuilt — hence 2 client configurations instead of 1. The injected grace period goes to 1 second, so the hop cannot outlast it. The paired test that needs the period to *expire* still passes, it just spins proportionally longer.

**A stale per-server entity cache.** `EntityPickerViewModel` primes `cachedEntitiesByServer` from `entities` while handling the initial `selectedServerId`, but assigning `entities` afterwards never invalidated it, so `entitiesForCurrentServer()` could keep serving an empty array. Whether the cache got primed at all depended on which database `Current.database` happened to point at, which is what made the test intermittent rather than always red: the suite swaps that global, and Swift Testing runs tests in a suite concurrently. The cache is now invalidated whenever `entities` changes, and the suite is `.serialized` like the other suites here that swap globals.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Not user facing.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Two things this does not close out:

- `AppContainerCoordinatorTests.testAppIntentOpensThePanelWhileASheetIsPresented` also failed once (`openedPanelURLs` empty and `isSheetPresented` still true, while the expectation for the same call did fulfil). `MockWebFrontend` records the URL before invoking `onOpen`, so those cannot both be true of one frontend instance, and I could not pin the cause down by reading. Left alone rather than guessed at.
- 45 test files swap the global `Current`, and `.serialized` only orders the tests within one suite — two suites swapping `Current.database` can still overlap. Injecting these dependencies instead of mutating the global is the durable fix and is much larger than this change.
