### PR TITLE
Keep a picked icon color on widgets and the watch too

### DIFF
--- a/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
+++ b/Sources/CarPlay/Templates/Entities/CarPlayEntityListItem.swift
@@ -158,7 +158,7 @@ final class CarPlayEntityListItem: CarPlayListItemProvider {
         let componentIcons = Current.entityComponentIcons().iconsMap(for: serverId)
 
         let customIconColor = (magicItem?.customization?.customIconColor).map { UIColor(hex: $0) }
-        let iconColor = customIconColor ?? entity.stateIconColor()
+        let iconColor = entity.stateIconColor(customColor: customIconColor)
 
         var icon = entity.getMDI(componentIcons: componentIcons)
         if let magicItem, let magicItemInfo {

--- a/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
+++ b/Sources/Extensions/Widgets/Common/WidgetTimelineProviderSupport.swift
@@ -16,7 +16,7 @@ struct WidgetEntityState: Codable {
     let groupMemberDomain: String?
 
     /// The icon color home-assistant/frontend gives this entity, or `customColor` when the user
-    /// picked one — which, as in the tile card, only applies while the entity is active.
+    /// picked one, which wins whatever the entity's state.
     func iconColor(domain: Domain?, customColor: Color? = nil) -> Color {
         EntityIconColorProvider.iconColor(
             domain: domain?.rawValue ?? "",

--- a/Sources/Shared/EntityIconColorProvider.swift
+++ b/Sources/Shared/EntityIconColorProvider.swift
@@ -5,10 +5,12 @@ import SwiftUI
 /// The color an entity's icon is drawn with, following home-assistant/frontend's tile card
 /// (`hui-tile-card`'s `_computeStateColor` plus the neutral defaults its stylesheet sets):
 ///
-/// 1. a light's own color, when it reports one;
-/// 2. the `--state-…` palette for the entity's domain, device class and state — see
+/// 1. a color the user picked for the item, whatever the entity's state — the one place this
+///    departs from the tile card, which drops a picked color while the entity is inactive;
+/// 2. a light's own color, when it reports one;
+/// 3. the `--state-…` palette for the entity's domain, device class and state — see
 ///    ``EntityStateColor``;
-/// 3. `--state-icon-color` when active and `--state-inactive-color` when not, for the domains that
+/// 4. `--state-icon-color` when active and `--state-inactive-color` when not, for the domains that
 ///    take no state color at all (sensors, numbers, scripts, …).
 public enum EntityIconColorProvider {
     /// The color for an entity whose live color (if any) has already been resolved.
@@ -32,10 +34,11 @@ public enum EntityIconColorProvider {
         let normalizedState = state.lowercased()
         let active = EntityStateActive.isActive(domain: domain, state: normalizedState)
 
-        // The tile card's `color` option: a picked color only applies while the entity is active,
-        // so an off light still reads as off.
+        // A color the user picked for this item wins outright. The frontend's tile card drops it
+        // while the entity is inactive; the companion app keeps it, because a picked color is how
+        // an item is told apart at a glance on a watch face, a widget or a CarPlay list.
         if let customColor {
-            return active ? customColor : neutralColor(active: false)
+            return customColor
         }
 
         // A light that is on shows its own color rather than the domain accent.

--- a/Sources/Shared/HAEntity+CarPlay.swift
+++ b/Sources/Shared/HAEntity+CarPlay.swift
@@ -27,8 +27,8 @@ public extension HAEntity {
     /// state's `--state-…` palette, or a light's own color. Shared by CarPlay and the watch so both
     /// read the same as the widgets and the frontend itself.
     ///
-    /// - Parameter customColor: a color the user picked for this entity on the calling surface. As
-    ///   in the frontend's tile card, it only applies while the entity is active.
+    /// - Parameter customColor: a color the user picked for this entity on the calling surface,
+    ///   which wins over everything below it whatever the entity's state.
     func stateIconColor(customColor: UIColor? = nil) -> UIColor? {
         UIColor(
             EntityIconColorProvider.iconColor(

--- a/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Cover/WatchCoverControlsViewModel.swift
@@ -63,7 +63,7 @@ final class WatchCoverControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Light/WatchLightControlsViewModel.swift
@@ -78,7 +78,7 @@ final class WatchLightControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
+++ b/Sources/WatchApp/Home/EntityDetails/Lock/WatchLockControlsViewModel.swift
@@ -61,7 +61,7 @@ final class WatchLockControlsViewModel: ObservableObject {
     }
 
     /// The color follows the entity's state whichever icon is drawn, so a custom icon still shows
-    /// whether the thing is on. Only a custom *color* overrides it, and only while active.
+    /// whether the thing is on. Only a custom *color* overrides it, whatever the state.
     var iconColor: UIColor {
         if let entity {
             let customColor = itemInfo.customization?.customIconColor.map { UIColor(hex: $0) }

--- a/Tests/Shared/EntityIconColorProvider.test.swift
+++ b/Tests/Shared/EntityIconColorProvider.test.swift
@@ -151,23 +151,38 @@ struct EntityIconColorProviderTests {
 
     // MARK: - User override
 
-    @Test func aPickedColorOnlyAppliesWhileActive() throws {
+    @Test func aPickedColorAlwaysApplies() throws {
         let picked = Color(hex: "#FF00FF")
         try expectColor(
             EntityIconColorProvider.iconColor(domain: "light", state: "on", customColor: picked),
             isHex: "#FF00FF"
         )
-        // Off, the tile reads as off rather than as the picked color, as the tile card does.
+        // Unlike the tile card, an inactive entity keeps the picked color rather than reading as off.
         try expectColor(
             EntityIconColorProvider.iconColor(domain: "light", state: "off", customColor: picked),
-            isHex: "#9E9E9E"
+            isHex: "#FF00FF"
         )
-        // …and it beats a light's own color while on.
+        // It beats a light's own color while on…
         try expectColor(
             EntityIconColorProvider.iconColor(
                 domain: "light",
                 state: "on",
                 liveColor: Color(hex: "#FF8C00"),
+                customColor: picked
+            ),
+            isHex: "#FF00FF"
+        )
+        // …and the domain's own state color, which an unpicked lock would take.
+        try expectColor(
+            EntityIconColorProvider.iconColor(domain: "lock", state: "unlocked", customColor: picked),
+            isHex: "#FF00FF"
+        )
+        // The attribute-reading overload resolves to the same color.
+        try expectColor(
+            EntityIconColorProvider.iconColor(
+                domain: "light",
+                state: "off",
+                attributes: ["rgb_color": [255, 140, 0]],
                 customColor: picked
             ),
             isHex: "#FF00FF"


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Applies one rule everywhere: an icon color the user picked for an item wins outright, whatever the entity's state. The frontend's tile card drops a picked color while the entity is inactive, and `EntityIconColorProvider` copied that, so widgets and the watch turned a colored item grey when it went off.

Items with no color of their own are unchanged: a light's own color, the `--state-…` palette, and the neutral active/inactive defaults all still apply. CarPlay goes back to the shared helper now that it is the same rule.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A — only affects items the user gave a color, on widgets, the watch and CarPlay.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Built on #5755, which fixes the same thing for CarPlay only — this PR targets that branch so the diff stays small, and can be retargeted to `main` once it merges.

This is a deliberate departure from the frontend tile card: a colored item no longer signals on/off through color, which state still carries through the icon glyph and the subtitle.
