### PR TITLE
Fix macOS audio in-use sensors never activating

### DIFF
--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectDevice.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectDevice.swift
@@ -34,20 +34,23 @@ class HACoreAudioObjectDevice: HACoreAudioObject {
         }
     }
 
-    var isInputOn: Bool {
-        if let isOn = value(for: .isInputRunningSomewhere) {
-            return isOn != 0
-        } else {
-            return false
-        }
+    /// Whether the device is currently recording.
+    ///
+    /// `isOn` covers the device as a whole, in either direction, so it can't answer this on its own for a
+    /// device that both records and plays back: playing music through a USB headset would report its
+    /// microphone as in use. `runningDevices` resolves the direction where CoreAudio can tell us, and is
+    /// `nil` where it can't.
+    func isInputOn(runningDevices: HACoreAudioRunningDevices?) -> Bool {
+        guard isInput else { return false }
+        guard let runningDevices else { return isOn }
+        return runningDevices.isRecording(deviceID: id, isRunningSomewhere: isOn)
     }
 
-    var isOutputOn: Bool {
-        if let isOn = value(for: .isOutputRunningSomewhere) {
-            return isOn != 0
-        } else {
-            return false
-        }
+    /// Whether the device is currently playing back. See `isInputOn(runningDevices:)`.
+    func isOutputOn(runningDevices: HACoreAudioRunningDevices?) -> Bool {
+        guard isOutput else { return false }
+        guard let runningDevices else { return isOn }
+        return runningDevices.isPlayingBack(deviceID: id, isRunningSomewhere: isOn)
     }
 
     var isInput: Bool {

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectProcess.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectProcess.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+#if targetEnvironment(macCatalyst)
+import CoreAudio
+
+/// One of the processes doing audio IO on the system, from `kAudioHardwarePropertyProcessObjectList`.
+///
+/// These objects are the only place CoreAudio reports the *direction* of activity:
+/// `kAudioDevicePropertyDeviceIsRunningSomewhere` is device-global and says nothing about whether the
+/// device is recording, playing back, or both.
+class HACoreAudioObjectProcess: HACoreAudioObject {
+    var isRunningInput: Bool {
+        if let isRunning = value(for: .isProcessRunningInput) {
+            return isRunning != 0
+        } else {
+            return false
+        }
+    }
+
+    var isRunningOutput: Bool {
+        if let isRunning = value(for: .isProcessRunningOutput) {
+            return isRunning != 0
+        } else {
+            return false
+        }
+    }
+
+    var inputDeviceIDs: [AudioDeviceID] {
+        value(for: .processInputDevices) ?? []
+    }
+
+    var outputDeviceIDs: [AudioDeviceID] {
+        value(for: .processOutputDevices) ?? []
+    }
+}
+
+#endif

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectSystem.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioObjectSystem.swift
@@ -23,6 +23,13 @@ class HACoreAudioObjectSystem: HACoreAudioObject {
     var allOutputDevices: [HACoreAudioObjectDevice] {
         allDevices.filter(\.isOutput)
     }
+
+    /// `nil` when CoreAudio has no per-process state to offer, which is the case on macOS 13 and earlier.
+    /// Callers fall back to the devices' own stream configuration for direction when that happens.
+    var runningDevices: HACoreAudioRunningDevices? {
+        guard let ids = value(for: .processObjectList) else { return nil }
+        return HACoreAudioRunningDevices(processes: ids.map { HACoreAudioObjectProcess(id: $0) })
+    }
 }
 
 #endif

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioRunningDevices.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreAudioRunningDevices.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Which audio devices are recording and which are playing back, right now, across the whole system.
+///
+/// This exists because `kAudioDevicePropertyDeviceIsRunningSomewhere` cannot answer that question: it is a
+/// device-global flag, with no per-direction meaning, published only in `kAudioObjectPropertyScopeGlobal`.
+/// A device that both records and plays back — a USB headset, say — reports itself as running when either
+/// direction is in use, which is why playing music through a headset used to turn `Audio Input In Use` on.
+/// Direction has to come from the processes doing the IO instead.
+struct HACoreAudioRunningDevices {
+    let inputDeviceIDs: Set<UInt32>
+    let outputDeviceIDs: Set<UInt32>
+}
+
+extension HACoreAudioRunningDevices {
+    /// Whether the device is recording, given the device-global running flag as a fallback.
+    ///
+    /// A process doing input IO on the device settles it. So does a process doing only output IO on it:
+    /// something is playing through it and nothing is recording from it. A device that is running while no
+    /// process claims it in either direction falls back to the global flag, which is what the app relied on
+    /// before it looked at direction at all.
+    func isRecording(deviceID: UInt32, isRunningSomewhere: Bool) -> Bool {
+        if inputDeviceIDs.contains(deviceID) {
+            return true
+        }
+        if outputDeviceIDs.contains(deviceID) {
+            return false
+        }
+        return isRunningSomewhere
+    }
+
+    /// Whether the device is playing back. See `isRecording(deviceID:isRunningSomewhere:)`.
+    func isPlayingBack(deviceID: UInt32, isRunningSomewhere: Bool) -> Bool {
+        if outputDeviceIDs.contains(deviceID) {
+            return true
+        }
+        if inputDeviceIDs.contains(deviceID) {
+            return false
+        }
+        return isRunningSomewhere
+    }
+}
+
+#if targetEnvironment(macCatalyst)
+extension HACoreAudioRunningDevices {
+    init(processes: [HACoreAudioObjectProcess]) {
+        var recording = Set<UInt32>()
+        var playingBack = Set<UInt32>()
+
+        for process in processes {
+            if process.isRunningInput {
+                recording.formUnion(process.inputDeviceIDs)
+            }
+            if process.isRunningOutput {
+                playingBack.formUnion(process.outputDeviceIDs)
+            }
+        }
+
+        self.init(inputDeviceIDs: recording, outputDeviceIDs: playingBack)
+    }
+}
+#endif

--- a/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
+++ b/Sources/Shared/API/Webhook/Sensors/CoreMedia and CoreAudio Helpers/HACoreBlahProperty.swift
@@ -213,17 +213,59 @@ extension HACoreAudioProperty {
         )
     }
 
-    static var isInputRunningSomewhere: HACoreAudioProperty<UInt32> {
+    static var processObjectList: HACoreAudioProperty<[AudioObjectID]> {
+        /*
+         An array of AudioObjectIDs that represent the processes currently doing IO on the system. Reading it
+         fails on macOS 13 and earlier, where the process objects do not exist.
+         */
         .init(
-            mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceIsRunningSomewhere),
+            mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyProcessObjectList),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+    }
+
+    static var isProcessRunningInput: HACoreAudioProperty<UInt32> {
+        /*
+         A UInt32 where 1 means that the process is doing input IO. Unlike
+         kAudioDevicePropertyDeviceIsRunningSomewhere, this genuinely distinguishes the two directions.
+         */
+        .init(
+            mSelector: AudioObjectPropertySelector(kAudioProcessPropertyIsRunningInput),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+    }
+
+    static var isProcessRunningOutput: HACoreAudioProperty<UInt32> {
+        /*
+         A UInt32 where 1 means that the process is doing output IO.
+         */
+        .init(
+            mSelector: AudioObjectPropertySelector(kAudioProcessPropertyIsRunningOutput),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+    }
+
+    static var processInputDevices: HACoreAudioProperty<[AudioDeviceID]> {
+        /*
+         An array of AudioObjectIDs for the devices the process is using for IO. The scope of the address
+         picks the direction, so this address returns the devices it records from.
+         */
+        .init(
+            mSelector: AudioObjectPropertySelector(kAudioProcessPropertyDevices),
             mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeInput),
             mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
         )
     }
 
-    static var isOutputRunningSomewhere: HACoreAudioProperty<UInt32> {
+    static var processOutputDevices: HACoreAudioProperty<[AudioDeviceID]> {
+        /*
+         The devices the process is using for playback. See processInputDevices.
+         */
         .init(
-            mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceIsRunningSomewhere),
+            mSelector: AudioObjectPropertySelector(kAudioProcessPropertyDevices),
             mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeOutput),
             mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
         )

--- a/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
@@ -160,14 +160,19 @@ public class InputOutputDeviceSensor: SensorProvider {
             (cameraSystemObject.allCameras, audioSystemObject.allInputDevices, audioSystemObject.allOutputDevices)
         }.get(on: queue) { cameras, audioInputs, audioOutputs in
             cameras.forEach { updateSignaler.addCoreMediaObserver(for: $0.id, property: .isRunningSomewhere) }
-            for audioInput in audioInputs {
-                updateSignaler.addCoreAudioObserver(for: audioInput.id, property: .isInputRunningSomewhere)
+            // kAudioDevicePropertyDeviceIsRunningSomewhere is only ever published in the global scope, so a
+            // listener scoped to input or output registers happily and then never fires. A device that both
+            // records and plays back needs a single listener here, and the direction sorted out on read.
+            for device in audioInputs + audioOutputs {
+                updateSignaler.addCoreAudioObserver(for: device.id, property: .isRunningSomewhere)
             }
-            for audioOutput in audioOutputs {
-                updateSignaler.addCoreAudioObserver(for: audioOutput.id, property: .isOutputRunningSomewhere)
-            }
-        }.map(on: queue) { cameras, audioInputs, audioOutputs -> [WebhookSensor] in
-            Self.sensors(cameras: cameras, audioInputs: audioInputs, audioOutputs: audioOutputs)
+        }.map(on: queue) { [audioSystemObject] cameras, audioInputs, audioOutputs -> [WebhookSensor] in
+            Self.sensors(
+                cameras: cameras,
+                audioInputs: audioInputs,
+                audioOutputs: audioOutputs,
+                runningDevices: audioSystemObject.runningDevices
+            )
         }
         #else
         sensors = .init(error: InputOutputDeviceError.noInputsOrOutputs)
@@ -180,11 +185,15 @@ public class InputOutputDeviceSensor: SensorProvider {
     private static func sensors(
         cameras: [HACoreMediaObjectCamera],
         audioInputs: [HACoreAudioObjectDevice],
-        audioOutputs: [HACoreAudioObjectDevice]
+        audioOutputs: [HACoreAudioObjectDevice],
+        runningDevices: HACoreAudioRunningDevices?
     ) -> [WebhookSensor] {
         let cameraFallback = "Unknown Camera"
         let audioInputFallback = "Unknown Audio Input"
         let audioOutputFallback = "Unknown Audio Output"
+
+        let activeAudioInputs = audioInputs.filter { $0.isInputOn(runningDevices: runningDevices) }
+        let activeAudioOutputs = audioOutputs.filter { $0.isOutputOn(runningDevices: runningDevices) }
 
         return Self.sensors(
             name: "Camera",
@@ -199,14 +208,14 @@ public class InputOutputDeviceSensor: SensorProvider {
             iconOn: "mdi:microphone",
             iconOff: "mdi:microphone-off",
             all: audioInputs.map { $0.name ?? audioInputFallback },
-            active: audioInputs.filter(\.isInputOn).map { $0.name ?? audioInputFallback }
+            active: activeAudioInputs.map { $0.name ?? audioInputFallback }
         ) + Self.sensors(
             name: "Audio Output",
             uniqueID: WebhookSensorId.audioOutput.rawValue,
             iconOn: "mdi:volume-high",
             iconOff: "mdi:volume-low",
             all: audioOutputs.map { $0.name ?? audioOutputFallback },
-            active: audioOutputs.filter(\.isOutputOn).map { $0.name ?? audioOutputFallback }
+            active: activeAudioOutputs.map { $0.name ?? audioOutputFallback }
         )
     }
 

--- a/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
+++ b/Sources/Shared/API/Webhook/Sensors/InputOutputDeviceSensor.swift
@@ -16,7 +16,9 @@ private class InputOutputDeviceUpdateSignaler: BaseSensorUpdateSignaler, SensorP
         case invalid
 
         #if targetEnvironment(macCatalyst)
-        case coreAudio(AudioObjectID)
+        // Carries the property selector as well as the object, because the system object is observed
+        // for more than one property and the two registrations must not collapse into one.
+        case coreAudio(AudioObjectID, AudioObjectPropertySelector)
         #if canImport(CoreMediaIO)
         case coreMedia(CMIOObjectID)
         #endif
@@ -26,7 +28,7 @@ private class InputOutputDeviceUpdateSignaler: BaseSensorUpdateSignaler, SensorP
             switch self {
             case .invalid: return .max
             #if targetEnvironment(macCatalyst)
-            case let .coreAudio(id): return id
+            case let .coreAudio(id, _): return id
             #if canImport(CoreMediaIO)
             case let .coreMedia(id): return id
             #endif
@@ -72,13 +74,14 @@ private class InputOutputDeviceUpdateSignaler: BaseSensorUpdateSignaler, SensorP
         for id: AudioObjectID,
         property: HACoreAudioProperty<some Any>
     ) {
-        addObserver(object: .coreAudio(id), property: property)
+        addObserver(object: .coreAudio(id, property.address.mSelector), property: property)
     }
 
     func removeCoreAudioObserver(
-        for id: AudioObjectID
+        for id: AudioObjectID,
+        property: HACoreAudioProperty<some Any>
     ) {
-        removeObserver(object: .coreAudio(id))
+        removeObserver(object: .coreAudio(id, property.address.mSelector))
     }
 
     func addCoreMediaObserver(
@@ -105,6 +108,11 @@ private class InputOutputDeviceUpdateSignaler: BaseSensorUpdateSignaler, SensorP
         #endif
 
         addCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject), property: .allDevices)
+        // A device already running in one direction stays running as the other direction starts and
+        // stops, so the device flag alone misses that transition. The process object list changes
+        // whenever a process starts or stops doing IO, which covers one app recording while another
+        // plays back through the same device.
+        addCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject), property: .processObjectList)
         #endif
         isObserving = true
     }
@@ -117,7 +125,8 @@ private class InputOutputDeviceUpdateSignaler: BaseSensorUpdateSignaler, SensorP
         removeCoreMediaObserver(for: CMIOObjectID(kCMIOObjectSystemObject))
         #endif
 
-        removeCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject))
+        removeCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject), property: .allDevices)
+        removeCoreAudioObserver(for: AudioObjectID(kAudioObjectSystemObject), property: .processObjectList)
         #endif
         isObserving = false
     }

