### PR TITLE
Support Live Activities on iPadOS 26 and later

### DIFF
--- a/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
+++ b/Sources/App/Settings/LiveActivity/LiveActivitySettingsView.swift
@@ -146,8 +146,15 @@ struct LiveActivitySettingsView: View {
         }
     }
 
-    private var isLiveActivitySupportedOnDevice: Bool {
-        UIDevice.current.userInterfaceIdiom != .pad
+    var isLiveActivitySupportedOnDevice: Bool {
+        Self.isLiveActivitySupported(
+            idiom: UIDevice.current.userInterfaceIdiom,
+            majorSystemVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        )
+    }
+
+    static func isLiveActivitySupported(idiom: UIUserInterfaceIdiom, majorSystemVersion: Int) -> Bool {
+        idiom != .pad || majorSystemVersion >= 26
     }
 
     private var samplesSection: some View {

--- a/Tests/App/Settings/LiveActivitySettingsView.test.swift
+++ b/Tests/App/Settings/LiveActivitySettingsView.test.swift
@@ -1,0 +1,29 @@
+@testable import HomeAssistant
+import Testing
+import UIKit
+
+#if os(iOS) && !targetEnvironment(macCatalyst)
+@available(iOS 17.2, *)
+struct LiveActivitySettingsViewTests {
+    @Test func testIPhoneIsSupportedBeforeIPadOS26() {
+        #expect(LiveActivitySettingsView.isLiveActivitySupported(idiom: .phone, majorSystemVersion: 18))
+    }
+
+    @Test func testIPadIsUnsupportedBeforeIPadOS26() {
+        #expect(!LiveActivitySettingsView.isLiveActivitySupported(idiom: .pad, majorSystemVersion: 18))
+    }
+
+    @Test func testIPadIsSupportedFromIPadOS26() {
+        #expect(LiveActivitySettingsView.isLiveActivitySupported(idiom: .pad, majorSystemVersion: 26))
+    }
+
+    @MainActor
+    @Test func testCurrentDeviceMatchesItsIdiomAndVersion() {
+        let expected = LiveActivitySettingsView.isLiveActivitySupported(
+            idiom: UIDevice.current.userInterfaceIdiom,
+            majorSystemVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        )
+        #expect(LiveActivitySettingsView().isLiveActivitySupportedOnDevice == expected)
+    }
+}
+#endif

--- a/Tests/App/Settings/LiveActivitySettingsView.test.swift
+++ b/Tests/App/Settings/LiveActivitySettingsView.test.swift
@@ -3,22 +3,24 @@ import Testing
 import UIKit
 
 #if os(iOS) && !targetEnvironment(macCatalyst)
-@available(iOS 17.2, *)
 struct LiveActivitySettingsViewTests {
+    @available(iOS 17.2, *)
     @Test func testIPhoneIsSupportedBeforeIPadOS26() {
         #expect(LiveActivitySettingsView.isLiveActivitySupported(idiom: .phone, majorSystemVersion: 18))
     }
 
+    @available(iOS 17.2, *)
     @Test func testIPadIsUnsupportedBeforeIPadOS26() {
         #expect(!LiveActivitySettingsView.isLiveActivitySupported(idiom: .pad, majorSystemVersion: 18))
     }
 
+    @available(iOS 17.2, *)
     @Test func testIPadIsSupportedFromIPadOS26() {
         #expect(LiveActivitySettingsView.isLiveActivitySupported(idiom: .pad, majorSystemVersion: 26))
     }
 
-    @MainActor
-    @Test func testCurrentDeviceMatchesItsIdiomAndVersion() {
+    @available(iOS 17.2, *)
+    @MainActor @Test func testCurrentDeviceMatchesItsIdiomAndVersion() {
         let expected = LiveActivitySettingsView.isLiveActivitySupported(
             idiom: UIDevice.current.userInterfaceIdiom,
             majorSystemVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Live Activities settings screen treated every iPad as unsupported, so the status rows read "Not available on iPad" even on iPadOS 26, where Live Activities do work. That state now only applies to iPads running earlier versions.

Fixes #5731

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual change on iPhone. On iPadOS 26 the two status rows now show the real authorization state instead of "Not available on iPad".

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The check is split into a pure `isLiveActivitySupported(idiom:majorSystemVersion:)` so both the iPad and pre-iPadOS 26 cases are unit tested.