### PR TITLE
Remove silence detection from Apple Watch Assist

### DIFF
--- a/Sources/WatchApp/Assist/WatchAudioRecorder.swift
+++ b/Sources/WatchApp/Assist/WatchAudioRecorder.swift
@@ -28,8 +28,8 @@ final class WatchAudioRecorder: NSObject, WatchAudioRecorderProtocol {
         /// the orb barely moving.
         static let powerFloor: Float = -45
         static let powerCeiling: Float = -15
-        /// The meter now drives the voice orb as well as the silence check, so it is read at about
-        /// 20 Hz — often enough for the orb to follow speech, cheap enough for the watch.
+        /// The meter drives the voice orb, so it is read at about 20 Hz — often enough for the orb
+        /// to follow speech, cheap enough for the watch.
         static let meteringInterval: TimeInterval = 1.0 / 20
     }
 
@@ -38,9 +38,6 @@ final class WatchAudioRecorder: NSObject, WatchAudioRecorderProtocol {
     weak var delegate: WatchAudioRecorderDelegate?
 
     private var meteringTimer: Timer?
-    private var silenceTimer: Timer?
-    private let silenceThreshold: TimeInterval = 3.0
-    private let silenceLevel: Float = -50.0
 
     private var firstLaunch = true
 
@@ -118,23 +115,12 @@ final class WatchAudioRecorder: NSObject, WatchAudioRecorderProtocol {
                 let averagePower = audioRecorder.averagePower(forChannel: 0)
                 let range = Constants.powerCeiling - Constants.powerFloor
                 delegate?.didUpdateAudioLevel(max(0, min(1, (averagePower - Constants.powerFloor) / range)))
-
-                // The first drop into silence starts the countdown that ends the recording. Metering
-                // carries on through it — it is what the voice orb is drawn from — so the countdown is
-                // tracked by its own timer rather than by replacing this one.
-                guard averagePower < silenceLevel, silenceTimer == nil else { return }
-                silenceTimer = Timer
-                    .scheduledTimer(withTimeInterval: silenceThreshold, repeats: false) { [weak self] _ in
-                        self?.stopRecording()
-                    }
             }
     }
 
     private func stopMonitoringAudioLevels() {
         meteringTimer?.invalidate()
         meteringTimer = nil
-        silenceTimer?.invalidate()
-        silenceTimer = nil
     }
 }
 


### PR DESCRIPTION
## AI Policy

- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary

Removes silence detection from Assist on Apple Watch. Recording stopped on its own after 3 seconds below the silence level and submitted an incomplete request, even though the screen tells the user to tap to send. Recording now ends only when the user taps, as the UI says.

Fixes #5739

## Screenshots

No visual change.

## Link to pull request in Documentation repository

Documentation: home-assistant/companion.home-assistant#

## Any other notes

Audio metering stays in place, it still drives the voice orb.
