### PR TITLE
Add NFC Tag option to the entity "Add to" menu

### DIFF
--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToAction.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToAction.swift
@@ -47,6 +47,7 @@ enum EntityAddToActionType: String, Codable {
     case customWidget
     case macToolbarItem
     case deeplink
+    case nfcTag
 }
 
 // MARK: - Action Implementations
@@ -190,6 +191,8 @@ private struct AnyEntityAddToAction: Codable {
             self.action = try container.decode(MacToolbarItemAction.self, forKey: .data)
         case .deeplink:
             self.action = try container.decode(DeeplinkAction.self, forKey: .data)
+        case .nfcTag:
+            self.action = try container.decode(NFCTagAction.self, forKey: .data)
         }
     }
 
@@ -227,6 +230,12 @@ private struct AnyEntityAddToAction: Codable {
             }
         case .deeplink:
             if let typed = action as? DeeplinkAction {
+                try container.encode(typed, forKey: .data)
+            } else {
+                throw EntityAddToError.encodingFailed
+            }
+        case .nfcTag:
+            if let typed = action as? NFCTagAction {
                 try container.encode(typed, forKey: .data)
             } else {
                 throw EntityAddToError.encodingFailed

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -217,14 +217,14 @@ final class EntityAddToHandler {
     /// tag opens the entity's more info dialog. The system NFC sheet is the whole UI here: it asks for
     /// the tag, reports success, and shows any write failure.
     private func writeDeeplinkToNFCTag(entityId: String) -> Promise<Void> {
-        guard let url = DeeplinkTarget.entity(id: entityId).url(serverName: nil) else {
+        guard let deeplink = DeeplinkTarget.entity(id: entityId).url(serverName: nil) else {
             Current.Log.error("Could not build a deeplink for entity \(entityId) to write to an NFC tag")
             return .init(error: EntityAddToError.invalidPayload)
         }
 
         Current.Log.info("Writing deeplink for entity \(entityId) to an NFC tag")
         return Current.tags.writeNFC(
-            url: url,
+            deeplink: deeplink,
             alertMessage: L10n.Nfc.Write.Deeplink.startMessage(Current.device.inspecificModel())
         )
     }

--- a/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/EntityAddToHandler.swift
@@ -60,6 +60,12 @@ final class EntityAddToHandler {
 
                 if domain != nil {
                     actions.append(DeeplinkAction())
+
+                    // Writing the deep link onto a tag needs NFC hardware, which Catalyst and the
+                    // older devices never have.
+                    if Current.tags.isNFCAvailable {
+                        actions.append(NFCTagAction())
+                    }
                 }
 
                 seal.fulfill(actions)
@@ -114,6 +120,13 @@ final class EntityAddToHandler {
                 case .deeplink:
                     openDeeplink(entityId: entityId, webViewController: webViewController)
                     seal.fulfill(())
+
+                case .nfcTag:
+                    writeDeeplinkToNFCTag(entityId: entityId).done {
+                        seal.fulfill(())
+                    }.catch { error in
+                        seal.reject(error)
+                    }
 
                 case .none:
                     seal.reject(EntityAddToError.unknownActionType)
@@ -198,6 +211,22 @@ final class EntityAddToHandler {
 
     private func openDeeplink(entityId: String, webViewController: WebViewControllerProtocol) {
         DeeplinkPresenter.present(target: .entity(id: entityId), from: webViewController)
+    }
+
+    /// Writes the same deep link the `DeeplinkAction` hands out onto an NFC tag, so that scanning the
+    /// tag opens the entity's more info dialog. The system NFC sheet is the whole UI here: it asks for
+    /// the tag, reports success, and shows any write failure.
+    private func writeDeeplinkToNFCTag(entityId: String) -> Promise<Void> {
+        guard let url = DeeplinkTarget.entity(id: entityId).url(serverName: nil) else {
+            Current.Log.error("Could not build a deeplink for entity \(entityId) to write to an NFC tag")
+            return .init(error: EntityAddToError.invalidPayload)
+        }
+
+        Current.Log.info("Writing deeplink for entity \(entityId) to an NFC tag")
+        return Current.tags.writeNFC(
+            url: url,
+            alertMessage: L10n.Nfc.Write.Deeplink.startMessage(Current.device.inspecificModel())
+        )
     }
 
     private func openWidgetBuilder(

--- a/Sources/App/Frontend/ExternalMessageBus/NFCTagAction.swift
+++ b/Sources/App/Frontend/ExternalMessageBus/NFCTagAction.swift
@@ -1,0 +1,14 @@
+import Foundation
+@preconcurrency import Shared
+
+/// Action that writes the entity's deep link straight onto an NFC tag, so that scanning the tag
+/// opens the entity's more info dialog. It is the `DeeplinkAction` link, stored on a physical tag
+/// instead of being copied to the clipboard.
+struct NFCTagAction: EntityAddToAction {
+    var mdiIcon: String { "mdi:nfc-variant" }
+    var actionType: String { EntityAddToActionType.nfcTag.rawValue }
+
+    func text() -> String {
+        L10n.WebView.AddTo.Option.NfcTag.title
+    }
+}

--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -1196,8 +1196,10 @@ Tags will work on any device with Home Assistant installed which has hardware su
 "nfc.tag_approval.tag_id.title" = "Tag identifier";
 "nfc.tag_approval.title" = "Allow tag?";
 "nfc.tag_read" = "NFC Tag Read";
+"nfc.write.deeplink.start_message" = "Bring an NFC tag near your %@ to create a deeplink to this entity";
 "nfc.write.error.capacity" = "NFC tag has insufficient capacity: needs %ld but only has %ld";
 "nfc.write.error.invalid_format" = "NFC tag is not NDEF format";
+"nfc.write.error.invalid_url" = "This link cannot be written to an NFC tag";
 "nfc.write.error.not_writable" = "NFC tag is read-only";
 "nfc.write.identifier_choice.manual" = "Manual";
 "nfc.write.identifier_choice.message" = "The identifier helps differentiate various tags.";
@@ -2890,6 +2892,7 @@ While no URL is considered safe, this server's data won't sync to the watch and 
 "web_view.add_to.option.CarPlay.title" = "CarPlay";
 "web_view.add_to.option.Deeplink.title" = "Deeplink";
 "web_view.add_to.option.MacToolbar.title" = "Mac Toolbar";
+"web_view.add_to.option.NfcTag.title" = "NFC Tag";
 "web_view.add_to.option.Widget.title" = "Widget";
 "web_view.empty_state.body" = "Please check your connection or try again later. If Home Assistant is restarting it will reconnect after it is back online.";
 "web_view.empty_state.clean_cache_and_reload_button" = "Clean cache and reload";

--- a/Sources/App/Settings/NFC/NFCWriter.swift
+++ b/Sources/App/Settings/NFC/NFCWriter.swift
@@ -28,7 +28,7 @@ class NFCWriter: NSObject, NFCNDEFReaderSessionDelegate {
         }
     }
 
-    init(requiredPayload: [NFCNDEFPayload], optionalPayload: [NFCNDEFPayload]) {
+    init(requiredPayload: [NFCNDEFPayload], optionalPayload: [NFCNDEFPayload], alertMessage: String) {
         self.requiredMessage = NFCNDEFMessage(records: requiredPayload)
         self.optionalMessage = NFCNDEFMessage(records: requiredPayload + optionalPayload)
         (self.promise, self.seal) = Promise<NFCNDEFMessage>.pending()
@@ -39,7 +39,7 @@ class NFCWriter: NSObject, NFCNDEFReaderSessionDelegate {
             queue: nil,
             invalidateAfterFirstRead: false
         )
-        readerSession.alertMessage = L10n.Nfc.Write.startMessage(Current.device.inspecificModel())
+        readerSession.alertMessage = alertMessage
         readerSession.begin()
     }
 

--- a/Sources/App/Settings/NFC/SimulatorNFCManager.swift
+++ b/Sources/App/Settings/NFC/SimulatorNFCManager.swift
@@ -15,5 +15,10 @@ final class SimulatorTagManager: iOSTagManager {
     override func writeNFC(value: String) -> Promise<String> {
         .value(value)
     }
+
+    override func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+        Current.Log.info("Simulator pretending to write \(url.absoluteString) to an NFC tag")
+        return .value(())
+    }
 }
 #endif

--- a/Sources/App/Settings/NFC/SimulatorNFCManager.swift
+++ b/Sources/App/Settings/NFC/SimulatorNFCManager.swift
@@ -16,8 +16,8 @@ final class SimulatorTagManager: iOSTagManager {
         .value(value)
     }
 
-    override func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
-        Current.Log.info("Simulator pretending to write \(url.absoluteString) to an NFC tag")
+    override func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void> {
+        Current.Log.info("Simulator pretending to write \(deeplink.absoluteString) to an NFC tag")
         return .value(())
     }
 }

--- a/Sources/App/Settings/NFC/iOSTagManager.swift
+++ b/Sources/App/Settings/NFC/iOSTagManager.swift
@@ -18,6 +18,10 @@ class TagActivityManager: TagManager {
         .init(error: TagManagerError.nfcUnavailable)
     }
 
+    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+        .init(error: TagManagerError.nfcUnavailable)
+    }
+
     func handle(userActivity: NSUserActivity) -> TagManagerHandleResult {
         guard let url = userActivity.webpageURL else {
             return .unhandled
@@ -111,7 +115,11 @@ class iOSTagManager: TagActivityManager {
             return .init(error: TagManagerError.notHomeAssistantTag)
         }
 
-        let writer = NFCWriter(requiredPayload: [uriPayload], optionalPayload: [aarPayload])
+        let writer = NFCWriter(
+            requiredPayload: [uriPayload],
+            optionalPayload: [aarPayload],
+            alertMessage: L10n.Nfc.Write.startMessage(Current.device.inspecificModel())
+        )
         var writerRetain: NFCWriter? = writer
 
         return firstly {
@@ -124,6 +132,25 @@ class iOSTagManager: TagActivityManager {
             // we use the same logic as reading, so we can be sure the identifier is right
             Self.identifier(from: message)
         }
+    }
+
+    override func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+        guard let uriPayload = NFCNDEFPayload.wellKnownTypeURIPayload(url: url) else {
+            return .init(error: TagManagerError.invalidURL)
+        }
+
+        // No Android application record here: the URL is the whole point of the tag, and the
+        // companion app it should open is decided by whoever owns the link, not by us.
+        let writer = NFCWriter(requiredPayload: [uriPayload], optionalPayload: [], alertMessage: alertMessage)
+        var writerRetain: NFCWriter? = writer
+
+        return firstly {
+            writer.promise
+        }.ensure {
+            withExtendedLifetime(writerRetain) {
+                writerRetain = nil
+            }
+        }.asVoid()
     }
 
     override func handledType(from userActivity: NSUserActivity) -> TagManagerHandleResult.HandledType {

--- a/Sources/App/Settings/NFC/iOSTagManager.swift
+++ b/Sources/App/Settings/NFC/iOSTagManager.swift
@@ -18,7 +18,7 @@ class TagActivityManager: TagManager {
         .init(error: TagManagerError.nfcUnavailable)
     }
 
-    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+    func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void> {
         .init(error: TagManagerError.nfcUnavailable)
     }
 
@@ -134,13 +134,23 @@ class iOSTagManager: TagActivityManager {
         }
     }
 
-    override func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
-        guard let uriPayload = NFCNDEFPayload.wellKnownTypeURIPayload(url: url) else {
+    /// The record a deep link is written to a tag as.
+    ///
+    /// A tag holds the app's NFC universal link rather than the deep link itself: background tag reading
+    /// only routes the `https` links the app has claimed, so a bare `homeassistant://` record is ignored
+    /// on a scan.
+    static func deeplinkPayload(for deeplink: URL) -> NFCNDEFPayload? {
+        guard let tagURL = AppConstants.nfcTagURL(deeplink: deeplink) else {
+            return nil
+        }
+        return NFCNDEFPayload.wellKnownTypeURIPayload(url: tagURL)
+    }
+
+    override func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void> {
+        guard let uriPayload = Self.deeplinkPayload(for: deeplink) else {
             return .init(error: TagManagerError.invalidURL)
         }
 
-        // No Android application record here: the URL is the whole point of the tag, and the
-        // companion app it should open is decided by whoever owns the link, not by us.
         let writer = NFCWriter(requiredPayload: [uriPayload], optionalPayload: [], alertMessage: alertMessage)
         var writerRetain: NFCWriter? = writer
 

--- a/Sources/Shared/Environment/AppConstants.swift
+++ b/Sources/Shared/Environment/AppConstants.swift
@@ -187,6 +187,26 @@ public enum AppConstants {
         pageDeeplinkURL(path: path)?.appending(queryItems: [URLQueryItem(name: "server", value: serverName)])
     }
 
+    /// Everything that survives unescaped in the `url` value of an NFC tag link: the unreserved set
+    /// from RFC 3986, so the deep link's own separators cannot be mistaken for the outer URL's.
+    private static let nfcTagURLAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    /// The URL an NFC tag carries so that scanning it opens `deeplink` in the app.
+    ///
+    /// iPhone background tag reading only routes the `https` universal links the app has claimed, so a
+    /// bare `homeassistant://` URL written to a tag is ignored on a scan. A deep link travels on a tag
+    /// wrapped in the app's documented NFC universal link instead, which `TagManager.handle(userActivity:)`
+    /// unwraps back into the deep link when the scan reaches the app.
+    public static func nfcTagURL(deeplink: URL) -> URL? {
+        guard let encoded = deeplink.absoluteString
+            .addingPercentEncoding(withAllowedCharacters: nfcTagURLAllowed) else {
+            return nil
+        }
+        return URL(string: "https://www.home-assistant.io/ios/nfc/?url=\(encoded)")
+    }
+
     /// Where tapping an entity lands: the frontend's more-info dialog, cameras included.
     public static func openEntityDestinationURL(entityId: String, serverId: String) -> URL? {
         openEntityDeeplinkURL(entityId: entityId, serverId: serverId)

--- a/Sources/Shared/Environment/TagManagerProtocol.swift
+++ b/Sources/Shared/Environment/TagManagerProtocol.swift
@@ -16,11 +16,13 @@ public enum TagManagerHandleResult {
 public enum TagManagerError: LocalizedError {
     case nfcUnavailable
     case notHomeAssistantTag
+    case invalidURL
 
     public var errorDescription: String? {
         switch self {
         case .nfcUnavailable: return L10n.Nfc.notAvailable
         case .notHomeAssistantTag: return L10n.Nfc.Read.Error.notHomeAssistant
+        case .invalidURL: return L10n.Nfc.Write.Error.invalidUrl
         }
     }
 }
@@ -29,6 +31,12 @@ public protocol TagManager {
     var isNFCAvailable: Bool { get }
     func readNFC() -> Promise<String>
     func writeNFC(value: String) -> Promise<String>
+    /// Writes an arbitrary URL - a deep link, for example - to a tag, instead of a Home Assistant tag
+    /// identifier. The tag is then a plain link: reading it opens the URL rather than firing a tag event.
+    /// - Parameters:
+    ///   - url: The URL to store on the tag.
+    ///   - alertMessage: What the system NFC sheet tells the user to do while it waits for a tag.
+    func writeNFC(url: URL, alertMessage: String) -> Promise<Void>
     func handle(userActivity: NSUserActivity) -> TagManagerHandleResult
     func fireEvent(tag: String) -> Promise<Void>
 }
@@ -63,6 +71,10 @@ class EmptyTagManager: TagManager {
     }
 
     func writeNFC(value: String) -> Promise<String> {
+        .init(error: TagManagerError.nfcUnavailable)
+    }
+
+    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
         .init(error: TagManagerError.nfcUnavailable)
     }
 

--- a/Sources/Shared/Environment/TagManagerProtocol.swift
+++ b/Sources/Shared/Environment/TagManagerProtocol.swift
@@ -31,12 +31,13 @@ public protocol TagManager {
     var isNFCAvailable: Bool { get }
     func readNFC() -> Promise<String>
     func writeNFC(value: String) -> Promise<String>
-    /// Writes an arbitrary URL - a deep link, for example - to a tag, instead of a Home Assistant tag
-    /// identifier. The tag is then a plain link: reading it opens the URL rather than firing a tag event.
+    /// Writes a deep link to a tag, instead of a Home Assistant tag identifier, so that scanning the tag
+    /// opens the link in the app rather than firing a tag event. The deep link travels wrapped in the
+    /// app's NFC universal link, since that is the only form an iPhone routes back to the app on a scan.
     /// - Parameters:
-    ///   - url: The URL to store on the tag.
+    ///   - deeplink: The deep link a scan of the tag should open.
     ///   - alertMessage: What the system NFC sheet tells the user to do while it waits for a tag.
-    func writeNFC(url: URL, alertMessage: String) -> Promise<Void>
+    func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void>
     func handle(userActivity: NSUserActivity) -> TagManagerHandleResult
     func fireEvent(tag: String) -> Promise<Void>
 }
@@ -74,7 +75,7 @@ class EmptyTagManager: TagManager {
         .init(error: TagManagerError.nfcUnavailable)
     }
 
-    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+    func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void> {
         .init(error: TagManagerError.nfcUnavailable)
     }
 

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -4098,6 +4098,12 @@ public enum L10n {
       }
       /// Tag Written!
       public static var successMessage: String { return L10n.tr("Localizable", "nfc.write.success_message") }
+      public enum Deeplink {
+        /// Bring an NFC tag near your %@ to create a deeplink to this entity
+        public static func startMessage(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "nfc.write.deeplink.start_message", String(describing: p1))
+        }
+      }
       public enum Error {
         /// NFC tag has insufficient capacity: needs %ld but only has %ld
         public static func capacity(_ p1: Int, _ p2: Int) -> String {
@@ -4105,6 +4111,8 @@ public enum L10n {
         }
         /// NFC tag is not NDEF format
         public static var invalidFormat: String { return L10n.tr("Localizable", "nfc.write.error.invalid_format") }
+        /// This link cannot be written to an NFC tag
+        public static var invalidUrl: String { return L10n.tr("Localizable", "nfc.write.error.invalid_url") }
         /// NFC tag is read-only
         public static var notWritable: String { return L10n.tr("Localizable", "nfc.write.error.not_writable") }
       }
@@ -9352,6 +9360,10 @@ public enum L10n {
         public enum MacToolbar {
           /// Mac Toolbar
           public static var title: String { return L10n.tr("Localizable", "web_view.add_to.option.MacToolbar.title") }
+        }
+        public enum NfcTag {
+          /// NFC Tag
+          public static var title: String { return L10n.tr("Localizable", "web_view.add_to.option.NfcTag.title") }
         }
         public enum Widget {
           /// Widget

--- a/Tests/App/Settings/NFCDeeplinkTagTests.swift
+++ b/Tests/App/Settings/NFCDeeplinkTagTests.swift
@@ -1,0 +1,94 @@
+import CoreNFC
+import Foundation
+@testable import HomeAssistant
+import PromiseKit
+@testable import Shared
+import Testing
+
+/// A tag written for an entity deep link has to survive the round trip: what the app puts on the tag is
+/// what iOS hands back when the tag is scanned, and the app has to find the deep link inside it again.
+struct NFCDeeplinkTagTests {
+    @Test("A scanned deeplink tag opens the deeplink it was written with")
+    func deeplinkTagRoundTripsThroughAScan() throws {
+        let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
+        let tagURL = try #require(AppConstants.nfcTagURL(deeplink: deeplink))
+
+        // Background tag reading only routes the universal links the app claims, never the deep link itself.
+        #expect(tagURL.absoluteString.hasPrefix("https://www.home-assistant.io/ios/nfc/?url="))
+
+        guard case let .open(scanned) = TagActivityManager().handle(userActivity: activity(for: tagURL)) else {
+            Issue.record("Expected a scanned deeplink tag to open its deeplink")
+            return
+        }
+
+        #expect(scanned == deeplink)
+    }
+
+    @Test("A deeplink's own separators cannot leak into the tag URL")
+    func deeplinkSeparatorsAreEscaped() throws {
+        let deeplink = try #require(URL(string: "homeassistant://navigate/?more-info-entity-id=light.a&server=Home"))
+        let tagURL = try #require(AppConstants.nfcTagURL(deeplink: deeplink))
+
+        // An unescaped "&" or "?" would end the url value early and lose the rest of the deep link.
+        let value = tagURL.absoluteString.replacingOccurrences(
+            of: "https://www.home-assistant.io/ios/nfc/?url=",
+            with: ""
+        )
+        #expect(!value.contains("&"))
+        #expect(!value.contains("?"))
+
+        guard case let .open(scanned) = TagActivityManager().handle(userActivity: activity(for: tagURL)) else {
+            Issue.record("Expected a scanned deeplink tag to open its deeplink")
+            return
+        }
+
+        #expect(scanned == deeplink)
+    }
+
+    @Test("The record written to a tag carries the deeplink's universal link")
+    func writtenRecordCarriesTheTagURL() throws {
+        let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
+        let payload = try #require(iOSTagManager.deeplinkPayload(for: deeplink))
+
+        let written = try #require(payload.wellKnownTypeURIPayload())
+        #expect(written == AppConstants.nfcTagURL(deeplink: deeplink))
+
+        // What was written is what a scan has to be able to turn back into the deeplink.
+        guard case let .open(scanned) = TagActivityManager().handle(userActivity: activity(for: written)) else {
+            Issue.record("Expected the written record to open its deeplink")
+            return
+        }
+
+        #expect(scanned == deeplink)
+    }
+
+    #if targetEnvironment(simulator)
+    @Test("The simulator reports a deeplink tag as written without any hardware")
+    @MainActor
+    func simulatorWritesWithoutHardware() throws {
+        let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
+
+        try hang(SimulatorTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+    }
+    #endif
+
+    // `hang` needs the main thread's run loop, so this test stays on it.
+    @MainActor
+    @Test("Writing a deeplink tag fails where NFC is unavailable")
+    func writingFailsWithoutNFC() throws {
+        let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
+
+        #expect(throws: TagManagerError.nfcUnavailable) {
+            try hang(TagActivityManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+        }
+        #expect(throws: TagManagerError.nfcUnavailable) {
+            try hang(EmptyTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+        }
+    }
+
+    private func activity(for url: URL) -> NSUserActivity {
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+        return activity
+    }
+}

--- a/Tests/App/Settings/NFCDeeplinkTagTests.swift
+++ b/Tests/App/Settings/NFCDeeplinkTagTests.swift
@@ -64,31 +64,41 @@ struct NFCDeeplinkTagTests {
 
     #if targetEnvironment(simulator)
     @Test("The simulator reports a deeplink tag as written without any hardware")
-    @MainActor
-    func simulatorWritesWithoutHardware() throws {
+    func simulatorWritesWithoutHardware() async throws {
         let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
 
-        try hang(SimulatorTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+        let error = await rejection(of: SimulatorTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+
+        #expect(error == nil)
     }
     #endif
 
-    // `hang` needs the main thread's run loop, so this test stays on it.
-    @MainActor
     @Test("Writing a deeplink tag fails where NFC is unavailable")
-    func writingFailsWithoutNFC() throws {
+    func writingFailsWithoutNFC() async throws {
         let deeplink = try #require(AppConstants.openEntityMoreInfoDeeplinkURL(entityId: "light.kitchen"))
 
-        #expect(throws: TagManagerError.nfcUnavailable) {
-            try hang(TagActivityManager().writeNFC(deeplink: deeplink, alertMessage: ""))
-        }
-        #expect(throws: TagManagerError.nfcUnavailable) {
-            try hang(EmptyTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
-        }
+        let onCatalyst = await rejection(of: TagActivityManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+        #expect(onCatalyst as? TagManagerError == .nfcUnavailable)
+
+        let withoutNFC = await rejection(of: EmptyTagManager().writeNFC(deeplink: deeplink, alertMessage: ""))
+        #expect(withoutNFC as? TagManagerError == .nfcUnavailable)
     }
 
     private func activity(for url: URL) -> NSUserActivity {
         let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
         activity.webpageURL = url
         return activity
+    }
+
+    /// Why the promise was rejected, or `nil` if it was fulfilled. Waiting for it rather than blocking a
+    /// thread on it keeps the test off the run loop the promise may itself need to settle.
+    private func rejection(of promise: Promise<Void>) async -> (any Error)? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<(any Error)?, Never>) in
+            promise.done {
+                continuation.resume(returning: nil)
+            }.catch { error in
+                continuation.resume(returning: error)
+            }
+        }
     }
 }

--- a/Tests/App/WebView/EntityAddToHandlerTests.swift
+++ b/Tests/App/WebView/EntityAddToHandlerTests.swift
@@ -1,9 +1,25 @@
 @testable import HomeAssistant
+import PromiseKit
 import Shared
 import XCTest
 
 @MainActor
 final class EntityAddToHandlerTests: XCTestCase {
+    private var originalTags: TagManager!
+    private var tags: MockTagManager!
+
+    override func setUp() {
+        super.setUp()
+        originalTags = Current.tags
+        tags = MockTagManager()
+        Current.tags = tags
+    }
+
+    override func tearDown() {
+        Current.tags = originalTags
+        super.tearDown()
+    }
+
     func testDeeplinkActionPresentsTheDeeplinkSheetForTheEntity() throws {
         let webView = MockWebViewController()
         let sut = EntityAddToHandler(webViewController: webView)
@@ -17,5 +33,86 @@ final class EntityAddToHandlerTests: XCTestCase {
         XCTAssertTrue(webView.presentOverlayControllerCalled)
         let controller = try XCTUnwrap(webView.overlayedController)
         XCTAssertTrue(String(describing: type(of: controller)).contains("DeeplinkView"))
+    }
+
+    func testNFCTagActionWritesTheEntityDeeplinkToATag() throws {
+        let webView = MockWebViewController()
+        let sut = EntityAddToHandler(webViewController: webView)
+        let executed = expectation(description: "nfc tag action executed")
+
+        sut.execute(action: NFCTagAction(), entityId: "light.kitchen").done {
+            executed.fulfill()
+        }.cauterize()
+        wait(for: [executed], timeout: 10.0)
+
+        let expectedURL = try XCTUnwrap(DeeplinkTarget.entity(id: "light.kitchen").url(serverName: nil))
+        XCTAssertEqual(tags.writtenURLs, [expectedURL])
+        XCTAssertEqual(
+            tags.writeURLAlertMessages,
+            [L10n.Nfc.Write.Deeplink.startMessage(Current.device.inspecificModel())]
+        )
+        // The system NFC sheet is the whole interaction, so nothing of ours is presented on top of it.
+        XCTAssertFalse(webView.presentOverlayControllerCalled)
+    }
+
+    func testNFCTagActionFailsWhenTheTagCannotBeWritten() {
+        tags.writeURLResult = .init(error: TagManagerError.invalidURL)
+        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let failed = expectation(description: "nfc tag action failed")
+
+        sut.execute(action: NFCTagAction(), entityId: "light.kitchen").catch { error in
+            XCTAssertEqual(error as? TagManagerError, .invalidURL)
+            failed.fulfill()
+        }
+        wait(for: [failed], timeout: 10.0)
+    }
+
+    func testActionsForEntityIncludesNFCTagActionWhenNFCIsAvailable() {
+        tags.isNFCAvailable = true
+        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let resolved = expectation(description: "actions resolved")
+
+        sut.actionsForEntity(entityId: "light.kitchen").done { actions in
+            XCTAssertTrue(actions.contains { $0.actionType == EntityAddToActionType.nfcTag.rawValue })
+            resolved.fulfill()
+        }.cauterize()
+        wait(for: [resolved], timeout: 10.0)
+    }
+
+    func testActionsForEntityOmitsNFCTagActionWhenNFCIsUnavailable() {
+        tags.isNFCAvailable = false
+        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let resolved = expectation(description: "actions resolved")
+
+        sut.actionsForEntity(entityId: "light.kitchen").done { actions in
+            XCTAssertFalse(actions.contains { $0.actionType == EntityAddToActionType.nfcTag.rawValue })
+            XCTAssertTrue(actions.contains { $0.actionType == EntityAddToActionType.deeplink.rawValue })
+            resolved.fulfill()
+        }.cauterize()
+        wait(for: [resolved], timeout: 10.0)
+    }
+
+    func testActionsForEntityOmitsBothLinkActionsForAnUnknownDomain() {
+        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let resolved = expectation(description: "actions resolved")
+
+        sut.actionsForEntity(entityId: "not_a_domain.kitchen").done { actions in
+            XCTAssertFalse(actions.contains { $0.actionType == EntityAddToActionType.nfcTag.rawValue })
+            XCTAssertFalse(actions.contains { $0.actionType == EntityAddToActionType.deeplink.rawValue })
+            resolved.fulfill()
+        }.cauterize()
+        wait(for: [resolved], timeout: 10.0)
+    }
+
+    func testNFCTagActionSurvivesTheRoundTripThroughTheFrontend() throws {
+        let external = try ExternalEntityAddToAction.from(action: NFCTagAction())
+
+        XCTAssertEqual(external.name, L10n.WebView.AddTo.Option.NfcTag.title)
+        XCTAssertEqual(external.mdiIcon, "mdi:nfc-variant")
+        XCTAssertTrue(external.enabled)
+
+        let decoded = try ExternalEntityAddToAction.toAction(from: external.appPayload)
+        XCTAssertEqual(decoded.actionType, EntityAddToActionType.nfcTag.rawValue)
+        XCTAssertTrue(decoded is NFCTagAction)
     }
 }

--- a/Tests/App/WebView/EntityAddToHandlerTests.swift
+++ b/Tests/App/WebView/EntityAddToHandlerTests.swift
@@ -46,9 +46,9 @@ final class EntityAddToHandlerTests: XCTestCase {
         wait(for: [executed], timeout: 10.0)
 
         let expectedURL = try XCTUnwrap(DeeplinkTarget.entity(id: "light.kitchen").url(serverName: nil))
-        XCTAssertEqual(tags.writtenURLs, [expectedURL])
+        XCTAssertEqual(tags.writtenDeeplinks, [expectedURL])
         XCTAssertEqual(
-            tags.writeURLAlertMessages,
+            tags.writeDeeplinkAlertMessages,
             [L10n.Nfc.Write.Deeplink.startMessage(Current.device.inspecificModel())]
         )
         // The system NFC sheet is the whole interaction, so nothing of ours is presented on top of it.
@@ -56,8 +56,9 @@ final class EntityAddToHandlerTests: XCTestCase {
     }
 
     func testNFCTagActionFailsWhenTheTagCannotBeWritten() {
-        tags.writeURLResult = .init(error: TagManagerError.invalidURL)
-        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        tags.writeDeeplinkResult = .init(error: TagManagerError.invalidURL)
+        let webView = MockWebViewController()
+        let sut = EntityAddToHandler(webViewController: webView)
         let failed = expectation(description: "nfc tag action failed")
 
         sut.execute(action: NFCTagAction(), entityId: "light.kitchen").catch { error in
@@ -69,7 +70,8 @@ final class EntityAddToHandlerTests: XCTestCase {
 
     func testActionsForEntityIncludesNFCTagActionWhenNFCIsAvailable() {
         tags.isNFCAvailable = true
-        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let webView = MockWebViewController()
+        let sut = EntityAddToHandler(webViewController: webView)
         let resolved = expectation(description: "actions resolved")
 
         sut.actionsForEntity(entityId: "light.kitchen").done { actions in
@@ -81,7 +83,8 @@ final class EntityAddToHandlerTests: XCTestCase {
 
     func testActionsForEntityOmitsNFCTagActionWhenNFCIsUnavailable() {
         tags.isNFCAvailable = false
-        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let webView = MockWebViewController()
+        let sut = EntityAddToHandler(webViewController: webView)
         let resolved = expectation(description: "actions resolved")
 
         sut.actionsForEntity(entityId: "light.kitchen").done { actions in
@@ -93,7 +96,8 @@ final class EntityAddToHandlerTests: XCTestCase {
     }
 
     func testActionsForEntityOmitsBothLinkActionsForAnUnknownDomain() {
-        let sut = EntityAddToHandler(webViewController: MockWebViewController())
+        let webView = MockWebViewController()
+        let sut = EntityAddToHandler(webViewController: webView)
         let resolved = expectation(description: "actions resolved")
 
         sut.actionsForEntity(entityId: "not_a_domain.kitchen").done { actions in

--- a/Tests/App/WebView/Mocks/MockTagManager.swift
+++ b/Tests/App/WebView/Mocks/MockTagManager.swift
@@ -1,0 +1,36 @@
+import Foundation
+import PromiseKit
+import Shared
+
+/// Test double for `TagManager`, recording what the app asks it to write to an NFC tag.
+final class MockTagManager: TagManager {
+    var isNFCAvailable = true
+    var writeURLResult: Promise<Void> = .value(())
+
+    private(set) var writtenValues: [String] = []
+    private(set) var writtenURLs: [URL] = []
+    private(set) var writeURLAlertMessages: [String] = []
+
+    func readNFC() -> Promise<String> {
+        .value("mock-tag")
+    }
+
+    func writeNFC(value: String) -> Promise<String> {
+        writtenValues.append(value)
+        return .value(value)
+    }
+
+    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
+        writtenURLs.append(url)
+        writeURLAlertMessages.append(alertMessage)
+        return writeURLResult
+    }
+
+    func handle(userActivity: NSUserActivity) -> TagManagerHandleResult {
+        .unhandled
+    }
+
+    func fireEvent(tag: String) -> Promise<Void> {
+        .value(())
+    }
+}

--- a/Tests/App/WebView/Mocks/MockTagManager.swift
+++ b/Tests/App/WebView/Mocks/MockTagManager.swift
@@ -5,11 +5,11 @@ import Shared
 /// Test double for `TagManager`, recording what the app asks it to write to an NFC tag.
 final class MockTagManager: TagManager {
     var isNFCAvailable = true
-    var writeURLResult: Promise<Void> = .value(())
+    var writeDeeplinkResult: Promise<Void> = .value(())
 
     private(set) var writtenValues: [String] = []
-    private(set) var writtenURLs: [URL] = []
-    private(set) var writeURLAlertMessages: [String] = []
+    private(set) var writtenDeeplinks: [URL] = []
+    private(set) var writeDeeplinkAlertMessages: [String] = []
 
     func readNFC() -> Promise<String> {
         .value("mock-tag")
@@ -20,10 +20,10 @@ final class MockTagManager: TagManager {
         return .value(value)
     }
 
-    func writeNFC(url: URL, alertMessage: String) -> Promise<Void> {
-        writtenURLs.append(url)
-        writeURLAlertMessages.append(alertMessage)
-        return writeURLResult
+    func writeNFC(deeplink: URL, alertMessage: String) -> Promise<Void> {
+        writtenDeeplinks.append(deeplink)
+        writeDeeplinkAlertMessages.append(alertMessage)
+        return writeDeeplinkResult
     }
 
     func handle(userActivity: NSUserActivity) -> TagManagerHandleResult {


### PR DESCRIPTION
## AI Policy
<!-- Please read our AI policy before contributing: https://developers.home-assistant.io/docs/ai_policy -->
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new "NFC Tag" option to the entity "Add to" menu. Picking it writes the same deep link the existing "Deeplink" option produces onto an NFC tag, so scanning the tag opens that entity's more info dialog.

The system NFC sheet is the whole interaction: it asks the user to bring a tag near the device to create a deeplink to the entity, reports the write, and shows any failure. The option only shows up where NFC is available.

The tag carries the deep link wrapped in the app's NFC universal link, `https://www.home-assistant.io/ios/nfc/?url=<deeplink>`. iPhone background tag reading only routes the `https` universal links the app has claimed, so a bare `homeassistant://` record would be ignored on a scan; the wrapper is the form `TagManager.handle(userActivity:)` already unwraps back into a deep link.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The only new UI is the system NFC sheet and a new row in the frontend's "Add to" list.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
`TagManager` gains `writeNFC(deeplink:alertMessage:)` for writing a deep link rather than a Home Assistant tag identifier, `AppConstants.nfcTagURL(deeplink:)` builds the universal link it travels in, and `NFCWriter` now takes its sheet message from the caller.

Patch coverage lands at 64.71%: most of the uncovered lines are the CoreNFC reader-session plumbing in `iOSTagManager.writeNFC(deeplink:)` and `NFCWriter`, which cannot run in a unit test. The part that decides what goes on the tag is covered, including a round trip that reads the written record back and checks it routes to the deep link.
