### PR TITLE
Integrate durable zone event delivery and beacon lifecycle handling - 4

### DIFF
--- a/Sources/App/ZoneManager/ZoneManager.swift
+++ b/Sources/App/ZoneManager/ZoneManager.swift
@@ -10,12 +10,18 @@ class ZoneManager {
     let collector: ZoneManagerCollector
     let processor: ZoneManagerProcessor
     let regionFilter: ZoneManagerRegionFilter
+    let zoneEventOutbox: ZoneEventOutbox
     private(set) var zones: [AppZone]
 
     private var observationToken: AnyDatabaseCancellable?
     private let syncExecutor: (@escaping () -> Void) -> Void
-
     private static let regionSyncQueue = DispatchQueue(label: "zone-manager-region-sync", qos: .utility)
+    private var drainingZoneEventIDs = Set<UUID>()
+    private var reconcilingZoneEventIDs = Set<UUID>()
+    private var confirmedZoneEventIDs = Set<UUID>()
+    private var zoneEventRetryAttempt = 0
+    private var zoneEventRetryWorkItem: DispatchWorkItem?
+    private let zoneEventRetryDelay: (Int) -> TimeInterval
 
     init(
         locationManager: CLLocationManager = .init(),
@@ -24,6 +30,10 @@ class ZoneManager {
         regionFilter: ZoneManagerRegionFilter = ZoneManagerRegionFilterImpl(),
         syncExecutor: @escaping (@escaping () -> Void) -> Void = { work in
             ZoneManager.regionSyncQueue.async(execute: work)
+        },
+        zoneEventOutbox: ZoneEventOutbox = AtomicFileZoneEventOutbox(),
+        zoneEventRetryDelay: @escaping (Int) -> TimeInterval = { attempt in
+            min(pow(2, Double(max(0, attempt - 1))), 30)
         }
     ) {
         self.locationManager = locationManager
@@ -31,6 +41,8 @@ class ZoneManager {
         self.processor = processor
         self.regionFilter = regionFilter
         self.syncExecutor = syncExecutor
+        self.zoneEventOutbox = zoneEventOutbox
+        self.zoneEventRetryDelay = zoneEventRetryDelay
         self.zones = AppZone.trackedZones()
 
         self.collector.delegate = self
@@ -39,6 +51,9 @@ class ZoneManager {
         log(state: .initialize)
 
         updateLocationManager(isInitial: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.flushPendingZoneEvents()
+        }
 
         NotificationCenter.default.addObserver(
             self,
@@ -46,15 +61,56 @@ class ZoneManager {
             name: SettingsStore.locationRelatedSettingDidChange,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
     }
 
     deinit {
+        zoneEventRetryWorkItem?.cancel()
         observationToken?.cancel()
+        NotificationCenter.default.removeObserver(self)
         Current.Log.info("going away")
     }
 
     @objc private func locationSettingDidChange() {
         updateLocationManager(isInitial: false)
+    }
+
+    @objc func applicationDidBecomeActive() {
+        guard Current.settingsStore.locationSources.zone else {
+            collector.stopBackgroundBeaconMonitoring(manager: locationManager)
+            return
+        }
+
+        flushPendingZoneEvents()
+
+        collector.startForegroundBeaconScanning(
+            in: locationManager.monitoredRegions,
+            manager: locationManager
+        )
+        collector.stopBackgroundBeaconMonitoring(manager: locationManager)
+    }
+
+    @objc func applicationWillResignActive() {
+        guard Current.settingsStore.locationSources.zone else {
+            collector.stopForegroundBeaconScanning(manager: locationManager)
+            return
+        }
+        collector.startBackgroundBeaconMonitoring(
+            in: locationManager.monitoredRegions,
+            manager: locationManager
+        )
+        collector.stopForegroundBeaconScanning(manager: locationManager)
     }
 
     private func updateLocationManager(isInitial: Bool) {
@@ -153,8 +209,17 @@ class ZoneManager {
     }
 
     private func fire(event: ZoneManagerEvent) {
-        guard let zone = event.associatedZone,
-              let server = Current.servers.server(forServerIdentifier: zone.serverIdentifier) else { return }
+        if case .locationChange = event.eventType {
+            flushPendingZoneEvents()
+            return
+        }
+
+        guard let zone = event.associatedZone else {
+            return
+        }
+        guard let server = Current.servers.server(forServerIdentifier: zone.serverIdentifier) else {
+            return
+        }
 
         switch event.eventType {
         case let .region(region, state):
@@ -163,24 +228,302 @@ class ZoneManager {
                 return
             }
             let eventInfo = api.zoneStateEvent(region: region, state: state, zone: zone)
-            api.CreateEvent(eventType: eventInfo.eventType, eventData: eventInfo.eventData).pipe { result in
-                switch result {
-                case .fulfilled:
-                    Current.Log.info("Fired ZoneManager event")
-                case let .rejected(error):
-                    let message = "Failed to fire ZoneManager event: \(error.localizedDescription)"
-                    Current.Log.error(message)
-                    Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
-                    Current.notificationDispatcher.send(.init(
-                        id: .debug,
-                        title: "DEBUG: Failed to fire ZoneManager",
-                        body: message
-                    ))
-                }
-            }
+            enqueueZoneEvent(
+                serverIdentifier: server.identifier.rawValue,
+                eventType: eventInfo.eventType,
+                eventData: eventInfo.eventData,
+                isBeacon: region is CLBeaconRegion
+            )
         case .locationChange:
             break
         }
+    }
+
+    private func enqueueZoneEvent(
+        serverIdentifier: String,
+        eventType: String,
+        eventData: [String: Any],
+        isBeacon: Bool
+    ) {
+        do {
+            let pending = try PendingZoneEvent(
+                serverIdentifier: serverIdentifier,
+                eventType: eventType,
+                eventData: eventData,
+                createdAt: Current.date(),
+                isBeacon: isBeacon
+            )
+            // Persist before any asynchronous URL resolution or URLSession task creation.
+            // iOS may suspend us at either boundary; the next wake can then resume delivery.
+            try zoneEventOutbox.append(pending)
+            logBeaconDeliveryStage("outbox_persisted", pendingEvent: pending)
+            flushPendingZoneEvents()
+        } catch {
+            let message = "Failed to persist ZoneManager event before delivery: \(error.localizedDescription)"
+            Current.Log.error(message)
+            Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
+        }
+    }
+
+    private func startZoneEvent(
+        api: HomeAssistantAPI,
+        pendingEvent: PendingZoneEvent,
+        eventData: [String: Any]
+    ) -> Bool {
+        let startResult = api.startPersistentEvent(
+            eventType: pendingEvent.eventType,
+            eventData: eventData,
+            eventIdentifier: pendingEvent.id
+        )
+
+        guard case let .success(delivery) = startResult else {
+            if case let .failure(error) = startResult {
+                let message = "Failed to start ZoneManager background upload; queued for retry: " +
+                    error.localizedDescription
+                Current.Log.error(message)
+                Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
+            }
+            clearDeliveryStarted(for: pendingEvent)
+            scheduleZoneEventRetry()
+            return false
+        }
+
+        attach(delivery: delivery, to: pendingEvent)
+        return true
+    }
+
+    private func handleZoneEventResult(
+        _ result: Swift.Result<Void, Error>,
+        pendingEvent: PendingZoneEvent
+    ) {
+        drainingZoneEventIDs.remove(pendingEvent.id)
+
+        switch result {
+        case .success:
+            zoneEventRetryAttempt = 0
+            logBeaconDeliveryStage("webhook_confirmed", pendingEvent: pendingEvent)
+            confirmedZoneEventIDs.insert(pendingEvent.id)
+            removeConfirmedZoneEvent(pendingEvent)
+            Current.Log.info("Fired ZoneManager event")
+        case let .failure(error):
+            logBeaconDeliveryStage(
+                "webhook_failed",
+                pendingEvent: pendingEvent,
+                detail: error.localizedDescription
+            )
+            let message = "Failed to fire ZoneManager event; queued for retry: \(error.localizedDescription)"
+            Current.Log.error(message)
+            Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
+            clearDeliveryStarted(for: pendingEvent)
+            scheduleZoneEventRetry()
+        }
+    }
+
+    private func flushPendingZoneEvents() {
+        guard let pendingEvents = loadPendingZoneEvents() else { return }
+        guard !pendingEvents.isEmpty else {
+            zoneEventRetryAttempt = 0
+            zoneEventRetryWorkItem?.cancel()
+            zoneEventRetryWorkItem = nil
+            return
+        }
+        guard drainingZoneEventIDs.isEmpty, reconcilingZoneEventIDs.isEmpty else { return }
+
+        drainPendingZoneEvents(pendingEvents)
+    }
+
+    private func loadPendingZoneEvents() -> [PendingZoneEvent]? {
+        do {
+            return try zoneEventOutbox.pendingEvents()
+        } catch {
+            logZoneEventOutboxFailure("read", error: error)
+            scheduleZoneEventRetry()
+            return nil
+        }
+    }
+
+    private func drainPendingZoneEvents(_ pendingEvents: [PendingZoneEvent]) {
+        guard let pending = pendingEvents.first else {
+            flushPendingZoneEvents()
+            return
+        }
+        if confirmedZoneEventIDs.contains(pending.id) {
+            removeConfirmedZoneEvent(pending)
+            return
+        }
+        guard let eventData = pending.decodedEventData else {
+            removeUnreadableZoneEvent(pending, remainingEvents: Array(pendingEvents.dropFirst()))
+            return
+        }
+        guard let server = Current.servers.server(forServerIdentifier: pending.serverIdentifier) else {
+            logZoneEventDrainBlocked(pending, reason: "Server is unavailable")
+            scheduleZoneEventRetry()
+            return
+        }
+        guard let api = Current.api(for: server) else {
+            logZoneEventDrainBlocked(pending, reason: "Home Assistant API is unavailable")
+            scheduleZoneEventRetry()
+            return
+        }
+        if pending.deliveryStartedAt != nil {
+            reconcileZoneEvent(api: api, pendingEvent: pending)
+            return
+        }
+
+        do {
+            try zoneEventOutbox.markDeliveryStarted(id: pending.id, at: Current.date())
+            // Marking can prune an event that expired since the first read. Never upload
+            // the stale snapshot when the store no longer contains its start marker.
+            let markedEvents = try zoneEventOutbox.pendingEvents()
+            guard let marked = markedEvents.first,
+                  marked.id == pending.id,
+                  marked.deliveryStartedAt != nil else {
+                flushPendingZoneEvents()
+                return
+            }
+            _ = startZoneEvent(api: api, pendingEvent: marked, eventData: eventData)
+        } catch {
+            logZoneEventOutboxFailure("mark delivery started", error: error)
+            scheduleZoneEventRetry()
+        }
+    }
+
+    private func removeUnreadableZoneEvent(
+        _ pendingEvent: PendingZoneEvent,
+        remainingEvents: [PendingZoneEvent]
+    ) {
+        logZoneEventDrainBlocked(pendingEvent, reason: "Event data is unreadable")
+        do {
+            try zoneEventOutbox.remove(id: pendingEvent.id)
+            drainPendingZoneEvents(remainingEvents)
+        } catch {
+            logZoneEventOutboxFailure("remove unreadable event", error: error)
+            scheduleZoneEventRetry()
+        }
+    }
+
+    private func attach(delivery: Task<Void, Error>, to pendingEvent: PendingZoneEvent) {
+        drainingZoneEventIDs.insert(pendingEvent.id)
+        zoneEventRetryWorkItem?.cancel()
+        zoneEventRetryWorkItem = nil
+        logBeaconDeliveryStage("background_upload_started", pendingEvent: pendingEvent)
+        if pendingEvent.isBeacon == true {
+            scheduleBeaconUploadWatchdog(for: pendingEvent)
+        }
+
+        Task { [weak self] in
+            let result = await delivery.result
+            await MainActor.run {
+                self?.handleZoneEventResult(result, pendingEvent: pendingEvent)
+            }
+        }
+    }
+
+    private func reconcileZoneEvent(api: HomeAssistantAPI, pendingEvent: PendingZoneEvent) {
+        guard reconcilingZoneEventIDs.insert(pendingEvent.id).inserted else { return }
+
+        Task { [weak self] in
+            let state = await api.reconcilePersistentEvent(eventIdentifier: pendingEvent.id)
+            await MainActor.run {
+                guard let self else { return }
+                reconcilingZoneEventIDs.remove(pendingEvent.id)
+                switch state {
+                case let .running(delivery):
+                    attach(delivery: delivery, to: pendingEvent)
+                case let .completed(result):
+                    handleZoneEventResult(result, pendingEvent: pendingEvent)
+                case .absent:
+                    if clearDeliveryStarted(for: pendingEvent) {
+                        flushPendingZoneEvents()
+                    } else {
+                        scheduleZoneEventRetry()
+                    }
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    private func clearDeliveryStarted(for pendingEvent: PendingZoneEvent) -> Bool {
+        do {
+            try zoneEventOutbox.clearDeliveryStarted(id: pendingEvent.id)
+            return true
+        } catch {
+            logZoneEventOutboxFailure("clear delivery state", error: error)
+            return false
+        }
+    }
+
+    private func removeConfirmedZoneEvent(_ pendingEvent: PendingZoneEvent) {
+        do {
+            try zoneEventOutbox.remove(id: pendingEvent.id)
+            confirmedZoneEventIDs.remove(pendingEvent.id)
+            flushPendingZoneEvents()
+        } catch {
+            logZoneEventOutboxFailure("remove confirmed event", error: error)
+            scheduleZoneEventRetry()
+        }
+    }
+
+    private func logZoneEventOutboxFailure(_ operation: String, error: Error) {
+        let message = "ZoneManager outbox failed to \(operation): \(error.localizedDescription)"
+        Current.Log.error(message)
+        Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
+    }
+
+    private func scheduleZoneEventRetry() {
+        guard zoneEventRetryWorkItem == nil else { return }
+        zoneEventRetryAttempt += 1
+        let delay = zoneEventRetryDelay(zoneEventRetryAttempt)
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            zoneEventRetryWorkItem = nil
+            flushPendingZoneEvents()
+        }
+        zoneEventRetryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func logZoneEventDrainBlocked(_ pendingEvent: PendingZoneEvent, reason: String) {
+        let message = "ZoneManager outbox drain blocked: \(reason)"
+        Current.Log.error(message)
+        Current.clientEventStore.addEvent(.init(text: message, type: .locationUpdate))
+    }
+
+    private func scheduleBeaconUploadWatchdog(for pendingEvent: PendingZoneEvent) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15) { [weak self] in
+            guard let self,
+                  drainingZoneEventIDs.contains(pendingEvent.id),
+                  (try? self.zoneEventOutbox.pendingEvents())?.contains(where: {
+                      $0.id == pendingEvent.id
+                  }) == true else { return }
+
+            logBeaconDeliveryStage(
+                "webhook_stalled",
+                pendingEvent: pendingEvent,
+                detail: "No completion after 15 seconds"
+            )
+        }
+    }
+
+    private func logBeaconDeliveryStage(
+        _ stage: String,
+        pendingEvent: PendingZoneEvent,
+        detail: String? = nil
+    ) {
+        guard pendingEvent.isBeacon == true else { return }
+        Current.clientEventStore.addEvent(ClientEvent(
+            text: "Beacon delivery: \(stage)",
+            type: .networkRequest,
+            payload: [
+                "stage": stage,
+                "event_id": pendingEvent.id.uuidString,
+                "event_type": pendingEvent.eventType,
+                "created_at": ISO8601DateFormatter().string(from: pendingEvent.createdAt),
+                "recorded_at": ISO8601DateFormatter().string(from: Current.date()),
+                "detail": detail ?? "",
+            ]
+        ))
     }
 
     private func sync(zones: AnyCollection<AppZone>) {
@@ -215,6 +558,7 @@ class ZoneManager {
         // Applied on the main thread because the collector (and its ignore-next-state bookkeeping)
         // is only ever touched from there; synchronously, so the next queued sync's reads observe
         // these mutations and can't re-add the same regions.
+        let expectedRegions = Set(expected.map(\.region))
         Self.runOnMain { [self] in
             // process removals before additions
             // this is important because the system is focused on identifier
@@ -240,6 +584,14 @@ class ZoneManager {
 
                 collector.ignoreNextState(for: region)
                 locationManager.startMonitoring(for: region)
+            }
+
+            if UIApplication.shared.applicationState == .active {
+                collector.startForegroundBeaconScanning(in: expectedRegions, manager: locationManager)
+                collector.stopBackgroundBeaconMonitoring(manager: locationManager)
+            } else {
+                collector.startBackgroundBeaconMonitoring(in: expectedRegions, manager: locationManager)
+                collector.stopForegroundBeaconScanning(manager: locationManager)
             }
         }
 
@@ -276,6 +628,18 @@ extension ZoneManager: ZoneManagerCollectorDelegate {
     }
 
     func collector(_ collector: ZoneManagerCollector, didCollect event: ZoneManagerEvent) {
+        if case let .region(region, state) = event.eventType, region is CLBeaconRegion {
+            Current.clientEventStore.addEvent(ClientEvent(
+                text: "Beacon delivery: accepted_sample",
+                type: .locationUpdate,
+                payload: [
+                    "stage": "accepted_sample",
+                    "region": region.identifier,
+                    "state": String(describing: state),
+                    "recorded_at": ISO8601DateFormatter().string(from: Current.date()),
+                ]
+            ))
+        }
         fire(event: event)
         perform(event: event)
     }

--- a/Tests/App/ZoneManager/ZoneManager.test.swift
+++ b/Tests/App/ZoneManager/ZoneManager.test.swift
@@ -8,24 +8,57 @@ import UserNotifications
 import XCTest
 
 final class MockClientEventStore: ClientEventStoreProtocol {
-    let addEventAction: (ClientEvent) -> Void
-
-    var addedEvents: [ClientEvent] = []
+    private let lock = NSLock()
+    private let addEventAction: (ClientEvent) -> Void
+    private var addedEvents: [ClientEvent] = []
+    private var processedEventObserver: (count: Int, completion: () -> Void)?
 
     init(addEventAction: @escaping (ClientEvent) -> Void) {
         self.addEventAction = addEventAction
     }
 
+    private func processedCount() -> Int {
+        addedEvents.filter { $0.jsonPayloadJSONObject()["event"] != nil }.count
+    }
+
+    var processorCompletionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return processedCount()
+    }
+
+    func observeProcessorCompletions(count: Int, completion: @escaping () -> Void) {
+        lock.lock()
+        let alreadyComplete = processedCount() >= count
+        if !alreadyComplete { processedEventObserver = (count, completion) }
+        lock.unlock()
+        if alreadyComplete { completion() }
+    }
+
     func addEvent(_ event: ClientEvent) {
+        lock.lock()
         addedEvents.append(event)
+        let completion: (() -> Void)?
+        if let observer = processedEventObserver, processedCount() >= observer.count {
+            completion = observer.completion
+            processedEventObserver = nil
+        } else {
+            completion = nil
+        }
+        lock.unlock()
         addEventAction(event)
+        completion?()
     }
 
     func getEvents() -> [ClientEvent] {
-        addedEvents
+        lock.lock()
+        defer { lock.unlock() }
+        return addedEvents
     }
 
     func clearAllEvents() {
+        lock.lock()
+        defer { lock.unlock() }
         addedEvents = []
     }
 }
@@ -157,13 +190,31 @@ class ZoneManagerTests: XCTestCase {
     private var previousNotificationDispatcher: LocalNotificationDispatcherProtocol!
     private var notificationDispatcher: ZoneManagerNotificationDispatcher!
     private var managers = [ZoneManager]()
-    private var loggedEventsUpdatedExpectation: XCTestExpectation?
-    private var loggedEvents: [ClientEvent]! {
-        didSet {
-            let expectation = loggedEventsUpdatedExpectation
-            loggedEventsUpdatedExpectation = nil
-            expectation?.fulfill()
+    private var clientEventStore: MockClientEventStore!
+    private var previousClientEventStore: ClientEventStoreProtocol!
+    private let logExpectationLock = NSLock()
+    private var storedLogExpectation: XCTestExpectation?
+    private var loggedEventsUpdatedExpectation: XCTestExpectation? {
+        get {
+            logExpectationLock.lock()
+            defer { logExpectationLock.unlock() }
+            return storedLogExpectation
         }
+        set {
+            logExpectationLock.lock()
+            defer { logExpectationLock.unlock() }
+            storedLogExpectation = newValue
+        }
+    }
+
+    private var loggedEvents: [ClientEvent] { clientEventStore.getEvents() }
+
+    private func didLogEvent() {
+        logExpectationLock.lock()
+        let expectation = storedLogExpectation
+        storedLogExpectation = nil
+        logExpectationLock.unlock()
+        expectation?.fulfill()
     }
 
     enum TestError: Error {
@@ -188,11 +239,12 @@ class ZoneManagerTests: XCTestCase {
         Current.servers = servers
         Current.cachedApis = [server1.identifier: apis[0], server2.identifier: apis[1]]
 
-        loggedEvents = []
         Current.connectivity.currentNetworkState = { NetworkState(ssid: "wifi_name") }
-        Current.clientEventStore = MockClientEventStore(addEventAction: { event in
-            self.loggedEvents.append(event)
+        previousClientEventStore = Current.clientEventStore
+        clientEventStore = MockClientEventStore(addEventAction: { [weak self] _ in
+            self?.didLogEvent()
         })
+        Current.clientEventStore = clientEventStore
         Current.location.oneShotLocation = { _, _ in .value(.init(latitude: 0, longitude: 0)) }
         previousNotificationDispatcher = Current.notificationDispatcher
         notificationDispatcher = ZoneManagerNotificationDispatcher()
@@ -203,14 +255,23 @@ class ZoneManagerTests: XCTestCase {
         locationManager = FakeCLLocationManager()
     }
 
-    override func tearDown() {
-        loggedEventsUpdatedExpectation = nil
-        managers.removeAll()
-        Current.database = previousDatabase
-        Current.clientEventStore.clearAllEvents()
-        Current.notificationDispatcher = previousNotificationDispatcher
+    override func tearDown() async throws {
+        // Upload completion is separate from the processor's asynchronous SSID/logging chain.
+        // Drain every chain before the next test replaces the global Current event store.
+        let completed = expectation(description: "all processor logs completed before teardown")
+        let expectedCount = processor.performCount
+        clientEventStore.observeProcessorCompletions(count: expectedCount) { completed.fulfill() }
+        await fulfillment(of: [completed], timeout: 10)
+        await MainActor.run {
+            XCTAssertEqual(clientEventStore.processorCompletionCount, expectedCount)
+            loggedEventsUpdatedExpectation = nil
+            managers.removeAll()
+            Current.database = previousDatabase
+            Current.clientEventStore = previousClientEventStore
+            Current.notificationDispatcher = previousNotificationDispatcher
+        }
 
-        super.tearDown()
+        try await super.tearDown()
     }
 
     private func newZoneManager(
@@ -1432,8 +1493,10 @@ private class FakeProcessor: ZoneManagerProcessor {
     weak var delegate: ZoneManagerProcessorDelegate?
 
     var promiseToReturn: Promise<Void>?
+    private(set) var performCount = 0
     var performEvent: ZoneManagerEvent?
     func perform(event: ZoneManagerEvent) -> Promise<Void> {
+        performCount += 1
         performEvent = event
         return promiseToReturn!
     }

--- a/Tests/App/ZoneManager/ZoneManager.test.swift
+++ b/Tests/App/ZoneManager/ZoneManager.test.swift
@@ -4,6 +4,7 @@ import GRDB
 @testable import HomeAssistant
 import PromiseKit
 @testable import Shared
+import UserNotifications
 import XCTest
 
 final class MockClientEventStore: ClientEventStoreProtocol {
@@ -30,6 +31,122 @@ final class MockClientEventStore: ClientEventStoreProtocol {
 }
 
 class ZoneManagerTests: XCTestCase {
+    private final class ZoneManagerNotificationDispatcher: LocalNotificationDispatcherProtocol {
+        var notifications = [LocalNotificationDispatcher.Notification]()
+
+        func send(_ notification: LocalNotificationDispatcher.Notification) {
+            notifications.append(notification)
+        }
+
+        func reschedule(_ content: UNNotificationContent, after delay: TimeInterval) {}
+    }
+
+    private final class FakeZoneEventOutbox: ZoneEventOutbox {
+        private let lock = NSLock()
+        private var storedEvents = [PendingZoneEvent]()
+        private var deliveryClearedObserver: ((PendingZoneEvent) -> Void)?
+        private var removalObserver: ((PendingZoneEvent) -> Void)?
+        var failMark = false
+        var failAppend = false
+        var failRead = false
+        var failRemove = false
+        var removalAttempt: (() -> Void)?
+
+        var events: [PendingZoneEvent] {
+            get { synchronized { storedEvents } }
+            set { synchronized { storedEvents = newValue } }
+        }
+
+        private func synchronized<T>(_ action: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return action()
+        }
+
+        func observeDeliveryCleared(_ observer: @escaping (PendingZoneEvent) -> Void) {
+            synchronized { deliveryClearedObserver = observer }
+        }
+
+        func observeRemoval(_ observer: @escaping (PendingZoneEvent) -> Void) {
+            synchronized { removalObserver = observer }
+        }
+
+        func pendingEvents() throws -> [PendingZoneEvent] {
+            if failRead { throw TestError.anyError }
+            return synchronized { storedEvents }
+        }
+
+        func append(_ event: PendingZoneEvent) throws {
+            if failAppend { throw TestError.anyError }
+            synchronized { storedEvents.append(event) }
+        }
+
+        func markDeliveryStarted(id: UUID, at date: Date) throws {
+            if failMark { throw TestError.anyError }
+            synchronized {
+                guard let index = storedEvents.firstIndex(where: { $0.id == id }) else { return }
+                storedEvents[index].deliveryStartedAt = date
+            }
+        }
+
+        func clearDeliveryStarted(id: UUID) throws {
+            let result: (PendingZoneEvent, ((PendingZoneEvent) -> Void)?)? = synchronized {
+                guard let index = storedEvents.firstIndex(where: { $0.id == id }) else { return nil }
+                storedEvents[index].deliveryStartedAt = nil
+                return (storedEvents[index], deliveryClearedObserver)
+            }
+            if let (event, observer) = result {
+                observer?(event)
+            }
+        }
+
+        func remove(id: UUID) throws {
+            removalAttempt?()
+            if failRemove { throw TestError.anyError }
+            let result: (PendingZoneEvent, ((PendingZoneEvent) -> Void)?)? = synchronized {
+                guard let event = storedEvents.first(where: { $0.id == id }) else { return nil }
+                storedEvents.removeAll { $0.id == id }
+                return (event, removalObserver)
+            }
+            if let (event, observer) = result {
+                observer?(event)
+            }
+        }
+    }
+
+    private final class ObservingZoneEventOutbox: ZoneEventOutbox {
+        private let outbox: ZoneEventOutbox
+        private let didRemove: (UUID) -> Void
+        var beforeMark: (() -> Void)?
+
+        init(outbox: ZoneEventOutbox, didRemove: @escaping (UUID) -> Void) {
+            self.outbox = outbox
+            self.didRemove = didRemove
+        }
+
+        func pendingEvents() throws -> [PendingZoneEvent] {
+            try outbox.pendingEvents()
+        }
+
+        func append(_ event: PendingZoneEvent) throws {
+            try outbox.append(event)
+        }
+
+        func markDeliveryStarted(id: UUID, at date: Date) throws {
+            beforeMark?()
+            try outbox.markDeliveryStarted(id: id, at: date)
+        }
+
+        func clearDeliveryStarted(id: UUID) throws {
+            try outbox.clearDeliveryStarted(id: id)
+        }
+
+        func remove(id: UUID) throws {
+            try outbox.remove(id: id)
+            didRemove(id)
+        }
+    }
+
     private var database: DatabaseQueue!
     private var previousDatabase: (() -> DatabaseQueue)!
     private var collector: FakeCollector!
@@ -37,10 +154,15 @@ class ZoneManagerTests: XCTestCase {
     private var regionFilter: FakeRegionFilter!
     private var locationManager: FakeCLLocationManager!
     private var apis: [FakeHassAPI]!
+    private var previousNotificationDispatcher: LocalNotificationDispatcherProtocol!
+    private var notificationDispatcher: ZoneManagerNotificationDispatcher!
+    private var managers = [ZoneManager]()
     private var loggedEventsUpdatedExpectation: XCTestExpectation?
     private var loggedEvents: [ClientEvent]! {
         didSet {
-            loggedEventsUpdatedExpectation?.fulfill()
+            let expectation = loggedEventsUpdatedExpectation
+            loggedEventsUpdatedExpectation = nil
+            expectation?.fulfill()
         }
     }
 
@@ -72,6 +194,9 @@ class ZoneManagerTests: XCTestCase {
             self.loggedEvents.append(event)
         })
         Current.location.oneShotLocation = { _, _ in .value(.init(latitude: 0, longitude: 0)) }
+        previousNotificationDispatcher = Current.notificationDispatcher
+        notificationDispatcher = ZoneManagerNotificationDispatcher()
+        Current.notificationDispatcher = notificationDispatcher
         collector = FakeCollector()
         processor = FakeProcessor()
         regionFilter = FakeRegionFilter()
@@ -79,22 +204,248 @@ class ZoneManagerTests: XCTestCase {
     }
 
     override func tearDown() {
+        loggedEventsUpdatedExpectation = nil
+        managers.removeAll()
         Current.database = previousDatabase
         Current.clientEventStore.clearAllEvents()
+        Current.notificationDispatcher = previousNotificationDispatcher
 
         super.tearDown()
     }
 
     private func newZoneManager(
-        syncExecutor: @escaping (@escaping () -> Void) -> Void = { $0() }
+        syncExecutor: @escaping (@escaping () -> Void) -> Void = { $0() },
+        zoneEventOutbox: ZoneEventOutbox = FakeZoneEventOutbox(),
+        zoneEventRetryDelay: @escaping (Int) -> TimeInterval = { _ in 1 }
     ) -> ZoneManager {
-        ZoneManager(
+        let manager = ZoneManager(
             locationManager: locationManager,
             collector: collector,
             processor: processor,
             regionFilter: regionFilter,
-            syncExecutor: syncExecutor
+            syncExecutor: syncExecutor,
+            zoneEventOutbox: zoneEventOutbox,
+            zoneEventRetryDelay: zoneEventRetryDelay
         )
+        managers.append(manager)
+        return manager
+    }
+
+    func testBecomingActiveScansMonitoredBeaconRegions() {
+        let beaconRegion = CLBeaconRegion(uuid: UUID(), identifier: "beacon")
+        let circularRegion = CLCircularRegion(
+            center: .init(latitude: 1, longitude: 2),
+            radius: 20,
+            identifier: "circular"
+        )
+        locationManager.overrideMonitoredRegions = [beaconRegion, circularRegion]
+        regionFilter.regionsBlock = { AnyCollection([beaconRegion, circularRegion]) }
+
+        let manager = newZoneManager()
+        manager.applicationDidBecomeActive()
+
+        XCTAssertEqual(collector.scannedRegions, locationManager.monitoredRegions)
+        XCTAssertTrue(collector.scanManager === locationManager)
+
+        manager.applicationWillResignActive()
+        XCTAssertEqual(collector.stopScanningCount, 1)
+        XCTAssertEqual(collector.backgroundMonitoredRegions, locationManager.monitoredRegions)
+    }
+
+    func testScanHandoffAcquiresNewOwnerBeforeReleasingOldOwner() {
+        let manager = newZoneManager()
+        collector.handoffCalls.removeAll()
+        manager.applicationDidBecomeActive()
+        XCTAssertEqual(collector.handoffCalls, ["startForeground", "stopBackground"])
+        collector.handoffCalls.removeAll()
+        manager.applicationWillResignActive()
+        XCTAssertEqual(collector.handoffCalls, ["startBackground", "stopForeground"])
+    }
+
+    @MainActor
+    func testExpiredDuringStartMarkerIsNotUploadedAndNextEventDrains() async throws {
+        var now = Date()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let backing = AtomicFileZoneEventOutbox(
+            fileURL: directory.appendingPathComponent("outbox.json"), date: { now }
+        )
+        let api = apis[1]
+        let expiring = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"], createdAt: now.addingTimeInterval(-119)
+        )
+        let following = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_exited",
+            eventData: ["zone": "zone.test"], createdAt: now
+        )
+        try backing.append(expiring)
+        try backing.append(following)
+        let removed = expectation(description: "only following delivery confirmed")
+        let outbox = ObservingZoneEventOutbox(outbox: backing) { id in
+            XCTAssertEqual(id, following.id)
+            removed.fulfill()
+        }
+        outbox.beforeMark = { now = now.addingTimeInterval(2) }
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [following.id])
+        XCTAssertTrue(try backing.pendingEvents().isEmpty)
+    }
+
+    @MainActor
+    func testStartMarkerWriteFailurePreventsUploadUntilNextWake() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"]
+        )
+        outbox.events = [pending]
+        outbox.failMark = true
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 60 })
+        manager.applicationDidBecomeActive()
+        XCTAssertTrue(api.createdEvents.isEmpty)
+        XCTAssertNil(outbox.events.first?.deliveryStartedAt)
+        outbox.failMark = false
+        let removed = expectation(description: "next wake completes persisted event")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+        XCTAssertTrue(outbox.events.isEmpty)
+    }
+
+    @MainActor
+    func testConfirmedDeliveryIsNotResentWhenRemovalFails() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"]
+        )
+        outbox.events = [pending]
+        outbox.failRemove = true
+        let attempted = expectation(description: "confirmed event removal attempted")
+        attempted.assertForOverFulfill = false
+        outbox.removalAttempt = { attempted.fulfill() }
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 60 })
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [attempted], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+        XCTAssertEqual(outbox.events.map(\.id), [pending.id])
+        outbox.failRemove = false
+        outbox.removalAttempt = nil
+        manager.applicationDidBecomeActive()
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+    }
+
+    @MainActor
+    func testRestoredSuccessRemovesEventWithoutResending() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"], deliveryStartedAt: Date()
+        )
+        outbox.events = [pending]
+        api.persistentEventReconciliationState = .completed(.success(()))
+        let removed = expectation(description: "restored success removed")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertTrue(api.createdEvents.isEmpty)
+    }
+
+    @MainActor
+    func testAbsentRestoredTaskRestartsSameStableIdentifier() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"], deliveryStartedAt: Date()
+        )
+        outbox.events = [pending]
+        api.persistentEventReconciliationState = .absent
+        let removed = expectation(description: "absent task retried")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+        XCTAssertTrue(outbox.events.isEmpty)
+    }
+
+    @MainActor
+    func testOutboxReadFailureDoesNotStartUpload() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"]
+        )
+        outbox.events = [pending]
+        outbox.failRead = true
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 60 })
+        manager.applicationDidBecomeActive()
+        XCTAssertTrue(api.createdEvents.isEmpty)
+        outbox.failRead = false
+        let removed = expectation(description: "read recovers on wake")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+    }
+
+    @MainActor
+    func testAppendFailureNeverStartsEphemeralOrPersistentUpload() throws {
+        let outbox = FakeZoneEventOutbox()
+        outbox.failAppend = true
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let zone = try addedZones([AppZone(
+            entityId: "zone.test", serverIdentifier: api.server.identifier.rawValue,
+            latitude: 1, longitude: 2, radius: 100, trackingEnabled: true
+        )])[0]
+        let region = CLCircularRegion(center: .init(latitude: 1, longitude: 2), radius: 100, identifier: "zone")
+        processor.promiseToReturn = .value(())
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside), associatedZone: zone
+        ))
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertTrue(api.createdEvents.isEmpty)
+        XCTAssertEqual(api.ephemeralEventCount, 0)
+        XCTAssertTrue(loggedEvents.contains { $0.text.contains("Failed to persist") })
+    }
+
+    @MainActor
+    func testRestoredFailureClearsMarkerAndRetriesOnNextWake() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        let pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue, eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.test"], deliveryStartedAt: Date()
+        )
+        outbox.events = [pending]
+        api.persistentEventReconciliationState = .completed(.failure(TestError.anyError))
+        let cleared = expectation(description: "failed restored upload becomes retryable")
+        outbox.observeDeliveryCleared { _ in cleared.fulfill() }
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 60 })
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [cleared], timeout: 5)
+        XCTAssertTrue(api.createdEvents.isEmpty)
+        XCTAssertNil(outbox.events.first?.deliveryStartedAt)
+        let removed = expectation(description: "restored failure retried on wake")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        manager.applicationDidBecomeActive()
+        await fulfillment(of: [removed], timeout: 5)
+        XCTAssertEqual(api.createdEventIdentifiers, [pending.id])
+        XCTAssertTrue(outbox.events.isEmpty)
     }
 
     private func addedZones(_ toAdd: [AppZone]) throws -> [AppZone] {
@@ -168,7 +519,10 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertEqual(locationManager.monitoredRegions, currentRegions)
         XCTAssertEqual(locationManager.stopMonitoringRegions.hackilySorted(), removedRegions.hackilySorted())
         XCTAssertEqual(locationManager.startMonitoringRegions.hackilySorted(), addedRegions.hackilySorted())
-        XCTAssertEqual(collector.ignoringNextStates, Set(addedRegions))
+        XCTAssertEqual(
+            collector.ignoringNextStates,
+            Set(addedRegions)
+        )
 
         // remove a zone
         let toRemove = zones.popLast()!
@@ -184,7 +538,10 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertEqual(locationManager.monitoredRegions, currentRegions)
         XCTAssertEqual(locationManager.stopMonitoringRegions.hackilySorted(), removedRegions.hackilySorted())
         XCTAssertEqual(locationManager.startMonitoringRegions.hackilySorted(), addedRegions.hackilySorted())
-        XCTAssertEqual(collector.ignoringNextStates, Set(addedRegions))
+        XCTAssertEqual(
+            collector.ignoringNextStates,
+            Set(addedRegions)
+        )
 
         withExtendedLifetime(manager) { /* silences unused variable */ }
     }
