### PR TITLE
Keep the configured icon color on CarPlay Quick Access rows

### DIFF
--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -157,11 +157,8 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
         var displayText = entity.attributes.friendlyName ?? entity.entityId
         let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
 
-        // The color always comes from the entity's live state — the same palette the frontend, the
-        // widgets and the watch use. Only the *icon* is subject to the saved/customized choice: a
-        // user who picked a custom icon still wants to see whether the thing is on.
         let customIconColor = (magicItem?.customization?.customIconColor).map { UIColor(hex: $0) }
-        let iconColor = entity.stateIconColor(customColor: customIconColor)
+        let iconColor = customIconColor ?? entity.stateIconColor()
 
         var icon = entity.getMDI(componentIcons: componentIcons)
         if let magicItem, let magicItemInfo {

--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -158,7 +158,7 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
         let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
 
         let customIconColor = (magicItem?.customization?.customIconColor).map { UIColor(hex: $0) }
-        let iconColor = customIconColor ?? entity.stateIconColor()
+        let iconColor = entity.stateIconColor(customColor: customIconColor)
 
         var icon = entity.getMDI(componentIcons: componentIcons)
         if let magicItem, let magicItemInfo {

--- a/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
@@ -16,7 +16,7 @@ struct WidgetEntityState: Codable {
     let groupMemberDomain: String?
 
     /// The icon color home-assistant/frontend gives this entity, or `customColor` when the user
-    /// picked one — which, as in the tile card, only applies while the entity is active.
+    /// picked one, which wins whatever the entity's state.
     func iconColor(domain: Domain?, customColor: Color? = nil) -> Color {
         EntityIconColorProvider.iconColor(
             domain: domain?.rawValue ?? "",

--- a/Sources/Shared/EntityIconColorProvider.swift
+++ b/Sources/Shared/EntityIconColorProvider.swift
@@ -5,10 +5,12 @@ import SwiftUI
 /// The color an entity's icon is drawn with, following home-assistant/frontend's tile card
 /// (`hui-tile-card`'s `_computeStateColor` plus the neutral defaults its stylesheet sets):
 ///
-/// 1. a light's own color, when it reports one;
-/// 2. the `--state-…` palette for the entity's domain, device class and state — see
+/// 1. a color the user picked for the item, whatever the entity's state — the one place this
+///    departs from the tile card, which drops a picked color while the entity is inactive;
+/// 2. a light's own color, when it reports one;
+/// 3. the `--state-…` palette for the entity's domain, device class and state — see
 ///    ``EntityStateColor``;
-/// 3. `--state-icon-color` when active and `--state-inactive-color` when not, for the domains that
+/// 4. `--state-icon-color` when active and `--state-inactive-color` when not, for the domains that
 ///    take no state color at all (sensors, numbers, scripts, …).
 public enum EntityIconColorProvider {
     /// The color for an entity whose live color (if any) has already been resolved.
@@ -32,10 +34,11 @@ public enum EntityIconColorProvider {
         let normalizedState = state.lowercased()
         let active = EntityStateActive.isActive(domain: domain, state: normalizedState)
 
-        // The tile card's `color` option: a picked color only applies while the entity is active,
-        // so an off light still reads as off.
+        // A color the user picked for this item wins outright. The frontend's tile card drops it
+        // while the entity is inactive; the companion app keeps it, because a picked color is how
+        // an item is told apart at a glance on a watch face, a widget or a CarPlay list.
         if let customColor {
-            return active ? customColor : neutralColor(active: false)
+            return customColor
         }
 
         // A light that is on shows its own color rather than the domain accent.

--- a/Sources/Shared/HAEntity+CarPlay.swift
+++ b/Sources/Shared/HAEntity+CarPlay.swift
@@ -27,8 +27,8 @@ public extension HAEntity {
     /// state's `--state-…` palette, or a light's own color. Shared by CarPlay and the watch so both
     /// read the same as the widgets and the frontend itself.
     ///
-    /// - Parameter customColor: a color the user picked for this entity on the calling surface. As
-    ///   in the frontend's tile card, it only applies while the entity is active.
+    /// - Parameter customColor: a color the user picked for this entity on the calling surface,
+    ///   which wins over everything below it whatever the entity's state.
     func stateIconColor(customColor: UIColor? = nil) -> UIColor? {
         UIColor(
             EntityIconColorProvider.iconColor(

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -63,7 +63,7 @@ final class WatchCoverControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -78,7 +78,7 @@ final class WatchLightControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -61,7 +61,7 @@ final class WatchLockControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Tests/App/Assist/AssistEntryPointsTests.swift
+++ b/Tests/App/Assist/AssistEntryPointsTests.swift
@@ -97,7 +97,7 @@ final class AssistEntryPointsTests: XCTestCase {
             pipelineId: "pipeline-3",
             withVoice: false
         )
-        wait(for: [requested], timeout: 2)
+        wait(for: [requested], timeout: 30)
 
         XCTAssertEqual(delegate.contexts.first?.server.identifier, server.identifier)
         XCTAssertEqual(delegate.contexts.first?.pipelineId, "pipeline-3")
@@ -118,7 +118,7 @@ final class AssistEntryPointsTests: XCTestCase {
         delegate.onContext = { requested.fulfill() }
 
         XCTAssertTrue(handler.handle(url: url))
-        wait(for: [requested], timeout: 2)
+        wait(for: [requested], timeout: 30)
 
         XCTAssertEqual(delegate.contexts.first?.server.identifier, server.identifier)
         XCTAssertEqual(delegate.contexts.first?.pipelineId, "pipeline-2")

--- a/Tests/App/Cameras/WebRTCViewPlayerViewModelSignalingTests.swift
+++ b/Tests/App/Cameras/WebRTCViewPlayerViewModelSignalingTests.swift
@@ -229,7 +229,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
         _ = try startAndOffer()
 
         try XCTUnwrap(clients.first).changeConnectionState(.disconnected)
-        spinMain(for: timing.disconnectedGracePeriod * 3)
+        spinMain(until: { clientConfigRequests.count == 2 })
 
         XCTAssertEqual(clientConfigRequests.count, 2)
         XCTAssertTrue(try XCTUnwrap(clients.first).isClosed)
@@ -254,7 +254,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
     func testNoFrameBeforeTheTimeoutFailsTheStream() throws {
         _ = try startAndOffer()
 
-        spinMain(for: timing.connectionTimeout * 3)
+        spinMain(until: { viewModel.didFail })
 
         XCTAssertTrue(viewModel.didFail)
         XCTAssertFalse(viewModel.showLoader)
@@ -273,7 +273,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
         connection.setState(.connecting, waitForQueue: false)
         viewModel.start()
 
-        spinMain(for: timing.connectionWaitTimeout * 1.5)
+        spinMain(until: { viewModel.didFail })
 
         XCTAssertTrue(viewModel.didFail)
         XCTAssertTrue(connection.pendingRequests.isEmpty)
@@ -306,7 +306,7 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
             XCTAssertEqual(clientConfigRequests.count, attempt + 1)
         }
 
-        spinMain(for: timing.signalingStallTimeout * 2)
+        spinMain(until: { viewModel.didFail })
 
         XCTAssertTrue(viewModel.didFail)
         XCTAssertEqual(clientConfigRequests.count, 3, "Nothing more is sent once the retries are spent")
@@ -400,10 +400,27 @@ final class WebRTCViewPlayerViewModelSignalingTests: XCTestCase {
     private func flushMainQueue() {
         let flushed = expectation(description: "main queue flushed")
         DispatchQueue.main.async { flushed.fulfill() }
-        wait(for: [flushed], timeout: 10.0)
+        wait(for: [flushed], timeout: 30.0)
     }
 
+    /// Spins for a fixed stretch, to prove something does *not* happen within it.
     private func spinMain(for interval: TimeInterval) {
         RunLoop.main.run(until: Date().addingTimeInterval(interval))
+    }
+
+    /// Spins until `condition` holds. Waiting for the outcome rather than for the interval keeps a
+    /// deadline that lands late — `asyncAfter` overshoots badly on a loaded machine — from reading
+    /// as a failure.
+    private func spinMain(
+        until condition: () -> Bool,
+        timeout: TimeInterval = 30,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(condition(), "Timed out spinning the main run loop", file: file, line: line)
     }
 }

--- a/Tests/App/CarPlay/CarPlayEntitiesListViewModel.test.swift
+++ b/Tests/App/CarPlay/CarPlayEntitiesListViewModel.test.swift
@@ -86,7 +86,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
 
         sut.handleEntityTap(entity: entity) { released.fulfill() }
 
-        wait(for: [released], timeout: 2)
+        wait(for: [released], timeout: 30)
     }
 
     func testATapReleasesTheRowHandlerWithoutWaitingForTheServer() throws {
@@ -96,7 +96,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
 
         sut.handleEntityTap(entity: entity) { released.fulfill() }
 
-        wait(for: [released], timeout: 2)
+        wait(for: [released], timeout: 30)
         XCTAssertEqual(connection.pendingRequests.count, 1)
     }
 
@@ -121,7 +121,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
         let request = try XCTUnwrap(connection.pendingRequests.first)
         request.completion(.success(.empty))
 
-        wait(for: [settled], timeout: 2)
+        wait(for: [settled], timeout: 30)
         XCTAssertTrue(finished)
     }
 
@@ -139,7 +139,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
         let request = try XCTUnwrap(connection.pendingRequests.first)
         request.completion(.failure(.internal(debugDescription: "nope")))
 
-        wait(for: [settled], timeout: 2)
+        wait(for: [settled], timeout: 30)
     }
 
     /// Climate rows open a control screen rather than executing anything.
@@ -150,7 +150,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
 
         sut.handleEntityTap(entity: entity) { released.fulfill() }
 
-        wait(for: [released], timeout: 2)
+        wait(for: [released], timeout: 30)
         XCTAssertTrue(connection.pendingRequests.isEmpty)
     }
 
@@ -172,7 +172,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
         XCTAssertEqual(connection.pendingRequests.count, 1)
         let request = try XCTUnwrap(connection.pendingRequests.first)
         request.completion(.success(.empty))
-        wait(for: [settled], timeout: 2)
+        wait(for: [settled], timeout: 30)
     }
 
     /// The rendered rows carry the same repeat-tap guard the view model does.
@@ -207,7 +207,7 @@ final class CarPlayEntitiesListViewModelTests: XCTestCase {
         }
 
         schedule(cycles)
-        wait(for: [drained], timeout: 10.0)
+        wait(for: [drained], timeout: 30.0)
     }
 
     /// The row refuses a repeat tap while its call is outstanding, which is what stops a slow

--- a/Tests/App/CarPlay/CarPlayEntityListItem.test.swift
+++ b/Tests/App/CarPlay/CarPlayEntityListItem.test.swift
@@ -1,0 +1,112 @@
+import CarPlay
+import HAKit
+@testable import HomeAssistant
+@testable import Shared
+import XCTest
+
+/// Covers which color a Quick Access entity row paints its icon with: the one the driver picked in
+/// the CarPlay configuration when there is one, and the entity's live state color otherwise.
+final class CarPlayEntityListItemTests: XCTestCase {
+    private let serverId = "server-1"
+
+    private func entity(id: String = "light.kitchen", state: String) throws -> HAEntity {
+        try HAEntity(
+            entityId: id,
+            state: state,
+            lastChanged: Date(),
+            lastUpdated: Date(),
+            attributes: [:],
+            context: .init(id: "", userId: "", parentId: "")
+        )
+    }
+
+    private func magicItem(id: String = "light.kitchen", customization: MagicItem.Customization?) -> MagicItem {
+        MagicItem(id: id, serverId: serverId, type: .entity, customization: customization)
+    }
+
+    private func info(for item: MagicItem) -> MagicItem.Info {
+        .init(id: item.id, name: item.id, iconName: "", customization: item.customization)
+    }
+
+    private func iconColor(entity: HAEntity, item: MagicItem?) -> UIColor? {
+        CarPlayEntityListItem(
+            serverId: serverId,
+            entity: entity,
+            magicItem: item,
+            magicItemInfo: item.map { info(for: $0) }
+        ).currentDisplayContent().iconColor
+    }
+
+    private func components(of color: UIColor) -> [CGFloat] {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return [red, green, blue, alpha]
+    }
+
+    /// `UIColor` equality depends on the color space, so compare what actually gets drawn.
+    private func assertSameColor(
+        _ lhs: UIColor?,
+        _ rhs: UIColor?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let lhs = try components(of: XCTUnwrap(lhs, file: file, line: line))
+        let rhs = try components(of: XCTUnwrap(rhs, file: file, line: line))
+
+        for (lhs, rhs) in zip(lhs, rhs) {
+            XCTAssertEqual(lhs, rhs, accuracy: 0.01, file: file, line: line)
+        }
+    }
+
+    /// The regression: an inactive entity used to drop the picked color for the neutral "off" grey,
+    /// so a configured row turned grey as soon as its state arrived.
+    func testAnInactiveEntityKeepsTheConfiguredIconColor() throws {
+        let offEntity = try entity(state: "off")
+        let item = magicItem(customization: .init(iconColor: "#FF0000", iconColorIsCustomized: true))
+
+        let color = iconColor(entity: offEntity, item: item)
+
+        try assertSameColor(color, UIColor(hex: "#FF0000"))
+    }
+
+    func testAnActiveEntityKeepsTheConfiguredIconColor() throws {
+        let onEntity = try entity(state: "on")
+        let item = magicItem(customization: .init(iconColor: "#FF0000", iconColorIsCustomized: true))
+
+        let color = iconColor(entity: onEntity, item: item)
+
+        try assertSameColor(color, UIColor(hex: "#FF0000"))
+    }
+
+    func testAnItemWithoutAConfiguredColorUsesTheStateColor() throws {
+        let offEntity = try entity(state: "off")
+        let item = magicItem(customization: .init())
+
+        let color = iconColor(entity: offEntity, item: item)
+
+        try assertSameColor(color, offEntity.stateIconColor())
+    }
+
+    /// The customization screen seeds its picker with the app's tint, so an item carrying that color
+    /// without ``MagicItem/Customization/iconColorIsCustomized`` never had a color picked for it.
+    func testASeededColorIsNotTreatedAsConfigured() throws {
+        let offEntity = try entity(state: "off")
+        let item = magicItem(customization: .init(iconColor: MagicItem.defaultIconColorHex))
+
+        let color = iconColor(entity: offEntity, item: item)
+
+        try assertSameColor(color, offEntity.stateIconColor())
+    }
+
+    /// Rows outside Quick Access carry no magic item at all, so they stay on the state color.
+    func testAnEntityRowWithoutAMagicItemUsesTheStateColor() throws {
+        let onEntity = try entity(state: "on")
+
+        let color = iconColor(entity: onEntity, item: nil)
+
+        try assertSameColor(color, onEntity.stateIconColor())
+    }
+}

--- a/Tests/App/CarPlay/CarPlayQuickAccessTemplate.test.swift
+++ b/Tests/App/CarPlay/CarPlayQuickAccessTemplate.test.swift
@@ -55,7 +55,7 @@ final class CarPlayQuickAccessTemplateTests: XCTestCase {
         }
 
         schedule(cycles)
-        wait(for: [drained], timeout: 5)
+        wait(for: [drained], timeout: 30)
     }
 
     private func item(id: String, type: MagicItem.ItemType) -> MagicItem {

--- a/Tests/App/Container/AppContainerCoordinatorTests.swift
+++ b/Tests/App/Container/AppContainerCoordinatorTests.swift
@@ -56,7 +56,7 @@ final class AppContainerCoordinatorTests: XCTestCase {
             isComingFromAppIntent: false
         )
 
-        wait(for: [navigated], timeout: 5)
+        wait(for: [navigated], timeout: 30)
         XCTAssertEqual(frontend.openedInlineURLs.last?.path, "/lovelace/dashboard")
         XCTAssertTrue(frontend.openedPanelURLs.isEmpty)
         XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
@@ -75,7 +75,7 @@ final class AppContainerCoordinatorTests: XCTestCase {
             isComingFromAppIntent: true
         )
 
-        wait(for: [navigated], timeout: 5)
+        wait(for: [navigated], timeout: 30)
         XCTAssertEqual(frontend.openedPanelURLs.last?.path, "/lovelace/dashboard")
         XCTAssertTrue(frontend.openedInlineURLs.isEmpty)
         XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
@@ -111,10 +111,23 @@ final class AppContainerCoordinatorTests: XCTestCase {
         // picker takes its place a runloop later.
         XCTAssertFalse(AppSettingsPresenter.shared.isSheetPresented)
 
-        let presented = expectation(description: "picker presented")
-        DispatchQueue.main.async { presented.fulfill() }
-        wait(for: [presented], timeout: 5)
+        waitUntil { AppSettingsPresenter.shared.isSheetPresented }
 
         XCTAssertTrue(AppSettingsPresenter.shared.isSheetPresented)
+    }
+
+    /// Spins the main run loop until `condition` holds. `selectServer` clears the screen and only then
+    /// hops to present, so the picker can take more than the one turn a single `async` would cover.
+    private func waitUntil(
+        _ condition: () -> Bool,
+        timeout: TimeInterval = 30,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(condition(), "Timed out spinning the main run loop", file: file, line: line)
     }
 }

--- a/Tests/Shared/EntityIconColorProvider.test.swift
+++ b/Tests/Shared/EntityIconColorProvider.test.swift
@@ -151,23 +151,38 @@ struct EntityIconColorProviderTests {
 
     // MARK: - User override
 
-    @Test func aPickedColorOnlyAppliesWhileActive() throws {
+    @Test func aPickedColorAlwaysApplies() throws {
         let picked = Color(hex: "#FF00FF")
         try expectColor(
             EntityIconColorProvider.iconColor(domain: "light", state: "on", customColor: picked),
             isHex: "#FF00FF"
         )
-        // Off, the tile reads as off rather than as the picked color, as the tile card does.
+        // Unlike the tile card, an inactive entity keeps the picked color rather than reading as off.
         try expectColor(
             EntityIconColorProvider.iconColor(domain: "light", state: "off", customColor: picked),
-            isHex: "#9E9E9E"
+            isHex: "#FF00FF"
         )
-        // …and it beats a light's own color while on.
+        // It beats a light's own color while on…
         try expectColor(
             EntityIconColorProvider.iconColor(
                 domain: "light",
                 state: "on",
                 liveColor: Color(hex: "#FF8C00"),
+                customColor: picked
+            ),
+            isHex: "#FF00FF"
+        )
+        // …and the domain's own state color, which an unpicked lock would take.
+        try expectColor(
+            EntityIconColorProvider.iconColor(domain: "lock", state: "unlocked", customColor: picked),
+            isHex: "#FF00FF"
+        )
+        // The attribute-reading overload resolves to the same color.
+        try expectColor(
+            EntityIconColorProvider.iconColor(
+                domain: "light",
+                state: "off",
+                attributes: ["rgb_color": [255, 140, 0]],
                 customColor: picked
             ),
             isHex: "#FF00FF"


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
An icon color the user picked for an item was only painted while the entity was active, following the frontend tile card's rule. On CarPlay a Quick Access row therefore rendered in its chosen color and turned grey as soon as the entity's state arrived and reported it inactive.

A picked color now wins outright, whatever the state, on CarPlay, widgets and the watch alike. Items with no color of their own are unchanged: a light's own color, the `--state-…` palette, and the neutral active/inactive defaults all still apply.

Fixes #5752

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — only affects items the user gave a color, on CarPlay, widgets and the watch.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Only a color the user actually picked counts: `Customization.customIconColor` already ignores the value the color picker seeds itself with, so items that were never customized are unaffected.

This is a deliberate departure from the frontend tile card: a colored item no longer signals on/off through color, which state still carries through the icon glyph and the subtitle.

Includes #5756, which was merged into this branch.
