### PR TITLE
Add Assist control for the Apple Watch Ultra Action button

### DIFF
--- a/HomeAssistant.xcodeproj/project.pbxproj
+++ b/HomeAssistant.xcodeproj/project.pbxproj
@@ -717,6 +717,13 @@
 			);
 			target = 423FB76B2FFFDFDE000CB8FD /* Extensions-WatchWidgets */;
 		};
+		42FD0000001800510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				WatchAssistAppIntent.swift,
+			);
+			target = B6CC5D812159D10D00833E5D /* WatchApp */;
+		};
 		42479B7530013FE400F7FCD3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -2418,7 +2425,7 @@
 		11F2F28D2587285300F61F7C /* NotificationAttachment */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = NotificationAttachment; sourceTree = "<group>"; };
 		420E64B72D676A4200A31E86 /* Widgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000001600510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Widgets; sourceTree = "<group>"; };
 		42196AD92DA5AF7A00BD501E /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42FD0000001200510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
-		423FB76F2FFFDFDE000CB8FD /* WatchWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (423FB77E2FFFDFDF000CB8FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WatchWidgets; sourceTree = "<group>"; };
+		423FB76F2FFFDFDE000CB8FD /* WatchWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (423FB77E2FFFDFDF000CB8FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 42FD0000001800510051FC9B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WatchWidgets; sourceTree = "<group>"; };
 		42479B4630013FE300F7FCD3 /* WatchApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (42479B7530013FE400F7FCD3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 42479B7630013FE400F7FCD3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = WatchApp; sourceTree = "<group>"; };
 		4283C0A63004CD31004D1061 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4283C1A63004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 42A11C0130010001000A0001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1A73004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1A83004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1A93004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AA3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AB3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AC3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AD3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AE3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283C1AF3004CD32004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
 		4283E0D53004DCF4004D1061 /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4283E1713004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283E1723004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283E1733004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283E1743004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283E1753004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4283E1763004DCF5004D1061 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (gallery.ckcomplication, ); path = Resources; sourceTree = "<group>"; };
@@ -5032,7 +5039,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG WIDGET_EXTENSION $(inherited)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5112,6 +5119,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "WIDGET_EXTENSION $(inherited)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -294,6 +294,8 @@
 "app_intents.update_sensors.description" = "Send a sensor update to Home Assistant";
 "app_intents.update_sensors.success" = "Updated sensors on all servers";
 "app_intents.update_sensors.title" = "Update sensors";
+"app_intents.watch_assist.description" = "Opens Assist using the pipeline configured for the watch";
+"app_intents.watch_assist.title" = "Assist";
 "app_shortcuts.activate_scene.title" = "Activate Scene";
 "app_shortcuts.ask_assist.title" = "Ask Assist";
 "app_shortcuts.close.title" = "Close";

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -1151,6 +1151,12 @@ public enum L10n {
       /// Update sensors
       public static var title: String { return L10n.tr("Localizable", "app_intents.update_sensors.title") }
     }
+    public enum WatchAssist {
+      /// Opens Assist using the pipeline configured for the watch
+      public static var description: String { return L10n.tr("Localizable", "app_intents.watch_assist.description") }
+      /// Assist
+      public static var title: String { return L10n.tr("Localizable", "app_intents.watch_assist.title") }
+    }
   }
 
   public enum AppShortcuts {

--- a/Sources/WatchApp/WatchAssistLaunch.swift
+++ b/Sources/WatchApp/WatchAssistLaunch.swift
@@ -1,6 +1,7 @@
 import Foundation
+import Shared
 
-/// Bridges the "Assist in app" App Intent to the watch's full-screen Assist cover.
+/// Bridges the Assist App Intents to the watch's full-screen Assist cover.
 enum WatchAssistLaunch {
     static let launchNotification: Notification.Name = .init("watch-assist-launch")
 
@@ -11,16 +12,36 @@ enum WatchAssistLaunch {
 
     /// Asks the app to run `pipelineId` on `serverId`, whether or not the UI is already on screen.
     /// An empty `pipelineId` means the server's preferred pipeline.
-    ///
+    static func request(serverId: String, pipelineId: String) {
+        request(.session(serverId: serverId, pipelineId: pipelineId, prompt: nil))
+    }
+
+    /// Asks the app to open the Assist configured for the watch (the same server and pipeline the
+    /// complication and the home screen button use), falling back to the first server's preferred
+    /// pipeline when nothing is configured.
+    static func requestConfigured() {
+        request(configuredPresentation(
+            assist: ((try? WatchConfig.config()) ?? nil)?.assist,
+            servers: Current.servers.all
+        ))
+    }
+
+    static func configuredPresentation(assist: WatchConfig.Assist?, servers: [Server]) -> WatchAssistPresentation {
+        let configuredServer = servers.first { $0.identifier.rawValue == assist?.serverId }
+        guard let server = configuredServer ?? servers.first else { return .unconfigured }
+        let pipelineId = configuredServer == nil ? "" : (assist?.pipelineId ?? "")
+        return .session(serverId: server.identifier.rawValue, pipelineId: pipelineId, prompt: nil)
+    }
+
     /// App Intents can run `perform()` off the main thread, and `NotificationCenter` delivers
     /// synchronously on the posting thread — which would land `WatchHomeView`'s SwiftUI state
     /// mutation off-main. Hop first so both the latch and the delivery happen on the main thread.
-    static func request(serverId: String, pipelineId: String) {
+    private static func request(_ presentation: WatchAssistPresentation) {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async { request(serverId: serverId, pipelineId: pipelineId) }
+            DispatchQueue.main.async { request(presentation) }
             return
         }
-        pendingPresentation = .session(serverId: serverId, pipelineId: pipelineId, prompt: nil)
+        pendingPresentation = presentation
         NotificationCenter.default.post(name: launchNotification, object: nil)
     }
 }

--- a/Sources/WatchWidgets/WatchAssistAppIntent.swift
+++ b/Sources/WatchWidgets/WatchAssistAppIntent.swift
@@ -1,0 +1,25 @@
+import AppIntents
+
+struct WatchAssistAppIntent: AppIntent {
+    static var title: LocalizedStringResource = .init(
+        "app_intents.watch_assist.title",
+        defaultValue: "Assist"
+    )
+
+    static var description = IntentDescription(.init(
+        "app_intents.watch_assist.description",
+        defaultValue: "Opens Assist using the pipeline configured for the watch"
+    ))
+
+    static var openAppWhenRun: Bool = true
+    // `openAppWhenRun` is deprecated from watchOS 26; both stay until the deployment target passes 26.
+    @available(watchOS 26.0, *)
+    static var supportedModes: IntentModes { .foreground }
+
+    func perform() async throws -> some IntentResult {
+        #if !WIDGET_EXTENSION
+        WatchAssistLaunch.requestConfigured()
+        #endif
+        return .result()
+    }
+}

--- a/Sources/WatchWidgets/WatchControlAssist.swift
+++ b/Sources/WatchWidgets/WatchControlAssist.swift
@@ -7,11 +7,11 @@ struct WatchControlAssist: ControlWidget {
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(kind: WatchWidgetConstants.controlAssistKind) {
             ControlWidgetButton(action: WatchAssistAppIntent()) {
-                Label(WatchWidgetConstants.assistTitle, image: WatchWidgetConstants.assistIconAssetName)
+                Label(WatchWidgetStrings.assistTitle, image: WatchWidgetConstants.assistIconAssetName)
             }
             .tint(.haPrimary)
         }
-        .displayName(.init(stringLiteral: WatchWidgetConstants.assistTitle))
-        .description(.init(stringLiteral: WatchWidgetConstants.assistControlDescription))
+        .displayName(.init(stringLiteral: WatchWidgetStrings.assistTitle))
+        .description(.init(stringLiteral: WatchWidgetStrings.assistControlDescription))
     }
 }

--- a/Sources/WatchWidgets/WatchControlAssist.swift
+++ b/Sources/WatchWidgets/WatchControlAssist.swift
@@ -1,0 +1,17 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+@available(watchOS 26.0, *)
+struct WatchControlAssist: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: WatchWidgetConstants.controlAssistKind) {
+            ControlWidgetButton(action: WatchAssistAppIntent()) {
+                Label(WatchWidgetConstants.assistTitle, image: WatchWidgetConstants.assistIconAssetName)
+            }
+            .tint(.haPrimary)
+        }
+        .displayName(.init(stringLiteral: WatchWidgetConstants.assistTitle))
+        .description(.init(stringLiteral: WatchWidgetConstants.assistControlDescription))
+    }
+}

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -12,8 +12,6 @@ enum WatchWidgetConstants {
     static let logoAssetName = "Logo"
     static let templateLogoAssetName = "TemplateLogo"
     static let assistIconAssetName = "message-processing-outline"
-    static let assistTitle = "Assist"
-    static let assistControlDescription = "Opens Assist on your Apple Watch"
     static let placeholderSubtitle = "Complication"
     /// Neutral value shown in the complication picker's preview instead of a possibly-stale
     /// live value (see `WatchWidgetComplicationSnapshot.previewVariant`).

--- a/Sources/WatchWidgets/WatchWidgetConstants.swift
+++ b/Sources/WatchWidgets/WatchWidgetConstants.swift
@@ -12,6 +12,8 @@ enum WatchWidgetConstants {
     static let logoAssetName = "Logo"
     static let templateLogoAssetName = "TemplateLogo"
     static let assistIconAssetName = "message-processing-outline"
+    static let assistTitle = "Assist"
+    static let assistControlDescription = "Opens Assist on your Apple Watch"
     static let placeholderSubtitle = "Complication"
     /// Neutral value shown in the complication picker's preview instead of a possibly-stale
     /// live value (see `WatchWidgetComplicationSnapshot.previewVariant`).
@@ -69,6 +71,10 @@ enum WatchWidgetConstants {
 
     static var kind: String {
         widgetBundleID
+    }
+
+    static var controlAssistKind: String {
+        widgetBundleID + ".control.assist"
     }
 
     static let supportedFamilies: [WidgetFamily] = [

--- a/Sources/WatchWidgets/WatchWidgetStrings.swift
+++ b/Sources/WatchWidgets/WatchWidgetStrings.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Localized copy for the widget extension. The extension bundle carries no strings tables, so keys
+/// are resolved against the containing watch app's `Localizable.strings`, which Lokalise maintains.
+enum WatchWidgetStrings {
+    static var assistTitle: String {
+        localized("app_intents.watch_assist.title", defaultValue: "Assist")
+    }
+
+    static var assistControlDescription: String {
+        localized(
+            "app_intents.watch_assist.description",
+            defaultValue: "Opens Assist using the pipeline configured for the watch"
+        )
+    }
+
+    private static let containingAppBundle: Bundle = {
+        let appURL = Bundle.main.bundleURL.deletingLastPathComponent().deletingLastPathComponent()
+        return Bundle(url: appURL) ?? .main
+    }()
+
+    private static func localized(_ key: String, defaultValue: String) -> String {
+        containingAppBundle.localizedString(forKey: key, value: defaultValue, table: nil)
+    }
+}

--- a/Sources/WatchWidgets/WatchWidgets.swift
+++ b/Sources/WatchWidgets/WatchWidgets.swift
@@ -7,6 +7,9 @@ struct WatchWidgetsBundle: WidgetBundle {
         if #available(watchOS 10.0, *) {
             WatchWidgets()
         }
+        if #available(watchOS 26.0, *) {
+            WatchControlAssist()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds an Assist control to the watch widget extension so it can be assigned to the Action button on Apple Watch Ultra (Settings > Action Button > Controls) and added to Control Center on watchOS 26 and later. Pressing it opens Assist on the watch using the pipeline configured for the watch, falling back to the first server's preferred pipeline.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Controls require watchOS 26; earlier versions are unaffected.