@@ -298,7 +655,6 @@ class ZoneManagerTests: XCTestCase {
         processor.promiseToReturn = .value(())
 
         let expectation = expectation(description: "promise")
-        expectation.assertForOverFulfill = false // changing zones adds logs and we don't care
         loggedEventsUpdatedExpectation = expectation
 
         manager.collector(collector, didCollect: .init(
@@ -351,6 +707,16 @@ class ZoneManagerTests: XCTestCase {
             locationManager.startMonitoringCallsWereOnMainThread.count
         )
         XCTAssertFalse(collector.ignoreNextStateCallsWereOnMainThread.contains(false))
+        XCTAssertFalse(collector.foregroundScanCallsWereOnMainThread.contains(false))
+        XCTAssertFalse(collector.backgroundScanCallsWereOnMainThread.contains(false))
+        XCTAssertFalse(
+            collector.foregroundScanCallsWereOnMainThread.isEmpty &&
+                collector.backgroundScanCallsWereOnMainThread.isEmpty
+        )
+        XCTAssertEqual(
+            collector.scannedRegions.isEmpty ? collector.backgroundMonitoredRegions : collector.scannedRegions,
+            locationManager.overrideMonitoredRegions
+        )
 
         withExtendedLifetime(manager) { /* silences unused variable */ }
     }
@@ -431,7 +797,8 @@ class ZoneManagerTests: XCTestCase {
         }
     }
 
-    func testCollectorCollectsSingleRegionZoneAndEventFires() throws {
+    @MainActor
+    func testCollectorCollectsSingleRegionZoneAndEventFires() async throws {
         let manager = newZoneManager()
         let api = apis[1]
         let region = CLCircularRegion(
@@ -458,7 +825,7 @@ class ZoneManagerTests: XCTestCase {
             associatedZone: zone
         ))
 
-        let createdEvent1 = try hang(api.createdEventPromise)
+        let createdEvent1 = try await api.createdEventPromise.asyncValue()
         XCTAssertEqual(createdEvent1.eventType, "ios.zone_entered")
         XCTAssertEqual(createdEvent1.eventData["zone"] as? String, "zone.zid")
 
@@ -468,12 +835,431 @@ class ZoneManagerTests: XCTestCase {
             associatedZone: zone
         ))
 
-        let createdEvent2 = try hang(api.createdEventPromise)
+        let createdEvent2 = try await api.createdEventPromise.asyncValue()
         XCTAssertEqual(createdEvent2.eventType, "ios.zone_exited")
         XCTAssertEqual(createdEvent2.eventData["zone"] as? String, "zone.zid")
     }
 
-    func testCollectorCollectsMultipleRegionZoneAndEventFires() throws {
+    func testBeaconEntryAndExitDoNotShowDiagnosticNotifications() throws {
+        let manager = newZoneManager()
+        let api = apis[1]
+        let region = CLBeaconRegion(uuid: UUID(), identifier: "beacon-zone")
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.beacon",
+                serverIdentifier: api.server.identifier.rawValue,
+                friendlyName: "Beacon Zone",
+                trackingEnabled: true,
+                beaconUUID: region.uuid.uuidString
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        XCTAssertTrue(notificationDispatcher.notifications.isEmpty)
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .outside),
+            associatedZone: zone
+        ))
+
+        XCTAssertTrue(notificationDispatcher.notifications.isEmpty)
+    }
+
+    func testSuccessfulBeaconDeliveryDoesNotShowDiagnosticNotifications() throws {
+        let manager = newZoneManager()
+        let api = apis[1]
+        let region = CLBeaconRegion(uuid: UUID(), identifier: "beacon-zone")
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.beacon",
+                serverIdentifier: api.server.identifier.rawValue,
+                friendlyName: "Beacon Zone",
+                trackingEnabled: true,
+                beaconUUID: region.uuid.uuidString
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        XCTAssertTrue(notificationDispatcher.notifications.isEmpty)
+    }
+
+    func testFailedBeaconUploadStartQueuesWithoutDiagnosticNotification() throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let region = CLBeaconRegion(uuid: UUID(), identifier: "beacon-zone")
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.beacon",
+                serverIdentifier: api.server.identifier.rawValue,
+                friendlyName: "Beacon Zone",
+                trackingEnabled: true,
+                beaconUUID: region.uuid.uuidString
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        api.persistentEventStartResult = .failure(TestError.anyError)
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        XCTAssertEqual(outbox.events.count, 1)
+        XCTAssertTrue(notificationDispatcher.notifications.isEmpty)
+    }
+
+    @MainActor
+    func testUnreadableZoneEventIsRemovedAndFollowingEventDrains() async throws {
+        let api = apis[1]
+        let malformedID = UUID()
+        let encodedMalformedEvent = try JSONSerialization.data(withJSONObject: [
+            "id": malformedID.uuidString,
+            "serverIdentifier": api.server.identifier.rawValue,
+            "eventType": "ios.zone_entered",
+            "eventData": Data("not-json".utf8).base64EncodedString(),
+            "createdAt": Date().timeIntervalSinceReferenceDate,
+            "isBeacon": false,
+        ])
+        let malformedEvent = try JSONDecoder().decode(PendingZoneEvent.self, from: encodedMalformedEvent)
+        let validEvent = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue,
+            eventType: "ios.zone_exited",
+            eventData: ["zone": "zone.zid"]
+        )
+        let outbox = FakeZoneEventOutbox()
+        outbox.events = [malformedEvent, validEvent]
+        let removed = expectation(description: "unreadable and delivered events removed")
+        removed.expectedFulfillmentCount = 2
+        outbox.observeRemoval { _ in removed.fulfill() }
+
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_exited"])
+        XCTAssertTrue(loggedEvents.contains { $0.text.contains("Event data is unreadable") })
+        withExtendedLifetime(manager) { /* retain during drain */ }
+    }
+
+    @MainActor
+    func testRejectedZoneEventRetriesAutomaticallyAndThenDrainsFollowingEvent() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 0 })
+        let api = apis[1]
+        let region = CLCircularRegion(
+            center: .init(latitude: 42.4242, longitude: 43.4343),
+            radius: 456,
+            identifier: "dogs"
+        )
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.zid",
+                serverIdentifier: api.server.identifier.rawValue,
+                latitude: 42.2222,
+                longitude: 43.3333,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        api.enqueuePersistentEventStartResults([
+            .success(.init(error: TestError.anyError)),
+            .success(.value(())),
+            .success(.value(())),
+        ])
+        let removed = expectation(description: "retried entry and following exit removed")
+        removed.expectedFulfillmentCount = 2
+        outbox.observeRemoval { _ in removed.fulfill() }
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .outside),
+            associatedZone: zone
+        ))
+
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(
+            api.createdEvents.map(\.eventType),
+            ["ios.zone_entered", "ios.zone_entered", "ios.zone_exited"]
+        )
+        XCTAssertFalse(notificationDispatcher.notifications.contains { $0.id == .debug })
+    }
+
+    @MainActor
+    func testFailedZoneEventIsQueuedAndRetriedWhenAppBecomesActive() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox, zoneEventRetryDelay: { _ in 60 })
+        let api = apis[1]
+        let region = CLCircularRegion(
+            center: .init(latitude: 42.4242, longitude: 43.4343),
+            radius: 456,
+            identifier: "dogs"
+        )
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.zid",
+                serverIdentifier: api.server.identifier.rawValue,
+                latitude: 42.2222,
+                longitude: 43.3333,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        api.persistentEventResult = .init(error: TestError.anyError)
+        let deliveryFailed = expectation(description: "failed delivery becomes retryable")
+        outbox.observeDeliveryCleared { _ in deliveryFailed.fulfill() }
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        await fulfillment(of: [deliveryFailed], timeout: 1)
+        XCTAssertEqual(api.createdEvents.count, 1)
+        XCTAssertEqual(outbox.events.first?.eventType, "ios.zone_entered")
+
+        let removed = expectation(description: "app-active retry removed delivered event")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        api.persistentEventResult = .value(())
+        manager.applicationDidBecomeActive()
+
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered", "ios.zone_entered"])
+    }
+
+    @MainActor
+    func testZoneEventStartFailureRemainsImmediatelyRetryableOnNextWake() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let region = CLCircularRegion(
+            center: .init(latitude: 42.4242, longitude: 43.4343),
+            radius: 456,
+            identifier: "dogs"
+        )
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.zid",
+                serverIdentifier: api.server.identifier.rawValue,
+                latitude: 42.2222,
+                longitude: 43.3333,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        api.persistentEventStartResult = .failure(TestError.anyError)
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        XCTAssertEqual(outbox.events.count, 1)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered"])
+
+        let removed = expectation(description: "next wake removed delivered event")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        api.persistentEventStartResult = .success(.value(()))
+        manager.applicationDidBecomeActive()
+
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered", "ios.zone_entered"])
+    }
+
+    @MainActor
+    func testZoneEventIsPersistedBeforeBackgroundDeliveryCompletes() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let region = CLCircularRegion(
+            center: .init(latitude: 42.4242, longitude: 43.4343),
+            radius: 456,
+            identifier: "dogs"
+        )
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.zid",
+                serverIdentifier: api.server.identifier.rawValue,
+                latitude: 42.2222,
+                longitude: 43.3333,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        let (delivery, deliverySeal) = Promise<Void>.pending()
+        api.persistentEventResult = delivery
+        var observedDurableStart = false
+        api.beforePersistentEventStart = { id in
+            XCTAssertEqual(outbox.events.map(\.id), [id])
+            XCTAssertNotNil(outbox.events.first?.deliveryStartedAt)
+            XCTAssertEqual(outbox.events.first?.decodedEventData?["zone"] as? String, "zone.zid")
+            observedDurableStart = true
+        }
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+
+        XCTAssertTrue(observedDurableStart)
+        XCTAssertEqual(api.ephemeralEventCount, 0)
+        XCTAssertEqual(outbox.events.count, 1)
+        XCTAssertEqual(outbox.events.first?.eventType, "ios.zone_entered")
+
+        let removed = expectation(description: "completed delivery removed persisted event")
+        outbox.observeRemoval { _ in removed.fulfill() }
+        deliverySeal.fulfill(())
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+    }
+
+    @MainActor
+    func testQueuedZoneEventsRemainOrderedUntilEachDeliverySucceeds() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let region = CLCircularRegion(
+            center: .init(latitude: 42.4242, longitude: 43.4343),
+            radius: 456,
+            identifier: "dogs"
+        )
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.zid",
+                serverIdentifier: api.server.identifier.rawValue,
+                latitude: 42.2222,
+                longitude: 43.3333,
+                radius: 100,
+                trackingEnabled: true
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        let (firstDelivery, firstDeliverySeal) = Promise<Void>.pending()
+        api.persistentEventResult = firstDelivery
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .outside),
+            associatedZone: zone
+        ))
+
+        XCTAssertEqual(outbox.events.map(\.eventType), ["ios.zone_entered", "ios.zone_exited"])
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered"])
+
+        let removed = expectation(description: "ordered deliveries removed")
+        removed.expectedFulfillmentCount = 2
+        outbox.observeRemoval { _ in removed.fulfill() }
+        firstDeliverySeal.fulfill(())
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered", "ios.zone_exited"])
+    }
+
+    @MainActor
+    func testCoalescedBeaconExitWaitsForInFlightEntry() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let backingOutbox = AtomicFileZoneEventOutbox(fileURL: directoryURL.appendingPathComponent("outbox.json"))
+        let removed = expectation(description: "coalesced entry and exit removed in order")
+        removed.expectedFulfillmentCount = 2
+        let outbox = ObservingZoneEventOutbox(outbox: backingOutbox) { _ in removed.fulfill() }
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        let api = apis[1]
+        let region = CLBeaconRegion(uuid: UUID(), identifier: "beacon-zone")
+        let zone = try addedZones([
+            AppZone(
+                entityId: "zone.beacon",
+                serverIdentifier: api.server.identifier.rawValue,
+                friendlyName: "Beacon Zone",
+                trackingEnabled: true,
+                beaconUUID: region.uuid.uuidString
+            ),
+        ])[0]
+        processor.promiseToReturn = .value(())
+        let (entryDelivery, entryDeliverySeal) = Promise<Void>.pending()
+        api.persistentEventStartResult = .success(entryDelivery)
+
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .inside),
+            associatedZone: zone
+        ))
+        manager.collector(collector, didCollect: ZoneManagerEvent(
+            eventType: .region(region, .outside),
+            associatedZone: zone
+        ))
+
+        XCTAssertEqual(try outbox.pendingEvents().map(\.eventType), ["ios.zone_entered", "ios.zone_exited"])
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered"])
+
+        api.persistentEventStartResult = .success(.value(()))
+        entryDeliverySeal.fulfill(())
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(try outbox.pendingEvents().isEmpty)
+        XCTAssertEqual(api.createdEvents.map(\.eventType), ["ios.zone_entered", "ios.zone_exited"])
+    }
+
+    @MainActor
+    func testRelaunchAdoptsPersistedUploadWithoutStartingDuplicate() async throws {
+        let outbox = FakeZoneEventOutbox()
+        let api = apis[1]
+        var pending = try PendingZoneEvent(
+            serverIdentifier: api.server.identifier.rawValue,
+            eventType: "ios.zone_entered",
+            eventData: ["zone": "zone.beacon"],
+            isBeacon: true
+        )
+        pending.deliveryStartedAt = Date()
+        outbox.events = [pending]
+
+        let (promise, seal) = Promise<Void>.pending()
+        api.persistentEventReconciliationState = .running(Task {
+            try await promise.asyncValue()
+        })
+        let reconciled = expectation(description: "persisted upload reconciled")
+        api.observePersistentEventReconciliation { _ in reconciled.fulfill() }
+        let removed = expectation(description: "adopted upload removed delivered event")
+        outbox.observeRemoval { _ in removed.fulfill() }
+
+        let manager = newZoneManager(zoneEventOutbox: outbox)
+        await fulfillment(of: [reconciled], timeout: 1)
+
+        XCTAssertTrue(api.createdEvents.isEmpty)
+        XCTAssertEqual(outbox.events.map(\.id), [pending.id])
+
+        seal.fulfill(())
+        await fulfillment(of: [removed], timeout: 1)
+        XCTAssertTrue(outbox.events.isEmpty)
+        XCTAssertTrue(api.createdEvents.isEmpty)
+
+        withExtendedLifetime(manager) { /* retain through completion */ }
+    }
+
+    @MainActor
+    func testCollectorCollectsMultipleRegionZoneAndEventFires() async throws {
         let manager = newZoneManager()
         let api = apis[1]
         let region = CLCircularRegion(
@@ -499,9 +1285,10 @@ class ZoneManagerTests: XCTestCase {
             associatedZone: zone
         ))
 
-        let createdEvent1 = try hang(api.createdEventPromise)
+        let createdEvent1 = try await api.createdEventPromise.asyncValue()
         XCTAssertEqual(createdEvent1.eventType, "ios.zone_entered")
         XCTAssertEqual(createdEvent1.eventData["zone"] as? String, "zone.zid")
+        XCTAssertEqual(api.ephemeralEventCount, 0)
         XCTAssertEqual(createdEvent1.eventData["multi_region_zone_id"] as? String, "868")
 
         api.resetCreatedEventInfo()
@@ -509,9 +1296,10 @@ class ZoneManagerTests: XCTestCase {
             eventType: .region(region, .outside),
             associatedZone: zone
         ))
