### PR TITLE
Move start button to top of Watch vacuum clean areas list

### DIFF
--- a/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumCleanAreasView.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Vacuum/WatchVacuumCleanAreasView.swift
@@ -20,8 +20,8 @@ struct WatchVacuumCleanAreasView: View {
             } else if viewModel.cleanableAreas.isEmpty {
                 empty
             } else {
-                areas
                 startButton
+                areas
             }
         }
         .navigationTitle(Text(verbatim: L10n.Vacuum.Control.CleanAreas.title))


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On the Apple Watch vacuum clean areas screen, the start button was the last row of the list. With more than a couple of areas mapped, starting a clean meant scrolling all the way past every area. Moving it to the top of the list keeps it in reach.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Row order only; the button and the area rows are otherwise unchanged.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
No behaviour change: the button still starts `vacuum.clean_area` with the selected areas and stays disabled while nothing is selected.