--- a/Tests/Shared/Sensors/HACoreAudioRunningDevices.test.swift
+++ b/Tests/Shared/Sensors/HACoreAudioRunningDevices.test.swift
@@ -1,0 +1,45 @@
+@testable import Shared
+import XCTest
+
+class HACoreAudioRunningDevicesTests: XCTestCase {
+    private let device: UInt32 = 42
+
+    func testRecordingWhenAProcessRecordsFromIt() {
+        let running = HACoreAudioRunningDevices(inputDeviceIDs: [device], outputDeviceIDs: [])
+
+        XCTAssertTrue(running.isRecording(deviceID: device, isRunningSomewhere: true))
+        XCTAssertFalse(running.isPlayingBack(deviceID: device, isRunningSomewhere: true))
+    }
+
+    func testPlayingBackWhenAProcessPlaysThroughIt() {
+        let running = HACoreAudioRunningDevices(inputDeviceIDs: [], outputDeviceIDs: [device])
+
+        XCTAssertTrue(running.isPlayingBack(deviceID: device, isRunningSomewhere: true))
+        XCTAssertFalse(running.isRecording(deviceID: device, isRunningSomewhere: true))
+    }
+
+    /// A headset recording and playing back at once is in use in both directions.
+    func testBothDirectionsWhenAProcessClaimsItForEach() {
+        let running = HACoreAudioRunningDevices(inputDeviceIDs: [device], outputDeviceIDs: [device])
+
+        XCTAssertTrue(running.isRecording(deviceID: device, isRunningSomewhere: true))
+        XCTAssertTrue(running.isPlayingBack(deviceID: device, isRunningSomewhere: true))
+    }
+
+    /// Nothing claims the device, so the device-global flag is all there is to go on.
+    func testFallsBackToTheGlobalFlagWhenUnclaimed() {
+        let running = HACoreAudioRunningDevices(inputDeviceIDs: [1], outputDeviceIDs: [2])
+
+        XCTAssertTrue(running.isRecording(deviceID: device, isRunningSomewhere: true))
+        XCTAssertTrue(running.isPlayingBack(deviceID: device, isRunningSomewhere: true))
+        XCTAssertFalse(running.isRecording(deviceID: device, isRunningSomewhere: false))
+        XCTAssertFalse(running.isPlayingBack(deviceID: device, isRunningSomewhere: false))
+    }
+
+    func testNothingRunsWhenNoProcessIsDoingIO() {
+        let running = HACoreAudioRunningDevices(inputDeviceIDs: [], outputDeviceIDs: [])
+
+        XCTAssertFalse(running.isRecording(deviceID: device, isRunningSomewhere: false))
+        XCTAssertFalse(running.isPlayingBack(deviceID: device, isRunningSomewhere: false))
+    }
+}


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #5635: on macOS, `Audio Input In Use` and `Active Audio Input` never activate.

`kAudioDevicePropertyDeviceIsRunningSomewhere` is device-global and is only published in `kAudioObjectPropertyScopeGlobal`, so the input- and output-scoped listeners the sensors have used register successfully and then never fire. The sensors stopped being refreshed when a microphone or speaker started and stopped.

This observes the property in the global scope again and takes the direction from the processes doing the IO (`kAudioProcessPropertyIsRunningInput`/`Output` plus the devices each process uses per direction), which is real per-direction state. Playing music through a USB headset still does not report its microphone as in use. Where per-process state cannot be read, direction falls back to the device's stream configuration.

The process object list is observed as well: a device already running in one direction keeps the device-global flag at 1 while the other direction starts and stops, so that flag alone would miss the transition.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No UI change — the change is in sensor values.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#
Not needed — no documented behaviour changes, the sensors go back to working as documented.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Worth verifying on a Mac with both an input-only microphone and a duplex headset.