### PR TITLE
Round widget attribute values with the entity's display precision

### DIFF
--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
@@ -118,7 +118,7 @@ struct WidgetGaugeAppIntentTimelineProvider: AppIntentTimelineProvider {
     /// Builds the gauge from a single picked entity's live state, fetched over the REST `/states`
     /// endpoint (no admin required). The 0…1 fill maps the numeric state across the configured
     /// `minValue`…`maxValue` range; labels are generated from the state, unit and range.
-    private func entityEntry(for configuration: WidgetGaugeAppIntent) async throws -> Entry {
+    func entityEntry(for configuration: WidgetGaugeAppIntent) async throws -> Entry {
         guard let entity = configuration.entity else {
             Current.Log.error("Failed to fetch data for gauge widget: No entity selected")
             throw WidgetGaugeDataError.noEntity

--- a/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
+++ b/Sources/Extensions/AppIntents/Widget/Gauge/WidgetGaugeAppIntentTimelineProvider.swift
@@ -137,7 +137,7 @@ struct WidgetGaugeAppIntentTimelineProvider: AppIntentTimelineProvider {
             throw WidgetGaugeDataError.apiError
         }
 
-        let numericValue = Double(resolved.value.replacingOccurrences(of: ",", with: ".")) ?? 0
+        let numericValue = resolved.number ?? 0
         let range = configuration.maxValue - configuration.minValue
         let fraction = range != 0 ? Swift.min(Swift.max((numericValue - configuration.minValue) / range, 0), 1) : 0
 

--- a/Sources/Extensions/AppIntents/Widget/WidgetEntityAttributes.swift
+++ b/Sources/Extensions/AppIntents/Widget/WidgetEntityAttributes.swift
@@ -14,8 +14,10 @@ enum WidgetEntityAttributes {
         return attributes?.keys.sorted() ?? []
     }
 
-    /// Resolves the displayed value + unit for a widget's entity source. When `attribute` is set, reads
-    /// that attribute (unit via the shared `attributeUnit` map); otherwise reads the entity state.
+    /// Resolves the displayed value + unit for a widget's entity source, with the number behind a
+    /// numeric value for the gauge's fill (the displayed value is locale-formatted, with grouping, so it
+    /// is not parseable back). When `attribute` is set, reads that attribute (unit via the shared
+    /// `attributeUnit` map); otherwise reads the entity state.
     ///
     /// Numeric values are rounded the way the frontend rounds them, to the entity's display precision
     /// from the entity registry mirrored in GRDB. The state provider already does that for the state;
@@ -26,7 +28,7 @@ enum WidgetEntityAttributes {
         entityId: String,
         attribute: String?,
         server: Server
-    ) async -> (value: String, unit: String?)? {
+    ) async -> (value: String, unit: String?, number: Double?)? {
         let provider = ControlEntityProvider(domains: [])
         if let attribute {
             guard let attributes = await provider.attributes(server: server, entityId: entityId),
@@ -38,16 +40,17 @@ enum WidgetEntityAttributes {
                 attributes: attributes,
                 domain: entityId.components(separatedBy: ".").first
             )
+            let rawValue = String(describing: raw)
             let value = StatePrecision.adjustPrecision(
                 serverId: server.identifier.rawValue,
                 entityId: entityId,
-                stateValue: String(describing: raw)
+                stateValue: rawValue
             )
-            return (value, unit)
+            return (value, unit, Double(rawValue))
         }
         guard let state = await provider.state(server: server, entityId: entityId) else {
             return nil
         }
-        return (state.value, state.unitOfMeasurement)
+        return (state.value, state.unitOfMeasurement, Double(state.rawState))
     }
 }

--- a/Sources/Extensions/AppIntents/Widget/WidgetEntityAttributes.swift
+++ b/Sources/Extensions/AppIntents/Widget/WidgetEntityAttributes.swift
@@ -15,8 +15,13 @@ enum WidgetEntityAttributes {
     }
 
     /// Resolves the displayed value + unit for a widget's entity source. When `attribute` is set, reads
-    /// that attribute (unit via the shared `attributeUnit` map); otherwise reads the entity state (which
-    /// already carries Home Assistant's precision + unit). Returns nil when the value can't be fetched.
+    /// that attribute (unit via the shared `attributeUnit` map); otherwise reads the entity state.
+    ///
+    /// Numeric values are rounded the way the frontend rounds them, to the entity's display precision
+    /// from the entity registry mirrored in GRDB. The state provider already does that for the state;
+    /// an attribute gets the same treatment here, as on the watch, so a unit-converted temperature such
+    /// as `78.99999999999999` reads `79.0` like it does in the app and the web UI. Returns nil when the
+    /// value can't be fetched.
     static func resolvedValue(
         entityId: String,
         attribute: String?,
@@ -33,7 +38,12 @@ enum WidgetEntityAttributes {
                 attributes: attributes,
                 domain: entityId.components(separatedBy: ".").first
             )
-            return (String(describing: raw), unit)
+            let value = StatePrecision.adjustPrecision(
+                serverId: server.identifier.rawValue,
+                entityId: entityId,
+                stateValue: String(describing: raw)
+            )
+            return (value, unit)
         }
         guard let state = await provider.state(server: server, entityId: entityId) else {
             return nil

--- a/Tests/Shared/StatePrecision.test.swift
+++ b/Tests/Shared/StatePrecision.test.swift
@@ -59,6 +59,28 @@ struct StatePrecisionTests {
         #expect(result == "-7,418")
     }
 
+    @Test("Given a unit-converted state with float noise when adjusted then rounds like the frontend")
+    func floatNoiseRoundsToDisplayPrecision() {
+        let result = StatePrecision.adjustPrecision(
+            stateValue: "78.99999999999999",
+            decimalPlaces: 1,
+            locale: Locale(identifier: "en_US")
+        )
+
+        #expect(result == "79.0")
+    }
+
+    @Test("Given a non-numeric state when adjusted then passes through unchanged")
+    func nonNumericStatePassesThrough() {
+        let result = StatePrecision.adjustPrecision(
+            stateValue: "unavailable",
+            decimalPlaces: 1,
+            locale: Locale(identifier: "en_US")
+        )
+
+        #expect(result == "unavailable")
+    }
+
     @Test("Given comma decimal state value in locale when adjusted then keeps locale decimals without grouping")
     func localizedDecimalValue() {
         let result = StatePrecision.adjustPrecision(

--- a/Tests/Widgets/WidgetEntityAttributesTests.swift
+++ b/Tests/Widgets/WidgetEntityAttributesTests.swift
@@ -7,9 +7,11 @@ import XCTest
 
 /// The value the Details and Gauge widgets show for a picked entity, resolved against a mock
 /// connection and an in-memory copy of the entity registry that carries the display precision.
+@available(iOS 17, *)
 final class WidgetEntityAttributesTests: XCTestCase {
     private var previousServers: ServerManager!
     private var previousDatabase: (() -> DatabaseQueue)!
+    private var previousCachedApis: [Identifier<Server>: HomeAssistantAPI]!
     private var server: Server!
     private var api: HomeAssistantAPI!
     private var connection: HAMockConnection!
@@ -18,6 +20,7 @@ final class WidgetEntityAttributesTests: XCTestCase {
         try super.setUpWithError()
         previousServers = Current.servers
         previousDatabase = Current.database
+        previousCachedApis = Current.cachedApis
 
         let database = try DatabaseQueue(path: ":memory:")
         try DisplayEntityRegistryTable().createIfNeeded(database: database)
@@ -29,7 +32,7 @@ final class WidgetEntityAttributesTests: XCTestCase {
         api = HomeAssistantAPI(server: server)
         connection = HAMockConnection()
         api.connection = connection
-        Current.cachedApis[server.identifier] = api
+        Current.setCachedApi(api, for: server.identifier)
 
         try database.write { db in
             try EntityRegistryListForDisplay.Entity(
@@ -41,7 +44,7 @@ final class WidgetEntityAttributesTests: XCTestCase {
     }
 
     override func tearDown() {
-        Current.cachedApis = [:]
+        Current.cachedApis = previousCachedApis
         Current.servers = previousServers
         Current.database = previousDatabase
         api = nil
@@ -78,6 +81,7 @@ final class WidgetEntityAttributesTests: XCTestCase {
         )
         XCTAssertFalse(resolved.value.contains("9999"))
         XCTAssertEqual(resolved.unit, "°F")
+        XCTAssertEqual(resolved.number, 78.99999999999999)
     }
 
     /// A non-numeric attribute has nothing to round and passes through as the server sent it.
@@ -100,6 +104,7 @@ final class WidgetEntityAttributesTests: XCTestCase {
         let resolved = try XCTUnwrap(value)
         XCTAssertEqual(resolved.value, "heating")
         XCTAssertNil(resolved.unit)
+        XCTAssertNil(resolved.number)
     }
 
     /// The resolver runs off this test's own execution context, so wait for the `/states` request to

--- a/Tests/Widgets/WidgetEntityAttributesTests.swift
+++ b/Tests/Widgets/WidgetEntityAttributesTests.swift
@@ -84,6 +84,33 @@ final class WidgetEntityAttributesTests: XCTestCase {
         XCTAssertEqual(resolved.number, 78.99999999999999)
     }
 
+    /// Without an attribute the entity state is read, already rounded by the state provider, with the
+    /// number behind it for the gauge.
+    func testStateValueCarriesItsUnitAndNumber() async throws {
+        let task = Task { [server] in
+            await WidgetEntityAttributes.resolvedValue(
+                entityId: "climate.living_room",
+                attribute: nil,
+                server: server!
+            )
+        }
+
+        let request = try await stateRequest()
+        request.completion(.success(.init(value: [
+            "state": "78.99999999999999",
+            "attributes": ["unit_of_measurement": "°F"],
+        ])))
+
+        let value = await task.value
+        let resolved = try XCTUnwrap(value)
+        XCTAssertEqual(
+            resolved.value,
+            StatePrecision.adjustPrecision(stateValue: "78.99999999999999", decimalPlaces: 1)
+        )
+        XCTAssertEqual(resolved.unit, "°F")
+        XCTAssertEqual(resolved.number, 78.99999999999999)
+    }
+
     /// A non-numeric attribute has nothing to round and passes through as the server sent it.
     func testNonNumericAttributeValuePassesThrough() async throws {
         let task = Task { [server] in

--- a/Tests/Widgets/WidgetEntityAttributesTests.swift
+++ b/Tests/Widgets/WidgetEntityAttributesTests.swift
@@ -1,0 +1,118 @@
+import GRDB
+import HAKit
+import HAKit_Mocks
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+/// The value the Details and Gauge widgets show for a picked entity, resolved against a mock
+/// connection and an in-memory copy of the entity registry that carries the display precision.
+final class WidgetEntityAttributesTests: XCTestCase {
+    private var previousServers: ServerManager!
+    private var previousDatabase: (() -> DatabaseQueue)!
+    private var server: Server!
+    private var api: HomeAssistantAPI!
+    private var connection: HAMockConnection!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        previousServers = Current.servers
+        previousDatabase = Current.database
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
+        Current.database = { database }
+
+        let servers = FakeServerManager()
+        Current.servers = servers
+        server = servers.addFake()
+        api = HomeAssistantAPI(server: server)
+        connection = HAMockConnection()
+        api.connection = connection
+        Current.cachedApis[server.identifier] = api
+
+        try database.write { db in
+            try EntityRegistryListForDisplay.Entity(
+                serverId: server.identifier.rawValue,
+                entityId: "climate.living_room",
+                decimalPlaces: 1
+            ).insert(db)
+        }
+    }
+
+    override func tearDown() {
+        Current.cachedApis = [:]
+        Current.servers = previousServers
+        Current.database = previousDatabase
+        api = nil
+        connection = nil
+        server = nil
+        super.tearDown()
+    }
+
+    /// A unit-converted temperature attribute carries floating point noise; the registry precision
+    /// rounds it the way the frontend does, and the sibling `_unit` attribute supplies the unit.
+    func testAttributeValueIsRoundedToTheRegistryPrecision() async throws {
+        let task = Task { [server] in
+            await WidgetEntityAttributes.resolvedValue(
+                entityId: "climate.living_room",
+                attribute: "current_temperature",
+                server: server!
+            )
+        }
+
+        let request = try await stateRequest()
+        request.completion(.success(.init(value: [
+            "state": "heat",
+            "attributes": [
+                "current_temperature": 78.99999999999999,
+                "current_temperature_unit": "°F",
+            ],
+        ])))
+
+        let value = await task.value
+        let resolved = try XCTUnwrap(value)
+        XCTAssertEqual(
+            resolved.value,
+            StatePrecision.adjustPrecision(stateValue: "78.99999999999999", decimalPlaces: 1)
+        )
+        XCTAssertFalse(resolved.value.contains("9999"))
+        XCTAssertEqual(resolved.unit, "°F")
+    }
+
+    /// A non-numeric attribute has nothing to round and passes through as the server sent it.
+    func testNonNumericAttributeValuePassesThrough() async throws {
+        let task = Task { [server] in
+            await WidgetEntityAttributes.resolvedValue(
+                entityId: "climate.living_room",
+                attribute: "hvac_action",
+                server: server!
+            )
+        }
+
+        let request = try await stateRequest()
+        request.completion(.success(.init(value: [
+            "state": "heat",
+            "attributes": ["hvac_action": "heating"],
+        ])))
+
+        let value = await task.value
+        let resolved = try XCTUnwrap(value)
+        XCTAssertEqual(resolved.value, "heating")
+        XCTAssertNil(resolved.unit)
+    }
+
+    /// The resolver runs off this test's own execution context, so wait for the `/states` request to
+    /// reach the mock connection rather than assuming it has been sent by the time the test looks.
+    private func stateRequest() async throws -> HAMockConnection.PendingRequest {
+        for _ in 0 ..< 200 {
+            if let pending = connection.pendingRequests.first {
+                return pending
+            }
+            try await Task.sleep(nanoseconds: 10 * NSEC_PER_MSEC)
+        }
+        throw StateRequestNeverSent()
+    }
+
+    private struct StateRequestNeverSent: Error {}
+}

--- a/Tests/Widgets/WidgetGaugeAppIntentTimelineProviderTests.swift
+++ b/Tests/Widgets/WidgetGaugeAppIntentTimelineProviderTests.swift
@@ -1,0 +1,106 @@
+import GRDB
+import HAKit
+import HAKit_Mocks
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+/// The gauge the Gauge widget builds from a picked entity, resolved against a mock connection and
+/// an in-memory copy of the entity registry that carries the display precision.
+@available(iOS 17, *)
+final class WidgetGaugeAppIntentTimelineProviderTests: XCTestCase {
+    private var previousServers: ServerManager!
+    private var previousDatabase: (() -> DatabaseQueue)!
+    private var previousCachedApis: [Identifier<Server>: HomeAssistantAPI]!
+    private var server: Server!
+    private var api: HomeAssistantAPI!
+    private var connection: HAMockConnection!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        previousServers = Current.servers
+        previousDatabase = Current.database
+        previousCachedApis = Current.cachedApis
+
+        let database = try DatabaseQueue(path: ":memory:")
+        try DisplayEntityRegistryTable().createIfNeeded(database: database)
+        Current.database = { database }
+
+        let servers = FakeServerManager()
+        Current.servers = servers
+        server = servers.addFake()
+        api = HomeAssistantAPI(server: server)
+        connection = HAMockConnection()
+        api.connection = connection
+        Current.setCachedApi(api, for: server.identifier)
+
+        try database.write { db in
+            try EntityRegistryListForDisplay.Entity(
+                serverId: server.identifier.rawValue,
+                entityId: "sensor.energy",
+                decimalPlaces: 1
+            ).insert(db)
+        }
+    }
+
+    override func tearDown() {
+        Current.cachedApis = previousCachedApis
+        Current.servers = previousServers
+        Current.database = previousDatabase
+        api = nil
+        connection = nil
+        server = nil
+        super.tearDown()
+    }
+
+    /// The fill maps the number behind the state onto the configured range, even once the label has
+    /// been rounded and grouped for display (`1,234.5 kWh`), which is no longer parseable as a number.
+    func testEntityGaugeFillsFromTheRawNumberAndLabelsWithTheRoundedValue() async throws {
+        let configuration = WidgetGaugeAppIntent()
+        configuration.server = .init(identifier: server.identifier)
+        configuration.entity = HAAppEntityAppIntentEntity(
+            id: "\(server.identifier.rawValue)-sensor.energy",
+            entityId: "sensor.energy",
+            serverId: server.identifier.rawValue,
+            serverName: server.info.name,
+            displayString: "Energy",
+            iconName: "bolt"
+        )
+        configuration.gaugeType = .normal
+        configuration.minValue = 0
+        configuration.maxValue = 2000
+
+        let task = Task {
+            try await WidgetGaugeAppIntentTimelineProvider().entityEntry(for: configuration)
+        }
+
+        let request = try await stateRequest()
+        request.completion(.success(.init(value: [
+            "state": "1234.5",
+            "attributes": ["unit_of_measurement": "kWh"],
+        ])))
+
+        let entry = try await task.value
+        XCTAssertEqual(entry.value, 1234.5 / 2000, accuracy: 0.0001)
+        XCTAssertEqual(
+            entry.valueLabel,
+            "\(StatePrecision.adjustPrecision(stateValue: "1234.5", decimalPlaces: 1)) kWh"
+        )
+        XCTAssertEqual(entry.min, "0")
+        XCTAssertEqual(entry.max, "2000")
+    }
+
+    /// The provider runs off this test's own execution context, so wait for the `/states` request to
+    /// reach the mock connection rather than assuming it has been sent by the time the test looks.
+    private func stateRequest() async throws -> HAMockConnection.PendingRequest {
+        for _ in 0 ..< 200 {
+            if let pending = connection.pendingRequests.first {
+                return pending
+            }
+            try await Task.sleep(nanoseconds: 10 * NSEC_PER_MSEC)
+        }
+        throw StateRequestNeverSent()
+    }
+
+    private struct StateRequestNeverSent: Error {}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Details and Gauge widgets already round an entity's state with the display precision stored in the entity registry, but a picked attribute was shown verbatim. A unit-converted temperature attribute rendered with every floating point digit (`78.99999999999999`) where the app and the web UI show `79.0`. Attribute values now go through the same stored precision, as they do on the watch.

Fixes #5744

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