-        let createdEvent2 = try hang(api.createdEventPromise)
+        let createdEvent2 = try await api.createdEventPromise.asyncValue()
         XCTAssertEqual(createdEvent2.eventType, "ios.zone_exited")
         XCTAssertEqual(createdEvent2.eventData["zone"] as? String, "zone.zid")
+        XCTAssertEqual(api.ephemeralEventCount, 0)
         XCTAssertEqual(createdEvent2.eventData["multi_region_zone_id"] as? String, "868")
     }
 
@@ -531,12 +1319,10 @@ class ZoneManagerTests: XCTestCase {
         XCTAssertEqual(processor.performEvent, event)
         XCTAssertTrue(loggedEvents.isEmpty)
 
-        seal.reject(TestError.anyError)
-
         let expectation = expectation(description: "promise")
         loggedEventsUpdatedExpectation = expectation
 
-        seal.fulfill(())
+        seal.reject(TestError.anyError)
         wait(for: [expectation], timeout: 10)
 
         guard let loggedEvent = loggedEvents.first else {
@@ -591,19 +1377,59 @@ private extension Array where Element: CLRegion {
 }
 
 private class FakeCollector: NSObject, ZoneManagerCollector {
-    var delegate: ZoneManagerCollectorDelegate?
+    weak var delegate: ZoneManagerCollectorDelegate?
 
     var ignoringNextStates = Set<CLRegion>()
     var ignoreNextStateCallsWereOnMainThread = [Bool]()
+    var foregroundScanCallsWereOnMainThread = [Bool]()
+    var backgroundScanCallsWereOnMainThread = [Bool]()
+    var scannedRegions = Set<CLRegion>()
+    weak var scanManager: CLLocationManager?
+    var stopScanningCount = 0
+    var opportunisticallyScannedRegions = Set<CLRegion>()
+    var backgroundMonitoredRegions = Set<CLRegion>()
+    var stopBackgroundMonitoringCount = 0
+    var handoffCalls = [String]()
 
     func ignoreNextState(for region: CLRegion) {
         ignoreNextStateCallsWereOnMainThread.append(Thread.isMainThread)
         ignoringNextStates.insert(region)
     }
+
+    func startForegroundBeaconScanning(in regions: Set<CLRegion>, manager: CLLocationManager) {
+        handoffCalls.append("startForeground")
+        foregroundScanCallsWereOnMainThread.append(Thread.isMainThread)
+        scannedRegions = regions
+        scanManager = manager
+    }
+
+    func stopForegroundBeaconScanning(manager: CLLocationManager) {
+        handoffCalls.append("stopForeground")
+        stopScanningCount += 1
+        scanManager = manager
+    }
+
+    func startBackgroundBeaconMonitoring(in regions: Set<CLRegion>, manager: CLLocationManager) {
+        handoffCalls.append("startBackground")
+        backgroundScanCallsWereOnMainThread.append(Thread.isMainThread)
+        backgroundMonitoredRegions = regions
+        scanManager = manager
+    }
+
+    func stopBackgroundBeaconMonitoring(manager: CLLocationManager) {
+        handoffCalls.append("stopBackground")
+        stopBackgroundMonitoringCount += 1
+        scanManager = manager
+    }
+
+    func startOpportunisticBeaconScanning(in regions: Set<CLRegion>, manager: CLLocationManager) {
+        opportunisticallyScannedRegions = regions
+        scanManager = manager
+    }
 }
 
 private class FakeProcessor: ZoneManagerProcessor {
-    var delegate: ZoneManagerProcessorDelegate?
+    weak var delegate: ZoneManagerProcessorDelegate?
 
     var promiseToReturn: Promise<Void>?
     var performEvent: ZoneManagerEvent?
@@ -635,15 +1461,97 @@ private class FakeRegionFilter: ZoneManagerRegionFilter {
 private class FakeHassAPI: HomeAssistantAPI {
     typealias CreatedEventInfo = (eventType: String, eventData: [String: Any])
 
+    private let lock = NSLock()
+    private var storedPersistentEventResult: Promise<Void> = .value(())
+    private var storedPersistentEventStartResult: Swift.Result<Promise<Void>, Error>?
+    private var queuedPersistentEventStartResults = [Swift.Result<Promise<Void>, Error>]()
+    private var storedPersistentEventReconciliationState: PersistedBackgroundRequestState = .absent
+    private var storedCreatedEvents = [CreatedEventInfo]()
+    private var storedCreatedEventIdentifiers = [UUID]()
+    private var persistentEventReconciliationObserver: ((UUID) -> Void)?
+    var beforePersistentEventStart: ((UUID) -> Void)?
+
+    private func synchronized<T>(_ action: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return action()
+    }
+
     func resetCreatedEventInfo() {
         (createdEventPromise, createdEventSeal) = Promise<CreatedEventInfo>.pending()
     }
 
+    func observePersistentEventReconciliation(_ observer: @escaping (UUID) -> Void) {
+        synchronized { persistentEventReconciliationObserver = observer }
+    }
+
+    func enqueuePersistentEventStartResults(_ results: [Swift.Result<Promise<Void>, Error>]) {
+        synchronized { queuedPersistentEventStartResults.append(contentsOf: results) }
+    }
+
     var createdEventPromise: Promise<CreatedEventInfo>!
     var createdEventSeal: Resolver<CreatedEventInfo>?
+    var ephemeralEventCount = 0
+    var persistentEventResult: Promise<Void> {
+        get { synchronized { storedPersistentEventResult } }
+        set { synchronized { storedPersistentEventResult = newValue } }
+    }
+
+    var persistentEventStartResult: Swift.Result<Promise<Void>, Error>? {
+        get { synchronized { storedPersistentEventStartResult } }
+        set { synchronized { storedPersistentEventStartResult = newValue } }
+    }
+
+    var persistentEventReconciliationState: PersistedBackgroundRequestState {
+        get { synchronized { storedPersistentEventReconciliationState } }
+        set { synchronized { storedPersistentEventReconciliationState = newValue } }
+    }
+
+    var createdEvents: [CreatedEventInfo] {
+        synchronized { storedCreatedEvents }
+    }
+
+    var createdEventIdentifiers: [UUID] {
+        synchronized { storedCreatedEventIdentifiers }
+    }
 
     override func CreateEvent(eventType: String, eventData: [String: Any]) -> Promise<Void> {
-        createdEventSeal?.fulfill((eventType: eventType, eventData: eventData))
+        ephemeralEventCount += 1
         return .value(())
+    }
+
+    override func startPersistentEvent(
+        eventType: String,
+        eventData: [String: Any],
+        eventIdentifier: UUID
+    ) -> Swift.Result<Task<Void, Error>, Error> {
+        beforePersistentEventStart?(eventIdentifier)
+        let startResult: Swift.Result<Promise<Void>, Error> = synchronized {
+            storedCreatedEvents.append((eventType: eventType, eventData: eventData))
+            storedCreatedEventIdentifiers.append(eventIdentifier)
+            if queuedPersistentEventStartResults.isEmpty {
+                return storedPersistentEventStartResult ?? .success(storedPersistentEventResult)
+            }
+            return queuedPersistentEventStartResults.removeFirst()
+        }
+        createdEventSeal?.fulfill((eventType: eventType, eventData: eventData))
+        switch startResult {
+        case let .success(promise):
+            return .success(Task {
+                try await promise.asyncValue()
+            })
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    override func reconcilePersistentEvent(
+        eventIdentifier: UUID
+    ) async -> PersistedBackgroundRequestState {
+        let (state, observer) = synchronized {
+            (storedPersistentEventReconciliationState, persistentEventReconciliationObserver)
+        }
+        observer?(eventIdentifier)
+        return state
     }
 }


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

This is part 4 of the split requested for #5629.

Integrate ZoneManager with the atomic event outbox, persistent background webhook transport and beacon scanning lifecycle.

- Persist events and delivery-start markers before starting uploads.
- Drain queued events in order and retain stable identifiers across retries.
- Reconcile restored uploads and their success, failure or absent-task results.
- Avoid uploading events that expire while their delivery marker is written.
- Resume pending delivery on application and location wakes.
- Acquire the next beacon scanning owner before releasing the previous owner.
- Add integration tests for persistence, recovery, storage failures, expiration and scan handoffs.

This does not guarantee exactly-once delivery across server processing, network failures and app termination.

## Dependencies and scope

Depends on:
- #5703 — Persistent background webhooks
- #5730 — Atomic zone event outbox
- #5735 — Bounded iBeacon ranging

This branch contains only ZoneManager integration and its tests: two files, based directly on main. It does not include the foundation implementations or their commits.

It is not independently buildable without those foundations. Please merge the foundation PRs first, then update and verify this branch before merging part 4.

## Screenshots

N/A — no visual changes or new settings.

## Link to pull request in Documentation repository

Pending. Documentation should describe delivery/retry behavior and its limitations.

## Any other notes

Completed local checks:
- Full SwiftFormat 0.53.1 check.
- Two-file scope and whitespace checks.
- Test target and scheme membership inspection.

Pending verification:
- Xcode compilation and XCTest execution.
- Full lint, including SwiftLint.
- Measured patch coverage of at least 90%.
- Real-device background delivery and beacon transition testing.

No successful Xcode test run or measured coverage is claimed for this revision.